### PR TITLE
fix(commitmentOptions): align savingsplans key (CodeRabbit nitpick sweep)

### DIFF
--- a/frontend/src/__tests__/commitmentOptions.test.ts
+++ b/frontend/src/__tests__/commitmentOptions.test.ts
@@ -35,8 +35,8 @@ describe('commitmentOptions', () => {
         expect(config.invalidCombinations).toBeUndefined();
       });
 
-      it('should return savings-plans config with all options', () => {
-        const config = getCommitmentConfig('aws', 'savings-plans');
+      it('should return savingsplans config with all options', () => {
+        const config = getCommitmentConfig('aws', 'savingsplans');
 
         expect(config.terms).toHaveLength(2);
         expect(config.payments).toHaveLength(3);
@@ -198,9 +198,9 @@ describe('commitmentOptions', () => {
         expect(isValidCombination('aws', 'ec2', 3, 'all-upfront')).toBe(true);
       });
 
-      it('should return true for all savings-plans combinations', () => {
-        expect(isValidCombination('aws', 'savings-plans', 1, 'no-upfront')).toBe(true);
-        expect(isValidCombination('aws', 'savings-plans', 3, 'no-upfront')).toBe(true);
+      it('should return true for all savingsplans combinations', () => {
+        expect(isValidCombination('aws', 'savingsplans', 1, 'no-upfront')).toBe(true);
+        expect(isValidCombination('aws', 'savingsplans', 3, 'no-upfront')).toBe(true);
       });
     });
 

--- a/frontend/src/commitmentOptions.ts
+++ b/frontend/src/commitmentOptions.ts
@@ -55,7 +55,7 @@ const commitmentConfigs: Record<string, Record<string, CommitmentConfig>> = {
       payments: AWS_PAYMENTS
     },
     // Savings Plans - all options available
-    'savings-plans': {
+    savingsplans: {
       terms: STANDARD_TERMS,
       payments: AWS_PAYMENTS
     },


### PR DESCRIPTION
## Summary

Addresses the only live CodeRabbit finding across all open/closed PRs (24–39, 52–54).

- CodeRabbit flagged a key mismatch on [PR #30](https://github.com/LeanerCloud/CUDly/pull/30): `SERVICE_FIELDS` in `settings.ts:32` uses `service: 'savingsplans'` while `commitmentConfigs` in `commitmentOptions.ts:58` registered the AWS entry under `'savings-plans'`. Any lookup through `isValidCombination`/`getCommitmentConfig` with the non-hyphenated identifier silently fell through to `_default`.
- CodeRabbit suggested renaming `SERVICE_FIELDS` to `'savings-plans'`, but that value also flows into `api.updateServiceConfig(provider, service, cfg)` at `settings.ts:1443` — the `service` column is the DB primary key in the `service_configs` table, existing rows are `('aws', 'savingsplans')`, and renaming without a migration would silently create duplicate rows. The dropdown at `index.html:112,703` (`<option value="savingsplans">`) and the backend CLI flag (`cmd/main.go:92`) also use the non-hyphenated form.
- Safer fix: rename the `commitmentConfigs.aws` key to `savingsplans` so every frontend call site — the SERVICE_FIELDS loop, the plan-form dropdown, and any direct lookup — resolves to the Savings-Plans-specific config. Update the two test cases.

## Scope of the PR

| PR | Finding | Status |
|----|---------|--------|
| #52 | Actionable: guard catch block against non-Error throws | ✅ already fixed in `db429fe` |
| #52 | Nitpick: `btn.disabled` vs `setAttribute`, drop dead `?? 'Refresh'` | ✅ already fixed in `db429fe` |
| **#30** | **Outside-diff: `savingsplans` vs `savings-plans` key mismatch** | ✅ **fixed here** |
| #30 | Nitpick: double `Promise.resolve()` in settings.test.ts:854 | ⤴ applies only to code on PR #30's branch |
| #30 | Advisory: memorydb absent from SERVICE_FIELDS | ⤴ forward-looking (no MemoryDB card exists yet) |
| All other PRs (24–29, 31–39, 53, 54, 3, 4) | "No actionable comments" from CodeRabbit | — |

## Test plan

- [x] `jest` — 1244/1244 pass (all 35 suites)
- [x] `tsc --noEmit` — clean
- [x] grep confirms no remaining `'savings-plans'` references in frontend code outside Go backend constants (`pkg/common/types.go:49` is the backend canonical — unchanged, and `execution.go:384` already accepts both forms)
- [ ] Smoke test on the deployed AWS Lambda URL once CI finishes

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated AWS savings plans configuration handling to improve consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->