### PR TITLE
obs(gcp): downgrade collector permission errors to [WARN] to silence noisy logs

### DIFF
--- a/internal/scheduler/permission_log_test.go
+++ b/internal/scheduler/permission_log_test.go
@@ -1,0 +1,86 @@
+package scheduler
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"google.golang.org/api/googleapi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestIsAccountPermissionError verifies that the scheduler routes
+// per-account collection errors to the correct log severity. Issue #57:
+// GCP 403 / PermissionDenied must downgrade to WARN so a single
+// misconfigured account doesn't drown out other log signals; non-GCP
+// providers and non-permission errors must keep the existing ERROR
+// behaviour until analogous predicates are added.
+func TestIsAccountPermissionError(t *testing.T) {
+	tests := []struct {
+		name          string
+		providerLabel string
+		err           error
+		want          bool
+	}{
+		{
+			name:          "GCP googleapi 403 → WARN",
+			providerLabel: "GCP",
+			err:           &googleapi.Error{Code: 403, Message: "Required 'compute.regions.list' permission"},
+			want:          true,
+		},
+		{
+			name:          "GCP wrapped 403 → WARN",
+			providerLabel: "GCP",
+			err: fmt.Errorf("get recommendations: failed to get regions: %w",
+				&googleapi.Error{Code: 403, Message: "missing role"}),
+			want: true,
+		},
+		{
+			name:          "GCP grpc PermissionDenied → WARN",
+			providerLabel: "GCP",
+			err:           status.Error(codes.PermissionDenied, "missing role"),
+			want:          true,
+		},
+		{
+			name:          "GCP googleapi 500 → ERROR (genuine failure)",
+			providerLabel: "GCP",
+			err:           &googleapi.Error{Code: 500, Message: "internal"},
+			want:          false,
+		},
+		{
+			name:          "GCP generic network error → ERROR",
+			providerLabel: "GCP",
+			err:           errors.New("connection refused"),
+			want:          false,
+		},
+		{
+			name:          "AWS 403-like error → ERROR (predicate not yet wired for AWS)",
+			providerLabel: "AWS",
+			err:           &googleapi.Error{Code: 403, Message: "ignored for AWS"},
+			want:          false,
+		},
+		{
+			name:          "Azure 403-like error → ERROR (predicate not yet wired for Azure)",
+			providerLabel: "Azure",
+			err:           status.Error(codes.PermissionDenied, "ignored for Azure"),
+			want:          false,
+		},
+		{
+			name:          "nil error → false",
+			providerLabel: "GCP",
+			err:           nil,
+			want:          false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isAccountPermissionError(tt.providerLabel, tt.err)
+			if got != tt.want {
+				t.Errorf("isAccountPermissionError(%q, %v) = %v, want %v",
+					tt.providerLabel, tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -381,7 +381,17 @@ func fanOutPerAccount(
 		g.Go(func() error {
 			recs, err := fn(gctx, acct)
 			if err != nil {
-				logging.Errorf("%s account %s (%s): %v", providerLabel, acct.Name, acct.ExternalID, err)
+				if isAccountPermissionError(providerLabel, err) {
+					// Operator-fixable misconfiguration (missing IAM role
+					// on the deploy SA): log at WARN so a single
+					// misconfigured account doesn't drown out other log
+					// signals. The collection still counts as a per-account
+					// failure — provider-success semantics are unchanged.
+					logging.Warnf("%s account %s (%s) permission gap (operator action needed: grant required IAM role): %v",
+						providerLabel, acct.Name, acct.ExternalID, err)
+				} else {
+					logging.Errorf("%s account %s (%s): %v", providerLabel, acct.Name, acct.ExternalID, err)
+				}
 				mu.Lock()
 				outcome.FailedCount++
 				outcome.LastErr = fmt.Sprintf("account %s (%s): %v", acct.Name, acct.ExternalID, err)
@@ -398,6 +408,29 @@ func fanOutPerAccount(
 	}
 	_ = g.Wait() // errs are always nil (swallowed above)
 	return all, outcome
+}
+
+// isAccountPermissionError reports whether err from a per-account
+// collection call represents an operator-fixable IAM permission gap
+// (rather than a genuine collector error). Used by fanOutPerAccount to
+// downgrade the log severity from ERROR to WARN — see issue #57: a
+// single misconfigured GCP account otherwise emits an [ERROR] line on
+// every scheduler tick (~15 min) and drowns out other log signals.
+//
+// Currently dispatches per provider:
+//   - "GCP": gcpprovider.IsPermissionError (HTTP 403 / gRPC PermissionDenied)
+//   - other providers: false (existing ERROR behaviour preserved until
+//     analogous predicates are added for AWS/Azure)
+func isAccountPermissionError(providerLabel string, err error) bool {
+	if err == nil {
+		return false
+	}
+	switch providerLabel {
+	case "GCP":
+		return gcpprovider.IsPermissionError(err)
+	default:
+		return false
+	}
 }
 
 // errAllAccountsFailed wraps an accountOutcome's LastErr so callers

--- a/providers/gcp/go.mod
+++ b/providers/gcp/go.mod
@@ -16,6 +16,7 @@ require (
 	golang.org/x/oauth2 v0.16.0
 	google.golang.org/api v0.160.0
 	google.golang.org/genproto v0.0.0-20240116215550-a9fa1716bcac
+	google.golang.org/grpc v1.61.0
 )
 
 require (
@@ -50,7 +51,6 @@ require (
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240125205218-1f4bbc51befe // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240116215550-a9fa1716bcac // indirect
-	google.golang.org/grpc v1.61.0 // indirect
 	google.golang.org/protobuf v1.32.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/providers/gcp/permission_errors.go
+++ b/providers/gcp/permission_errors.go
@@ -1,0 +1,44 @@
+// Package gcp provides helpers for classifying GCP API errors.
+package gcp
+
+import (
+	"errors"
+
+	"google.golang.org/api/googleapi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// IsPermissionError reports whether err represents a GCP permission /
+// authorization failure — typically a missing IAM role on the deploy
+// service account. The GCP collector uses this to downgrade per-account
+// log severity from ERROR to WARN: the operator can fix the gap by
+// granting the missing role, so it is not a genuine collector error and
+// should not drown out other signals in the log stream.
+//
+// It returns true for:
+//   - *googleapi.Error with Code == 403 (REST surface, e.g. compute REST
+//     client returns "googleapi: Error 403: Required '...' permission")
+//   - gRPC status with codes.PermissionDenied (gRPC surface, e.g. when
+//     a client uses the gRPC transport rather than REST)
+//
+// Wrapped errors (via fmt.Errorf("...: %w", err)) are unwrapped so the
+// scheduler's wrap-and-rethrow chain still classifies correctly.
+//
+// Returns false for nil and for any other error.
+func IsPermissionError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var gerr *googleapi.Error
+	if errors.As(err, &gerr) && gerr.Code == 403 {
+		return true
+	}
+
+	if s, ok := status.FromError(err); ok && s.Code() == codes.PermissionDenied {
+		return true
+	}
+
+	return false
+}

--- a/providers/gcp/permission_errors_test.go
+++ b/providers/gcp/permission_errors_test.go
@@ -1,0 +1,81 @@
+package gcp
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"google.golang.org/api/googleapi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestIsPermissionError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "googleapi 403 direct",
+			err:  &googleapi.Error{Code: 403, Message: "Required 'compute.regions.list' permission"},
+			want: true,
+		},
+		{
+			name: "googleapi 403 wrapped via fmt.Errorf",
+			err: fmt.Errorf("failed to list regions: %w",
+				&googleapi.Error{Code: 403, Message: "permission denied"}),
+			want: true,
+		},
+		{
+			name: "googleapi 404 not a permission error",
+			err:  &googleapi.Error{Code: 404, Message: "not found"},
+			want: false,
+		},
+		{
+			name: "googleapi 500 not a permission error",
+			err:  &googleapi.Error{Code: 500, Message: "internal"},
+			want: false,
+		},
+		{
+			name: "grpc PermissionDenied direct",
+			err:  status.Error(codes.PermissionDenied, "missing role"),
+			want: true,
+		},
+		{
+			name: "grpc PermissionDenied wrapped via fmt.Errorf",
+			err: fmt.Errorf("get recommendations: %w",
+				status.Error(codes.PermissionDenied, "missing role")),
+			want: true,
+		},
+		{
+			name: "grpc NotFound not a permission error",
+			err:  status.Error(codes.NotFound, "no such project"),
+			want: false,
+		},
+		{
+			name: "grpc Unavailable not a permission error",
+			err:  status.Error(codes.Unavailable, "transient"),
+			want: false,
+		},
+		{
+			name: "generic error",
+			err:  errors.New("network is unreachable"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsPermissionError(tt.err)
+			if got != tt.want {
+				t.Errorf("IsPermissionError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

A misconfigured GCP account whose deploy SA lacks `compute.regions.list` (or any other compute IAM permission) currently emits an `[ERROR]` line on every scheduler tick (~15 min) — thousands of `[ERROR]` lines per day from a single account, drowning out other log signals.

This change classifies operator-fixable IAM permission failures as `[WARN]` rather than `[ERROR]`. The collector still counts the per-account collection as a failure and the provider-level success/failure semantics are unchanged — only the log severity changes.

## What changed

- **`providers/gcp/permission_errors.go`** — new exported `IsPermissionError(err) bool` predicate. Detects:
  - `*googleapi.Error` with `Code == 403` (REST surface, e.g. compute REST client)
  - gRPC `codes.PermissionDenied` (gRPC surface)
  - Wrapped errors (via `errors.As` / `status.FromError`) so the scheduler's wrap-and-rethrow chain still classifies correctly.
- **`internal/scheduler/scheduler.go`** — `fanOutPerAccount` consults a small `isAccountPermissionError(providerLabel, err)` dispatcher that routes by provider label. Only `"GCP"` wires to the predicate today; AWS/Azure keep the existing `[ERROR]` behaviour until analogous classifiers exist.

## What did NOT change

- Per-account failure counters, `accountOutcome`, "all accounts failed" → provider-level error, banner surfacing — all identical.
- Other GCP collector behaviours (`known_issues/22_scheduler.md` silent-failure entry stays open).
- The Settings → Accounts UI surface for permission gaps mentioned in the issue body — separate follow-up.

## Test plan

- [x] `go test ./providers/gcp/... -run TestIsPermissionError` — covers direct + wrapped 403 / `PermissionDenied`, non-permission HTTP/gRPC codes (404/500/`NotFound`/`Unavailable`), generic non-google error, nil.
- [x] `go test ./internal/scheduler/... -run TestIsAccountPermissionError` — covers GCP routing to WARN, AWS/Azure preserving ERROR, nil error.
- [x] `go build ./...` (root + GCP submodule) clean.
- [x] Full `go test ./internal/scheduler/...` passes — no regression in scheduler behaviour.
- [ ] Post-deploy: tail Lambda logs for ~5 min, expect new `[WARN]` line for `serene-bazaar-666` rather than `[ERROR]`.

## Notes for the reviewer

- The `gcp.IsPermissionError` predicate is exported intentionally so analogous AWS/Azure classifiers can be added later by extending the scheduler's `switch providerLabel` block — no API churn needed.
- `providers/gcp/go.mod` promotes `google.golang.org/grpc` from indirect to direct, which is correct now that the package directly imports `grpc/codes` and `grpc/status`.

Closes #57
