### PR TITLE
fix(plans): Create Purchase Plan falls through to new-plan flow on empty selection

### DIFF
--- a/frontend/src/__tests__/plans.test.ts
+++ b/frontend/src/__tests__/plans.test.ts
@@ -896,12 +896,19 @@ describe('Plans Module', () => {
   });
 
   describe('openCreatePlanModal', () => {
-    test('shows alert when no recommendations selected', () => {
+    test('opens modal with "New Purchase Plan" title when selection is empty (issue #17)', () => {
       (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set());
 
       openCreatePlanModal();
 
-      expect(mockShowToast).toHaveBeenCalledWith(expect.objectContaining({ message: 'Please select at least one recommendation' }));
+      const modal = document.getElementById('plan-modal');
+      expect(modal?.classList.contains('hidden')).toBe(false);
+      const title = document.getElementById('plan-modal-title');
+      expect(title?.textContent).toBe('New Purchase Plan');
+      // Previously we early-returned behind a toast that users missed
+      // (e.g. after a provider-filter switch). Falling through to the
+      // new-plan flow never silently noop-s.
+      expect(mockShowToast).not.toHaveBeenCalled();
     });
 
     test('opens modal when recommendations are selected', () => {
@@ -913,7 +920,7 @@ describe('Plans Module', () => {
       expect(modal?.classList.contains('hidden')).toBe(false);
     });
 
-    test('sets correct title', () => {
+    test('sets "Create Purchase Plan" title when a selection exists', () => {
       (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set([0]));
 
       openCreatePlanModal();

--- a/frontend/src/plans.ts
+++ b/frontend/src/plans.ts
@@ -667,16 +667,20 @@ async function setupPlanAccountsSection(planId?: string): Promise<void> {
 }
 
 /**
- * Open create plan modal with selected recommendations
+ * Open create plan modal with selected recommendations.
+ *
+ * When the user has no selection (issue #17 reproducer: filter
+ * active, no checkboxes ticked), fall through to the plain new-plan
+ * flow instead of silently noop-ing behind a toast the user may
+ * miss. Same UX as the dedicated "New Plan" button — the modal
+ * always opens, and the user fills in provider/service from scratch.
  */
 export function openCreatePlanModal(): void {
-  const selectedIDs = state.getSelectedRecommendationIDs();
-  if (selectedIDs.size === 0) {
-    showToast({ message: 'Please select at least one recommendation', kind: 'warning' });
-    return;
-  }
   const titleEl = document.getElementById('plan-modal-title');
-  if (titleEl) titleEl.textContent = 'Create Purchase Plan';
+  const hasSelection = state.getSelectedRecommendationIDs().size > 0;
+  if (titleEl) {
+    titleEl.textContent = hasSelection ? 'Create Purchase Plan' : 'New Purchase Plan';
+  }
   (document.getElementById('plan-id') as HTMLInputElement).value = '';
   (document.getElementById('plan-form') as HTMLFormElement | null)?.reset();
 


### PR DESCRIPTION
## Summary

- Fixes the "Create Purchase Plan" button silently no-op-ing on Recommendations when no recs are selected (issue #17 reproducer: Azure filter active, no checkboxes ticked)
- Previously the handler early-returned behind a warning toast the user didn't see; now the modal always opens
- Title switches dynamically: "Create Purchase Plan" when a selection exists, "New Purchase Plan" when it's empty (same flow as the dedicated "New Plan" button)
- Existing save path pulls in selected recs when present, so the non-empty flow is unchanged

Closes #17.

## Test plan

- [x] `npx jest` — 1236 tests pass (the existing `shows alert when no recommendations selected` test is rewritten to assert the modal opens + title switches + showToast is NOT called)
- [x] `npx tsc --noEmit` — clean
- [x] Pre-commit hooks all pass
- [ ] Post-merge: verify in AWS-deployed Recommendations → switch Provider to Azure → click Create Purchase Plan → confirm the modal opens with title "New Purchase Plan"
