### PR TITLE
chore(tests): parallelize pkg/common test files

### DIFF
--- a/pkg/common/audit_test.go
+++ b/pkg/common/audit_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestWriteAuditRecord_Append(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "audit.jsonl")
 
@@ -37,6 +38,7 @@ func TestWriteAuditRecord_Append(t *testing.T) {
 }
 
 func TestWriteAuditRecord_EmptyRunID(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "audit.jsonl")
 
@@ -46,11 +48,13 @@ func TestWriteAuditRecord_EmptyRunID(t *testing.T) {
 }
 
 func TestWriteAuditRecord_NonwritablePath(t *testing.T) {
+	t.Parallel()
 	err := WriteAuditRecord(AuditRecord{RunID: "x"}, "/nonexistent/dir/audit.jsonl")
 	assert.Error(t, err)
 }
 
 func TestAuditRecord_JSONRoundtrip(t *testing.T) {
+	t.Parallel()
 	raw := json.RawMessage(`{"foo":"bar"}`)
 	ts := time.Date(2026, 4, 2, 12, 0, 0, 0, time.UTC)
 	record := AuditRecord{
@@ -96,6 +100,7 @@ func TestAuditRecord_JSONRoundtrip(t *testing.T) {
 }
 
 func TestRawRecommendation_Omitempty(t *testing.T) {
+	t.Parallel()
 	record := AuditRecord{RunID: "run-x", Status: "skipped"}
 	data, err := json.Marshal(record)
 	require.NoError(t, err)
@@ -103,6 +108,7 @@ func TestRawRecommendation_Omitempty(t *testing.T) {
 }
 
 func TestNewAuditRecord_Fields(t *testing.T) {
+	t.Parallel()
 	rec := Recommendation{
 		Provider:         ProviderAWS,
 		Account:          "111",
@@ -136,6 +142,7 @@ func TestNewAuditRecord_Fields(t *testing.T) {
 }
 
 func TestTermMonths(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		input    string
 		expected int
@@ -146,7 +153,9 @@ func TestTermMonths(t *testing.T) {
 		{"unknown", 0},
 	}
 	for _, tc := range cases {
+		tc := tc
 		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
 			assert.Equal(t, tc.expected, termMonths(tc.input))
 		})
 	}

--- a/pkg/common/matches_test.go
+++ b/pkg/common/matches_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestMatches(t *testing.T) {
+	t.Parallel()
 	base := Recommendation{
 		Provider:     ProviderAWS,
 		Region:       "us-east-1",
@@ -39,7 +40,9 @@ func TestMatches(t *testing.T) {
 	}
 
 	for _, tc := range cases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			c := matching // copy
 			tc.mutate(&c)
 			assert.Equal(t, tc.wantMatch, Matches(base, c))
@@ -48,6 +51,7 @@ func TestMatches(t *testing.T) {
 }
 
 func TestMatches_NormalizedEngine(t *testing.T) {
+	t.Parallel()
 	// "Aurora PostgreSQL" (CE format) on the recommendation should match "aurora-postgresql" on commitment
 	rec := Recommendation{
 		Provider:     ProviderAWS,
@@ -67,6 +71,7 @@ func TestMatches_NormalizedEngine(t *testing.T) {
 }
 
 func TestMatches_NoDetails(t *testing.T) {
+	t.Parallel()
 	// Compute recommendations have no engine — both sides normalize to ""
 	rec := Recommendation{
 		Provider:     ProviderAWS,

--- a/pkg/common/types_test.go
+++ b/pkg/common/types_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestProviderType_String(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		provider ProviderType
 		expected string
@@ -17,13 +18,16 @@ func TestProviderType_String(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(string(tt.provider), func(t *testing.T) {
+			t.Parallel()
 			assert.Equal(t, tt.expected, tt.provider.String())
 		})
 	}
 }
 
 func TestServiceType_String(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		service  ServiceType
 		expected string
@@ -47,13 +51,16 @@ func TestServiceType_String(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(string(tt.service), func(t *testing.T) {
+			t.Parallel()
 			assert.Equal(t, tt.expected, tt.service.String())
 		})
 	}
 }
 
 func TestCommitmentType_String(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		commitment CommitmentType
 		expected   string
@@ -65,13 +72,16 @@ func TestCommitmentType_String(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(string(tt.commitment), func(t *testing.T) {
+			t.Parallel()
 			assert.Equal(t, tt.expected, tt.commitment.String())
 		})
 	}
 }
 
 func TestComputeDetails_GetServiceType(t *testing.T) {
+	t.Parallel()
 	details := ComputeDetails{
 		InstanceType: "m5.large",
 		Platform:     "linux",
@@ -83,6 +93,7 @@ func TestComputeDetails_GetServiceType(t *testing.T) {
 }
 
 func TestComputeDetails_GetDetailDescription(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		details  ComputeDetails
@@ -107,13 +118,16 @@ func TestComputeDetails_GetDetailDescription(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			assert.Equal(t, tt.expected, tt.details.GetDetailDescription())
 		})
 	}
 }
 
 func TestDatabaseDetails_GetServiceType(t *testing.T) {
+	t.Parallel()
 	details := DatabaseDetails{
 		Engine:   "mysql",
 		AZConfig: "multi-az",
@@ -123,6 +137,7 @@ func TestDatabaseDetails_GetServiceType(t *testing.T) {
 }
 
 func TestDatabaseDetails_GetDetailDescription(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		details  DatabaseDetails
@@ -147,13 +162,16 @@ func TestDatabaseDetails_GetDetailDescription(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			assert.Equal(t, tt.expected, tt.details.GetDetailDescription())
 		})
 	}
 }
 
 func TestCacheDetails_GetServiceType(t *testing.T) {
+	t.Parallel()
 	details := CacheDetails{
 		Engine:   "redis",
 		NodeType: "cache.r6g.large",
@@ -163,6 +181,7 @@ func TestCacheDetails_GetServiceType(t *testing.T) {
 }
 
 func TestCacheDetails_GetDetailDescription(t *testing.T) {
+	t.Parallel()
 	details := CacheDetails{
 		Engine:   "redis",
 		NodeType: "cache.r6g.large",
@@ -172,6 +191,7 @@ func TestCacheDetails_GetDetailDescription(t *testing.T) {
 }
 
 func TestSearchDetails_GetServiceType(t *testing.T) {
+	t.Parallel()
 	details := SearchDetails{
 		InstanceType: "r5.large.search",
 	}
@@ -180,6 +200,7 @@ func TestSearchDetails_GetServiceType(t *testing.T) {
 }
 
 func TestSearchDetails_GetDetailDescription(t *testing.T) {
+	t.Parallel()
 	details := SearchDetails{
 		InstanceType: "r5.large.search",
 	}
@@ -188,6 +209,7 @@ func TestSearchDetails_GetDetailDescription(t *testing.T) {
 }
 
 func TestDataWarehouseDetails_GetServiceType(t *testing.T) {
+	t.Parallel()
 	details := DataWarehouseDetails{
 		NodeType:      "dc2.large",
 		NumberOfNodes: 3,
@@ -197,6 +219,7 @@ func TestDataWarehouseDetails_GetServiceType(t *testing.T) {
 }
 
 func TestDataWarehouseDetails_GetDetailDescription(t *testing.T) {
+	t.Parallel()
 	details := DataWarehouseDetails{
 		NodeType:      "dc2.large",
 		NumberOfNodes: 3,
@@ -206,6 +229,7 @@ func TestDataWarehouseDetails_GetDetailDescription(t *testing.T) {
 }
 
 func TestSavingsPlanDetails_GetServiceType(t *testing.T) {
+	t.Parallel()
 	details := SavingsPlanDetails{
 		PlanType:         "Compute",
 		HourlyCommitment: 10.50,
@@ -215,6 +239,7 @@ func TestSavingsPlanDetails_GetServiceType(t *testing.T) {
 }
 
 func TestSavingsPlanDetails_GetDetailDescription(t *testing.T) {
+	t.Parallel()
 	details := SavingsPlanDetails{
 		PlanType: "Compute",
 	}
@@ -223,6 +248,7 @@ func TestSavingsPlanDetails_GetDetailDescription(t *testing.T) {
 }
 
 func TestRecommendation_Struct(t *testing.T) {
+	t.Parallel()
 	rec := Recommendation{
 		Provider:          ProviderAWS,
 		Account:           "123456789012",
@@ -248,6 +274,7 @@ func TestRecommendation_Struct(t *testing.T) {
 }
 
 func TestPurchaseResult_Struct(t *testing.T) {
+	t.Parallel()
 	result := PurchaseResult{
 		Success:      true,
 		CommitmentID: "ri-12345",
@@ -262,6 +289,7 @@ func TestPurchaseResult_Struct(t *testing.T) {
 }
 
 func TestCommitment_Struct(t *testing.T) {
+	t.Parallel()
 	commitment := Commitment{
 		Provider:       ProviderAWS,
 		Account:        "123456789012",
@@ -280,6 +308,7 @@ func TestCommitment_Struct(t *testing.T) {
 }
 
 func TestOfferingDetails_Struct(t *testing.T) {
+	t.Parallel()
 	offering := OfferingDetails{
 		OfferingID:          "offering-123",
 		ResourceType:        "db.t3.medium",
@@ -298,6 +327,7 @@ func TestOfferingDetails_Struct(t *testing.T) {
 }
 
 func TestRecommendationParams_Struct(t *testing.T) {
+	t.Parallel()
 	params := RecommendationParams{
 		Service:        ServiceRDS,
 		Region:         "us-east-1",
@@ -315,6 +345,7 @@ func TestRecommendationParams_Struct(t *testing.T) {
 }
 
 func TestAccount_Struct(t *testing.T) {
+	t.Parallel()
 	account := Account{
 		Provider:    ProviderAWS,
 		ID:          "123456789012",
@@ -329,6 +360,7 @@ func TestAccount_Struct(t *testing.T) {
 }
 
 func TestRegion_Struct(t *testing.T) {
+	t.Parallel()
 	region := Region{
 		Provider:    ProviderAWS,
 		ID:          "us-east-1",
@@ -342,6 +374,7 @@ func TestRegion_Struct(t *testing.T) {
 }
 
 func TestNormalizeSource(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name    string
 		in      string
@@ -359,7 +392,9 @@ func TestNormalizeSource(t *testing.T) {
 		{"injection attempt", "cudly-cli; DROP TABLE", "", true},
 	}
 	for _, tc := range cases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := NormalizeSource(tc.in)
 			if tc.wantErr {
 				assert.Error(t, err)


### PR DESCRIPTION
## Summary

One incremental step toward closing #58 — adopts `t.Parallel()` across all three test files in `pkg/common/`. Picked as the safest leaf-package starting point: no `os.Setenv`, no shared mocks, no package-level mutable state, no shared file paths (each filesystem-touching test uses `t.TempDir()`).

Per the issue's explicit guidance, this is **one package per PR**, not a sweeping change. #58 stays open for subsequent packages.

## Changes

- `pkg/common/audit_test.go` — 7 top-level tests + 1 table-driven `t.Run` block parallelized.
- `pkg/common/matches_test.go` — 3 top-level tests + 1 table-driven `t.Run` block parallelized.
- `pkg/common/types_test.go` — 23 top-level tests + 6 table-driven `t.Run` blocks parallelized.

Total: 33 top-level test functions and 8 sub-test loops. Loop variables (`tc := tc`, `tt := tt`) captured defensively for pre-Go-1.22 safety even though current `go.mod` targets a newer toolchain — costless and matches the existing style in already-parallelized packages.

## Audit findings

| Risk | Status |
|------|--------|
| `os.Setenv`/`t.Setenv` | None present |
| Package-level mutable state | None — only `engine.go`'s read-only `engineNameMap` (concurrent-read safe) |
| Shared filesystem paths | None — `t.TempDir()` everywhere |
| Shared mocks/fixtures | None — all fixtures stack-local |

## Verification

- `go test -race -count=2 ./common/...` — clean (~2.78s wall-clock vs ~3.12s baseline).
- `go test -race -count=3 ./common/...` — clean.
- `go vet ./common/...` — clean.
- `go build ./...` — clean for both root module and `pkg/` submodule.
- `=== PAUSE` traces in `-v` output confirm the runtime is genuinely scheduling tests in parallel.

## Status of #58

Adopted (already done before this PR):
- `pkg/exchange/{auto,exchange,reshape}_test.go`
- `providers/aws/services/ec2/client_test.go`
- `internal/api/validation_test.go`
- `pkg/retry/exponential_test.go`

**This PR adds:** `pkg/common/{audit,matches,types}_test.go`.

Still pending audit + parallelization (kept for follow-up PRs):
- `internal/api/` other test files (handler fixtures + shared mocks)
- `internal/config/*_test.go` integration tests (share Postgres container — needs schema isolation)
- `internal/server/app_test.go` (package-level vars `runMigrations`, `migrationsTimeout`)
- `pkg/errors/`, `pkg/logging/`, `pkg/scorer/`, `pkg/config/`, `pkg/provider/`, `providers/azure/`, `providers/gcp/`, `cmd/`, `cmd/server/`, `cmd/lambda/`, `internal/database/`

## Test plan

- [x] `go test -race -count=2 ./pkg/common/...` from `pkg/` submodule
- [x] `go test -race -count=3 ./pkg/common/...` (extra repetition for flake hunting)
- [x] `go vet ./pkg/common/...`
- [x] `go build ./...` (both modules)
- [x] CI green on push (will be verified by ci-watch)

Refs #58
