### PR TITLE
fix(ui): scope service dropdown to selected provider in plan form

### DIFF
--- a/frontend/src/__tests__/plans.test.ts
+++ b/frontend/src/__tests__/plans.test.ts
@@ -988,10 +988,16 @@ describe('Plans Module', () => {
       providerSelect.value = 'azure';
       providerSelect.dispatchEvent(new Event('change'));
 
-      // Should hide AWS services optgroup
+      // Should hide + disable the AWS services optgroup. Previously this
+      // test asserted on inline style.display — that was indicator-only
+      // and missed the real bug (issue #11: the hidden class stayed
+      // baked in, so switching away from AWS never re-showed the target
+      // provider's services). The class + disabled state is the new
+      // source of truth.
       const serviceSelect = document.getElementById('plan-service') as HTMLSelectElement;
       const awsOptgroup = serviceSelect.querySelector('optgroup[label="AWS Services"]') as HTMLOptGroupElement;
-      expect(awsOptgroup.style.display).toBe('none');
+      expect(awsOptgroup.classList.contains('hidden')).toBe(true);
+      expect(awsOptgroup.disabled).toBe(true);
     });
 
     test('handles missing elements gracefully', () => {
@@ -1741,6 +1747,78 @@ describe('Plans Module', () => {
 
       // Should call populatePaymentSelect to fix invalid combination
       expect(populatePaymentSelect).toHaveBeenCalled();
+    });
+  });
+
+  describe('provider scopes service dropdown (issue #11)', () => {
+    // Match optgroups by label-prefix so both the real HTML labels
+    // ("AWS"/"Azure"/"GCP") and the test fixture's labels
+    // ("AWS Services"/"Azure Services"/"GCP Services") work.
+    const byProvider = (prefix: string) =>
+      document.querySelector(
+        `#plan-service > optgroup[label^="${prefix}"]`,
+      ) as HTMLOptGroupElement | null;
+
+    beforeEach(() => {
+      setupPlanHandlers();
+    });
+
+    test('initial state (provider=aws): only AWS optgroup enabled', () => {
+      const aws = byProvider('AWS')!;
+      const azure = byProvider('Azure')!;
+      const gcp = byProvider('GCP')!;
+
+      expect(aws.classList.contains('hidden')).toBe(false);
+      expect(aws.disabled).toBe(false);
+      expect(azure.classList.contains('hidden')).toBe(true);
+      expect(azure.disabled).toBe(true);
+      expect(gcp.classList.contains('hidden')).toBe(true);
+      expect(gcp.disabled).toBe(true);
+    });
+
+    test('switching to azure enables only the Azure optgroup', () => {
+      const provider = document.getElementById('plan-provider') as HTMLSelectElement;
+      provider.value = 'azure';
+      provider.dispatchEvent(new Event('change'));
+
+      expect(byProvider('AWS')!.classList.contains('hidden')).toBe(true);
+      expect(byProvider('AWS')!.disabled).toBe(true);
+      expect(byProvider('Azure')!.classList.contains('hidden')).toBe(false);
+      expect(byProvider('Azure')!.disabled).toBe(false);
+      expect(byProvider('GCP')!.classList.contains('hidden')).toBe(true);
+      expect(byProvider('GCP')!.disabled).toBe(true);
+    });
+
+    test('switching to gcp enables only the GCP optgroup', () => {
+      const provider = document.getElementById('plan-provider') as HTMLSelectElement;
+      provider.value = 'gcp';
+      provider.dispatchEvent(new Event('change'));
+
+      expect(byProvider('AWS')!.disabled).toBe(true);
+      expect(byProvider('Azure')!.disabled).toBe(true);
+      expect(byProvider('GCP')!.disabled).toBe(false);
+      expect(byProvider('GCP')!.classList.contains('hidden')).toBe(false);
+    });
+
+    test('resets service to first visible option when AWS-only selection becomes hidden', () => {
+      const provider = document.getElementById('plan-provider') as HTMLSelectElement;
+      const service = document.getElementById('plan-service') as HTMLSelectElement;
+
+      // User picks an AWS-only service, then switches provider to azure.
+      service.value = 'ec2';
+      provider.value = 'azure';
+      provider.dispatchEvent(new Event('change'));
+
+      // Implementation picks the first option in the first visible
+      // optgroup. Assert the chosen value lives inside an optgroup
+      // labelled with the selected provider — decoupling the test
+      // from the specific service name in the fixture.
+      const selected = service.options[service.selectedIndex];
+      expect(selected).toBeDefined();
+      const parent = selected?.parentElement;
+      expect(parent).toBeInstanceOf(HTMLOptGroupElement);
+      expect((parent as HTMLOptGroupElement).label.toLowerCase()).toMatch(/^azure/);
+      expect(service.value).not.toBe('ec2');
     });
   });
 });

--- a/frontend/src/plans.ts
+++ b/frontend/src/plans.ts
@@ -1065,14 +1065,25 @@ function updateServiceDropdownForProvider(provider: string): void {
   const serviceSelect = document.getElementById('plan-service') as HTMLSelectElement | null;
   if (!serviceSelect) return;
 
-  // Show/hide optgroups based on selected provider
+  // Show/hide optgroups based on selected provider.
+  //
+  // Toggle the `hidden` class (same class the HTML starts with) so the
+  // DOM state tracks a single source of truth — previously we flipped
+  // `style.display`, which doesn't clear the pre-existing `hidden`
+  // class, so Azure/GCP stayed hidden forever even when selected.
+  //
+  // Also flip `optgroup.disabled`: Chrome has a long-standing quirk
+  // where a `display: none` <optgroup> still renders its <option>s as
+  // selectable, so users could end up with provider=Azure + ec2. The
+  // `disabled` attribute disables selection in every browser.
   const optgroups = serviceSelect.querySelectorAll('optgroup');
   let firstVisibleOptionValue = '';
 
   optgroups.forEach(optgroup => {
     const optgroupLabel = optgroup.label.toLowerCase();
     const shouldShow = optgroupLabel.includes(provider.toLowerCase());
-    (optgroup as HTMLOptGroupElement).style.display = shouldShow ? '' : 'none';
+    optgroup.classList.toggle('hidden', !shouldShow);
+    optgroup.disabled = !shouldShow;
 
     // Track first visible option value to auto-select
     if (shouldShow && !firstVisibleOptionValue) {
@@ -1086,7 +1097,7 @@ function updateServiceDropdownForProvider(provider: string): void {
   // If current selection is hidden, select first visible option
   const currentOption = serviceSelect.options[serviceSelect.selectedIndex];
   const parentOptgroup = currentOption?.parentElement;
-  const isHidden = parentOptgroup instanceof HTMLOptGroupElement && parentOptgroup.style.display === 'none';
+  const isHidden = parentOptgroup instanceof HTMLOptGroupElement && parentOptgroup.classList.contains('hidden');
   if (isHidden && firstVisibleOptionValue) {
     serviceSelect.value = firstVisibleOptionValue;
     // Trigger change event to update term/payment options


### PR DESCRIPTION
## Summary

- Switching Provider in the New Plan form now filters the Service dropdown to only that provider's services
- Root cause: the old code flipped `optgroup.style.display` but the HTML declares Azure/GCP optgroups with `class="hidden"` — clearing the inline style left the class in place, so the target provider's optgroup never re-appeared
- Also toggling `optgroup.disabled` to defeat a Chrome quirk where a `display: none` optgroup still renders its options as selectable
- Updated the "current selection hidden → reset" check to look at the class instead of style.display
- New test block covers aws/azure/gcp provider switches and the auto-reset when an AWS-only service is selected before switching to Azure; existing `setupPlanHandlers` test updated from the old `style.display` assertion to the new class+disabled source of truth

Closes #11.

## Test plan

- [x] `npx jest` — all 1221 frontend tests pass (33 suites)
- [x] `npx tsc --noEmit` — clean
- [x] Frontend build — clean via pre-commit hook
- [ ] Manual verification at PR review: open New Plan, switch Provider to Azure → confirm Service dropdown only shows Azure services and EC2/RDS are not selectable
