### PR TITLE
fix(ui): scope service dropdown to selected provider in plan form

### DIFF
--- a/frontend/src/__tests__/plans.test.ts
+++ b/frontend/src/__tests__/plans.test.ts
@@ -988,10 +988,16 @@ describe('Plans Module', () => {
       providerSelect.value = 'azure';
       providerSelect.dispatchEvent(new Event('change'));
 
-      // Should hide AWS services optgroup
+      // Should hide + disable the AWS services optgroup. Previously this
+      // test asserted on inline style.display — that was indicator-only
+      // and missed the real bug (issue #11: the hidden class stayed
+      // baked in, so switching away from AWS never re-showed the target
+      // provider's services). The class + disabled state is the new
+      // source of truth.
       const serviceSelect = document.getElementById('plan-service') as HTMLSelectElement;
       const awsOptgroup = serviceSelect.querySelector('optgroup[label="AWS Services"]') as HTMLOptGroupElement;
-      expect(awsOptgroup.style.display).toBe('none');
+      expect(awsOptgroup.classList.contains('hidden')).toBe(true);
+      expect(awsOptgroup.disabled).toBe(true);
     });
 
     test('handles missing elements gracefully', () => {
@@ -1741,6 +1747,78 @@ describe('Plans Module', () => {
 
       // Should call populatePaymentSelect to fix invalid combination
       expect(populatePaymentSelect).toHaveBeenCalled();
+    });
+  });
+
+  describe('provider scopes service dropdown (issue #11)', () => {
+    // Match optgroups by label-prefix so both the real HTML labels
+    // ("AWS"/"Azure"/"GCP") and the test fixture's labels
+    // ("AWS Services"/"Azure Services"/"GCP Services") work.
+    const byProvider = (prefix: string) =>
+      document.querySelector(
+        `#plan-service > optgroup[label^="${prefix}"]`,
+      ) as HTMLOptGroupElement | null;
+
+    beforeEach(() => {
+      setupPlanHandlers();
+    });
+
+    test('initial state (provider=aws): only AWS optgroup enabled', () => {
+      const aws = byProvider('AWS')!;
+      const azure = byProvider('Azure')!;
+      const gcp = byProvider('GCP')!;
+
+      expect(aws.classList.contains('hidden')).toBe(false);
+      expect(aws.disabled).toBe(false);
+      expect(azure.classList.contains('hidden')).toBe(true);
+      expect(azure.disabled).toBe(true);
+      expect(gcp.classList.contains('hidden')).toBe(true);
+      expect(gcp.disabled).toBe(true);
+    });
+
+    test('switching to azure enables only the Azure optgroup', () => {
+      const provider = document.getElementById('plan-provider') as HTMLSelectElement;
+      provider.value = 'azure';
+      provider.dispatchEvent(new Event('change'));
+
+      expect(byProvider('AWS')!.classList.contains('hidden')).toBe(true);
+      expect(byProvider('AWS')!.disabled).toBe(true);
+      expect(byProvider('Azure')!.classList.contains('hidden')).toBe(false);
+      expect(byProvider('Azure')!.disabled).toBe(false);
+      expect(byProvider('GCP')!.classList.contains('hidden')).toBe(true);
+      expect(byProvider('GCP')!.disabled).toBe(true);
+    });
+
+    test('switching to gcp enables only the GCP optgroup', () => {
+      const provider = document.getElementById('plan-provider') as HTMLSelectElement;
+      provider.value = 'gcp';
+      provider.dispatchEvent(new Event('change'));
+
+      expect(byProvider('AWS')!.disabled).toBe(true);
+      expect(byProvider('Azure')!.disabled).toBe(true);
+      expect(byProvider('GCP')!.disabled).toBe(false);
+      expect(byProvider('GCP')!.classList.contains('hidden')).toBe(false);
+    });
+
+    test('resets service to first visible option when AWS-only selection becomes hidden', () => {
+      const provider = document.getElementById('plan-provider') as HTMLSelectElement;
+      const service = document.getElementById('plan-service') as HTMLSelectElement;
+
+      // User picks an AWS-only service, then switches provider to azure.
+      service.value = 'ec2';
+      provider.value = 'azure';
+      provider.dispatchEvent(new Event('change'));
+
+      // Implementation picks the first option in the first visible
+      // optgroup. Assert the chosen value lives inside an optgroup
+      // labelled with the selected provider — decoupling the test
+      // from the specific service name in the fixture.
+      const selected = service.options[service.selectedIndex];
+      expect(selected).toBeDefined();
+      const parent = selected?.parentElement;
+      expect(parent).toBeInstanceOf(HTMLOptGroupElement);
+      expect((parent as HTMLOptGroupElement).label.toLowerCase()).toMatch(/^azure/);
+      expect(service.value).not.toBe('ec2');
     });
   });
 });

--- a/frontend/src/plans.ts
+++ b/frontend/src/plans.ts
@@ -1065,14 +1065,25 @@ function updateServiceDropdownForProvider(provider: string): void {
   const serviceSelect = document.getElementById('plan-service') as HTMLSelectElement | null;
   if (!serviceSelect) return;
 
-  // Show/hide optgroups based on selected provider
+  // Show/hide optgroups based on selected provider.
+  //
+  // Toggle the `hidden` class (same class the HTML starts with) so the
+  // DOM state tracks a single source of truth — previously we flipped
+  // `style.display`, which doesn't clear the pre-existing `hidden`
+  // class, so Azure/GCP stayed hidden forever even when selected.
+  //
+  // Also flip `optgroup.disabled`: Chrome has a long-standing quirk
+  // where a `display: none` <optgroup> still renders its <option>s as
+  // selectable, so users could end up with provider=Azure + ec2. The
+  // `disabled` attribute disables selection in every browser.
   const optgroups = serviceSelect.querySelectorAll('optgroup');
   let firstVisibleOptionValue = '';
 
   optgroups.forEach(optgroup => {
     const optgroupLabel = optgroup.label.toLowerCase();
     const shouldShow = optgroupLabel.includes(provider.toLowerCase());
-    (optgroup as HTMLOptGroupElement).style.display = shouldShow ? '' : 'none';
+    optgroup.classList.toggle('hidden', !shouldShow);
+    optgroup.disabled = !shouldShow;
 
     // Track first visible option value to auto-select
     if (shouldShow && !firstVisibleOptionValue) {
@@ -1086,7 +1097,7 @@ function updateServiceDropdownForProvider(provider: string): void {
   // If current selection is hidden, select first visible option
   const currentOption = serviceSelect.options[serviceSelect.selectedIndex];
   const parentOptgroup = currentOption?.parentElement;
-  const isHidden = parentOptgroup instanceof HTMLOptGroupElement && parentOptgroup.style.display === 'none';
+  const isHidden = parentOptgroup instanceof HTMLOptGroupElement && parentOptgroup.classList.contains('hidden');
   if (isHidden && firstVisibleOptionValue) {
     serviceSelect.value = firstVisibleOptionValue;
     // Trigger change event to update term/payment options


### PR DESCRIPTION
## Summary

Closes #11.

The Service dropdown in the New Plan modal was not being re-scoped when the Provider was changed. AWS-only services (EC2, RDS, etc.) remained selectable under Azure or GCP, allowing invalid plans like `provider=azure + service=ec2` to be saved.

## Root cause

Two bugs compounded in `updateServiceDropdownForProvider` (`frontend/src/plans.ts`):

1. The handler flipped `optgroup.style.display`, but the HTML declares the Azure/GCP optgroups with `class="hidden"` from the start. Clearing the inline style does not clear the class, so the target provider's optgroup stayed hidden no matter what the user picked — the dropdown effectively froze on the initial AWS provider.
2. Chrome has a long-standing quirk where a `display: none` `<optgroup>` still renders its `<option>` children as selectable. Even if (1) were fixed, the children could still be picked.

## Fix

- Toggle the `hidden` class on each `<optgroup>` (single source of truth shared with the HTML) so the selected provider's optgroup becomes visible and the others retract.
- Also flip `optgroup.disabled` — disables the children at the selection layer, defeating the Chrome render quirk in every browser.
- Update the "current selection hidden -> reset" check to look at the class instead of `style.display`.

## Test coverage

`frontend/src/__tests__/plans.test.ts` adds a new `provider scopes service dropdown (issue #11)` block:

- Initial state with `provider=aws` enables only the AWS optgroup.
- Switching to `azure` enables only the Azure optgroup (others get `hidden` + `disabled`).
- Switching to `gcp` enables only the GCP optgroup.
- Pre-selecting an AWS-only service (e.g. `ec2`) and switching to Azure auto-resets the selection to the first valid Azure service.

Existing `setupPlanHandlers` test was updated from the old `style.display === 'none'` indicator-only assertion (which missed the real bug) to assert the new `hidden` class + `disabled` attribute that are the actual source of truth.

All 81 plans tests pass; `tsc --noEmit` and `npm run build` clean.

## Test plan

- [ ] Open the deployed New Plan modal, switch Provider between AWS / Azure / GCP, confirm the Service dropdown re-scopes.
- [ ] Try to save a plan with provider=Azure: only Azure-valid services should be available.
- [ ] Pre-select EC2 under AWS, switch to Azure: Service should auto-reset to the first Azure service.
