### PR TITLE
feat(onboarding): render IAM trust policy snippet in AWS account modal

### DIFF
--- a/frontend/src/__tests__/html.test.ts
+++ b/frontend/src/__tests__/html.test.ts
@@ -640,5 +640,19 @@ describe('HTML Structure', () => {
       const small = roleFields?.querySelector('small');
       expect(small?.textContent).toMatch(/sts:ExternalId/);
     });
+
+    test('aws trust-policy snippet block + copy button exist in role-fields (issue #19)', () => {
+      const roleFields = document.getElementById('account-aws-role-fields');
+      expect(roleFields).not.toBeNull();
+      const pre = document.getElementById('account-aws-trust-policy');
+      expect(pre?.tagName.toLowerCase()).toBe('pre');
+      const copyBtn = document.getElementById('account-aws-trust-policy-copy');
+      expect(copyBtn).not.toBeNull();
+      expect(copyBtn?.classList.contains('copy-btn')).toBe(true);
+      // Hint is rendered dynamically by settings.ts; confirm the
+      // placeholder element exists so the render target is stable.
+      const hint = document.getElementById('account-aws-trust-policy-hint');
+      expect(hint).not.toBeNull();
+    });
   });
 });

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -1026,6 +1026,14 @@
                                 </span>
                             </label>
                             <small>CUDly auto-generates this value per account. Copy it into the <code>sts:ExternalId</code> condition of your IAM role's trust policy so only CUDly with this account registered can assume the role.</small>
+                            <div class="trust-policy-section">
+                                <label for="account-aws-trust-policy">IAM Trust Policy (paste into the role's trust relationship):</label>
+                                <div class="input-with-copy">
+                                    <pre id="account-aws-trust-policy" class="code-block"></pre>
+                                    <button type="button" id="account-aws-trust-policy-copy" class="copy-btn" aria-label="Copy trust policy JSON to clipboard"><span class="copy-icon">Copy</span></button>
+                                </div>
+                                <small id="account-aws-trust-policy-hint">Attach this policy to the IAM role's trust relationship so CUDly can assume it. The <code>sts:ExternalId</code> condition locks the role to this specific CUDly registration.</small>
+                            </div>
                         </div>
                         <div id="account-aws-bastion-fields" class="hidden">
                             <label>Bastion Account: <select id="account-aws-bastion-id"><option value="">Select bastion account...</option></select></label>

--- a/frontend/src/settings.ts
+++ b/frontend/src/settings.ts
@@ -640,6 +640,69 @@ function populateAwsAccountFields(account?: api.CloudAccount): void {
   setInputChecked('account-aws-is-org-root', account?.aws_is_org_root ?? false);
 
   updateAwsAuthModeFields(authMode, account?.aws_bastion_id);
+
+  // Render the trust-policy snippet asynchronously — we need the CUDly
+  // host account ID from getConfig.source_identity (issue #19). Kept
+  // void so the modal doesn't block waiting for the network.
+  void renderAwsTrustPolicy();
+}
+
+/**
+ * Render the IAM trust-policy JSON snippet into the AWS role-mode
+ * section. The snippet interpolates the CUDly host AWS account ID and
+ * the per-account External ID so operators can copy it straight into
+ * the role's trust relationship (issue #19).
+ */
+async function renderAwsTrustPolicy(): Promise<void> {
+  const block = document.getElementById('account-aws-trust-policy');
+  const hint = document.getElementById('account-aws-trust-policy-hint');
+  if (!block) return;
+  const externalID = (document.getElementById('account-aws-external-id') as HTMLInputElement | null)?.value ?? '';
+
+  let sourceAccountID = '';
+  try {
+    const cfg = await api.getConfig();
+    if (cfg.source_identity?.provider === 'aws') {
+      sourceAccountID = cfg.source_identity.account_id ?? '';
+    }
+  } catch {
+    // Non-critical — fall through to the placeholder text below.
+  }
+
+  if (!sourceAccountID) {
+    block.textContent = '';
+    if (hint) {
+      hint.textContent =
+        "CUDly can't determine its host AWS account ID from this deployment " +
+        "(either CUDly isn't running on AWS, or the Lambda/Container role " +
+        "lacks sts:GetCallerIdentity). Ask a CUDly admin for the account ID, " +
+        "then build the trust policy manually with Principal=arn:aws:iam::" +
+        "<CUDly account ID>:root, Action=sts:AssumeRole, and a StringEquals " +
+        "sts:ExternalId condition on the value above.";
+    }
+    return;
+  }
+
+  const policy = {
+    Version: '2012-10-17',
+    Statement: [
+      {
+        Effect: 'Allow',
+        Principal: { AWS: `arn:aws:iam::${sourceAccountID}:root` },
+        Action: 'sts:AssumeRole',
+        Condition: {
+          StringEquals: { 'sts:ExternalId': externalID },
+        },
+      },
+    ],
+  };
+  block.textContent = JSON.stringify(policy, null, 2);
+  if (hint) {
+    hint.textContent =
+      "Attach this policy to the IAM role's trust relationship so CUDly can " +
+      "assume it. The sts:ExternalId condition locks the role to this " +
+      "specific CUDly registration.";
+  }
 }
 
 /**
@@ -949,6 +1012,13 @@ export function setupSettingsHandlers(signal?: AbortSignal): void {
   document.getElementById('account-aws-external-id-copy')?.addEventListener(
     'click',
     () => copyToClipboard('account-aws-external-id'),
+    { signal },
+  );
+
+  // Copy the rendered AWS IAM trust policy snippet (issue #19).
+  document.getElementById('account-aws-trust-policy-copy')?.addEventListener(
+    'click',
+    () => copyToClipboard('account-aws-trust-policy'),
     { signal },
   );
 

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -1174,6 +1174,29 @@ tr.recommendation-row:hover {
     color: #333;
 }
 
+/* Inline JSON / code snippet (e.g. the auto-rendered AWS IAM trust
+   policy). Sits next to a copy button inside `.input-with-copy`. */
+.input-with-copy .code-block {
+    flex: 1;
+    margin: 0;
+    padding: 0.5rem 0.75rem;
+    background: #f5f5f5;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 0.85rem;
+    line-height: 1.4;
+    color: #333;
+    white-space: pre-wrap;
+    word-break: break-word;
+    max-height: 240px;
+    overflow: auto;
+}
+
+.trust-policy-section {
+    margin-top: 0.75rem;
+}
+
 /* CLI command display */
 .cli-command {
     display: flex;


### PR DESCRIPTION
## Summary

- Renders a fully-qualified IAM trust-policy JSON snippet inside the AWS Add-Account modal's Role ARN section
- CUDly host AWS account ID is pulled from `api.getConfig().source_identity.account_id` (already exposed by the config endpoint); External ID comes from the local input (auto-generated per #18)
- Copy button copies the rendered JSON to the clipboard

## Degraded state

When CUDly can't determine its own AWS account ID (running on Azure / GCP, or missing `sts:GetCallerIdentity`), the `<pre>` stays empty and the hint copy is swapped for an operator-facing explanation of what to do manually. Never renders a half-filled policy.

Depends on #18 (External ID auto-generation), which landed in #36.

Closes #19.

## Test plan

- [x] `npx jest` — 1239 tests pass (+1 new: DOM hooks for the snippet block)
- [x] `npx tsc --noEmit` — clean
- [x] Pre-commit hooks all pass
- [ ] Post-merge: verify in AWS-deployed Settings → Accounts → Add AWS Account → IAM Role ARN mode → confirm the trust policy snippet renders with the correct CUDly principal + the auto-generated External ID
