### PR TITLE
feat(settings): add Azure Cognitive Search service defaults card

### DIFF
--- a/frontend/src/__tests__/html.test.ts
+++ b/frontend/src/__tests__/html.test.ts
@@ -597,5 +597,22 @@ describe('HTML Structure', () => {
       const password = document.getElementById('user-password') as HTMLInputElement | null;
       expect(password?.getAttribute('minlength')).toBe('12');
     });
+
+    test('azure cognitive search has service-default term + payment selectors (issue #16)', () => {
+      // The recommendation filter offered "search" as an Azure service,
+      // but the purchasing settings panel lacked a matching card.
+      // providers/azure/services/search supports Cognitive Search
+      // reservations, so the right fix is to expose the defaults.
+      const termSel = document.getElementById('azure-search-term') as HTMLSelectElement | null;
+      const paySel = document.getElementById('azure-search-payment') as HTMLSelectElement | null;
+      expect(termSel).not.toBeNull();
+      expect(paySel).not.toBeNull();
+      expect(termSel?.querySelector('option[value="1"]')).not.toBeNull();
+      expect(termSel?.querySelector('option[value="3"]')).not.toBeNull();
+      // Azure payment values round-trip through the backend's AWS-style
+      // vocabulary — "all-upfront" for Upfront, "no-upfront" for Monthly.
+      expect(paySel?.querySelector('option[value="all-upfront"]')).not.toBeNull();
+      expect(paySel?.querySelector('option[value="no-upfront"]')).not.toBeNull();
+    });
   });
 });

--- a/frontend/src/__tests__/settings.test.ts
+++ b/frontend/src/__tests__/settings.test.ts
@@ -499,7 +499,7 @@ describe('Settings Module', () => {
       expect(api.updateConfig).toHaveBeenCalled();
     });
 
-    test('calls updateServiceConfig once per service field (14 calls)', async () => {
+    test('calls updateServiceConfig once per service field (15 calls)', async () => {
       (api.updateConfig as jest.Mock).mockResolvedValue({});
       (api.updateServiceConfig as jest.Mock).mockResolvedValue(undefined);
       window.alert = jest.fn();
@@ -507,7 +507,8 @@ describe('Settings Module', () => {
       const event = { preventDefault: jest.fn() } as unknown as Event;
       await saveGlobalSettings(event);
 
-      expect(api.updateServiceConfig).toHaveBeenCalledTimes(14);
+      // 6 AWS + 5 Azure (vm, sql, cosmosdb, redis, search) + 4 GCP.
+      expect(api.updateServiceConfig).toHaveBeenCalledTimes(15);
     });
   }); // end saveGlobalSettings
 

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -516,6 +516,11 @@
                                 <label>Term: <select id="azure-redis-term"><option value="1">1 Year</option><option value="3" selected>3 Years</option></select></label>
                                 <label>Payment: <select id="azure-redis-payment"><option value="all-upfront" selected>Upfront</option><option value="no-upfront">Monthly</option></select></label>
                             </div>
+                            <div class="service-default-card">
+                                <h5>Cognitive Search Reservations</h5>
+                                <label>Term: <select id="azure-search-term"><option value="1">1 Year</option><option value="3" selected>3 Years</option></select></label>
+                                <label>Payment: <select id="azure-search-payment"><option value="all-upfront" selected>Upfront</option><option value="no-upfront">Monthly</option></select></label>
+                            </div>
                         </div>
                     </fieldset>
 

--- a/frontend/src/settings.ts
+++ b/frontend/src/settings.ts
@@ -34,6 +34,7 @@ const SERVICE_FIELDS = [
   { provider: 'azure', service: 'sql',        termId: 'azure-sql-term',        paymentId: 'azure-sql-payment' },
   { provider: 'azure', service: 'cosmosdb',   termId: 'azure-cosmosdb-term',   paymentId: 'azure-cosmosdb-payment' },
   { provider: 'azure', service: 'redis',      termId: 'azure-redis-term',      paymentId: 'azure-redis-payment' },
+  { provider: 'azure', service: 'search',     termId: 'azure-search-term',     paymentId: 'azure-search-payment' },
   { provider: 'gcp',   service: 'compute',    termId: 'gcp-compute-term',      paymentId: null },
   { provider: 'gcp',   service: 'sql',        termId: 'gcp-sql-term',          paymentId: null },
   { provider: 'gcp',   service: 'memorystore',termId: 'gcp-memorystore-term',  paymentId: null },


### PR DESCRIPTION
## Summary

- Adds an Azure Cognitive Search card to Settings → Purchasing → Azure Service Defaults, alongside VM / SQL / CosmosDB / Redis, with term (1/3 Year) + payment (Upfront/Monthly) selectors matching the other Azure cards
- Adds the matching `SERVICE_FIELDS` entry so load + save pick up the per-service values
- Bumps the `updateServiceConfig` call-count test from 14 to 15 and annotates the expected split (6 AWS + 5 Azure + 4 GCP) so a future addition lands with clear math to update
- Regression test in `html.test.ts` locks in the new selectors + option sets

## Why add (not remove)

`providers/azure/services/search/client.go` already implements Azure Cognitive Search Reserved Capacity — the backend supports purchasing, so the filter entry in Recommendations isn't phantom and the right fix is to expose the defaults.

Closes #16.

## Test plan

- [x] `npx jest` — 1235 tests pass
- [x] `npx tsc --noEmit` — clean
- [x] Pre-commit hooks all pass
- [ ] Post-merge: verify in AWS-deployed Settings → Purchasing with Azure enabled → confirm the new card appears


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration options for Azure Cognitive Search, including reservation term and payment method settings in the application.

* **Tests**
  * Added verification tests for Azure Cognitive Search settings UI controls to ensure proper rendering of available options.
  * Updated existing configuration tests to reflect expanded service configuration coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->