### PR TITLE
docs(release-notes): tell pre-zero-touch federation bundle customers to re-download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - **Federation IaC bundles downloaded before 2026-04-22 need to be
   re-downloaded** to get zero-touch registration. Older bundles silently
   skip auto-registration unless manually edited (Terraform `registration.tf`
-  gated `do_register` on `contact_email`; CLI shell scripts gated the
-  registration call on `CUDLY_CONTACT_EMAIL`; CloudFormation deploy scripts
-  had no registration call at all). Re-download the bundle from the CUDly
-  UI and the new copy will register your account automatically with no
-  manual edits required.
+  gated `do_register` on `cudly_api_url`; CLI shell scripts included the
+  registration call only when `CUDlyAPIURL` was present at render time;
+  CloudFormation deploy scripts had no registration call at all).
+  Re-download the bundle from the CUDly UI and the new copy will register
+  your account automatically with no manual edits required.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Notices
+
+- **Federation IaC bundles downloaded before 2026-04-22 need to be
+  re-downloaded** to get zero-touch registration. Older bundles silently
+  skip auto-registration unless manually edited (Terraform `registration.tf`
+  gated `do_register` on `contact_email`; CLI shell scripts gated the
+  registration call on `CUDLY_CONTACT_EMAIL`; CloudFormation deploy scripts
+  had no registration call at all). Re-download the bundle from the CUDly
+  UI and the new copy will register your account automatically with no
+  manual edits required.
+
 ### Fixed
 
 - Remove debug console.log from frontend recommendation handler


### PR DESCRIPTION
## Summary

Adds a `Notices` subsection under `[Unreleased]` in `CHANGELOG.md` informing customers that federation IaC bundles downloaded before the zero-touch registration fix landed on **2026-04-22** need to be re-downloaded to get auto-registration. Old bundles silently skip registration unless manually edited.

## Why

The zero-touch registration fix (commit `3b4dc5108 fix(federation): zero-touch self-registration across all IaC formats`) only takes effect in bundles downloaded *after* the fix shipped — there's no way to back-fix files customers already have on disk. Without this notice, affected customers complete `terraform apply` / shell-script deploys with no error and then wonder why their account never appears in CUDly.

Old bundles included:

- Terraform `registration.tf` with `do_register = var.cudly_api_url != "" && var.contact_email != ""`
- CLI shell scripts gated on `if [[ -n "${CUDLY_CONTACT_EMAIL:-}" ]]; then ...`
- CFN deploy scripts with no registration curl call at all

Tracked in `known_issues/27_federation_old_bundle_redownload_notice.md`.

## Test plan

- [x] `cat CHANGELOG.md` — markdown renders cleanly, `### Notices` subsection sits above `### Fixed` under `[Unreleased]`.
- [x] Pre-commit hooks pass (`Lint Markdown files` passed).
- [x] No code changes — docs only; no tests apply.

Closes #43


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a notice regarding Federation IaC bundles released before April 22, 2026. Users must re-download their bundles to restore zero-touch registration functionality. Previously downloaded bundles will not auto-register without manual modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->