### PR TITLE
ux(settings): clarify Savings Plans card covers SageMaker + Lambda (#22)

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -484,7 +484,8 @@
                                 <label>Payment: <select id="aws-redshift-payment"><option value="no-upfront">No Upfront</option><option value="partial-upfront">Partial</option><option value="all-upfront" selected>All Upfront</option></select></label>
                             </div>
                             <div class="service-default-card">
-                                <h5>Compute Savings Plans</h5>
+                                <h5>Savings Plans</h5>
+                                <p class="service-default-hint">Compute (EC2, Fargate, Lambda), EC2 Instance, SageMaker, and Database (RDS) plans share these defaults.</p>
                                 <label>Term: <select id="aws-savingsplans-term"><option value="1">1 Year</option><option value="3" selected>3 Years</option></select></label>
                                 <label>Payment: <select id="aws-savingsplans-payment"><option value="no-upfront">No Upfront</option><option value="partial-upfront">Partial</option><option value="all-upfront" selected>All Upfront</option></select></label>
                             </div>

--- a/frontend/src/styles/settings.css
+++ b/frontend/src/styles/settings.css
@@ -198,6 +198,13 @@
     color: #333;
 }
 
+.service-default-card .service-default-hint {
+    margin: -0.5rem 0 0.75rem;
+    font-size: 0.75rem;
+    line-height: 1.3;
+    color: #666;
+}
+
 .service-default-card label {
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Summary

Closes #22.

The "Compute Savings Plans" card in Settings → Purchasing actually drives defaults for **all four** Savings Plans types that `providers/aws/recommendations/parser_sp.go` fetches on every collection:

- `ComputeSp` — covers EC2, Fargate, **Lambda**
- `Ec2InstanceSp` — specific EC2 instance families
- `SagemakerSp` — **SageMaker**
- `DatabaseSp` — RDS

All four share the same term/payment vocabulary at the AWS API, so the UI intentionally exposes a single card rather than four near-identical rows. The old header "Compute Savings Plans" made that invisible to the reporter, who reasonably concluded SageMaker and Lambda had no purchasing defaults.

## Change

- Rename the card header from **Compute Savings Plans** → **Savings Plans**.
- Add a small hint beneath the header listing the covered services: *"Compute (EC2, Fargate, Lambda), EC2 Instance, SageMaker, and Database (RDS) plans share these defaults."*
- Add a scoped `.service-default-hint` CSS rule in `styles/settings.css`.

Why not separate Lambda / SageMaker cards (as the issue originally proposed):

- **Lambda**: no Lambda-specific reserved product exists; Lambda usage only buys Compute SP. A separate "Lambda" row would be misleading.
- **SageMaker**: shares the exact same 1yr/3yr × upfront/partial/no-upfront vocabulary as the existing card, so a distinct row adds no real configurability. Per-plan-type defaults would require `ServiceConfig` plumbing, a DB migration, and scheduler/UI changes — out of scope for a documentation fix and unwarranted without evidence users have divergent preferences per plan type.

IDs `aws-savingsplans-term` and `aws-savingsplans-payment` are preserved, so `settings.ts` wiring and the existing save/load paths are unchanged.

## Test plan

- [x] `npm run build` (frontend) — clean webpack production build
- [x] `npm test` (frontend) — 1242/1242 tests pass across 35 suites
- [x] Card IDs unchanged → `settings.ts` wiring, `settings.test.ts` coverage, and the save/reset bar continue to work
- [x] CSS rule scoped to `.service-default-card .service-default-hint` so it can't bleed into other cards

## Screenshot

_(Text-only label tweak; the new hint renders as a single muted subtitle line immediately under the card title, above the Term/Payment selects.)_
