### PR TITLE
fix(api): default timeout on apiRequest so hung backends surface as errors

### DIFF
--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -375,6 +375,35 @@ describe('API Requests', () => {
       });
       await expect(apiRequest('/test')).resolves.toBeNull();
     });
+
+    test('surfaces a timeout error when the backend hangs past timeoutMs (issue #20)', async () => {
+      // Simulate a hanging backend: fetch rejects with AbortError when
+      // its AbortSignal fires. That's exactly what the browser does in
+      // real life when the controller times out.
+      fetchMock.mockImplementation((_url: string, init: RequestInit) => new Promise((_resolve, reject) => {
+        init.signal?.addEventListener('abort', () => {
+          const err = new Error('The operation was aborted.');
+          err.name = 'AbortError';
+          reject(err);
+        });
+      }));
+
+      await expect(apiRequest('/test', { timeoutMs: 10 })).rejects.toThrow(/timed out after 10ms/);
+    });
+
+    test('passes the caller-provided signal through alongside the timeout controller', async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({}),
+      });
+      const controller = new AbortController();
+      await apiRequest('/test', { signal: controller.signal });
+      const callArgs = fetchMock.mock.calls[0][1] as { signal?: AbortSignal };
+      // The client wraps the caller signal in a combined AbortSignal
+      // (via AbortSignal.any or a manual listener). We can't assert
+      // referential equality, but we can assert a signal was forwarded.
+      expect(callArgs.signal).toBeDefined();
+    });
   });
 
   describe('login', () => {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -148,6 +148,16 @@ export function base64Encode(str: string): string {
 }
 
 /**
+ * Default request timeout in milliseconds. Generous enough for legit
+ * long-running endpoints (AWS Cost Explorer / RI utilization can take
+ * 20–40s during cold starts), tight enough that a hung backend
+ * surfaces as an error in the UI instead of spinning forever (issue
+ * #20). Callers can override via `options.timeoutMs` or by passing
+ * their own `signal`.
+ */
+const DEFAULT_API_TIMEOUT_MS = 90_000;
+
+/**
  * Make an authenticated API request
  */
 export async function apiRequest<T>(endpoint: string, options: RequestOptions = {}): Promise<T> {
@@ -161,10 +171,39 @@ export async function apiRequest<T>(endpoint: string, options: RequestOptions = 
     await addContentHashHeader(headers, body);
   }
 
-  const response = await fetch(url, {
-    ...options,
-    headers
-  });
+  // Layer a timeout-driven AbortController on top of any caller-
+  // provided signal so both paths can cancel the request. If the
+  // caller passes their own signal we still add a timeout (unless
+  // they opt out by passing timeoutMs: 0) — the UI doesn't want an
+  // indefinite hang regardless of who owns cancellation.
+  const timeoutMs = options.timeoutMs ?? DEFAULT_API_TIMEOUT_MS;
+  const timeoutController = new AbortController();
+  const timeoutHandle = timeoutMs > 0
+    ? setTimeout(() => timeoutController.abort(), timeoutMs)
+    : undefined;
+  const signal = options.signal
+    ? anySignal([options.signal, timeoutController.signal])
+    : timeoutController.signal;
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      ...options,
+      headers,
+      signal,
+    });
+  } catch (err) {
+    if (timeoutController.signal.aborted) {
+      const error: ApiError = new Error(
+        `Request to ${endpoint} timed out after ${timeoutMs}ms`,
+      );
+      error.status = 0;
+      throw error;
+    }
+    throw err;
+  } finally {
+    if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
+  }
 
   if (!response.ok) {
     const error: ApiError = new Error(`HTTP ${response.status}`);
@@ -189,6 +228,29 @@ export async function apiRequest<T>(endpoint: string, options: RequestOptions = 
   } catch {
     return null as T;
   }
+}
+
+/**
+ * Combine multiple AbortSignals into one. AbortSignal.any is available
+ * in modern browsers (Chrome 116+, Firefox 124+, Safari 17.4+); fall
+ * back to a manual listener for older targets.
+ */
+function anySignal(signals: AbortSignal[]): AbortSignal {
+  const AnyFn = (AbortSignal as unknown as {
+    any?: (s: AbortSignal[]) => AbortSignal;
+  }).any;
+  if (typeof AnyFn === 'function') {
+    return AnyFn.call(AbortSignal, signals);
+  }
+  const controller = new AbortController();
+  for (const s of signals) {
+    if (s.aborted) {
+      controller.abort(s.reason);
+      return controller.signal;
+    }
+    s.addEventListener('abort', () => controller.abort(s.reason), { once: true });
+  }
+  return controller.signal;
 }
 
 /**

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -519,4 +519,11 @@ export interface ApiError extends Error {
 
 export interface RequestOptions extends RequestInit {
   headers?: Record<string, string>;
+  /**
+   * Hard timeout for the request in milliseconds. Defaults to
+   * DEFAULT_API_TIMEOUT_MS (90 000) in client.ts; pass `0` to disable
+   * the timeout (e.g. for long-running admin flows that genuinely
+   * need to block) or a smaller value for cheap endpoints.
+   */
+  timeoutMs?: number;
 }


### PR DESCRIPTION
## Summary

- Adds a default 90s AbortController timeout to every `apiRequest` so hanging backends surface as errors in the UI instead of spinning forever (issue #20's reproducer was the RI Exchange tab)
- Preserves caller-provided `signal` by combining it with the timeout's signal via `AbortSignal.any` (with a manual-listener fallback for older browsers)
- `RequestOptions` gains a `timeoutMs?` field; pass `0` to disable or a shorter value for cheap endpoints
- On timeout, throws a clear `"Request to /<endpoint> timed out after <ms>ms"` error with `status: 0`

## Why the existing error paths weren't firing

Every caller in `riexchange.ts` (and elsewhere) already has try/catch around its API calls, but `fetch` without a timeout never rejects on a hung backend, so the catch never runs. The fix targets the shared `apiRequest` helper, not individual call sites, so this improves every endpoint.

Closes #20.

## Test plan

- [x] `npx jest` — 1241 tests pass (+2 new: timeout-fires error path, signal-combine path)
- [x] `npx tsc --noEmit` — clean
- [x] Pre-commit hooks all pass
- [ ] Post-merge: verify in AWS-deployed RI Exchange tab with a healthy backend (normal load), and optionally temporarily suspend a backend to confirm the spinner clears with an error after ~90s


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable timeout functionality for API requests with clear timeout error messages.
  * Timeouts can be customized per request or disabled entirely as needed.
  * Request cancellation signals work alongside the timeout mechanism for flexible request control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->