### PR TITLE
feat(frontend): refresh button shows in-flight state + toasts

### DIFF
--- a/frontend/src/__tests__/freshness.test.ts
+++ b/frontend/src/__tests__/freshness.test.ts
@@ -144,7 +144,7 @@ test('refresh button renames to "Refreshing..." while in flight, then emits a su
   await new Promise((r) => setTimeout(r, 0));
 
   expect(btn.textContent).toBe('Refreshing...');
-  expect(btn.getAttribute('disabled')).toBe('true');
+  expect(btn.disabled).toBe(true);
 
   const inFlightToast = document.querySelector('#toast-container .toast-message');
   expect(inFlightToast?.textContent).toBe('Refreshing recommendations…');
@@ -179,7 +179,7 @@ test('refresh button restores original text and surfaces an error toast on failu
   for (let i = 0; i < 5; i++) await new Promise((r) => setTimeout(r, 0));
 
   expect(btn.textContent).toBe('Refresh');
-  expect(btn.hasAttribute('disabled')).toBe(false);
+  expect(btn.disabled).toBe(false);
   const toastMessages = Array.from(
     document.querySelectorAll('#toast-container .toast-message'),
   ).map((n) => n.textContent);

--- a/frontend/src/__tests__/freshness.test.ts
+++ b/frontend/src/__tests__/freshness.test.ts
@@ -21,6 +21,7 @@ import {
   getRecommendationsFreshness,
   refreshRecommendations,
 } from '../api/recommendations';
+import type { RefreshRecommendationsResult } from '../api/recommendations';
 
 const mockedGet = getRecommendationsFreshness as jest.MockedFunction<typeof getRecommendationsFreshness>;
 const mockedRefresh = refreshRecommendations as jest.MockedFunction<typeof refreshRecommendations>;
@@ -118,6 +119,74 @@ test('refresh button triggers POST /recommendations/refresh + onRefresh callback
 
   expect(mockedRefresh).toHaveBeenCalledTimes(1);
   expect(onRefresh).toHaveBeenCalledTimes(1);
+});
+
+test('refresh button renames to "Refreshing..." while in flight, then emits a success toast', async () => {
+  const initial = new Date(Date.now() - 60 * 60_000).toISOString();
+  const refreshed = new Date().toISOString();
+  mockedGet
+    .mockResolvedValueOnce({ last_collected_at: initial, last_collection_error: null })
+    .mockResolvedValueOnce({ last_collected_at: refreshed, last_collection_error: null });
+
+  // Hold the refresh API open so we can observe the in-flight state
+  // before resolving.
+  let resolveRefresh: ((v: RefreshRecommendationsResult) => void) | null = null;
+  mockedRefresh.mockImplementation(
+    () => new Promise((r) => { resolveRefresh = r; }),
+  );
+  const onRefresh = jest.fn().mockResolvedValue(undefined);
+
+  await renderFreshness('fresh', onRefresh);
+
+  const btn = document.querySelector('#fresh-refresh-btn') as HTMLButtonElement;
+  btn.click();
+  // let the click handler run up to the awaited refreshAPI() call
+  await new Promise((r) => setTimeout(r, 0));
+
+  expect(btn.textContent).toBe('Refreshing...');
+  expect(btn.getAttribute('disabled')).toBe('true');
+
+  const inFlightToast = document.querySelector('#toast-container .toast-message');
+  expect(inFlightToast?.textContent).toBe('Refreshing recommendations…');
+
+  resolveRefresh!({ recommendations: 0, total_savings: 0 });
+  // drain the rest of the handler: refreshAPI → onRefresh → renderFreshness → toasts
+  for (let i = 0; i < 5; i++) await new Promise((r) => setTimeout(r, 0));
+
+  const toastMessages = Array.from(
+    document.querySelectorAll('#toast-container .toast-message'),
+  ).map((n) => n.textContent);
+  expect(toastMessages).toContain('Recommendations refreshed');
+
+  // Bar was re-rendered with the newer timestamp.
+  expect(document.querySelector('#fresh')!.textContent).toContain('Data from');
+});
+
+test('refresh button restores original text and surfaces an error toast on failure', async () => {
+  mockedGet.mockResolvedValue({
+    last_collected_at: new Date().toISOString(),
+    last_collection_error: null,
+  });
+  mockedRefresh.mockRejectedValue(new Error('boom'));
+  const onRefresh = jest.fn();
+
+  await renderFreshness('fresh', onRefresh);
+  const btn = document.querySelector('#fresh-refresh-btn') as HTMLButtonElement;
+  // Swallow the expected console.error from the handler so the test output stays clean.
+  const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+  btn.click();
+  for (let i = 0; i < 5; i++) await new Promise((r) => setTimeout(r, 0));
+
+  expect(btn.textContent).toBe('Refresh');
+  expect(btn.hasAttribute('disabled')).toBe(false);
+  const toastMessages = Array.from(
+    document.querySelectorAll('#toast-container .toast-message'),
+  ).map((n) => n.textContent);
+  expect(toastMessages.some((m) => m?.includes('Refresh failed'))).toBe(true);
+  expect(onRefresh).not.toHaveBeenCalled();
+
+  spy.mockRestore();
 });
 
 test('silently no-ops when the container element is missing', async () => {

--- a/frontend/src/freshness.ts
+++ b/frontend/src/freshness.ts
@@ -14,6 +14,7 @@ import {
   refreshRecommendations as refreshAPI,
 } from './api/recommendations';
 import type { RecommendationsFreshness } from './api/recommendations';
+import { showToast } from './toast';
 import { formatDate, formatRelativeTime } from './utils';
 
 /**
@@ -179,17 +180,36 @@ export async function renderFreshness(
   const bar = buildFreshnessBar(relTime, absTime, containerID, band);
   container.appendChild(bar);
 
-  const btn = document.getElementById(`${containerID}-refresh-btn`);
+  const btn = document.getElementById(`${containerID}-refresh-btn`) as HTMLButtonElement | null;
   btn?.addEventListener('click', () => {
     void (async () => {
+      const originalText = btn.textContent ?? 'Refresh';
       btn.setAttribute('disabled', 'true');
+      btn.textContent = 'Refreshing...';
+      const inFlight = showToast({
+        message: 'Refreshing recommendations…',
+        kind: 'info',
+        timeout: null,
+      });
       try {
         await refreshAPI();
         await onRefresh();
         await renderFreshness(containerID, onRefresh);
+        inFlight.dismiss();
+        showToast({
+          message: 'Recommendations refreshed',
+          kind: 'success',
+          timeout: 5_000,
+        });
       } catch (err) {
         console.error('Refresh failed:', err);
+        inFlight.dismiss();
+        showToast({
+          message: `Refresh failed: ${(err as Error).message ?? 'unknown error'}`,
+          kind: 'error',
+        });
         btn.removeAttribute('disabled');
+        btn.textContent = originalText;
       }
     })();
   });

--- a/frontend/src/freshness.ts
+++ b/frontend/src/freshness.ts
@@ -183,8 +183,8 @@ export async function renderFreshness(
   const btn = document.getElementById(`${containerID}-refresh-btn`) as HTMLButtonElement | null;
   btn?.addEventListener('click', () => {
     void (async () => {
-      const originalText = btn.textContent ?? 'Refresh';
-      btn.setAttribute('disabled', 'true');
+      const originalText = btn.textContent;
+      btn.disabled = true;
       btn.textContent = 'Refreshing...';
       const inFlight = showToast({
         message: 'Refreshing recommendations…',
@@ -202,13 +202,22 @@ export async function renderFreshness(
           timeout: 5_000,
         });
       } catch (err) {
+        // Guard against non-Error throws: `(err as Error).message` would
+        // raise a TypeError if `err` were null/undefined, masking the real
+        // failure with a crash inside the error handler itself.
+        const message =
+          err instanceof Error
+            ? err.message
+            : err !== null && err !== undefined
+              ? String(err)
+              : 'unknown error';
         console.error('Refresh failed:', err);
         inFlight.dismiss();
         showToast({
-          message: `Refresh failed: ${(err as Error).message ?? 'unknown error'}`,
+          message: `Refresh failed: ${message}`,
           kind: 'error',
         });
-        btn.removeAttribute('disabled');
+        btn.disabled = false;
         btn.textContent = originalText;
       }
     })();


### PR DESCRIPTION
Closes #86

## Summary
- Refresh button on the shared freshness indicator (Dashboard + Recommendations) now temporarily renames to **"Refreshing..."** and disables itself while the POST `/api/recommendations/refresh` call is in flight.
- Surfaces a sticky **info toast** ("Refreshing recommendations…") on start, which is dismissed and replaced by a 5s **success toast** ("Recommendations refreshed") on completion. On failure the info toast is replaced by an **error toast** and the button text/enabled state are restored.
- The freshness bar is re-rendered on success, so the "Data from <relative-time>" timestamp updates in the same round-trip.

## Test plan
- [x] `npx jest src/__tests__/freshness.test.ts` — 17/17 pass, including two new cases covering the in-flight button state + toast sequence and the error-path rollback.
- [x] `npx tsc --noEmit` — clean.
- [x] Pre-commit build + frontend tests — passed locally.
- [x] End-to-end browser verification against the production bundle (results posted as a PR comment).
