### PR TITLE
fix(ui): wrap main nav tabs on narrow viewports

### DIFF
--- a/frontend/src/__tests__/responsive.test.ts
+++ b/frontend/src/__tests__/responsive.test.ts
@@ -1,0 +1,50 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * CSS-level regression test for issue #10 (responsive nav).
+ *
+ * JSDOM does not evaluate @media queries, so asserting on
+ * getComputedStyle(el).flexWrap would silently pass even if the rule
+ * were deleted. Reading the source CSS and asserting on its contents
+ * is the only way to lock down the fix.
+ */
+describe('responsive.css nav wrap rules', () => {
+  const css = fs.readFileSync(
+    path.join(__dirname, '../styles/responsive.css'),
+    'utf-8',
+  );
+
+  it('declares a @media (max-width: 1100px) block', () => {
+    expect(css).toMatch(/@media\s*\(max-width:\s*1100px\)/);
+  });
+
+  it('sets flex-wrap: wrap on .tabs inside the 1100px block', () => {
+    // Extract the contents of the 1100px block and assert the .tabs rule
+    // wraps. Using a [\s\S] group instead of a dotall flag to stay
+    // compatible with older TS lib targets.
+    const match = css.match(/@media\s*\(max-width:\s*1100px\)\s*{([\s\S]*?)\n}/);
+    expect(match).not.toBeNull();
+    const body = match?.[1] ?? '';
+    expect(body).toMatch(/\.tabs\s*{[\s\S]*?flex-wrap:\s*wrap/);
+  });
+
+  it('drops overflow-x: auto from the .tabs rule at ≤768px (wrap replaces it)', () => {
+    const match = css.match(/@media\s*\(max-width:\s*768px\)\s*{([\s\S]*?)\n}/);
+    expect(match).not.toBeNull();
+    const body = match?.[1] ?? '';
+    // Isolate the .tabs rule specifically and ensure it no longer sets
+    // overflow-x. Other selectors in the block (e.g. `table`) may still
+    // use overflow-x: auto — that is intentional and unrelated.
+    const tabsRule = body.match(/\.tabs\s*{[\s\S]*?}/);
+    expect(tabsRule).not.toBeNull();
+    expect(tabsRule?.[0] ?? '').not.toMatch(/overflow-x/);
+  });
+
+  it('wraps #user-info inside the ≤768px block so header children do not overflow', () => {
+    const match = css.match(/@media\s*\(max-width:\s*768px\)\s*{([\s\S]*?)\n}/);
+    expect(match).not.toBeNull();
+    const body = match?.[1] ?? '';
+    expect(body).toMatch(/#user-info\s*{[\s\S]*?flex-wrap:\s*wrap/);
+  });
+});

--- a/frontend/src/styles/responsive.css
+++ b/frontend/src/styles/responsive.css
@@ -24,13 +24,17 @@
 
     .tabs {
         padding: 0 1rem;
-        overflow-x: auto;
     }
 
     .tab-btn {
         padding: 0.75rem 1rem;
         font-size: 0.9rem;
         white-space: nowrap;
+    }
+
+    #user-info {
+        flex-wrap: wrap;
+        justify-content: center;
     }
 
     .form-row {
@@ -62,5 +66,22 @@
     .planned-purchases-table {
         display: block;
         overflow-x: auto;
+    }
+}
+
+/* Main nav: wrap tabs onto multiple rows on narrow viewports instead of
+   overflowing. Cascade: default (tabs.css) → this 1100px rule → the
+   768px rule above. Wrapping keeps every tab reachable without a
+   horizontal scroll on tablet / small-laptop widths. */
+@media (max-width: 1100px) {
+    .tabs {
+        flex-wrap: wrap;
+        row-gap: 0.25rem;
+    }
+
+    .tab-btn {
+        padding: 0.875rem 1.25rem;
+        font-size: 0.95rem;
+        white-space: nowrap;
     }
 }


### PR DESCRIPTION
## Summary

- Wrap the main nav tab strip onto multiple rows on narrow viewports (≤1100px) instead of overflowing horizontally
- Trim `.tab-btn` padding / font-size at the same breakpoint and keep `white-space: nowrap` so "Purchase Plans" / "Purchase History" stay single-line
- Wrap `#user-info` inside the existing ≤768px header block so the 5 header children (email, role badge, API Docs, Feedback, Logout) don't push body width on phones
- Drop `overflow-x: auto` from the existing `.tabs` ≤768px rule — wrap replaces scroll behaviour and every tab stays reachable without horizontal scroll
- Add a CSS file-content regression test (JSDOM doesn't evaluate `@media`, so computed-style assertions would silently pass regardless of the rule)

Closes #10.

## Test plan

- [x] `npx jest` — all 1221 frontend tests pass (34 suites)
- [x] `npx tsc --noEmit` — clean
- [x] `npx webpack --mode development` — clean
- [ ] Visual check at 375px / 430px / 768px / 900px / 1200px in Chrome DevTools — please verify, I couldn't connect to the Chrome extension during development.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)
