### PR TITLE
fix(security/gcp): flip Cloud Run ingress default to INTERNAL_LOAD_BALANCER

### DIFF
--- a/terraform/environments/gcp/README.md
+++ b/terraform/environments/gcp/README.md
@@ -144,12 +144,41 @@ The GCP deployment creates:
 - **Cloud Scheduler** job for periodic recommendation collection
 - **GCR** container image (built from project Dockerfile)
 
+## Security: Cloud Run ingress
+
+Two variables control how external callers reach the Cloud Run service:
+
+| Variable | Default | What it does |
+| --- | --- | --- |
+| `cloud_run_allow_unauthenticated` | `false` | IAM gate. `false` = only callers with `roles/run.invoker` can hit the URL. |
+| `cloud_run_ingress` | `INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER` | Network gate. Restricts the `*.run.app` URL to VPC + LB traffic only. |
+
+The defaults are **defence-in-depth**: even if a bad IAM binding ever grants `roles/run.invoker` to `allUsers`, the network gate keeps direct internet callers out of the `*.run.app` URL — only requests that come through the external HTTPS load balancer (and therefore Cloud Armor's WAF) can reach the service.
+
+### When to override
+
+`cloud_run_ingress` MUST be overridden to `INGRESS_TRAFFIC_ALL` whenever the supporting LB stack is not provisioned (`enable_cdn = false`), or the service becomes unreachable. All shipped tfvars (`dev.tfvars.example`, `github-dev.tfvars`, `github-staging.tfvars`, `github-prod.tfvars`) currently set `enable_cdn = false` and override `cloud_run_ingress` accordingly. When an environment flips `enable_cdn = true` (and provisions the LB + Cloud Armor + DNS), drop the `cloud_run_ingress` override so the service falls back to the secure default.
+
+### Verify
+
+```bash
+# Inspect the live ingress setting (after apply):
+gcloud run services describe <svc> --region <region> \
+  --format='value(spec.template.metadata.annotations[run.googleapis.com/ingress])'
+# Expected with the secure default:                  "internal-and-cloud-load-balancing"
+# Expected with the dev/staging/prod overrides today: "all"
+
+# Direct call to the *.run.app URL (when ingress is INTERNAL_LOAD_BALANCER):
+curl -I https://<service>-<hash>-<region>.a.run.app/health
+# Expected: HTTP/2 403  (request is rejected at the network layer)
+```
+
 ## Cost Notes (Dev Environment)
 
 The dev configuration uses minimal resources:
 
 | Resource | Size | Estimated Monthly Cost |
-|----------|------|----------------------|
+| --- | --- | --- |
 | Cloud SQL PostgreSQL | db-f1-micro, 10GB | ~$8 |
 | Cloud Run | 1 vCPU, 512Mi, scale-to-zero | ~$0 (pay per request) |
 | VPC Connector | f1-micro (2 instances) | ~$7 |

--- a/terraform/environments/gcp/compute.tf
+++ b/terraform/environments/gcp/compute.tf
@@ -25,6 +25,7 @@ module "compute_cloud_run" {
 
   # Access
   allow_unauthenticated = var.cloud_run_allow_unauthenticated
+  ingress               = var.cloud_run_ingress
 
   # Database connection
   database_host               = module.database.private_ip_address

--- a/terraform/environments/gcp/dev.tfvars.example
+++ b/terraform/environments/gcp/dev.tfvars.example
@@ -29,6 +29,9 @@ cloud_run_min_instances         = 0
 cloud_run_max_instances         = 10
 cloud_run_request_timeout       = 300
 cloud_run_allow_unauthenticated = true
+# Dev runs without the external HTTPS LB (`enable_cdn = false` below), so
+# the *.run.app URL must accept direct traffic — override the secure default.
+cloud_run_ingress = "INGRESS_TRAFFIC_ALL"
 
 # GKE settings (when compute_platform = "gke")
 # gke_node_count        = 1

--- a/terraform/environments/gcp/github-dev.tfvars
+++ b/terraform/environments/gcp/github-dev.tfvars
@@ -24,6 +24,9 @@ cloud_run_min_instances         = 0
 cloud_run_max_instances         = 10
 cloud_run_request_timeout       = 300
 cloud_run_allow_unauthenticated = true
+# github-dev runs without the external HTTPS LB (`enable_cdn = false`), so
+# the *.run.app URL must accept direct traffic — override the secure default.
+cloud_run_ingress = "INGRESS_TRAFFIC_ALL"
 
 # ==============================================
 # Database (Cloud SQL PostgreSQL)

--- a/terraform/environments/gcp/github-prod.tfvars
+++ b/terraform/environments/gcp/github-prod.tfvars
@@ -24,6 +24,12 @@ cloud_run_min_instances         = 2
 cloud_run_max_instances         = 50
 cloud_run_request_timeout       = 300
 cloud_run_allow_unauthenticated = true
+# Prod still has `enable_cdn = false` — the LB stack lands separately.
+# Until then, override the secure default so the *.run.app URL stays reachable.
+# When `enable_cdn` flips to `true`, drop this override (or set
+# `INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER` explicitly) to lock direct access
+# out and force all traffic through Cloud Armor's WAF.
+cloud_run_ingress = "INGRESS_TRAFFIC_ALL"
 
 # ==============================================
 # Database (Cloud SQL PostgreSQL)

--- a/terraform/environments/gcp/github-staging.tfvars
+++ b/terraform/environments/gcp/github-staging.tfvars
@@ -24,6 +24,11 @@ cloud_run_min_instances         = 1
 cloud_run_max_instances         = 10
 cloud_run_request_timeout       = 300
 cloud_run_allow_unauthenticated = true
+# Staging keeps `enable_cdn = false` for now — the LB stack lands separately.
+# Until then, override the secure default so the *.run.app URL stays reachable.
+# When `enable_cdn` flips to `true`, drop this override (or set
+# `INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER` explicitly) to lock direct access out.
+cloud_run_ingress = "INGRESS_TRAFFIC_ALL"
 
 # ==============================================
 # Database (Cloud SQL PostgreSQL)

--- a/terraform/environments/gcp/variables.tf
+++ b/terraform/environments/gcp/variables.tf
@@ -238,15 +238,52 @@ variable "cloud_run_allow_unauthenticated" {
     bundled frontend hitting the Cloud Run URL directly without an HTTPS
     load balancer in front.
 
-    NOTE: For production, prefer `false` plus an external HTTPS load
-    balancer with Cloud Armor (see `cloud_run_ingress` semantics in the
-    cloud-run module). The current default does not flip the module's
-    `ingress` default to `INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER` because
-    the supporting LB is not provisioned by this environment yet — when
-    that lands, this default and the ingress default should move together.
+    For production, prefer `false` plus the external HTTPS load balancer
+    with Cloud Armor in front (see `cloud_run_ingress` and `enable_cdn`).
+    The two defences are complementary: `allow_unauthenticated = false`
+    closes the IAM door, `cloud_run_ingress = "..._INTERNAL_LOAD_BALANCER"`
+    closes the network door so a misconfigured `roles/run.invoker` binding
+    on `allUsers` can't blow it open.
   EOT
   type        = bool
   default     = false
+}
+
+variable "cloud_run_ingress" {
+  description = <<-EOT
+    Cloud Run ingress traffic restriction. Controls which network paths
+    can reach the *.run.app URL. Accepted values:
+
+    - `INGRESS_TRAFFIC_ALL` — public internet can hit the *.run.app URL
+      directly. Use only when no HTTPS load balancer fronts the service
+      (typically dev / preview environments with `enable_cdn = false`).
+    - `INGRESS_TRAFFIC_INTERNAL_ONLY` — only VPC-internal traffic; the
+      *.run.app URL is unreachable from outside the project. Useful for
+      service-to-service back-ends with no external consumers.
+    - `INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER` — VPC-internal traffic
+      AND the external HTTPS load balancer (i.e. `enable_cdn = true`,
+      which provisions the Serverless NEG + Cloud Armor backend). The
+      *.run.app URL returns 403 to direct callers; only requests that
+      come through the LB (and therefore Cloud Armor's WAF rules) reach
+      the service.
+
+    The default is `INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER` (defence-in-
+    depth) — pair it with `allow_unauthenticated = false` so neither the
+    network nor the IAM door is open by accident. Environments that
+    don't yet provision the LB (`enable_cdn = false`) MUST override to
+    `INGRESS_TRAFFIC_ALL` or the service becomes unreachable.
+  EOT
+  type        = string
+  default     = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
+
+  validation {
+    condition = contains([
+      "INGRESS_TRAFFIC_ALL",
+      "INGRESS_TRAFFIC_INTERNAL_ONLY",
+      "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER",
+    ], var.cloud_run_ingress)
+    error_message = "cloud_run_ingress must be one of INGRESS_TRAFFIC_ALL, INGRESS_TRAFFIC_INTERNAL_ONLY, INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER."
+  }
 }
 
 # ==============================================


### PR DESCRIPTION
## Summary

Closes the defence-in-depth gap called out in #51: the env never plumbed the cloud-run module's `ingress` setting through, so the *.run.app URL was implicitly `INGRESS_TRAFFIC_ALL`. This PR adds a new env-level `cloud_run_ingress` variable, plumbs it into `module.compute_cloud_run`, and ships a secure-by-default `INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER`. Pairs with the existing `cloud_run_allow_unauthenticated = false` default so the IAM door and the network door are both closed by default.

- New `cloud_run_ingress` variable in `terraform/environments/gcp/variables.tf` with a `validation` block (typos fail at plan time, not apply time).
- Wired through `compute.tf` to `module.compute_cloud_run.ingress`.
- Variable godoc rewritten — drops the "deferred / supporting LB not provisioned yet" language; spells out the three accepted values, the IAM <-> network defence-in-depth pairing, and the `enable_cdn` gating.
- New "Security: Cloud Run ingress" section in `terraform/environments/gcp/README.md` with a `gcloud run services describe` verification recipe.

## Pre-flight findings

The frontend LB module (`terraform/modules/frontend/gcp/main.tf`) is **fully wired**:

- `google_compute_region_network_endpoint_group.cloudrun` (Serverless NEG -> Cloud Run service) — line 26.
- `google_compute_backend_service.cloudrun` with `security_policy = google_compute_security_policy.frontend[0].id` — line 63.
- `google_compute_security_policy.frontend` with rate-limiting / XSS / SQLi rules — line 182.

So flipping the env default lands cleanly **for any environment that enables the LB**.

**However**, every shipped tfvar still has `enable_cdn = false`, so the LB module is not instantiated today. Flipping `cloud_run_ingress` to `INTERNAL_LOAD_BALANCER` without an override would make the *.run.app URL unreachable.

## Tfvar override coverage

Every shipped tfvar explicitly overrides `cloud_run_ingress = "INGRESS_TRAFFIC_ALL"` so no current deployment breaks:

- `dev.tfvars.example`
- `github-dev.tfvars`
- `github-staging.tfvars`
- `github-prod.tfvars`

When an environment flips `enable_cdn = true` (and provisions the LB + Cloud Armor + DNS), dropping the `cloud_run_ingress` override is what closes the network gate.

## Expected `terraform plan` output

For each env, expect a single in-place change on `module.compute_cloud_run[0].google_cloud_run_v2_service.main`:

```text
~ template {
    ~ annotations = {
        ~ "run.googleapis.com/ingress" = "all" -> "all"   # no change (override matches today's behaviour)
      }
  }
```

i.e. **no behavioural change** on any current env — the module input `ingress` is now passed explicitly (`"INGRESS_TRAFFIC_ALL"`) instead of falling through to the cloud-run module's default (also `"INGRESS_TRAFFIC_ALL"`). Plan should be a no-op or a noise-only attribute touch.

## Breaking-change callout

**No env breaks today.** Future risk: if a new env or tfvars file is added that sets `enable_cdn = false` but forgets to override `cloud_run_ingress`, the *.run.app URL becomes unreachable. The README "Security" section + variable godoc both call this out, and the validation block guarantees only the three valid `INGRESS_TRAFFIC_*` strings are accepted.

## Out of scope

- Provisioning the LB stack in a real env (i.e. flipping `enable_cdn = true` + DNS + cert) — that's the follow-up that actually exercises the new secure default.
- Removing the `cloud_run_ingress` override from any tfvar (deferred until that env's LB lands).

## Refs

`Refs #51` — full closure happens once an environment flips `enable_cdn = true` (and drops the ingress override) so the secure default actually takes effect on a live deployment. Until then, this PR plumbs the variable, documents it, and ships secure-by-default.

## Test plan

- [x] `terraform fmt -recursive -check` clean.
- [x] `terraform validate` clean (with `-backend=false`).
- [ ] `terraform plan -var-file=github-dev.tfvars` shows no behavioural change on a real env.
- [ ] After merge: a follow-up enables `enable_cdn = true` on a non-prod env, drops the ingress override, and verifies `gcloud run services describe` reports `internal-and-cloud-load-balancing` and direct *.run.app calls return 403.
