### PR TITLE
ux(onboarding): add AWS IAM console deep link in account modal

### DIFF
--- a/frontend/src/__tests__/html.test.ts
+++ b/frontend/src/__tests__/html.test.ts
@@ -654,5 +654,18 @@ describe('HTML Structure', () => {
       const hint = document.getElementById('account-aws-trust-policy-hint');
       expect(hint).not.toBeNull();
     });
+
+    test('aws IAM console deep link opens the role-creation wizard in a new tab (issue #21)', () => {
+      const link = document.getElementById('account-aws-iam-console-link') as HTMLAnchorElement | null;
+      expect(link).not.toBeNull();
+      expect(link?.tagName.toLowerCase()).toBe('a');
+      // Must open in a new tab so operators don't lose the modal
+      // state they just configured. rel="noopener" is mandatory for
+      // target="_blank" to avoid reverse-tabnabbing.
+      expect(link?.getAttribute('target')).toBe('_blank');
+      expect(link?.getAttribute('rel') ?? '').toMatch(/noopener/);
+      // Link target must be the AWS console role-creation wizard.
+      expect(link?.getAttribute('href')).toBe('https://console.aws.amazon.com/iam/home#/roles$new');
+    });
   });
 });

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -1033,6 +1033,7 @@
                                     <button type="button" id="account-aws-trust-policy-copy" class="copy-btn" aria-label="Copy trust policy JSON to clipboard"><span class="copy-icon">Copy</span></button>
                                 </div>
                                 <small id="account-aws-trust-policy-hint">Attach this policy to the IAM role's trust relationship so CUDly can assume it. The <code>sts:ExternalId</code> condition locks the role to this specific CUDly registration.</small>
+                                <a id="account-aws-iam-console-link" class="btn btn-small" href="https://console.aws.amazon.com/iam/home#/roles$new" target="_blank" rel="noopener noreferrer">Open AWS IAM console &rarr;</a>
                             </div>
                         </div>
                         <div id="account-aws-bastion-fields" class="hidden">

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -1197,6 +1197,14 @@ tr.recommendation-row:hover {
     margin-top: 0.75rem;
 }
 
+/* Deep-link button to the AWS IAM console (issue #21). Sits below the
+   trust-policy snippet so the visual order matches the operator flow:
+   copy policy → open IAM → paste. */
+.trust-policy-section #account-aws-iam-console-link {
+    display: inline-block;
+    margin-top: 0.5rem;
+}
+
 /* CLI command display */
 .cli-command {
     display: flex;


### PR DESCRIPTION
## Summary

- Adds an "Open AWS IAM console →" link in the AWS account modal, below the trust-policy snippet, pointing at the role-creation wizard (`https://console.aws.amazon.com/iam/home#/roles$new`)
- Opens in a new tab with `rel="noopener noreferrer"` (reverse-tabnabbing guard)
- Tests lock in the href + target + rel attributes

Together with #19 (trust-policy snippet) and #18 (auto-generated External ID), this completes the self-service AWS onboarding flow: generate secret → copy policy → open IAM → paste → done.

Closes #21.

## Test plan

- [x] `npx jest` — all tests pass (+1 new)
- [x] `npx tsc --noEmit` — clean
- [x] Pre-commit hooks all pass
- [ ] Post-merge: verify the link appears in the AWS modal and opens in a new tab
