### PR TITLE
fix(onboarding): auto-generate AWS External ID and make field readonly

### DIFF
--- a/frontend/src/__tests__/html.test.ts
+++ b/frontend/src/__tests__/html.test.ts
@@ -626,5 +626,19 @@ describe('HTML Structure', () => {
       expect(paySel?.querySelector('option[value="all-upfront"]')).not.toBeNull();
       expect(paySel?.querySelector('option[value="no-upfront"]')).not.toBeNull();
     });
+
+    test('aws external-id input is readonly with a copy button + trust-policy hint (issue #18)', () => {
+      const input = document.getElementById('account-aws-external-id') as HTMLInputElement | null;
+      expect(input).not.toBeNull();
+      expect(input?.hasAttribute('readonly')).toBe(true);
+      const copyBtn = document.getElementById('account-aws-external-id-copy');
+      expect(copyBtn).not.toBeNull();
+      expect(copyBtn?.classList.contains('copy-btn')).toBe(true);
+      // The hint must point operators at sts:ExternalId so they don't
+      // paste the wrong value into the trust policy.
+      const roleFields = document.getElementById('account-aws-role-fields');
+      const small = roleFields?.querySelector('small');
+      expect(small?.textContent).toMatch(/sts:ExternalId/);
+    });
   });
 });

--- a/frontend/src/__tests__/settings-accounts.test.ts
+++ b/frontend/src/__tests__/settings-accounts.test.ts
@@ -337,6 +337,17 @@ describe('Account modal via setupSettingsHandlers', () => {
     expect(document.getElementById('account-aws-keys-fields')!.classList.contains('hidden')).toBe(false);
     expect(document.getElementById('account-aws-role-fields')!.classList.contains('hidden')).toBe(true);
   });
+
+  test('add-aws-account-btn auto-generates the External ID (issue #18)', () => {
+    document.getElementById('add-aws-account-btn')!.click();
+
+    const extID = document.getElementById('account-aws-external-id') as HTMLInputElement;
+    // UUIDs are 36 chars with dashes (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx);
+    // the test fixture doesn't set a readonly attribute (the production
+    // index.html does), so we only assert on the generated value here.
+    expect(extID.value).not.toBe('');
+    expect(extID.value.length).toBeGreaterThanOrEqual(16);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -1019,7 +1019,13 @@
                         </div>
                         <div id="account-aws-role-fields" class="hidden">
                             <label>Role ARN: <input type="text" id="account-aws-role-arn" placeholder="arn:aws:iam::123456789012:role/CUDly"></label>
-                            <label>External ID (optional): <input type="text" id="account-aws-external-id" placeholder="Optional external ID"></label>
+                            <label>External ID:
+                                <span class="input-with-copy">
+                                    <input type="text" id="account-aws-external-id" readonly>
+                                    <button type="button" id="account-aws-external-id-copy" class="copy-btn" aria-label="Copy External ID to clipboard"><span class="copy-icon">Copy</span></button>
+                                </span>
+                            </label>
+                            <small>CUDly auto-generates this value per account. Copy it into the <code>sts:ExternalId</code> condition of your IAM role's trust policy so only CUDly with this account registered can assume the role.</small>
                         </div>
                         <div id="account-aws-bastion-fields" class="hidden">
                             <label>Bastion Account: <select id="account-aws-bastion-id"><option value="">Select bastion account...</option></select></label>

--- a/frontend/src/settings.ts
+++ b/frontend/src/settings.ts
@@ -601,6 +601,17 @@ export function openAccountModal(provider: AccountProvider, account?: api.CloudA
 /**
  * Populate AWS-specific fields in the account modal
  */
+function generateExternalID(): string {
+  // crypto.randomUUID is available in all supported browsers (Chrome
+  // 92+, Firefox 95+, Safari 15.4+). Fall back to a timestamp-plus-
+  // random string only if it's somehow missing (test environments,
+  // odd webviews) so we never hand the user an empty field.
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `cudly-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
 function populateAwsAccountFields(account?: api.CloudAccount): void {
   const authMode = (account?.aws_auth_mode ?? 'workload_identity_federation') as string;
   const authModeSelect = document.getElementById('account-aws-auth-mode') as HTMLSelectElement | null;
@@ -616,7 +627,13 @@ function populateAwsAccountFields(account?: api.CloudAccount): void {
   // pre-fill all three with the same stored value so switching modes mid-edit
   // doesn't blank the input that just became visible.
   setInputValue('account-aws-role-arn', account?.aws_role_arn ?? '');
-  setInputValue('account-aws-external-id', account?.aws_external_id ?? '');
+  // External ID is a CUDly-managed shared secret for cross-account role
+  // assumption (issue #18). On edit, keep whatever was stored before; on
+  // create, auto-generate a UUID so every new account has a distinct
+  // secret the operator can paste into the IAM trust policy. The field
+  // itself is marked readonly in index.html so users can't hand-craft
+  // values that would defeat the purpose.
+  setInputValue('account-aws-external-id', account?.aws_external_id ?? generateExternalID());
   setInputValue('account-aws-bastion-role-arn', account?.aws_role_arn ?? '');
   setInputValue('account-aws-wif-role-arn', account?.aws_role_arn ?? '');
   setInputValue('account-aws-wif-token-file', account?.aws_web_identity_token_file ?? '');
@@ -927,6 +944,13 @@ export function setupSettingsHandlers(signal?: AbortSignal): void {
   // AWS auth mode change handler
   const awsAuthMode = document.getElementById('account-aws-auth-mode') as HTMLSelectElement | null;
   awsAuthMode?.addEventListener('change', () => updateAwsAuthModeFields(awsAuthMode.value), { signal });
+
+  // Copy the auto-generated AWS External ID to the clipboard (issue #18).
+  document.getElementById('account-aws-external-id-copy')?.addEventListener(
+    'click',
+    () => copyToClipboard('account-aws-external-id'),
+    { signal },
+  );
 
   // Azure auth mode change handler
   const azureAuthMode = document.getElementById('account-azure-auth-mode') as HTMLSelectElement | null;
@@ -1412,19 +1436,34 @@ export function copyToClipboard(elementId: string): void {
   const element = document.getElementById(elementId);
   if (!element) return;
 
-  const text = element.textContent || '';
+  // Prefer .value for form controls (the AWS External ID uses an
+  // <input readonly>) and fall back to textContent for code/span
+  // elements.
+  const text = element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement
+    ? element.value
+    : element.textContent ?? '';
   navigator.clipboard.writeText(text).then(() => {
-    // Show feedback
-    const btn = element.nextElementSibling as HTMLButtonElement;
-    if (btn) {
-      const originalContent = btn.innerHTML;
-      btn.innerHTML = '<span class="copy-icon">&#10003;</span>';
-      btn.classList.add('copied');
-      setTimeout(() => {
-        btn.innerHTML = originalContent;
-        btn.classList.remove('copied');
-      }, 2000);
-    }
+    // Show feedback on the first .copy-btn following the source in DOM
+    // order — handles both the adjacent-sibling layout (code + btn) and
+    // the .input-with-copy layout (input + btn nested under a wrapper).
+    const btn = element.nextElementSibling instanceof HTMLButtonElement
+      ? element.nextElementSibling
+      : element.parentElement?.querySelector<HTMLButtonElement>('.copy-btn') ?? null;
+    if (!btn) return;
+    const previousChildren = Array.from(btn.childNodes);
+    // Swap for a single "copied" checkmark without touching innerHTML —
+    // the content is static but XSS-scanner-friendly code avoids the
+    // pattern entirely so we don't need to re-prove safety at each edit.
+    btn.replaceChildren();
+    const tick = document.createElement('span');
+    tick.className = 'copy-icon';
+    tick.textContent = '✓'; // ✓
+    btn.appendChild(tick);
+    btn.classList.add('copied');
+    setTimeout(() => {
+      btn.replaceChildren(...previousChildren);
+      btn.classList.remove('copied');
+    }, 2000);
   }).catch(err => {
     console.error('Failed to copy:', err);
   });

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -1158,6 +1158,22 @@ tr.recommendation-row:hover {
     color: #4caf50;
 }
 
+/* Input + inline copy button (e.g. auto-generated AWS External ID). The
+   button sits flush with the input's right edge so the pair reads as a
+   single control. */
+.input-with-copy {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    width: 100%;
+}
+
+.input-with-copy input[type="text"] {
+    flex: 1;
+    background: #f5f5f5;
+    color: #333;
+}
+
 /* CLI command display */
 .cli-command {
     display: flex;


### PR DESCRIPTION
## Summary

- Auto-generates the AWS External ID on new accounts via `crypto.randomUUID()`; preserves the stored value for existing accounts
- Marks the field readonly and wraps it in a new `.input-with-copy` layout with a copy-to-clipboard button
- Replaces the "External ID (optional)" label + placeholder with a hint pointing operators at `sts:ExternalId` in their IAM trust policy
- Extends `copyToClipboard` to work with form inputs (reads `.value`) and nested wrappers (finds the `.copy-btn` via parent); also replaces the innerHTML-based feedback swap with childNode save/restore so the helper is scanner-friendly

## Why

The editable + blank External ID let operators set any value or leave it empty, defeating the cross-account role-assumption security model. CUDly must own this shared secret.

Closes #18.

## Test plan

- [x] `npx jest` — 1238 tests pass (+2 new: auto-generation on modal open; readonly + copy button + trust-policy hint in HTML)
- [x] `npx tsc --noEmit` — clean
- [x] Pre-commit hooks all pass
- [ ] Post-merge: verify in AWS-deployed Settings → Accounts → Add AWS Account → IAM Role ARN mode → confirm the External ID field is pre-filled with a UUID, is readonly, and the copy button works
