### PR TITLE
fix(frontend/apikeys): read api_keys field; defensive guard against undefined

### DIFF
--- a/frontend/src/__tests__/apikeys.test.ts
+++ b/frontend/src/__tests__/apikeys.test.ts
@@ -82,7 +82,7 @@ describe('API Keys Module', () => {
         }
       ];
 
-      (api.getApiKeys as jest.Mock).mockResolvedValue({ keys: mockKeys });
+      (api.getApiKeys as jest.Mock).mockResolvedValue({ api_keys: mockKeys });
 
       await loadApiKeys();
 
@@ -107,12 +107,63 @@ describe('API Keys Module', () => {
       expect(document.querySelector('.toast-error')?.querySelector('.toast-message')?.textContent).toBe('Failed to load API keys');
       consoleError.mockRestore();
     });
+
+    // Regression: GitHub issue #9. Backend returns `{api_keys: [...]}`
+    // (auth.APIListAPIKeysResponse with `json:"api_keys"`); the previous
+    // frontend read `response.keys`, leaving currentApiKeys = undefined
+    // and crashing renderApiKeysList with TypeError. Lock in the
+    // contract so a future field rename has to update tests too.
+    test('issue #9: parses api_keys field from backend response', async () => {
+      const mockKeys = [{
+        id: 'key-1', name: 'Test', key_prefix: 'abc',
+        is_active: true, created_at: '2024-01-15T10:00:00Z',
+      }];
+      (api.getApiKeys as jest.Mock).mockResolvedValue({ api_keys: mockKeys });
+
+      const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+      await loadApiKeys();
+
+      expect(document.getElementById('apikeys-list')?.innerHTML).toContain('Test');
+      expect(consoleError).not.toHaveBeenCalled();
+      consoleError.mockRestore();
+    });
+
+    test('issue #9: tolerates legacy bare-array response without crashing', async () => {
+      // Defence-in-depth — if a proxy or alternate handler returns the
+      // bare array (no envelope), we should still render the rows
+      // rather than crashing on currentApiKeys.length.
+      const mockKeys = [{
+        id: 'key-2', name: 'Bare', key_prefix: 'def',
+        is_active: true, created_at: '2024-01-15T10:00:00Z',
+      }];
+      (api.getApiKeys as jest.Mock).mockResolvedValue(mockKeys);
+
+      const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+      await expect(loadApiKeys()).resolves.toBeUndefined();
+      expect(document.getElementById('apikeys-list')?.innerHTML).toContain('Bare');
+      expect(consoleError).not.toHaveBeenCalled();
+      consoleError.mockRestore();
+    });
+
+    test('issue #9: renders empty state on unexpected response shape', async () => {
+      // The exact failure mode from the bug report: response has
+      // neither `api_keys` nor is an array. Old code crashed with
+      // TypeError; new code should render the empty state and not log
+      // an error.
+      (api.getApiKeys as jest.Mock).mockResolvedValue({ unexpected: 'shape' });
+
+      const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+      await expect(loadApiKeys()).resolves.toBeUndefined();
+      expect(document.getElementById('apikeys-list')?.textContent).toContain('No API keys yet');
+      expect(consoleError).not.toHaveBeenCalled();
+      consoleError.mockRestore();
+    });
   });
 
   describe('renderApiKeysList', () => {
     test('shows empty message when no keys', () => {
       // First load empty keys
-      (api.getApiKeys as jest.Mock).mockResolvedValue({ keys: [] });
+      (api.getApiKeys as jest.Mock).mockResolvedValue({ api_keys: [] });
 
       // Call renderApiKeysList (it uses internal state, so we need to load first)
       loadApiKeys().then(() => {
@@ -139,7 +190,7 @@ describe('API Keys Module', () => {
         }
       ];
 
-      (api.getApiKeys as jest.Mock).mockResolvedValue({ keys: mockKeys });
+      (api.getApiKeys as jest.Mock).mockResolvedValue({ api_keys: mockKeys });
 
       await loadApiKeys();
 
@@ -159,7 +210,7 @@ describe('API Keys Module', () => {
         }
       ];
 
-      (api.getApiKeys as jest.Mock).mockResolvedValue({ keys: mockKeys });
+      (api.getApiKeys as jest.Mock).mockResolvedValue({ api_keys: mockKeys });
 
       await loadApiKeys();
 
@@ -182,7 +233,7 @@ describe('API Keys Module', () => {
         }
       ];
 
-      (api.getApiKeys as jest.Mock).mockResolvedValue({ keys: mockKeys });
+      (api.getApiKeys as jest.Mock).mockResolvedValue({ api_keys: mockKeys });
 
       await loadApiKeys();
 
@@ -203,7 +254,7 @@ describe('API Keys Module', () => {
         }
       ];
 
-      (api.getApiKeys as jest.Mock).mockResolvedValue({ keys: mockKeys });
+      (api.getApiKeys as jest.Mock).mockResolvedValue({ api_keys: mockKeys });
 
       await loadApiKeys();
 
@@ -222,7 +273,7 @@ describe('API Keys Module', () => {
         }
       ];
 
-      (api.getApiKeys as jest.Mock).mockResolvedValue({ keys: mockKeys });
+      (api.getApiKeys as jest.Mock).mockResolvedValue({ api_keys: mockKeys });
       (api.revokeApiKey as jest.Mock).mockResolvedValue({});
 
       await loadApiKeys();
@@ -249,7 +300,7 @@ describe('API Keys Module', () => {
         }
       ];
 
-      (api.getApiKeys as jest.Mock).mockResolvedValue({ keys: mockKeys });
+      (api.getApiKeys as jest.Mock).mockResolvedValue({ api_keys: mockKeys });
       (api.deleteApiKey as jest.Mock).mockResolvedValue({});
 
       await loadApiKeys();
@@ -395,7 +446,7 @@ describe('API Keys Module', () => {
         key_id: 'key-1',
         key: { id: 'key-1', name: 'Test', key_prefix: 'abc' }
       });
-      (api.getApiKeys as jest.Mock).mockResolvedValue({ keys: [] });
+      (api.getApiKeys as jest.Mock).mockResolvedValue({ api_keys: [] });
 
       (document.getElementById('apikey-name') as HTMLInputElement).value = 'Test Key';
 
@@ -436,7 +487,7 @@ describe('API Keys Module', () => {
       };
 
       (api.createApiKey as jest.Mock).mockResolvedValue(mockResponse);
-      (api.getApiKeys as jest.Mock).mockResolvedValue({ keys: [] });
+      (api.getApiKeys as jest.Mock).mockResolvedValue({ api_keys: [] });
 
       (document.getElementById('apikey-name') as HTMLInputElement).value = 'Test Key';
 
@@ -459,7 +510,7 @@ describe('API Keys Module', () => {
       };
 
       (api.createApiKey as jest.Mock).mockResolvedValue(mockResponse);
-      (api.getApiKeys as jest.Mock).mockResolvedValue({ keys: [] });
+      (api.getApiKeys as jest.Mock).mockResolvedValue({ api_keys: [] });
 
       (document.getElementById('apikey-name') as HTMLInputElement).value = 'Test Key';
       (document.getElementById('apikey-expires') as HTMLInputElement).checked = true;
@@ -608,7 +659,7 @@ describe('API Keys Module', () => {
         }
       ];
 
-      (api.getApiKeys as jest.Mock).mockResolvedValue({ keys: mockKeys });
+      (api.getApiKeys as jest.Mock).mockResolvedValue({ api_keys: mockKeys });
       await loadApiKeys();
     });
 
@@ -662,7 +713,7 @@ describe('API Keys Module', () => {
         }
       ];
 
-      (api.getApiKeys as jest.Mock).mockResolvedValue({ keys: mockKeys });
+      (api.getApiKeys as jest.Mock).mockResolvedValue({ api_keys: mockKeys });
       await loadApiKeys();
     });
 
@@ -735,7 +786,7 @@ describe('API Keys Module', () => {
         key_id: 'key-1',
         key: { id: 'key-1', name: 'Test', key_prefix: 'abc' }
       });
-      (api.getApiKeys as jest.Mock).mockResolvedValue({ keys: [] });
+      (api.getApiKeys as jest.Mock).mockResolvedValue({ api_keys: [] });
 
       initApiKeys();
 
@@ -837,7 +888,7 @@ describe('API Keys Module', () => {
         }
       ];
 
-      (api.getApiKeys as jest.Mock).mockResolvedValue({ keys: mockKeys });
+      (api.getApiKeys as jest.Mock).mockResolvedValue({ api_keys: mockKeys });
 
       await loadApiKeys();
 
@@ -868,7 +919,7 @@ describe('API Keys Module', () => {
         }
       ];
 
-      (api.getApiKeys as jest.Mock).mockResolvedValue({ keys: mockKeys });
+      (api.getApiKeys as jest.Mock).mockResolvedValue({ api_keys: mockKeys });
 
       await loadApiKeys();
 

--- a/frontend/src/__tests__/freshness.test.ts
+++ b/frontend/src/__tests__/freshness.test.ts
@@ -98,7 +98,12 @@ test('refresh button triggers POST /recommendations/refresh + onRefresh callback
     last_collected_at: new Date().toISOString(),
     last_collection_error: null,
   });
-  mockedRefresh.mockResolvedValue({ message: 'ok' });
+  mockedRefresh.mockResolvedValue({
+    recommendations: 0,
+    total_savings: 0,
+    successful_providers: [],
+    failed_providers: {},
+  });
   const onRefresh = jest.fn().mockResolvedValue(undefined);
 
   await renderFreshness('fresh', onRefresh);

--- a/frontend/src/api/recommendations.ts
+++ b/frontend/src/api/recommendations.ts
@@ -21,10 +21,28 @@ export async function getRecommendations(filters: RecommendationFilters = {}): P
 }
 
 /**
- * Refresh recommendations
+ * Refresh recommendations.
+ *
+ * Backend returns `scheduler.CollectResult`:
+ *   { recommendations: int, total_savings: float64,
+ *     successful_providers: string[], failed_providers: {[k]: string} }
+ *
+ * The previous `{ message: string }` declaration had no overlap with
+ * the actual response — same bug class as issue #9. The current sole
+ * caller (`recommendations.ts:refreshRecommendations`) only awaits
+ * the promise without dereferencing fields, so the wrong type was
+ * benign in practice; tightening it now so a future caller doesn't
+ * read `response.message` and see undefined.
  */
-export async function refreshRecommendations(): Promise<{ message: string }> {
-  return apiRequest<{ message: string }>('/recommendations/refresh', { method: 'POST' });
+export interface RefreshRecommendationsResult {
+  recommendations: number;
+  total_savings: number;
+  successful_providers?: string[];
+  failed_providers?: Record<string, string>;
+}
+
+export async function refreshRecommendations(): Promise<RefreshRecommendationsResult> {
+  return apiRequest<RefreshRecommendationsResult>('/recommendations/refresh', { method: 'POST' });
 }
 
 /**

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -320,7 +320,10 @@ export interface CreateAPIKeyRequest {
 export interface CreateAPIKeyResponse {
   api_key: string;  // Full key shown only once
   key_id: string;
-  key: APIKeyInfo;
+  // Backend wire field is `info` (see internal/auth/service_apikeys_api.go
+  // APICreateAPIKeyResponse). Was previously typed as `key` which never
+  // matched the response — same bug class as issue #9 above.
+  info: APIKeyInfo;
 }
 
 export interface GetAPIKeysResponse {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -324,7 +324,12 @@ export interface CreateAPIKeyResponse {
 }
 
 export interface GetAPIKeysResponse {
-  keys: APIKeyInfo[];
+  // Backend wire field is `api_keys` (see internal/auth/service_apikeys_api.go
+  // APIListAPIKeysResponse). The previous `keys` declaration didn't match
+  // any backend field, so `response.keys` was always undefined and
+  // crashed renderApiKeysList() with "Cannot read properties of undefined
+  // (reading 'length')" — see GitHub issue #9.
+  api_keys: APIKeyInfo[];
 }
 
 // Savings Analytics Types

--- a/frontend/src/apikeys.ts
+++ b/frontend/src/apikeys.ts
@@ -12,12 +12,23 @@ import { showToast } from './toast';
 let currentApiKeys: APIKeyInfo[] = [];
 
 /**
- * Load and display API keys
+ * Load and display API keys.
+ *
+ * Defensive parsing (issue #9): the previous implementation read
+ * `response.keys` while the backend returns `{api_keys: [...]}`,
+ * leaving `currentApiKeys` set to undefined and crashing the next
+ * render with "Cannot read properties of undefined (reading 'length')".
+ * Read the documented `api_keys` field, then fall back to a bare array
+ * (some other deployments/proxies might unwrap) and finally to `[]` so
+ * a contract drift can never crash the page.
  */
 export async function loadApiKeys(): Promise<void> {
   try {
     const response = await api.getApiKeys();
-    currentApiKeys = response.keys;
+    const list = (response as { api_keys?: APIKeyInfo[] } | undefined)?.api_keys
+      ?? (Array.isArray(response) ? response as APIKeyInfo[] : undefined)
+      ?? [];
+    currentApiKeys = Array.isArray(list) ? list : [];
     renderApiKeysList();
   } catch (error) {
     console.error('Failed to load API keys:', error);
@@ -32,7 +43,7 @@ export function renderApiKeysList(): void {
   const container = document.getElementById('apikeys-list');
   if (!container) return;
 
-  if (currentApiKeys.length === 0) {
+  if (!Array.isArray(currentApiKeys) || currentApiKeys.length === 0) {
     // DOM construction rather than template literal so the security hook
     // doesn't flag the innerHTML write — and all copy is static anyway.
     container.replaceChildren();

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -258,7 +258,10 @@ export interface APIKeyInfo {
 export interface CreateAPIKeyResponse {
   api_key: string;  // Full key shown only once
   key_id: string;
-  key: APIKeyInfo;
+  // Backend wire field is `info` (see internal/auth/service_apikeys_api.go
+  // APICreateAPIKeyResponse). Was previously typed as `key` which never
+  // matched the response — same bug class as issue #9.
+  info: APIKeyInfo;
 }
 
 // Window type declarations


### PR DESCRIPTION
## Summary

Closes #9 — Settings → Users crashed with `TypeError: Cannot read properties of undefined (reading 'length')` when loading API keys.

Root cause: backend `listAPIKeys` returns `{"api_keys": [...]}` (struct tag `json:"api_keys"` in `internal/auth/service_apikeys_api.go:38-41`), but the frontend was reading `response.keys` — a field name that has never existed in the contract. The frontend's `GetAPIKeysResponse` type also declared the wrong field, so TypeScript didn't catch it. Result: `currentApiKeys = undefined`, then `renderApiKeysList` dereferenced `.length` and threw.

## Changes

- **`frontend/src/api/types.ts`** — `GetAPIKeysResponse.keys` → `api_keys` so the type matches the wire contract.
- **`frontend/src/apikeys.ts`** — `loadApiKeys` reads `response.api_keys` with a 3-layer defence: documented field → bare-array fallback → `[]`. `renderApiKeysList` adds `Array.isArray` guard before `.length`.
- **`frontend/src/__tests__/apikeys.test.ts`** — existing 16 mocks migrated from the (wrong) `{keys: ...}` shape to `{api_keys: ...}` so they actually exercise the production contract; 3 new regression tests cover documented shape, bare-array fallback, and unexpected-shape empty-state path with `console.error` spies asserting no crash.

## Why fix the frontend, not the backend

Backend tests assert on `api_keys` (`internal/auth/service_apikeys_api_test.go:144,166`); the field is part of an external HTTP contract; the frontend is the only known consumer.

## Test plan

- [x] `npx jest` — 1206 pass across 31 suites
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean
- [ ] Smoke after deploy: navigate to Settings → Users → API Keys; empty list shows empty-state copy, populated list shows the table, no console TypeError.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue preventing API keys from loading properly due to incorrect response field handling.

* **Tests**
  * Added regression tests to validate compatibility with multiple API response formats and prevent similar issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->