### PR TITLE
Fix AWS RI purchase: details assertion + reservation ID rules

### DIFF
--- a/pkg/common/identifiers.go
+++ b/pkg/common/identifiers.go
@@ -1,0 +1,31 @@
+package common
+
+import (
+	"strconv"
+	"strings"
+	"time"
+)
+
+// SanitizeReservationID returns an identifier safe for AWS reservation/reserved-instance
+// ID or name fields: only ASCII letters, digits, and hyphens; no leading/trailing
+// hyphen; no consecutive hyphens. Dots are replaced with hyphens. If the result
+// would be empty, returns fallbackPrefix plus a Unix timestamp.
+func SanitizeReservationID(id, fallbackPrefix string) string {
+	var b strings.Builder
+	for _, r := range id {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' {
+			b.WriteRune(r)
+		} else if r == '.' {
+			b.WriteRune('-')
+		}
+	}
+	s := b.String()
+	for strings.Contains(s, "--") {
+		s = strings.ReplaceAll(s, "--", "-")
+	}
+	s = strings.Trim(s, "-")
+	if s == "" {
+		s = fallbackPrefix + strconv.FormatInt(time.Now().Unix(), 10)
+	}
+	return s
+}

--- a/providers/aws/recommendations/client.go
+++ b/providers/aws/recommendations/client.go
@@ -322,7 +322,14 @@ func (c *Client) parseOpenSearchDetails(rec *common.Recommendation, details *typ
 	osInfo := &common.SearchDetails{}
 
 	if esDetails.InstanceClass != nil && esDetails.InstanceSize != nil {
-		rec.ResourceType = fmt.Sprintf("%s.%s", *esDetails.InstanceClass, *esDetails.InstanceSize)
+		instanceSize := *esDetails.InstanceSize
+		// Cost Explorer may return InstanceSize as the full type (e.g. "t3.medium.search");
+		// concatenating with InstanceClass would duplicate (e.g. "t3.medium.t3.medium.search").
+		if strings.HasSuffix(instanceSize, ".search") {
+			rec.ResourceType = instanceSize
+		} else {
+			rec.ResourceType = fmt.Sprintf("%s.%s.search", *esDetails.InstanceClass, instanceSize)
+		}
 		osInfo.InstanceType = rec.ResourceType
 	}
 	if esDetails.Region != nil {

--- a/providers/aws/services/ec2/client.go
+++ b/providers/aws/services/ec2/client.go
@@ -150,8 +150,8 @@ func (c *Client) PurchaseCommitment(ctx context.Context, rec common.Recommendati
 
 // findOfferingID finds the appropriate EC2 Reserved Instance offering ID
 func (c *Client) findOfferingID(ctx context.Context, rec common.Recommendation) (string, error) {
-	details, ok := rec.Details.(common.ComputeDetails)
-	if !ok {
+	details, ok := rec.Details.(*common.ComputeDetails)
+	if !ok || details == nil {
 		return "", fmt.Errorf("invalid service details for EC2")
 	}
 

--- a/providers/aws/services/ec2/client_test.go
+++ b/providers/aws/services/ec2/client_test.go
@@ -264,7 +264,7 @@ func TestClient_ValidateOffering(t *testing.T) {
 		ResourceType:  "t3.micro",
 		PaymentOption: "partial-upfront",
 		Term:          "3yr",
-		Details: common.ComputeDetails{
+		Details: &common.ComputeDetails{
 			Platform: "Linux/UNIX",
 			Tenancy:  "default",
 			Scope:    "Region",
@@ -303,7 +303,7 @@ func TestClient_PurchaseCommitment(t *testing.T) {
 		Count:         2,
 		PaymentOption: "partial-upfront",
 		Term:          "3yr",
-		Details: common.ComputeDetails{
+		Details: &common.ComputeDetails{
 			Platform: "Linux/UNIX",
 			Tenancy:  "default",
 			Scope:    "Region",
@@ -351,7 +351,7 @@ func TestClient_GetOfferingDetails(t *testing.T) {
 		PaymentOption: "partial-upfront",
 		Term:          "3yr",
 		Count:         1,
-		Details: common.ComputeDetails{
+		Details: &common.ComputeDetails{
 			Platform: "Linux/UNIX",
 			Tenancy:  "default",
 			Scope:    "Region",

--- a/providers/aws/services/elasticache/client.go
+++ b/providers/aws/services/elasticache/client.go
@@ -5,8 +5,6 @@ import (
 	"context"
 	"fmt"
 	"sort"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -125,7 +123,7 @@ func (c *Client) PurchaseCommitment(ctx context.Context, rec common.Recommendati
 		return result, result.Error
 	}
 
-	reservationID := c.sanitizeReservationID(fmt.Sprintf("elasticache-%s-%d", rec.ResourceType, time.Now().Unix()))
+	reservationID := common.SanitizeReservationID(fmt.Sprintf("elasticache-%s-%d", rec.ResourceType, time.Now().Unix()), "elasticache-reserved-")
 
 	input := &elasticache.PurchaseReservedCacheNodesOfferingInput{
 		ReservedCacheNodesOfferingId: aws.String(offeringID),
@@ -224,28 +222,6 @@ func (c *Client) GetOfferingDetails(ctx context.Context, rec common.Recommendati
 	}
 
 	return details, nil
-}
-
-// sanitizeReservationID ensures the reservation identifier uses only allowed characters
-// (letters, digits, hyphens), with no leading/trailing or consecutive hyphens.
-func (c *Client) sanitizeReservationID(id string) string {
-	var b strings.Builder
-	for _, r := range id {
-		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' {
-			b.WriteRune(r)
-		} else if r == '.' {
-			b.WriteRune('-')
-		}
-	}
-	s := b.String()
-	for strings.Contains(s, "--") {
-		s = strings.ReplaceAll(s, "--", "-")
-	}
-	s = strings.Trim(s, "-")
-	if s == "" {
-		s = "elasticache-reserved-" + strconv.FormatInt(time.Now().Unix(), 10)
-	}
-	return s
 }
 
 // GetValidResourceTypes returns valid ElastiCache node types

--- a/providers/aws/services/elasticache/client.go
+++ b/providers/aws/services/elasticache/client.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -123,7 +125,7 @@ func (c *Client) PurchaseCommitment(ctx context.Context, rec common.Recommendati
 		return result, result.Error
 	}
 
-	reservationID := fmt.Sprintf("elasticache-%s-%d", rec.ResourceType, time.Now().Unix())
+	reservationID := c.sanitizeReservationID(fmt.Sprintf("elasticache-%s-%d", rec.ResourceType, time.Now().Unix()))
 
 	input := &elasticache.PurchaseReservedCacheNodesOfferingInput{
 		ReservedCacheNodesOfferingId: aws.String(offeringID),
@@ -154,8 +156,8 @@ func (c *Client) PurchaseCommitment(ctx context.Context, rec common.Recommendati
 
 // findOfferingID finds the appropriate Reserved Cache Node offering ID
 func (c *Client) findOfferingID(ctx context.Context, rec common.Recommendation) (string, error) {
-	details, ok := rec.Details.(common.CacheDetails)
-	if !ok {
+	details, ok := rec.Details.(*common.CacheDetails)
+	if !ok || details == nil {
 		return "", fmt.Errorf("invalid service details for ElastiCache")
 	}
 
@@ -222,6 +224,28 @@ func (c *Client) GetOfferingDetails(ctx context.Context, rec common.Recommendati
 	}
 
 	return details, nil
+}
+
+// sanitizeReservationID ensures the reservation identifier uses only allowed characters
+// (letters, digits, hyphens), with no leading/trailing or consecutive hyphens.
+func (c *Client) sanitizeReservationID(id string) string {
+	var b strings.Builder
+	for _, r := range id {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' {
+			b.WriteRune(r)
+		} else if r == '.' {
+			b.WriteRune('-')
+		}
+	}
+	s := b.String()
+	for strings.Contains(s, "--") {
+		s = strings.ReplaceAll(s, "--", "-")
+	}
+	s = strings.Trim(s, "-")
+	if s == "" {
+		s = "elasticache-reserved-" + strconv.FormatInt(time.Now().Unix(), 10)
+	}
+	return s
 }
 
 // GetValidResourceTypes returns valid ElastiCache node types

--- a/providers/aws/services/elasticache/client_test.go
+++ b/providers/aws/services/elasticache/client_test.go
@@ -246,7 +246,7 @@ func TestClient_ValidateOffering(t *testing.T) {
 		ResourceType:  "cache.r6g.large",
 		PaymentOption: "no-upfront",
 		Term:          "3yr",
-		Details: common.CacheDetails{
+		Details: &common.CacheDetails{
 			Engine:   "redis",
 			NodeType: "cache.r6g.large",
 		},
@@ -283,7 +283,7 @@ func TestClient_PurchaseCommitment(t *testing.T) {
 		Count:         3,
 		PaymentOption: "partial-upfront",
 		Term:          "3yr",
-		Details: common.CacheDetails{
+		Details: &common.CacheDetails{
 			Engine:   "redis",
 			NodeType: "cache.m6g.xlarge",
 		},
@@ -336,7 +336,7 @@ func TestClient_GetOfferingDetails(t *testing.T) {
 		ResourceType:  "cache.r6g.xlarge",
 		PaymentOption: "all-upfront",
 		Term:          "1yr",
-		Details: common.CacheDetails{
+		Details: &common.CacheDetails{
 			Engine:   "redis",
 			NodeType: "cache.r6g.xlarge",
 		},

--- a/providers/aws/services/memorydb/client.go
+++ b/providers/aws/services/memorydb/client.go
@@ -4,6 +4,8 @@ package memorydb
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -118,7 +120,7 @@ func (c *Client) PurchaseCommitment(ctx context.Context, rec common.Recommendati
 		return result, result.Error
 	}
 
-	reservationID := fmt.Sprintf("memorydb-%s-%d", rec.ResourceType, time.Now().Unix())
+	reservationID := c.sanitizeReservationID(fmt.Sprintf("memorydb-%s-%d", rec.ResourceType, time.Now().Unix()))
 
 	input := &memorydb.PurchaseReservedNodesOfferingInput{
 		ReservedNodesOfferingId: aws.String(offeringID),
@@ -241,6 +243,28 @@ func (c *Client) GetOfferingDetails(ctx context.Context, rec common.Recommendati
 	}
 
 	return details, nil
+}
+
+// sanitizeReservationID normalizes the reservation identifier for MemoryDB:
+// letters, digits, and hyphens only, with no leading/trailing or consecutive hyphens.
+func (c *Client) sanitizeReservationID(id string) string {
+	var b strings.Builder
+	for _, r := range id {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' {
+			b.WriteRune(r)
+		} else if r == '.' {
+			b.WriteRune('-')
+		}
+	}
+	s := b.String()
+	for strings.Contains(s, "--") {
+		s = strings.ReplaceAll(s, "--", "-")
+	}
+	s = strings.Trim(s, "-")
+	if s == "" {
+		s = "memorydb-reserved-" + strconv.FormatInt(time.Now().Unix(), 10)
+	}
+	return s
 }
 
 // GetValidResourceTypes returns valid MemoryDB node types (static list)

--- a/providers/aws/services/memorydb/client.go
+++ b/providers/aws/services/memorydb/client.go
@@ -4,8 +4,6 @@ package memorydb
 import (
 	"context"
 	"fmt"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -120,7 +118,7 @@ func (c *Client) PurchaseCommitment(ctx context.Context, rec common.Recommendati
 		return result, result.Error
 	}
 
-	reservationID := c.sanitizeReservationID(fmt.Sprintf("memorydb-%s-%d", rec.ResourceType, time.Now().Unix()))
+	reservationID := common.SanitizeReservationID(fmt.Sprintf("memorydb-%s-%d", rec.ResourceType, time.Now().Unix()), "memorydb-reserved-")
 
 	input := &memorydb.PurchaseReservedNodesOfferingInput{
 		ReservedNodesOfferingId: aws.String(offeringID),
@@ -243,28 +241,6 @@ func (c *Client) GetOfferingDetails(ctx context.Context, rec common.Recommendati
 	}
 
 	return details, nil
-}
-
-// sanitizeReservationID normalizes the reservation identifier for MemoryDB:
-// letters, digits, and hyphens only, with no leading/trailing or consecutive hyphens.
-func (c *Client) sanitizeReservationID(id string) string {
-	var b strings.Builder
-	for _, r := range id {
-		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' {
-			b.WriteRune(r)
-		} else if r == '.' {
-			b.WriteRune('-')
-		}
-	}
-	s := b.String()
-	for strings.Contains(s, "--") {
-		s = strings.ReplaceAll(s, "--", "-")
-	}
-	s = strings.Trim(s, "-")
-	if s == "" {
-		s = "memorydb-reserved-" + strconv.FormatInt(time.Now().Unix(), 10)
-	}
-	return s
 }
 
 // GetValidResourceTypes returns valid MemoryDB node types (static list)

--- a/providers/aws/services/opensearch/client.go
+++ b/providers/aws/services/opensearch/client.go
@@ -4,8 +4,6 @@ package opensearch
 import (
 	"context"
 	"fmt"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -120,7 +118,7 @@ func (c *Client) PurchaseCommitment(ctx context.Context, rec common.Recommendati
 		return result, result.Error
 	}
 
-	reservationID := c.sanitizeReservationName(fmt.Sprintf("opensearch-%s-%d", rec.ResourceType, time.Now().Unix()))
+	reservationID := common.SanitizeReservationID(fmt.Sprintf("opensearch-%s-%d", rec.ResourceType, time.Now().Unix()), "opensearch-reserved-")
 
 	input := &opensearch.PurchaseReservedInstanceOfferingInput{
 		ReservedInstanceOfferingId: aws.String(offeringID),
@@ -232,28 +230,6 @@ func (c *Client) GetOfferingDetails(ctx context.Context, rec common.Recommendati
 	}
 
 	return details, nil
-}
-
-// sanitizeReservationName normalizes the reservation name for OpenSearch:
-// letters, digits, and hyphens only, with no leading/trailing or consecutive hyphens.
-func (c *Client) sanitizeReservationName(name string) string {
-	var b strings.Builder
-	for _, r := range name {
-		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' {
-			b.WriteRune(r)
-		} else if r == '.' {
-			b.WriteRune('-')
-		}
-	}
-	s := b.String()
-	for strings.Contains(s, "--") {
-		s = strings.ReplaceAll(s, "--", "-")
-	}
-	s = strings.Trim(s, "-")
-	if s == "" {
-		s = "opensearch-reserved-" + strconv.FormatInt(time.Now().Unix(), 10)
-	}
-	return s
 }
 
 // GetValidResourceTypes returns valid OpenSearch instance types (static list)

--- a/providers/aws/services/opensearch/client.go
+++ b/providers/aws/services/opensearch/client.go
@@ -4,6 +4,8 @@ package opensearch
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -118,7 +120,7 @@ func (c *Client) PurchaseCommitment(ctx context.Context, rec common.Recommendati
 		return result, result.Error
 	}
 
-	reservationID := fmt.Sprintf("opensearch-%s-%d", rec.ResourceType, time.Now().Unix())
+	reservationID := c.sanitizeReservationName(fmt.Sprintf("opensearch-%s-%d", rec.ResourceType, time.Now().Unix()))
 
 	input := &opensearch.PurchaseReservedInstanceOfferingInput{
 		ReservedInstanceOfferingId: aws.String(offeringID),
@@ -230,6 +232,28 @@ func (c *Client) GetOfferingDetails(ctx context.Context, rec common.Recommendati
 	}
 
 	return details, nil
+}
+
+// sanitizeReservationName normalizes the reservation name for OpenSearch:
+// letters, digits, and hyphens only, with no leading/trailing or consecutive hyphens.
+func (c *Client) sanitizeReservationName(name string) string {
+	var b strings.Builder
+	for _, r := range name {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' {
+			b.WriteRune(r)
+		} else if r == '.' {
+			b.WriteRune('-')
+		}
+	}
+	s := b.String()
+	for strings.Contains(s, "--") {
+		s = strings.ReplaceAll(s, "--", "-")
+	}
+	s = strings.Trim(s, "-")
+	if s == "" {
+		s = "opensearch-reserved-" + strconv.FormatInt(time.Now().Unix(), 10)
+	}
+	return s
 }
 
 // GetValidResourceTypes returns valid OpenSearch instance types (static list)

--- a/providers/aws/services/rds/client.go
+++ b/providers/aws/services/rds/client.go
@@ -128,7 +128,7 @@ func (c *Client) PurchaseCommitment(ctx context.Context, rec common.Recommendati
 	}
 
 	// Generate reservation ID (letters, digits, hyphens only; no leading/trailing/double hyphen)
-	reservationID := c.sanitizeReservedDBInstanceID(fmt.Sprintf("rds-%s-%d", rec.ResourceType, time.Now().Unix()))
+	reservationID := common.SanitizeReservationID(fmt.Sprintf("rds-%s-%d", rec.ResourceType, time.Now().Unix()), "rds-reserved-")
 
 	// Create the purchase request
 	input := &rds.PurchaseReservedDBInstancesOfferingInput{
@@ -282,30 +282,6 @@ func (c *Client) GetValidResourceTypes(ctx context.Context) ([]string, error) {
 
 	sort.Strings(instanceTypes)
 	return instanceTypes, nil
-}
-
-// sanitizeReservedDBInstanceID returns an ID valid for ReservedDBInstanceId:
-// only ASCII letters, digits, hyphens; no leading/trailing hyphen; no consecutive hyphens.
-func (c *Client) sanitizeReservedDBInstanceID(id string) string {
-	var b strings.Builder
-	for _, r := range id {
-		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' {
-			b.WriteRune(r)
-		} else if r == '.' {
-			b.WriteRune('-')
-		}
-		// drop any other character
-	}
-	s := b.String()
-	// collapse consecutive hyphens
-	for strings.Contains(s, "--") {
-		s = strings.ReplaceAll(s, "--", "-")
-	}
-	s = strings.Trim(s, "-")
-	if s == "" {
-		s = "rds-reserved-" + strconv.FormatInt(time.Now().Unix(), 10)
-	}
-	return s
 }
 
 // getDurationString converts term string to duration string for RDS API

--- a/providers/aws/services/rds/client_test.go
+++ b/providers/aws/services/rds/client_test.go
@@ -274,7 +274,7 @@ func TestClient_ValidateOffering(t *testing.T) {
 		ResourceType:  "db.t3.medium",
 		PaymentOption: "no-upfront",
 		Term:          "3yr",
-		Details: common.DatabaseDetails{
+		Details: &common.DatabaseDetails{
 			Engine:   "mysql",
 			AZConfig: "multi-az",
 		},
@@ -311,7 +311,7 @@ func TestClient_ValidateOffering_NotFound(t *testing.T) {
 		ResourceType:  "db.t3.medium",
 		PaymentOption: "no-upfront",
 		Term:          "3yr",
-		Details: common.DatabaseDetails{
+		Details: &common.DatabaseDetails{
 			Engine:   "mysql",
 			AZConfig: "multi-az",
 		},
@@ -341,7 +341,7 @@ func TestClient_PurchaseCommitment(t *testing.T) {
 		Count:         2,
 		PaymentOption: "partial-upfront",
 		Term:          "3yr",
-		Details: common.DatabaseDetails{
+		Details: &common.DatabaseDetails{
 			Engine:   "aurora-mysql",
 			AZConfig: "multi-az",
 		},
@@ -396,7 +396,7 @@ func TestClient_PurchaseCommitment_EmptyResponse(t *testing.T) {
 		Count:         1,
 		PaymentOption: "all-upfront",
 		Term:          "1yr",
-		Details: common.DatabaseDetails{
+		Details: &common.DatabaseDetails{
 			Engine:   "mysql",
 			AZConfig: "single-az",
 		},
@@ -441,7 +441,7 @@ func TestClient_GetOfferingDetails(t *testing.T) {
 		ResourceType:  "db.m6g.large",
 		PaymentOption: "all-upfront",
 		Term:          "1yr",
-		Details: common.DatabaseDetails{
+		Details: &common.DatabaseDetails{
 			Engine:   "postgres",
 			AZConfig: "multi-az",
 		},


### PR DESCRIPTION
Fix AWS RI purchase (details + reservation IDs)
RDS purchases were failing for two reasons; fixed both and applied the same fixes elsewhere they mattered.
Recommendations were setting rec.Details as pointers but RDS/EC2/ElastiCache were asserting to the value type, so the assertion always failed. Updated those clients to assert the pointer type (with a nil check) and adjusted the tests to pass pointers too.
We were also building reservation IDs from rec.ResourceType (e.g. db.t3.small), so they had dots in them. AWS only allows letters, digits, and hyphens for those IDs. Added sanitization where we set the ID (RDS, ElastiCache, OpenSearch, MemoryDB): replace dots with hyphens, collapse/trim hyphens, and use a fallback like rds-reserved-<timestamp> if the result is empty. Redshift is unchanged since it doesn’t send a custom ID.
All relevant tests pass.
