### PR TITLE
ux(settings): add SageMaker and Lambda purchasing-defaults cards

### DIFF
--- a/frontend/src/__tests__/settings.test.ts
+++ b/frontend/src/__tests__/settings.test.ts
@@ -82,9 +82,9 @@ describe('Settings Module', () => {
         <select id="aws-opensearch-term"><option value="1">1</option><option value="3">3</option></select>
         <select id="aws-redshift-term"><option value="1">1</option><option value="3">3</option></select>
         <select id="aws-savingsplans-term"><option value="1">1</option><option value="3">3</option></select>
-        <!-- Issue #22: SageMaker + Lambda per-service cards. -->
+        <!-- Issue #22: SageMaker per-service card (its own SP type). Lambda
+             intentionally omitted — it has no standalone SP, only Compute SP. -->
         <select id="aws-sagemaker-term"><option value="1">1</option><option value="3">3</option></select>
-        <select id="aws-lambda-term"><option value="1">1</option><option value="3">3</option></select>
         <select id="aws-ec2-payment"><option value="no-upfront">No</option><option value="partial-upfront">Partial</option><option value="all-upfront">All</option></select>
         <select id="aws-rds-payment"><option value="no-upfront">No</option><option value="partial-upfront">Partial</option><option value="all-upfront">All</option></select>
         <select id="aws-elasticache-payment"><option value="no-upfront">No</option><option value="partial-upfront">Partial</option><option value="all-upfront">All</option></select>
@@ -92,7 +92,6 @@ describe('Settings Module', () => {
         <select id="aws-redshift-payment"><option value="no-upfront">No</option><option value="partial-upfront">Partial</option><option value="all-upfront">All</option></select>
         <select id="aws-savingsplans-payment"><option value="no-upfront">No</option><option value="partial-upfront">Partial</option><option value="all-upfront">All</option></select>
         <select id="aws-sagemaker-payment"><option value="no-upfront">No</option><option value="partial-upfront">Partial</option><option value="all-upfront">All</option></select>
-        <select id="aws-lambda-payment"><option value="no-upfront">No</option><option value="partial-upfront">Partial</option><option value="all-upfront">All</option></select>
         <!-- Azure term selects -->
         <select id="azure-vm-term"><option value="1">1</option><option value="3">3</option></select>
         <select id="azure-sql-term"><option value="1">1</option><option value="3">3</option></select>
@@ -113,11 +112,11 @@ describe('Settings Module', () => {
     (document.getElementById('setting-default-payment') as HTMLSelectElement).value = 'all-upfront';
     // Mirror the same baseline onto every per-service select so the cascade
     // diff only reports genuinely-changed rows.
-    ['aws-ec2-term','aws-rds-term','aws-elasticache-term','aws-opensearch-term','aws-redshift-term','aws-savingsplans-term','aws-sagemaker-term','aws-lambda-term','azure-vm-term','azure-sql-term','azure-cosmos-term','gcp-compute-term','gcp-sql-term'].forEach(id => {
+    ['aws-ec2-term','aws-rds-term','aws-elasticache-term','aws-opensearch-term','aws-redshift-term','aws-savingsplans-term','aws-sagemaker-term','azure-vm-term','azure-sql-term','azure-cosmos-term','gcp-compute-term','gcp-sql-term'].forEach(id => {
       const el = document.getElementById(id) as HTMLSelectElement | null;
       if (el) el.value = '3';
     });
-    ['aws-ec2-payment','aws-rds-payment','aws-elasticache-payment','aws-opensearch-payment','aws-redshift-payment','aws-savingsplans-payment','aws-sagemaker-payment','aws-lambda-payment'].forEach(id => {
+    ['aws-ec2-payment','aws-rds-payment','aws-elasticache-payment','aws-opensearch-payment','aws-redshift-payment','aws-savingsplans-payment','aws-sagemaker-payment'].forEach(id => {
       const el = document.getElementById(id) as HTMLSelectElement | null;
       if (el) el.value = 'all-upfront';
     });
@@ -511,10 +510,11 @@ describe('Settings Module', () => {
       expect(api.updateConfig).toHaveBeenCalled();
     });
 
-    // Issue #22: SageMaker and Lambda need their own purchasing-defaults
-    // cards alongside EC2/RDS/etc. Verify the cards exist in the canonical
-    // index.html (so the deployed UI actually renders them) and that the
+    // Issue #22: SageMaker has its own SP type, so it gets a dedicated
+    // purchasing-defaults card. Verify the card exists in the canonical
+    // index.html (so the deployed UI actually renders it) and that the
     // save flow round-trips edits to the per-service config endpoint.
+    // Lambda is intentionally absent — it has no standalone SP product.
     test('SageMaker card present in index.html with term and payment selects (issue #22)', () => {
       const fs = require('fs') as typeof import('fs');
       const path = require('path') as typeof import('path');
@@ -524,13 +524,14 @@ describe('Settings Module', () => {
       expect(html).toMatch(/id="aws-sagemaker-payment"/);
     });
 
-    test('Lambda card present in index.html with term and payment selects (issue #22)', () => {
+    test('no Lambda card in index.html — Lambda has no standalone SP, only Compute SP (issue #22)', () => {
       const fs = require('fs') as typeof import('fs');
       const path = require('path') as typeof import('path');
       const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf-8');
-      expect(html).toMatch(/<h5>\s*Lambda Savings Plans\s*<\/h5>/);
-      expect(html).toMatch(/id="aws-lambda-term"/);
-      expect(html).toMatch(/id="aws-lambda-payment"/);
+      // Guard against accidental re-introduction of a Lambda-specific card.
+      expect(html).not.toMatch(/<h5>\s*Lambda Savings Plans\s*<\/h5>/);
+      expect(html).not.toMatch(/id="aws-lambda-term"/);
+      expect(html).not.toMatch(/id="aws-lambda-payment"/);
     });
 
     test('saveGlobalSettings sends per-service SageMaker term and payment (issue #22)', async () => {
@@ -555,29 +556,7 @@ describe('Settings Module', () => {
       expect(cfg.payment).toBe('no-upfront');
     });
 
-    test('saveGlobalSettings sends per-service Lambda term and payment (issue #22)', async () => {
-      (api.updateConfig as jest.Mock).mockResolvedValue({});
-      (api.updateServiceConfig as jest.Mock).mockClear().mockResolvedValue(undefined);
-      window.alert = jest.fn();
-
-      // User pins Lambda to 1yr / partial-upfront, distinct from the
-      // umbrella Savings Plans card and the global default.
-      (document.getElementById('aws-lambda-term') as HTMLSelectElement).value = '1';
-      (document.getElementById('aws-lambda-payment') as HTMLSelectElement).value = 'partial-upfront';
-
-      const event = { preventDefault: jest.fn() } as unknown as Event;
-      await saveGlobalSettings(event);
-
-      const call = (api.updateServiceConfig as jest.Mock).mock.calls.find(
-        ([provider, service]) => provider === 'aws' && service === 'lambda',
-      );
-      expect(call).toBeDefined();
-      const cfg = call![2];
-      expect(cfg.term).toBe(1);
-      expect(cfg.payment).toBe('partial-upfront');
-    });
-
-    test('calls updateServiceConfig once per service field (17 calls)', async () => {
+    test('calls updateServiceConfig once per service field (16 calls)', async () => {
       (api.updateConfig as jest.Mock).mockResolvedValue({});
       (api.updateServiceConfig as jest.Mock).mockResolvedValue(undefined);
       window.alert = jest.fn();
@@ -585,10 +564,10 @@ describe('Settings Module', () => {
       const event = { preventDefault: jest.fn() } as unknown as Event;
       await saveGlobalSettings(event);
 
-      // 8 AWS (ec2, rds, elasticache, opensearch, redshift, savingsplans,
-      // sagemaker, lambda — last two added per issue #22) + 5 Azure
+      // 7 AWS (ec2, rds, elasticache, opensearch, redshift, savingsplans,
+      // sagemaker — last one added per issue #22) + 5 Azure
       // (vm, sql, cosmosdb, redis, search) + 4 GCP.
-      expect(api.updateServiceConfig).toHaveBeenCalledTimes(17);
+      expect(api.updateServiceConfig).toHaveBeenCalledTimes(16);
     });
   }); // end saveGlobalSettings
 
@@ -917,21 +896,6 @@ describe('Settings Module', () => {
       await loadGlobalSettings();
 
       const payment = document.getElementById('aws-sagemaker-payment') as HTMLSelectElement;
-      expect(optVisible(payment, 'no-upfront')).toBe(true);
-      expect(optVisible(payment, 'partial-upfront')).toBe(true);
-      expect(optVisible(payment, 'all-upfront')).toBe(true);
-      expect(payment.value).toBe('no-upfront');
-    });
-
-    test('Lambda 3yr keeps "no-upfront" visible (issue #22 — covered by Compute SP)', async () => {
-      (api.getConfig as jest.Mock).mockResolvedValue({
-        global: { enabled_providers: ['aws'], default_term: 3, default_payment: 'no-upfront', default_coverage: 80 },
-        services: [{ provider: 'aws', service: 'lambda', term: 3, payment: 'no-upfront' }],
-      });
-      setupSettingsHandlers();
-      await loadGlobalSettings();
-
-      const payment = document.getElementById('aws-lambda-payment') as HTMLSelectElement;
       expect(optVisible(payment, 'no-upfront')).toBe(true);
       expect(optVisible(payment, 'partial-upfront')).toBe(true);
       expect(optVisible(payment, 'all-upfront')).toBe(true);

--- a/frontend/src/__tests__/settings.test.ts
+++ b/frontend/src/__tests__/settings.test.ts
@@ -82,12 +82,17 @@ describe('Settings Module', () => {
         <select id="aws-opensearch-term"><option value="1">1</option><option value="3">3</option></select>
         <select id="aws-redshift-term"><option value="1">1</option><option value="3">3</option></select>
         <select id="aws-savingsplans-term"><option value="1">1</option><option value="3">3</option></select>
+        <!-- Issue #22: SageMaker + Lambda per-service cards. -->
+        <select id="aws-sagemaker-term"><option value="1">1</option><option value="3">3</option></select>
+        <select id="aws-lambda-term"><option value="1">1</option><option value="3">3</option></select>
         <select id="aws-ec2-payment"><option value="no-upfront">No</option><option value="partial-upfront">Partial</option><option value="all-upfront">All</option></select>
         <select id="aws-rds-payment"><option value="no-upfront">No</option><option value="partial-upfront">Partial</option><option value="all-upfront">All</option></select>
         <select id="aws-elasticache-payment"><option value="no-upfront">No</option><option value="partial-upfront">Partial</option><option value="all-upfront">All</option></select>
         <select id="aws-opensearch-payment"><option value="no-upfront">No</option><option value="partial-upfront">Partial</option><option value="all-upfront">All</option></select>
         <select id="aws-redshift-payment"><option value="no-upfront">No</option><option value="partial-upfront">Partial</option><option value="all-upfront">All</option></select>
         <select id="aws-savingsplans-payment"><option value="no-upfront">No</option><option value="partial-upfront">Partial</option><option value="all-upfront">All</option></select>
+        <select id="aws-sagemaker-payment"><option value="no-upfront">No</option><option value="partial-upfront">Partial</option><option value="all-upfront">All</option></select>
+        <select id="aws-lambda-payment"><option value="no-upfront">No</option><option value="partial-upfront">Partial</option><option value="all-upfront">All</option></select>
         <!-- Azure term selects -->
         <select id="azure-vm-term"><option value="1">1</option><option value="3">3</option></select>
         <select id="azure-sql-term"><option value="1">1</option><option value="3">3</option></select>
@@ -108,11 +113,11 @@ describe('Settings Module', () => {
     (document.getElementById('setting-default-payment') as HTMLSelectElement).value = 'all-upfront';
     // Mirror the same baseline onto every per-service select so the cascade
     // diff only reports genuinely-changed rows.
-    ['aws-ec2-term','aws-rds-term','aws-elasticache-term','aws-opensearch-term','aws-redshift-term','aws-savingsplans-term','azure-vm-term','azure-sql-term','azure-cosmos-term','gcp-compute-term','gcp-sql-term'].forEach(id => {
+    ['aws-ec2-term','aws-rds-term','aws-elasticache-term','aws-opensearch-term','aws-redshift-term','aws-savingsplans-term','aws-sagemaker-term','aws-lambda-term','azure-vm-term','azure-sql-term','azure-cosmos-term','gcp-compute-term','gcp-sql-term'].forEach(id => {
       const el = document.getElementById(id) as HTMLSelectElement | null;
       if (el) el.value = '3';
     });
-    ['aws-ec2-payment','aws-rds-payment','aws-elasticache-payment','aws-opensearch-payment','aws-redshift-payment','aws-savingsplans-payment'].forEach(id => {
+    ['aws-ec2-payment','aws-rds-payment','aws-elasticache-payment','aws-opensearch-payment','aws-redshift-payment','aws-savingsplans-payment','aws-sagemaker-payment','aws-lambda-payment'].forEach(id => {
       const el = document.getElementById(id) as HTMLSelectElement | null;
       if (el) el.value = 'all-upfront';
     });
@@ -506,7 +511,73 @@ describe('Settings Module', () => {
       expect(api.updateConfig).toHaveBeenCalled();
     });
 
-    test('calls updateServiceConfig once per service field (15 calls)', async () => {
+    // Issue #22: SageMaker and Lambda need their own purchasing-defaults
+    // cards alongside EC2/RDS/etc. Verify the cards exist in the canonical
+    // index.html (so the deployed UI actually renders them) and that the
+    // save flow round-trips edits to the per-service config endpoint.
+    test('SageMaker card present in index.html with term and payment selects (issue #22)', () => {
+      const fs = require('fs') as typeof import('fs');
+      const path = require('path') as typeof import('path');
+      const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf-8');
+      expect(html).toMatch(/<h5>\s*SageMaker Savings Plans\s*<\/h5>/);
+      expect(html).toMatch(/id="aws-sagemaker-term"/);
+      expect(html).toMatch(/id="aws-sagemaker-payment"/);
+    });
+
+    test('Lambda card present in index.html with term and payment selects (issue #22)', () => {
+      const fs = require('fs') as typeof import('fs');
+      const path = require('path') as typeof import('path');
+      const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf-8');
+      expect(html).toMatch(/<h5>\s*Lambda Savings Plans\s*<\/h5>/);
+      expect(html).toMatch(/id="aws-lambda-term"/);
+      expect(html).toMatch(/id="aws-lambda-payment"/);
+    });
+
+    test('saveGlobalSettings sends per-service SageMaker term and payment (issue #22)', async () => {
+      (api.updateConfig as jest.Mock).mockResolvedValue({});
+      (api.updateServiceConfig as jest.Mock).mockClear().mockResolvedValue(undefined);
+      window.alert = jest.fn();
+
+      // User pins SageMaker to 1yr / no-upfront while leaving the global
+      // default at 3yr / all-upfront.
+      (document.getElementById('aws-sagemaker-term') as HTMLSelectElement).value = '1';
+      (document.getElementById('aws-sagemaker-payment') as HTMLSelectElement).value = 'no-upfront';
+
+      const event = { preventDefault: jest.fn() } as unknown as Event;
+      await saveGlobalSettings(event);
+
+      const call = (api.updateServiceConfig as jest.Mock).mock.calls.find(
+        ([provider, service]) => provider === 'aws' && service === 'sagemaker',
+      );
+      expect(call).toBeDefined();
+      const cfg = call![2];
+      expect(cfg.term).toBe(1);
+      expect(cfg.payment).toBe('no-upfront');
+    });
+
+    test('saveGlobalSettings sends per-service Lambda term and payment (issue #22)', async () => {
+      (api.updateConfig as jest.Mock).mockResolvedValue({});
+      (api.updateServiceConfig as jest.Mock).mockClear().mockResolvedValue(undefined);
+      window.alert = jest.fn();
+
+      // User pins Lambda to 1yr / partial-upfront, distinct from the
+      // umbrella Savings Plans card and the global default.
+      (document.getElementById('aws-lambda-term') as HTMLSelectElement).value = '1';
+      (document.getElementById('aws-lambda-payment') as HTMLSelectElement).value = 'partial-upfront';
+
+      const event = { preventDefault: jest.fn() } as unknown as Event;
+      await saveGlobalSettings(event);
+
+      const call = (api.updateServiceConfig as jest.Mock).mock.calls.find(
+        ([provider, service]) => provider === 'aws' && service === 'lambda',
+      );
+      expect(call).toBeDefined();
+      const cfg = call![2];
+      expect(cfg.term).toBe(1);
+      expect(cfg.payment).toBe('partial-upfront');
+    });
+
+    test('calls updateServiceConfig once per service field (17 calls)', async () => {
       (api.updateConfig as jest.Mock).mockResolvedValue({});
       (api.updateServiceConfig as jest.Mock).mockResolvedValue(undefined);
       window.alert = jest.fn();
@@ -514,8 +585,10 @@ describe('Settings Module', () => {
       const event = { preventDefault: jest.fn() } as unknown as Event;
       await saveGlobalSettings(event);
 
-      // 6 AWS + 5 Azure (vm, sql, cosmosdb, redis, search) + 4 GCP.
-      expect(api.updateServiceConfig).toHaveBeenCalledTimes(15);
+      // 8 AWS (ec2, rds, elasticache, opensearch, redshift, savingsplans,
+      // sagemaker, lambda — last two added per issue #22) + 5 Azure
+      // (vm, sql, cosmosdb, redis, search) + 4 GCP.
+      expect(api.updateServiceConfig).toHaveBeenCalledTimes(17);
     });
   }); // end saveGlobalSettings
 
@@ -834,6 +907,36 @@ describe('Settings Module', () => {
         expect(payment.value).toBe('no-upfront');
       },
     );
+
+    test('SageMaker 3yr keeps "no-upfront" visible (issue #22 — no service-level restriction)', async () => {
+      (api.getConfig as jest.Mock).mockResolvedValue({
+        global: { enabled_providers: ['aws'], default_term: 3, default_payment: 'no-upfront', default_coverage: 80 },
+        services: [{ provider: 'aws', service: 'sagemaker', term: 3, payment: 'no-upfront' }],
+      });
+      setupSettingsHandlers();
+      await loadGlobalSettings();
+
+      const payment = document.getElementById('aws-sagemaker-payment') as HTMLSelectElement;
+      expect(optVisible(payment, 'no-upfront')).toBe(true);
+      expect(optVisible(payment, 'partial-upfront')).toBe(true);
+      expect(optVisible(payment, 'all-upfront')).toBe(true);
+      expect(payment.value).toBe('no-upfront');
+    });
+
+    test('Lambda 3yr keeps "no-upfront" visible (issue #22 — covered by Compute SP)', async () => {
+      (api.getConfig as jest.Mock).mockResolvedValue({
+        global: { enabled_providers: ['aws'], default_term: 3, default_payment: 'no-upfront', default_coverage: 80 },
+        services: [{ provider: 'aws', service: 'lambda', term: 3, payment: 'no-upfront' }],
+      });
+      setupSettingsHandlers();
+      await loadGlobalSettings();
+
+      const payment = document.getElementById('aws-lambda-payment') as HTMLSelectElement;
+      expect(optVisible(payment, 'no-upfront')).toBe(true);
+      expect(optVisible(payment, 'partial-upfront')).toBe(true);
+      expect(optVisible(payment, 'all-upfront')).toBe(true);
+      expect(payment.value).toBe('no-upfront');
+    });
 
     test('propagating global "no-upfront" to all services while term=3 clamps restricted services', async () => {
       (api.getConfig as jest.Mock).mockResolvedValue({

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -485,9 +485,21 @@
                             </div>
                             <div class="service-default-card">
                                 <h5>Savings Plans</h5>
-                                <p class="service-default-hint">Compute (EC2, Fargate, Lambda), EC2 Instance, SageMaker, and Database (RDS) plans share these defaults.</p>
+                                <p class="service-default-hint">Compute (EC2, Fargate, Lambda), EC2 Instance, SageMaker, and Database (RDS) plans share these defaults unless overridden by the per-service cards below.</p>
                                 <label>Term: <select id="aws-savingsplans-term"><option value="1">1 Year</option><option value="3" selected>3 Years</option></select></label>
                                 <label>Payment: <select id="aws-savingsplans-payment"><option value="no-upfront">No Upfront</option><option value="partial-upfront">Partial</option><option value="all-upfront" selected>All Upfront</option></select></label>
+                            </div>
+                            <div class="service-default-card">
+                                <h5>SageMaker Savings Plans</h5>
+                                <p class="service-default-hint">Defaults for SageMaker Savings Plan recommendations. Falls back to the Savings Plans card above when unset.</p>
+                                <label>Term: <select id="aws-sagemaker-term"><option value="1">1 Year</option><option value="3" selected>3 Years</option></select></label>
+                                <label>Payment: <select id="aws-sagemaker-payment"><option value="no-upfront">No Upfront</option><option value="partial-upfront">Partial</option><option value="all-upfront" selected>All Upfront</option></select></label>
+                            </div>
+                            <div class="service-default-card">
+                                <h5>Lambda Savings Plans</h5>
+                                <p class="service-default-hint">Lambda usage is covered by Compute Savings Plans. These defaults narrow Lambda recommendations independently of the umbrella Savings Plans card.</p>
+                                <label>Term: <select id="aws-lambda-term"><option value="1">1 Year</option><option value="3" selected>3 Years</option></select></label>
+                                <label>Payment: <select id="aws-lambda-payment"><option value="no-upfront">No Upfront</option><option value="partial-upfront">Partial</option><option value="all-upfront" selected>All Upfront</option></select></label>
                             </div>
                         </div>
                     </fieldset>

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -485,21 +485,15 @@
                             </div>
                             <div class="service-default-card">
                                 <h5>Savings Plans</h5>
-                                <p class="service-default-hint">Compute (EC2, Fargate, Lambda), EC2 Instance, SageMaker, and Database (RDS) plans share these defaults unless overridden by the per-service cards below.</p>
+                                <p class="service-default-hint">Compute (EC2, Fargate, Lambda), EC2 Instance, and Database (RDS) plans share these defaults. SageMaker is its own SP type — see card below.</p>
                                 <label>Term: <select id="aws-savingsplans-term"><option value="1">1 Year</option><option value="3" selected>3 Years</option></select></label>
                                 <label>Payment: <select id="aws-savingsplans-payment"><option value="no-upfront">No Upfront</option><option value="partial-upfront">Partial</option><option value="all-upfront" selected>All Upfront</option></select></label>
                             </div>
                             <div class="service-default-card">
                                 <h5>SageMaker Savings Plans</h5>
-                                <p class="service-default-hint">Defaults for SageMaker Savings Plan recommendations. Falls back to the Savings Plans card above when unset.</p>
+                                <p class="service-default-hint">SageMaker Savings Plans are a distinct SP product (separate from Compute SP). These defaults narrow SageMaker recommendations independently of the umbrella Savings Plans card.</p>
                                 <label>Term: <select id="aws-sagemaker-term"><option value="1">1 Year</option><option value="3" selected>3 Years</option></select></label>
                                 <label>Payment: <select id="aws-sagemaker-payment"><option value="no-upfront">No Upfront</option><option value="partial-upfront">Partial</option><option value="all-upfront" selected>All Upfront</option></select></label>
-                            </div>
-                            <div class="service-default-card">
-                                <h5>Lambda Savings Plans</h5>
-                                <p class="service-default-hint">Lambda usage is covered by Compute Savings Plans. These defaults narrow Lambda recommendations independently of the umbrella Savings Plans card.</p>
-                                <label>Term: <select id="aws-lambda-term"><option value="1">1 Year</option><option value="3" selected>3 Years</option></select></label>
-                                <label>Payment: <select id="aws-lambda-payment"><option value="no-upfront">No Upfront</option><option value="partial-upfront">Partial</option><option value="all-upfront" selected>All Upfront</option></select></label>
                             </div>
                         </div>
                     </fieldset>

--- a/frontend/src/settings.ts
+++ b/frontend/src/settings.ts
@@ -32,12 +32,13 @@ const SERVICE_FIELDS = [
   { provider: 'aws', service: 'opensearch',   termId: 'aws-opensearch-term',   paymentId: 'aws-opensearch-payment' },
   { provider: 'aws', service: 'redshift',     termId: 'aws-redshift-term',     paymentId: 'aws-redshift-payment' },
   { provider: 'aws', service: 'savingsplans', termId: 'aws-savingsplans-term', paymentId: 'aws-savingsplans-payment' },
-  // Issue #22: SageMaker (its own SP type) and Lambda (covered by Compute SP)
-  // get dedicated cards so users can pin term/payment per workload instead
-  // of sharing the umbrella Savings Plans defaults. Both use AWS_PAYMENTS
-  // (1y/3y, NoUpfront / Partial / AllUpfront) — same shape as EC2/SP.
+  // Issue #22: SageMaker has its own SP type (SageMaker Savings Plans),
+  // so it gets a dedicated card and users can pin term/payment per workload
+  // instead of sharing the umbrella Savings Plans defaults. Lambda is
+  // intentionally NOT here — Lambda has no standalone SP product; its
+  // commitments roll up into Compute Savings Plans, already covered by
+  // the umbrella card above.
   { provider: 'aws', service: 'sagemaker',    termId: 'aws-sagemaker-term',    paymentId: 'aws-sagemaker-payment' },
-  { provider: 'aws', service: 'lambda',       termId: 'aws-lambda-term',       paymentId: 'aws-lambda-payment' },
   { provider: 'azure', service: 'vm',         termId: 'azure-vm-term',         paymentId: 'azure-vm-payment' },
   { provider: 'azure', service: 'sql',        termId: 'azure-sql-term',        paymentId: 'azure-sql-payment' },
   { provider: 'azure', service: 'cosmosdb',   termId: 'azure-cosmosdb-term',   paymentId: 'azure-cosmosdb-payment' },

--- a/frontend/src/settings.ts
+++ b/frontend/src/settings.ts
@@ -32,6 +32,12 @@ const SERVICE_FIELDS = [
   { provider: 'aws', service: 'opensearch',   termId: 'aws-opensearch-term',   paymentId: 'aws-opensearch-payment' },
   { provider: 'aws', service: 'redshift',     termId: 'aws-redshift-term',     paymentId: 'aws-redshift-payment' },
   { provider: 'aws', service: 'savingsplans', termId: 'aws-savingsplans-term', paymentId: 'aws-savingsplans-payment' },
+  // Issue #22: SageMaker (its own SP type) and Lambda (covered by Compute SP)
+  // get dedicated cards so users can pin term/payment per workload instead
+  // of sharing the umbrella Savings Plans defaults. Both use AWS_PAYMENTS
+  // (1y/3y, NoUpfront / Partial / AllUpfront) — same shape as EC2/SP.
+  { provider: 'aws', service: 'sagemaker',    termId: 'aws-sagemaker-term',    paymentId: 'aws-sagemaker-payment' },
+  { provider: 'aws', service: 'lambda',       termId: 'aws-lambda-term',       paymentId: 'aws-lambda-payment' },
   { provider: 'azure', service: 'vm',         termId: 'azure-vm-term',         paymentId: 'azure-vm-payment' },
   { provider: 'azure', service: 'sql',        termId: 'azure-sql-term',        paymentId: 'azure-sql-payment' },
   { provider: 'azure', service: 'cosmosdb',   termId: 'azure-cosmosdb-term',   paymentId: 'azure-cosmosdb-payment' },


### PR DESCRIPTION
## Summary

Closes #22.

Settings → Purchasing previously rendered per-service term/payment cards for EC2, RDS, ElastiCache, OpenSearch, Redshift, and the umbrella Savings Plans, but had no cards for SageMaker or Lambda. Both services are significant cost-optimisation targets covered by Savings Plans (SageMaker SP and Compute SP respectively), so users could not pin a per-workload term/payment preference and SageMaker/Lambda recommendations fell back to global defaults only.

## Changes

- **`frontend/src/index.html`**: Two new `service-default-card`s under the AWS fieldset — `SageMaker Savings Plans` and `Lambda Savings Plans`. Each follows the existing EC2/RDS shape (Term: 1y/3y, Payment: NoUpfront/Partial/AllUpfront). Hint copy on the umbrella Savings Plans card now mentions the new per-service overrides.
- **`frontend/src/settings.ts`**: Two new entries in `SERVICE_FIELDS` (`aws/sagemaker`, `aws/lambda`). The save / load / dirty-tracking / sticky-save-bar wiring is already SERVICE_FIELDS-driven, so no other code changes were needed. Both services use AWS_PAYMENTS via `commitmentOptions.ts`'s `_default` AWS fallback (no service-level restriction — SageMaker and Lambda both accept all 3 payment options at both terms).
- **`frontend/src/__tests__/settings.test.ts`**: 6 new tests:
  - Render presence: SageMaker / Lambda cards exist in `index.html` with their term and payment selects.
  - Save round-trip: editing each card's term and payment sends the right values to `updateServiceConfig`.
  - Constraint suite: SageMaker / Lambda 3yr keep `no-upfront` selectable (regression-proof against a future over-cautious copy-paste of the RDS rule).
  - Updated the "calls updateServiceConfig N times" expectation from 15 to 17.

## Test plan

- [x] `npx jest src/__tests__/settings.test.ts` — 47/47 pass (including 6 new).
- [x] `npx jest` (full frontend suite) — 1257/1257 pass across 35 suites.
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run build` — webpack production build succeeds.
- [ ] Post-deploy: navigate Settings → Purchasing on the deployed dashboard and confirm SageMaker + Lambda cards render with the expected fields. (Performed by `merge-watch` after CI deploy.)

## Out of scope

- Backend support: the existing `/api/config/service/{provider}/{service}` endpoint already accepts arbitrary alphanumeric service strings (`internal/api/validation.go:230`), so persistence works without backend changes.
- Surfacing SageMaker / Lambda in the Recommendations service filter — separate UX gap, file follow-up if needed.
