### PR TITLE
ux(accounts): add client-secret guidance hint in Azure account modal

### DIFF
--- a/frontend/src/__tests__/html.test.ts
+++ b/frontend/src/__tests__/html.test.ts
@@ -597,5 +597,17 @@ describe('HTML Structure', () => {
       const password = document.getElementById('user-password') as HTMLInputElement | null;
       expect(password?.getAttribute('minlength')).toBe('12');
     });
+
+    test('azure client-secret input carries a guidance hint (issue #15)', () => {
+      const secretFields = document.getElementById('account-azure-secret-fields');
+      expect(secretFields).not.toBeNull();
+      const small = secretFields?.querySelector('small');
+      expect(small).not.toBeNull();
+      // Confirm the copy steers operators away from storing a long-lived
+      // credential without spelling out a specific expiry policy the
+      // hint might drift from.
+      expect(small?.textContent).toMatch(/Workload Identity Federation/i);
+      expect(small?.textContent).toMatch(/rotate/i);
+    });
   });
 });

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -1046,6 +1046,7 @@
                         <!-- client_secret mode -->
                         <div id="account-azure-secret-fields" class="hidden">
                             <label>Client Secret: <input type="password" id="account-azure-client-secret" placeholder="Client secret value"></label>
+                            <small>Long-lived credential stored in CUDly. Prefer Workload Identity Federation (above) when possible &mdash; it uses CUDly's OIDC issuer so no secret is stored. If you keep this mode, rotate the client secret before its Azure expiry date to avoid authentication failures.</small>
                         </div>
                     </div>
 


### PR DESCRIPTION
## Summary

- Adds a `<small>` hint below the Azure Client Secret input with three beats: long-lived credential stored in CUDly, prefer Workload Identity Federation, rotate before Azure expiry
- Regression test in `html.test.ts` locks in the hint's presence plus the two load-bearing phrases ("Workload Identity Federation", "rotate")

Closes #15.

## Test plan

- [x] `npx jest` — all tests pass (html.test adds one new case)
- [x] `npx tsc --noEmit` — clean
- [x] Pre-commit hooks all pass
- [ ] Post-merge: verify in AWS-deployed modal
