### PR TITLE
fix(api): pre-flight validation for federation IaC bundles (target/source + Azure/GCP source-identity)

### DIFF
--- a/internal/api/handler_federation.go
+++ b/internal/api/handler_federation.go
@@ -135,9 +135,19 @@ func (h *Handler) getFederationIaC(ctx context.Context, req *events.LambdaFuncti
 		return nil, err
 	}
 
+	// Reject impossible target/source combinations early — before bundle
+	// construction — so the caller gets a clear 400 instead of a downloadable
+	// bundle that fails at terraform apply with a cryptic IAM error. See #42.
+	if err = validateFederationTargetSource(target, source); err != nil {
+		return nil, err
+	}
+
 	apiURL := deriveFederationAPIURL(h.dashboardURL, req.RequestContext.DomainName)
 	data := buildGenericIaCData(target, source, apiURL)
 	if err = h.populateSourceAccountID(ctx, source, &data); err != nil {
+		return nil, err
+	}
+	if err = h.validateSourceIdentity(ctx); err != nil {
 		return nil, err
 	}
 	// ContactEmail is always the email of the authenticated user who requested
@@ -180,6 +190,62 @@ func (h *Handler) populateSourceAccountID(ctx context.Context, source string, da
 		// the execution role has sts:GetCallerIdentity and AWS_REGION is set.
 		return fmt.Errorf("federation iac: CUDly failed to resolve its own AWS account ID; " +
 			"check that the execution role has sts:GetCallerIdentity and AWS_REGION is set")
+	}
+	return nil
+}
+
+// validateSourceIdentity asserts that CUDly's own source-cloud identity is
+// fully populated before rendering an IaC bundle. The Azure and GCP paths
+// read identity from environment variables (AZURE_SUBSCRIPTION_ID,
+// AZURE_TENANT_ID, GCP_PROJECT_ID) — when any of those are unset on the
+// Lambda/Function App, empty strings flow into the rendered tfvars and the
+// customer's `terraform apply` later fails with a blank client_id or missing
+// project. Fail loud here with a 500-class error naming the missing env var
+// so the operator knows exactly what to fix. See #41.
+//
+// AWS source-cloud is intentionally NOT covered here — populateSourceAccountID
+// already enforces the equivalent fail-loud guard for AWS deployments via STS
+// GetCallerIdentity, with a more specific error message naming the IAM
+// permission the execution role needs.
+func (h *Handler) validateSourceIdentity(ctx context.Context) error {
+	cloud := sourceCloud()
+	if cloud != "azure" && cloud != "gcp" {
+		return nil
+	}
+	id := h.resolveSourceIdentity(ctx)
+	switch cloud {
+	case "azure":
+		if id.SubscriptionID == "" {
+			return fmt.Errorf("federation iac: AZURE_SUBSCRIPTION_ID is not set; " +
+				"check the Lambda/Function App environment variables")
+		}
+		if id.TenantID == "" {
+			return fmt.Errorf("federation iac: AZURE_TENANT_ID is not set; " +
+				"check the Lambda/Function App environment variables")
+		}
+	case "gcp":
+		if id.ProjectID == "" {
+			return fmt.Errorf("federation iac: GCP_PROJECT_ID is not set; " +
+				"check the Cloud Run / Cloud Functions environment variables")
+		}
+	}
+	return nil
+}
+
+// validateFederationTargetSource rejects impossible target/source combinations
+// for the current CUDly deployment. It runs before bundle construction so the
+// caller gets a clear 400 instead of a downloadable bundle that fails at
+// `terraform apply` with a cryptic provider error. See #42.
+//
+// Today the only impossible-by-construction combination is target=aws-cross-account
+// (target == "aws" && source == "aws") from a non-AWS CUDly deployment: the
+// rendered trust policy needs CUDly's AWS account ID in the principal ARN,
+// which a CUDly running on Azure/GCP cannot supply.
+func validateFederationTargetSource(target, source string) error {
+	if target == "aws" && source == "aws" && sourceCloud() != "aws" {
+		return NewClientError(400, fmt.Sprintf(
+			"target=aws-cross-account requires CUDly to be deployed on AWS; "+
+				"this deployment is on %s", sourceCloud()))
 	}
 	return nil
 }

--- a/internal/api/handler_federation_test.go
+++ b/internal/api/handler_federation_test.go
@@ -25,6 +25,11 @@ import (
 // that need CUDLY_SOURCE_CLOUD=aws must call t.Setenv("CUDLY_SOURCE_CLOUD","aws")
 // BEFORE calling federationHandler (the check below will see the already-set
 // value and skip the override).
+//
+// Also pre-warms h.sourceID with a fully-populated identity matching the
+// active source cloud so the validateSourceIdentity guard (see #41) is
+// satisfied by default. Tests that specifically exercise the missing-env-var
+// failure modes call mockSourceIdentity afterwards to override.
 func federationHandler() *Handler {
 	if os.Getenv("CUDLY_SOURCE_CLOUD") == "" {
 		_ = os.Setenv("CUDLY_SOURCE_CLOUD", "gcp")
@@ -35,7 +40,37 @@ func federationHandler() *Handler {
 		Email:  "admin@example.com",
 		Role:   "admin",
 	}, nil)
-	return NewHandler(HandlerConfig{ConfigStore: new(MockConfigStore), AuthService: mockAuth})
+	h := NewHandler(HandlerConfig{ConfigStore: new(MockConfigStore), AuthService: mockAuth})
+	mockSourceIdentity(h, defaultTestSourceIdentity())
+	return h
+}
+
+// defaultTestSourceIdentity returns a fully-populated sourceIdentity matching
+// the active CUDLY_SOURCE_CLOUD env var. Used by federationHandler to satisfy
+// validateSourceIdentity and the AWS-cross-account fail-loud guard by default.
+func defaultTestSourceIdentity() *sourceIdentity {
+	switch sourceCloud() {
+	case "aws":
+		return &sourceIdentity{Provider: "aws", AccountID: "123456789012"}
+	case "azure":
+		return &sourceIdentity{
+			Provider:       "azure",
+			SubscriptionID: "00000000-0000-0000-0000-000000000001",
+			TenantID:       "00000000-0000-0000-0000-000000000002",
+			ClientID:       "00000000-0000-0000-0000-000000000003",
+		}
+	case "gcp":
+		return &sourceIdentity{Provider: "gcp", ProjectID: "cudly-test-project"}
+	}
+	return &sourceIdentity{}
+}
+
+// mockSourceIdentity overrides the cached source identity on a Handler and
+// trips the sync.Once so subsequent calls to resolveSourceIdentity return the
+// supplied value. Same-package access — only intended for tests.
+func mockSourceIdentity(h *Handler, id *sourceIdentity) {
+	h.sourceID = id
+	h.sourceIdentityOnce.Do(func() {})
 }
 
 func federationReq(params map[string]string) *events.LambdaFunctionURLRequest {
@@ -173,6 +208,9 @@ func TestGetFederationIaC_AWSWIF_CFNZip(t *testing.T) {
 }
 
 func TestGetFederationIaC_CFN_AWSCrossAccount(t *testing.T) {
+	// aws-cross-account requires CUDly itself to be running on AWS — the new
+	// validateFederationTargetSource guard (#42) rejects this combo otherwise.
+	t.Setenv("CUDLY_SOURCE_CLOUD", "aws")
 	h := federationHandler()
 	ctx := context.Background()
 
@@ -222,6 +260,9 @@ func TestGetFederationIaC_CFN_AWSCrossAccount(t *testing.T) {
 }
 
 func TestGetFederationIaC_Bundle_AWSCrossAccount(t *testing.T) {
+	// aws-cross-account requires CUDly itself to be running on AWS — the new
+	// validateFederationTargetSource guard (#42) rejects this combo otherwise.
+	t.Setenv("CUDLY_SOURCE_CLOUD", "aws")
 	h := federationHandler()
 	ctx := context.Background()
 
@@ -363,6 +404,9 @@ func TestSingleFileSpec_CLI_AllScenarios(t *testing.T) {
 }
 
 func TestGetFederationIaC_CLI_AWSCrossAccount(t *testing.T) {
+	// aws-cross-account requires CUDly itself to be running on AWS — the new
+	// validateFederationTargetSource guard (#42) rejects this combo otherwise.
+	t.Setenv("CUDLY_SOURCE_CLOUD", "aws")
 	h := federationHandler()
 	res, err := h.getFederationIaC(context.Background(), federationReq(map[string]string{
 		"target": "aws", "source": "aws", "format": "cli",
@@ -528,26 +572,11 @@ func TestGetFederationIaC_Bicep_RejectsNonAzure(t *testing.T) {
 // handler returns a non-nil error instead of shipping a broken bundle with an
 // empty source_account_id.
 func TestGetFederationIaC_FailsLoudOnEmptySourceAccountID(t *testing.T) {
-	// sourceCloud() returns "aws" by default (and we explicitly set it here for
-	// clarity). resolveAWSAccountID must return "" to trigger the fail-loud
-	// path — actively clear every AWS credential env var a developer (or
-	// pre-commit hook inheriting the shell env) might have set, otherwise the
-	// SDK default chain picks them up, STS succeeds, and the assertion flips.
 	t.Setenv("CUDLY_SOURCE_CLOUD", "aws")
-	for _, k := range []string{
-		"AWS_ACCESS_KEY_ID",
-		"AWS_SECRET_ACCESS_KEY",
-		"AWS_SESSION_TOKEN",
-		"AWS_PROFILE",
-		"AWS_DEFAULT_PROFILE",
-		"AWS_SHARED_CREDENTIALS_FILE",
-		"AWS_CONFIG_FILE",
-		"AWS_WEB_IDENTITY_TOKEN_FILE",
-		"AWS_ROLE_ARN",
-	} {
-		t.Setenv(k, "")
-	}
 	h := federationHandler()
+	// Override the federationHandler default ({Provider:"aws", AccountID:"…"}) with
+	// an empty AccountID to simulate the STS GetCallerIdentity failure path.
+	mockSourceIdentity(h, &sourceIdentity{Provider: "aws", AccountID: ""})
 
 	_, err := h.getFederationIaC(context.Background(), federationReq(map[string]string{
 		"target": "aws", "source": "aws", "format": "cli",
@@ -655,6 +684,8 @@ func TestGetFederationIaC_PreservesPlusInSessionEmail(t *testing.T) {
 		Role:   "admin",
 	}, nil)
 	h := NewHandler(HandlerConfig{ConfigStore: new(MockConfigStore), AuthService: mockAuth})
+	// Pre-warm the source identity to satisfy validateSourceIdentity (#41).
+	mockSourceIdentity(h, defaultTestSourceIdentity())
 
 	// Use federationReqWithDomain so the {{if .CUDlyAPIURL}} block renders and
 	// the CONTACT_EMAIL line (with the pre-filled email) appears in the output.
@@ -680,6 +711,8 @@ func TestGetFederationIaC_NoSessionEmail_ShipsBundleWithEmptyContact(t *testing.
 		Role:   "admin",
 	}, nil)
 	h := NewHandler(HandlerConfig{ConfigStore: new(MockConfigStore), AuthService: mockAuth})
+	// Pre-warm the source identity to satisfy validateSourceIdentity (#41).
+	mockSourceIdentity(h, defaultTestSourceIdentity())
 
 	res, err := h.getFederationIaC(context.Background(), federationReq(map[string]string{
 		"target": "gcp", "source": "aws", "format": "bundle",
@@ -727,6 +760,11 @@ func TestRenderedCLIShellScript_RegistrationAlwaysRuns(t *testing.T) {
 	for _, tc := range cases {
 		tc := tc
 		t.Run(tc.target+"/"+tc.source, func(t *testing.T) {
+			// aws-cross-account requires CUDLY_SOURCE_CLOUD=aws — the
+			// validateFederationTargetSource guard (#42) rejects it otherwise.
+			if tc.target == "aws" && tc.source == "aws" {
+				t.Setenv("CUDLY_SOURCE_CLOUD", "aws")
+			}
 			h := federationHandler()
 			// Use federationReqWithDomain so CUDlyAPIURL is populated and the
 			// {{if .CUDlyAPIURL}} registration block is rendered.
@@ -763,6 +801,11 @@ func TestRenderedCFNDeployScript_HasRegistrationBlock(t *testing.T) {
 	for _, tc := range cases {
 		tc := tc
 		t.Run(tc.target+"/"+tc.source, func(t *testing.T) {
+			// aws-cross-account requires CUDLY_SOURCE_CLOUD=aws — the
+			// validateFederationTargetSource guard (#42) rejects it otherwise.
+			if tc.target == "aws" && tc.source == "aws" {
+				t.Setenv("CUDLY_SOURCE_CLOUD", "aws")
+			}
 			h := federationHandler()
 			// Use federationReqWithDomain so CUDlyAPIURL is populated and the
 			// {{if .CUDlyAPIURL}} registration block is rendered in the deploy script.
@@ -883,6 +926,155 @@ func TestRenderedTerraformRegistrationTF_GateOnURLOnly(t *testing.T) {
 				"do_register must gate on cudly_api_url being non-empty")
 			assert.NotContains(t, src, `&& var.contact_email != ""`,
 				"do_register must NOT gate on contact_email")
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Pre-flight validation: source identity (issue #41) + target/source consistency (issue #42)
+// ---------------------------------------------------------------------------
+
+// TestGetFederationIaC_FailsLoudOnEmptyAzureSourceIdentity covers issue #41 for
+// the Azure source-cloud path: when CUDly runs on Azure but AZURE_SUBSCRIPTION_ID
+// or AZURE_TENANT_ID is missing, the bundle MUST fail with a 500-class error
+// naming the missing env var instead of shipping a broken tfvars with empty
+// client_id/tenant_id that fails at terraform apply.
+func TestGetFederationIaC_FailsLoudOnEmptyAzureSourceIdentity(t *testing.T) {
+	cases := []struct {
+		name           string
+		identity       *sourceIdentity
+		wantInErrorMsg string
+	}{
+		{
+			name: "missing-subscription-id",
+			identity: &sourceIdentity{
+				Provider:       "azure",
+				SubscriptionID: "",
+				TenantID:       "00000000-0000-0000-0000-000000000002",
+				ClientID:       "00000000-0000-0000-0000-000000000003",
+			},
+			wantInErrorMsg: "AZURE_SUBSCRIPTION_ID",
+		},
+		{
+			name: "missing-tenant-id",
+			identity: &sourceIdentity{
+				Provider:       "azure",
+				SubscriptionID: "00000000-0000-0000-0000-000000000001",
+				TenantID:       "",
+				ClientID:       "00000000-0000-0000-0000-000000000003",
+			},
+			wantInErrorMsg: "AZURE_TENANT_ID",
+		},
+		{
+			name: "all-populated-positive-control",
+			identity: &sourceIdentity{
+				Provider:       "azure",
+				SubscriptionID: "00000000-0000-0000-0000-000000000001",
+				TenantID:       "00000000-0000-0000-0000-000000000002",
+				ClientID:       "00000000-0000-0000-0000-000000000003",
+			},
+			wantInErrorMsg: "",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("CUDLY_SOURCE_CLOUD", "azure")
+			h := federationHandler()
+			mockSourceIdentity(h, tc.identity)
+
+			_, err := h.getFederationIaC(context.Background(), federationReq(map[string]string{
+				"target": "azure", "source": "azure", "format": "cli",
+			}))
+			if tc.wantInErrorMsg == "" {
+				require.NoError(t, err, "fully-populated identity must succeed")
+				return
+			}
+			require.Error(t, err, "expected error when %s is empty", tc.wantInErrorMsg)
+			// Operator misconfiguration → 500-class, not a client error.
+			_, isClientErr := IsClientError(err)
+			assert.False(t, isClientErr,
+				"missing source-identity env var should produce a 500-class error, not a client error")
+			assert.Contains(t, err.Error(), tc.wantInErrorMsg,
+				"error must name the missing env var so operators know what to fix")
+			assert.Contains(t, err.Error(), "federation iac")
+		})
+	}
+}
+
+// TestGetFederationIaC_FailsLoudOnEmptyGCPSourceIdentity covers issue #41 for
+// the GCP source-cloud path: when CUDly runs on GCP but GCP_PROJECT_ID is
+// unset, the bundle MUST fail with a 500-class error naming the missing env
+// var instead of shipping a broken tfvars with an empty project that fails at
+// terraform apply.
+func TestGetFederationIaC_FailsLoudOnEmptyGCPSourceIdentity(t *testing.T) {
+	t.Setenv("CUDLY_SOURCE_CLOUD", "gcp")
+	h := federationHandler()
+	mockSourceIdentity(h, &sourceIdentity{Provider: "gcp", ProjectID: ""})
+
+	_, err := h.getFederationIaC(context.Background(), federationReq(map[string]string{
+		"target": "gcp", "source": "gcp", "format": "cli",
+	}))
+	require.Error(t, err, "expected error when GCP_PROJECT_ID is empty")
+	_, isClientErr := IsClientError(err)
+	assert.False(t, isClientErr,
+		"missing GCP_PROJECT_ID should produce a 500-class error, not a client error")
+	assert.Contains(t, err.Error(), "GCP_PROJECT_ID",
+		"error must name GCP_PROJECT_ID so operators know what to fix")
+	assert.Contains(t, err.Error(), "federation iac")
+}
+
+// TestGetFederationIaC_RejectsImpossibleTargetSourceCombo covers issue #42:
+// requesting target=aws-cross-account (target=aws + source=aws) from a CUDly
+// not running on AWS must return HTTP 400 — the rendered trust policy needs
+// CUDly's AWS account ID, which a non-AWS deployment cannot supply.
+func TestGetFederationIaC_RejectsImpossibleTargetSourceCombo(t *testing.T) {
+	cases := []struct {
+		name        string
+		sourceCloud string
+		wantStatus  int
+		wantErrSub  string
+	}{
+		{
+			name:        "cudly-on-azure-rejects-aws-cross-account",
+			sourceCloud: "azure",
+			wantStatus:  400,
+			wantErrSub:  "deployment is on azure",
+		},
+		{
+			name:        "cudly-on-gcp-rejects-aws-cross-account",
+			sourceCloud: "gcp",
+			wantStatus:  400,
+			wantErrSub:  "deployment is on gcp",
+		},
+		{
+			name:        "cudly-on-aws-allows-aws-cross-account",
+			sourceCloud: "aws",
+			wantStatus:  0, // success
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("CUDLY_SOURCE_CLOUD", tc.sourceCloud)
+			h := federationHandler()
+
+			_, err := h.getFederationIaC(context.Background(), federationReq(map[string]string{
+				"target": "aws", "source": "aws", "format": "cli",
+			}))
+			if tc.wantStatus == 0 {
+				require.NoError(t, err, "CUDly-on-AWS aws-cross-account regression guard")
+				return
+			}
+			require.Error(t, err, "expected client error for impossible combo")
+			ce, ok := IsClientError(err)
+			require.True(t, ok, "must be a client error (400), got %T: %v", err, err)
+			assert.Equal(t, tc.wantStatus, ce.code,
+				"target/source consistency rejection must be a 400")
+			assert.Contains(t, err.Error(), "target=aws-cross-account requires CUDly to be deployed on AWS",
+				"error must explain the constraint")
+			assert.Contains(t, err.Error(), tc.wantErrSub,
+				"error must name the actual deployment cloud")
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Adds two pre-flight validation guards to the federation IaC handler so operator misconfigurations fail loudly at download time instead of silently shipping broken bundles that fail at `terraform apply`.

Combines fixes for two related issues that touch the same code path (`internal/api/handler_federation.go::getFederationIaC` and the surrounding helpers), so reviewers don't have to look at the same function twice.

Closes #41
Closes #42

## Changes

### #42 — `validateFederationTargetSource` (HTTP 400, fail fast)

Reject impossible target/source combinations *before* bundle construction. Today the only impossible-by-construction combo is `target=aws-cross-account` (`target=aws` + `source=aws`) from a non-AWS CUDly deployment: the rendered trust policy needs CUDly's AWS account ID in the principal ARN, which a CUDly running on Azure/GCP cannot supply. Returns `NewClientError(400)` naming the actual deployment cloud so the caller sees:

```
target=aws-cross-account requires CUDly to be deployed on AWS; this deployment is on azure
```

instead of a downloadable bundle that later fails with a cryptic `invalid principal ARN` IAM error.

### #41 — `validateSourceIdentity` (HTTP 500, operator misconfig)

Extends the existing AWS-only fail-loud guard in `populateSourceAccountID` to cover Azure and GCP source clouds. When CUDly runs on Azure but `AZURE_SUBSCRIPTION_ID` or `AZURE_TENANT_ID` is unset (or on GCP without `GCP_PROJECT_ID`), the bundle previously shipped with empty identity fields. Customers ran `terraform apply` and got a blank `client_id` / missing project. Now the handler returns a 500-class error naming the missing env var so the operator knows exactly what to fix.

### Test seam

Introduces `mockSourceIdentity` + `defaultTestSourceIdentity` in `handler_federation_test.go` so tests can pre-warm the cached `sourceIdentity` without going through STS / env vars. The existing `TestGetFederationIaC_FailsLoudOnEmptySourceAccountID` is simplified to use the new seam instead of clearing every `AWS_*` env var. The AWS-cross-account tests (which previously relied on the default `CUDLY_SOURCE_CLOUD=gcp` test fixture and the absence of the new target/source check) now correctly set `CUDLY_SOURCE_CLOUD=aws`.

## Files changed

- `internal/api/handler_federation.go` — +66 LOC (two new helpers + two new call sites in `getFederationIaC`)
- `internal/api/handler_federation_test.go` — +258 / -19 (new test seam, 7 new test cases across 3 test functions, updates to existing AWS-cross-account tests)

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` clean (full repo suite)
- [x] `TestGetFederationIaC_FailsLoudOnEmptyAzureSourceIdentity` — 3 subtests (missing-subscription-id, missing-tenant-id, all-populated positive control)
- [x] `TestGetFederationIaC_FailsLoudOnEmptyGCPSourceIdentity` — missing GCP_PROJECT_ID
- [x] `TestGetFederationIaC_RejectsImpossibleTargetSourceCombo` — 3 subtests (azure→reject, gcp→reject, aws→allow regression guard)
- [x] All previously-passing federation tests still pass

## Notes

- **CodeRabbit auto-review may skip** because the base branch (`feat/multicloud-web-frontend`) is not the repo's default branch — that's expected; the `@coderabbitai review` comment is still posted per project convention.
- No frontend, IaC template, or deploy-time changes — Go-only PR. Existing rendered bundles remain unchanged in shape.
