### PR TITLE
fix(ui): stabilise savings trend chart height through empty state transitions

### DIFF
--- a/frontend/src/__tests__/charts-css.test.ts
+++ b/frontend/src/__tests__/charts-css.test.ts
@@ -1,0 +1,35 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Regression test for issue #13 — dashboard savings-trend chart collapsed
+ * to zero size when filters switched. The CSS now reserves space for both
+ * the canvas and the empty-state paragraph so the widget never flashes
+ * at zero height during Chart.js destroy→recreate cycles.
+ *
+ * JSDOM can't lay out CSS, so a computed-style check would silently pass
+ * even if the rule were deleted. File-content assertion is the reliable
+ * lock.
+ */
+describe('charts.css empty-state size safeguards', () => {
+  const css = fs.readFileSync(
+    path.join(__dirname, '..', 'styles', 'charts.css'),
+    'utf-8',
+  );
+
+  it('.chart-section canvas rule reserves a min-height', () => {
+    const rule = css.match(/\.chart-section canvas\s*{([\s\S]*?)}/);
+    expect(rule).not.toBeNull();
+    expect(rule?.[1] ?? '').toMatch(/min-height\s*:\s*\d+px/);
+  });
+
+  it('.chart-section .empty rule reserves height and centres content', () => {
+    const rule = css.match(/\.chart-section \.empty\s*{([\s\S]*?)}/);
+    expect(rule).not.toBeNull();
+    const body = rule?.[1] ?? '';
+    expect(body).toMatch(/min-height\s*:\s*\d+px/);
+    expect(body).toMatch(/display\s*:\s*flex/);
+    expect(body).toMatch(/align-items\s*:\s*center/);
+    expect(body).toMatch(/justify-content\s*:\s*center/);
+  });
+});

--- a/frontend/src/styles/charts.css
+++ b/frontend/src/styles/charts.css
@@ -10,6 +10,18 @@
 
 .chart-section canvas {
     max-height: 300px;
+    min-height: 280px;
+}
+
+/* Empty state for chart sections stays centred and occupies roughly
+ * the same vertical space as the canvas so the widget doesn't collapse
+ * when Chart.js is destroyed during provider-filter transitions
+ * (issue #13). */
+.chart-section .empty {
+    min-height: 200px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
 /* Chart container */


### PR DESCRIPTION
## Summary

- Issue #13's "zero-size chart" was downstream of #7's 500 errors from /api/history/analytics; #7 turned that into a graceful 200+empty, but the destroy→recreate cycle on every provider switch still briefly flashed the widget at zero height because the container had no min-height
- Adds `min-height: 280px` to `.chart-section canvas` so Chart.js always has a stable container
- Adds `.chart-section .empty` rule giving the empty-state `<p>` a matching `min-height: 200px` with centred flex layout — the widget renders the same height whether data rendered or not
- File-content regression test (JSDOM can't lay out CSS, so computed-style checks would silently pass)

Closes #13.

## Test plan

- [x] `npx jest` — 1220 tests pass (34 suites with the new file)
- [x] `npx tsc --noEmit` — clean
- [x] Frontend build via pre-commit hook — clean
- [ ] Manual: Dashboard → switch Provider to Azure → confirm the chart section keeps its height and the empty-state text is visible (PR review)
