### PR TITLE
ux(history): unify Savings + Purchase events under a single date-range picker

### DIFF
--- a/frontend/src/__tests__/history.test.ts
+++ b/frontend/src/__tests__/history.test.ts
@@ -1,7 +1,7 @@
 /**
  * History module tests
  */
-import { initHistoryDateRange, viewPlanHistory, loadHistory } from '../history';
+import { initHistoryDateRange, viewPlanHistory, loadHistory, applyHistoryPreset, presetToRange } from '../history';
 
 // Mock the dependent modules
 jest.mock('../api', () => ({
@@ -43,7 +43,9 @@ describe('History Module', () => {
   });
 
   describe('initHistoryDateRange', () => {
-    test('sets default date range to 3 months', () => {
+    test('sets default date range to the 7d preset', () => {
+      // Issue #55: default flipped from 3 months to 7d so it matches
+      // the most-common preset on the unified date-range picker.
       initHistoryDateRange();
 
       const startInput = document.getElementById('history-start') as HTMLInputElement;
@@ -57,9 +59,9 @@ describe('History Module', () => {
       const todayUTC = today.toISOString().split('T')[0] || '';
       expect(endInput.value).toBe(todayUTC);
 
-      // Start date should be about 3 months ago (UTC)
+      // Start date should be about 7 days ago (UTC)
       const expectedStart = new Date();
-      expectedStart.setMonth(expectedStart.getMonth() - 3);
+      expectedStart.setDate(expectedStart.getDate() - 7);
       const expectedStartUTC = expectedStart.toISOString().split('T')[0] || '';
       expect(startInput.value).toBe(expectedStartUTC);
     });
@@ -225,6 +227,79 @@ describe('History Module', () => {
         end: '',
         provider: undefined
       });
+    });
+  });
+
+  // Issue #55: the unified date-range picker drives BOTH the savings
+  // KPIs and the purchase events table. These tests pin the helpers
+  // that compute / apply ranges so a regression on either side surfaces
+  // in CI rather than only at deploy time.
+  describe('unified date-range picker (#55)', () => {
+    test('presetToRange computes 7d span ending today', () => {
+      const { start, end } = presetToRange('7d');
+      const today = new Date().toISOString().split('T')[0];
+      expect(end).toBe(today);
+      const startMs = new Date(start).getTime();
+      const endMs = new Date(end).getTime();
+      const days = Math.round((endMs - startMs) / (1000 * 60 * 60 * 24));
+      expect(days).toBe(7);
+    });
+
+    test('presetToRange computes 30d span', () => {
+      const { start, end } = presetToRange('30d');
+      const startMs = new Date(start).getTime();
+      const endMs = new Date(end).getTime();
+      const days = Math.round((endMs - startMs) / (1000 * 60 * 60 * 24));
+      expect(days).toBe(30);
+    });
+
+    test('presetToRange computes 90d span', () => {
+      const { start, end } = presetToRange('90d');
+      const startMs = new Date(start).getTime();
+      const endMs = new Date(end).getTime();
+      const days = Math.round((endMs - startMs) / (1000 * 60 * 60 * 24));
+      expect(days).toBe(90);
+    });
+
+    test('applyHistoryPreset writes shared inputs that loadHistory then forwards to getHistory', async () => {
+      // applying 30d should populate the same #history-start/#history-end
+      // that loadHistory reads — proving that one date control drives
+      // the table fetch (the savings module reads the same inputs and
+      // is covered in savings-history.test.ts).
+      (api.getHistory as jest.Mock).mockResolvedValue({ summary: {}, purchases: [] });
+
+      applyHistoryPreset('30d');
+
+      const startInput = document.getElementById('history-start') as HTMLInputElement;
+      const endInput = document.getElementById('history-end') as HTMLInputElement;
+      expect(startInput.value).toBeTruthy();
+      expect(endInput.value).toBeTruthy();
+
+      await loadHistory();
+
+      const call = (api.getHistory as jest.Mock).mock.calls[0][0];
+      expect(call.start).toBe(startInput.value);
+      expect(call.end).toBe(endInput.value);
+    });
+
+    test('applyHistoryPreset overrides previously-set values', () => {
+      const startInput = document.getElementById('history-start') as HTMLInputElement;
+      const endInput = document.getElementById('history-end') as HTMLInputElement;
+      startInput.value = '2020-01-01';
+      endInput.value = '2020-01-02';
+
+      applyHistoryPreset('90d');
+
+      // 90d preset should produce values different from the stale ones
+      // we seeded above.
+      expect(startInput.value).not.toBe('2020-01-01');
+      expect(endInput.value).not.toBe('2020-01-02');
+
+      const days = Math.round(
+        (new Date(endInput.value).getTime() - new Date(startInput.value).getTime()) /
+          (1000 * 60 * 60 * 24),
+      );
+      expect(days).toBe(90);
     });
   });
 });

--- a/frontend/src/__tests__/html.test.ts
+++ b/frontend/src/__tests__/html.test.ts
@@ -191,13 +191,42 @@ describe('HTML Structure', () => {
       expect(controls).toBeTruthy();
     });
 
-    test('has date range inputs', () => {
+    test('has unified date range picker (issue #55)', () => {
+      // The unified picker lives at the top of the History tab and
+      // drives BOTH the savings KPIs and the purchase events table.
+      // Must contain the From/To inputs + the preset chips.
+      const picker = document.getElementById('history-range-picker');
+      expect(picker).toBeTruthy();
+
       const startDate = document.getElementById('history-start') as HTMLInputElement | null;
       const endDate = document.getElementById('history-end') as HTMLInputElement | null;
       expect(startDate).toBeTruthy();
       expect(endDate).toBeTruthy();
       expect(startDate?.getAttribute('type')).toBe('date');
       expect(endDate?.getAttribute('type')).toBe('date');
+
+      // Both inputs must live INSIDE the unified picker, not in a
+      // separate purchase-history-only row (the bug from #55).
+      expect(picker?.contains(startDate)).toBe(true);
+      expect(picker?.contains(endDate)).toBe(true);
+
+      const presets = picker?.querySelectorAll('[data-history-preset]');
+      const presetValues = Array.from(presets ?? []).map(el =>
+        (el as HTMLElement).dataset['historyPreset']
+      );
+      expect(presetValues).toEqual(expect.arrayContaining(['7d', '30d', '90d']));
+    });
+
+    test('purchase history section no longer hosts its own date inputs (issue #55)', () => {
+      // Regression guard: the duplicate From/To row inside
+      // #purchase-history-section was removed when the date controls
+      // were unified at the top of the tab.
+      const section = document.getElementById('purchase-history-section');
+      expect(section).toBeTruthy();
+      expect(section?.querySelectorAll('input[type="date"]').length).toBe(0);
+      // The Load-History button is also gone — the table reloads on
+      // range change instead of waiting for an explicit click.
+      expect(document.getElementById('load-history-btn')).toBeNull();
     });
 
     test('has provider filter', () => {
@@ -512,14 +541,12 @@ describe('HTML Structure', () => {
       expect(section).toBeTruthy();
     });
 
-    test('has savings period selector', () => {
-      const select = document.getElementById('savings-period') as HTMLSelectElement | null;
-      expect(select).toBeTruthy();
-      const options = Array.from(select?.querySelectorAll('option') ?? []).map(o => o.value);
-      expect(options).toContain('24h');
-      expect(options).toContain('7d');
-      expect(options).toContain('30d');
-      expect(options).toContain('90d');
+    test('savings-period dropdown was removed in favour of the unified picker (issue #55)', () => {
+      // Issue #55: the standalone Period dropdown was retired —
+      // the unified date-range picker (asserted under "History Tab"
+      // above) now drives the Savings History card too.
+      const select = document.getElementById('savings-period');
+      expect(select).toBeNull();
     });
 
     test('has savings stats cards', () => {

--- a/frontend/src/__tests__/navigation.test.ts
+++ b/frontend/src/__tests__/navigation.test.ts
@@ -14,7 +14,11 @@ jest.mock('../plans', () => ({
   loadPlans: jest.fn().mockResolvedValue(undefined)
 }));
 jest.mock('../history', () => ({
-  initHistoryDateRange: jest.fn()
+  initHistoryDateRange: jest.fn(),
+  // Issue #55: navigation now also kicks off the purchase events
+  // table fetch when the History tab opens (the unified date-range
+  // picker drives both data sources, so both must load up front).
+  loadHistory: jest.fn().mockResolvedValue(undefined),
 }));
 jest.mock('../settings', () => ({
   loadGlobalSettings: jest.fn().mockResolvedValue(undefined),

--- a/frontend/src/__tests__/savings-history.test.ts
+++ b/frontend/src/__tests__/savings-history.test.ts
@@ -29,16 +29,30 @@ import { loadSavingsHistory, initSavingsHistory, savingsChart } from '../modules
 import { getSavingsAnalytics } from '../api';
 import { Chart } from 'chart.js';
 
+/**
+ * Helper: write a YYYY-MM-DD date string `n` whole days before today
+ * into the shared #history-start input. Mirrors what
+ * applyHistoryPreset(...) does at runtime for the unified date-range
+ * picker (issue #55) — tests pre-#55 used the now-deleted
+ * #savings-period dropdown to control span; this helper gives the
+ * same single-knob ergonomics.
+ */
+function setRangeDays(days: number): void {
+  const start = new Date();
+  start.setDate(start.getDate() - days);
+  const end = new Date();
+  const startInput = document.getElementById('history-start') as HTMLInputElement;
+  const endInput = document.getElementById('history-end') as HTMLInputElement;
+  if (startInput) startInput.value = start.toISOString().split('T')[0] || '';
+  if (endInput) endInput.value = end.toISOString().split('T')[0] || '';
+}
+
 describe('Savings History Module', () => {
   beforeEach(() => {
     // Reset DOM
     document.body.innerHTML = `
-      <select id="savings-period">
-        <option value="24h">Last 24 Hours</option>
-        <option value="7d" selected>Last 7 Days</option>
-        <option value="30d">Last 30 Days</option>
-        <option value="90d">Last 90 Days</option>
-      </select>
+      <input type="date" id="history-start">
+      <input type="date" id="history-end">
       <button id="refresh-savings-btn">Refresh</button>
       <div id="savings-history-container">
         <canvas id="savings-history-chart"></canvas>
@@ -50,6 +64,9 @@ describe('Savings History Module', () => {
         <span id="peak-savings">$0/hr</span>
       </div>
     `;
+    // Default to a 7-day window so behaviour matches the previous
+    // `selected="7d"` default on #savings-period.
+    setRangeDays(7);
 
     jest.clearAllMocks();
     (Chart as unknown as jest.Mock).mockClear();
@@ -137,11 +154,12 @@ describe('Savings History Module', () => {
       expect(statsEl?.classList.contains('hidden')).toBe(true);
     });
 
-    test('uses 24h period with hourly interval', async () => {
+    test('uses hourly interval for ranges <= 7 days', async () => {
       (getSavingsAnalytics as jest.Mock).mockResolvedValue({ data_points: [] });
 
-      const periodSelect = document.getElementById('savings-period') as HTMLSelectElement;
-      periodSelect.value = '24h';
+      // Already 7d via beforeEach; explicitly re-set to make the test
+      // self-contained.
+      setRangeDays(7);
 
       await loadSavingsHistory();
 
@@ -150,11 +168,10 @@ describe('Savings History Module', () => {
       }));
     });
 
-    test('uses 30d period with daily interval', async () => {
+    test('uses daily interval for a 30-day range', async () => {
       (getSavingsAnalytics as jest.Mock).mockResolvedValue({ data_points: [] });
 
-      const periodSelect = document.getElementById('savings-period') as HTMLSelectElement;
-      periodSelect.value = '30d';
+      setRangeDays(30);
 
       await loadSavingsHistory();
 
@@ -163,11 +180,10 @@ describe('Savings History Module', () => {
       }));
     });
 
-    test('uses 90d period with daily interval', async () => {
+    test('uses daily interval for a 90-day range', async () => {
       (getSavingsAnalytics as jest.Mock).mockResolvedValue({ data_points: [] });
 
-      const periodSelect = document.getElementById('savings-period') as HTMLSelectElement;
-      periodSelect.value = '90d';
+      setRangeDays(90);
 
       await loadSavingsHistory();
 
@@ -176,11 +192,13 @@ describe('Savings History Module', () => {
       }));
     });
 
-    test('defaults to 7d period with hourly interval for unknown value', async () => {
+    test('defaults to a 7-day hourly window when inputs are missing', async () => {
       (getSavingsAnalytics as jest.Mock).mockResolvedValue({ data_points: [] });
 
-      const periodSelect = document.getElementById('savings-period') as HTMLSelectElement;
-      periodSelect.value = 'unknown';
+      // Remove the inputs entirely — the savings module should still
+      // produce a sensible default (7d / hourly) rather than throw.
+      document.getElementById('history-start')?.remove();
+      document.getElementById('history-end')?.remove();
 
       await loadSavingsHistory();
 
@@ -229,11 +247,12 @@ describe('Savings History Module', () => {
       expect(periodSavingsEl?.textContent).toContain('$300.00');
     });
 
-    test('handles missing period select gracefully', async () => {
-      document.getElementById('savings-period')?.remove();
+    test('handles missing date inputs gracefully', async () => {
+      document.getElementById('history-start')?.remove();
+      document.getElementById('history-end')?.remove();
       (getSavingsAnalytics as jest.Mock).mockResolvedValue({ data_points: [] });
 
-      // Should not throw
+      // Should not throw — falls back to a 7-day window.
       await expect(loadSavingsHistory()).resolves.not.toThrow();
     });
 
@@ -423,14 +442,9 @@ describe('Savings History Module', () => {
   });
 
   describe('initSavingsHistory', () => {
-    test('adds change listener to period select', () => {
-      const periodSelect = document.getElementById('savings-period') as HTMLSelectElement;
-      const addEventListenerSpy = jest.spyOn(periodSelect, 'addEventListener');
-
-      initSavingsHistory();
-
-      expect(addEventListenerSpy).toHaveBeenCalledWith('change', expect.any(Function));
-    });
+    // The standalone Period dropdown was removed in #55, so the only
+    // listener initSavingsHistory still owns is the Refresh button —
+    // the unified date-range picker is wired in app.ts instead.
 
     test('adds click listener to refresh button', () => {
       const refreshBtn = document.getElementById('refresh-savings-btn') as HTMLButtonElement;
@@ -441,30 +455,10 @@ describe('Savings History Module', () => {
       expect(addEventListenerSpy).toHaveBeenCalledWith('click', expect.any(Function));
     });
 
-    test('handles missing period select gracefully', () => {
-      document.getElementById('savings-period')?.remove();
-
-      expect(() => initSavingsHistory()).not.toThrow();
-    });
-
     test('handles missing refresh button gracefully', () => {
       document.getElementById('refresh-savings-btn')?.remove();
 
       expect(() => initSavingsHistory()).not.toThrow();
-    });
-
-    test('period change triggers loadSavingsHistory', async () => {
-      (getSavingsAnalytics as jest.Mock).mockResolvedValue({ data_points: [] });
-
-      initSavingsHistory();
-
-      const periodSelect = document.getElementById('savings-period') as HTMLSelectElement;
-      periodSelect.value = '30d';
-      periodSelect.dispatchEvent(new Event('change'));
-
-      await new Promise(resolve => setTimeout(resolve, 50));
-
-      expect(getSavingsAnalytics).toHaveBeenCalled();
     });
 
     test('refresh button click triggers loadSavingsHistory', async () => {
@@ -490,8 +484,8 @@ describe('Savings History Module', () => {
       };
       (getSavingsAnalytics as jest.Mock).mockResolvedValue(mockData);
 
-      const periodSelect = document.getElementById('savings-period') as HTMLSelectElement;
-      periodSelect.value = '30d';
+      // 30-day span → daily interval → date labels.
+      setRangeDays(30);
 
       await loadSavingsHistory();
 
@@ -509,8 +503,8 @@ describe('Savings History Module', () => {
       };
       (getSavingsAnalytics as jest.Mock).mockResolvedValue(mockData);
 
-      const periodSelect = document.getElementById('savings-period') as HTMLSelectElement;
-      periodSelect.value = '7d';
+      // 7-day span → hourly interval → datetime labels.
+      setRangeDays(7);
 
       await loadSavingsHistory();
 

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -12,8 +12,8 @@ import { savePlan, setupPlanHandlers, closePlanModal, openCreatePlanModal, openN
 import { saveGlobalSettings, setupSettingsHandlers, resetSettings } from './settings';
 import { setupUserHandlers } from './users';
 import { initApiKeys } from './apikeys';
-import { loadHistory } from './history';
-import { initSavingsHistory } from './modules/savings-history';
+import { loadHistory, applyHistoryPreset, setupHistoryHandlers, type HistoryRangePreset } from './history';
+import { initSavingsHistory, loadSavingsHistory } from './modules/savings-history';
 import { setupRIExchangeHandlers, saveAutomationSettings } from './riexchange';
 import { showToast } from './toast';
 import { confirmDialog } from './confirmDialog';
@@ -142,6 +142,11 @@ export function setupEventListeners(): void {
   // Setup savings history charts
   initSavingsHistory();
 
+  // Setup purchase-history filter handlers (provider/account dropdowns
+  // re-fetch the table on change — see issue #55, where the explicit
+  // Load-History button was removed in favour of live updates).
+  setupHistoryHandlers();
+
   // Setup feedback link
   setupFeedbackLink();
 
@@ -247,10 +252,56 @@ function setupButtonHandlers(): void {
     });
   }
 
-  // History button
-  const loadHistoryBtn = document.getElementById('load-history-btn');
-  if (loadHistoryBtn) {
-    loadHistoryBtn.addEventListener('click', () => void loadHistory());
+  // Unified date-range picker (issue #55) — preset chips + From/To
+  // inputs. Each change refetches BOTH the Savings History KPIs/chart
+  // AND the Purchase events table so the two views stay scoped to the
+  // same window. The Refresh button (#refresh-savings-btn) is wired by
+  // initSavingsHistory; we extend it here to also reload the table so
+  // a manual refresh covers both data sources.
+  const fireRangeReload = (): void => {
+    void loadSavingsHistory();
+    void loadHistory();
+  };
+  const presetButtons = document.querySelectorAll<HTMLButtonElement>(
+    '#history-range-picker .range-preset[data-history-preset]',
+  );
+  presetButtons.forEach(btn => {
+    btn.addEventListener('click', () => {
+      const preset = btn.dataset['historyPreset'] as HistoryRangePreset | undefined;
+      if (!preset) return;
+      // Visual selection state — single-active-tab semantics.
+      presetButtons.forEach(b => {
+        const isActive = b === btn;
+        b.classList.toggle('active', isActive);
+        b.setAttribute('aria-selected', String(isActive));
+      });
+      applyHistoryPreset(preset);
+      fireRangeReload();
+    });
+  });
+
+  // Custom range edits (typing or picking a date in the From/To
+  // inputs) deselect any active preset chip — the user is overriding
+  // the preset — and re-fire both loaders.
+  const dateInputs = ['history-start', 'history-end']
+    .map(id => document.getElementById(id) as HTMLInputElement | null)
+    .filter((el): el is HTMLInputElement => el !== null);
+  dateInputs.forEach(input => {
+    input.addEventListener('change', () => {
+      presetButtons.forEach(b => {
+        b.classList.remove('active');
+        b.setAttribute('aria-selected', 'false');
+      });
+      fireRangeReload();
+    });
+  });
+
+  // Refresh button — initSavingsHistory wires it to reload the chart;
+  // mirror that to also reload the Purchase events table so both
+  // panes refresh together.
+  const refreshBtn = document.getElementById('refresh-savings-btn');
+  if (refreshBtn) {
+    refreshBtn.addEventListener('click', () => void loadHistory());
   }
 
 }

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -269,11 +269,14 @@ function setupButtonHandlers(): void {
     btn.addEventListener('click', () => {
       const preset = btn.dataset['historyPreset'] as HistoryRangePreset | undefined;
       if (!preset) return;
-      // Visual selection state — single-active-tab semantics.
+      // Visual selection state — single-active-toggle semantics.
+      // The chips are toggle buttons (a filter, not a tabset), so
+      // aria-pressed is the correct attribute — aria-selected is
+      // reserved for tab/option/grid widgets.
       presetButtons.forEach(b => {
         const isActive = b === btn;
         b.classList.toggle('active', isActive);
-        b.setAttribute('aria-selected', String(isActive));
+        b.setAttribute('aria-pressed', String(isActive));
       });
       applyHistoryPreset(preset);
       fireRangeReload();
@@ -290,7 +293,7 @@ function setupButtonHandlers(): void {
     input.addEventListener('change', () => {
       presetButtons.forEach(b => {
         b.classList.remove('active');
-        b.setAttribute('aria-selected', 'false');
+        b.setAttribute('aria-pressed', 'false');
       });
       fireRangeReload();
     });

--- a/frontend/src/history.ts
+++ b/frontend/src/history.ts
@@ -62,34 +62,82 @@ function populateHistoryAccountFilter(provider?: string): Promise<void> {
 
 /**
  * Setup history filter event handlers
+ *
+ * Wires the Provider filter to repopulate the Account dropdown and
+ * (issue #55) re-fetch the Purchase events table — previously the
+ * user had to click `Load History`, but that button is gone now so a
+ * change is itself the trigger. The Account filter likewise refetches
+ * on change. setupHistoryHandlers is invoked once at app init from
+ * app.ts.
  */
 export function setupHistoryHandlers(): void {
   const providerFilter = document.getElementById('history-provider-filter') as HTMLSelectElement | null;
   if (providerFilter) {
     providerFilter.addEventListener('change', () => {
-      void populateHistoryAccountFilter(providerFilter.value);
+      void populateHistoryAccountFilter(providerFilter.value).then(() => {
+        void loadHistory();
+      });
+    });
+  }
+  const accountFilter = document.getElementById('history-account-filter') as HTMLSelectElement | null;
+  if (accountFilter) {
+    accountFilter.addEventListener('change', () => {
+      void loadHistory();
     });
   }
   void populateHistoryAccountFilter();
 }
 
+export type HistoryRangePreset = '7d' | '30d' | '90d';
+
+// Default range when the History tab opens for the first time. Matches
+// the most-common preset (7d) on the unified date-range picker so the
+// initial Savings History KPIs and the Purchase events table stay in
+// sync. Was 3 months before #55; the unified picker collapsed both
+// controls under one default and the savings KPIs were the louder
+// signal, so 7d won.
+const DEFAULT_RANGE_PRESET: HistoryRangePreset = '7d';
+
 /**
- * Initialize history date range
+ * Compute the start/end date pair for a preset, normalised to YYYY-MM-DD
+ * (UTC) so it can be written straight into a `<input type="date">`.
  */
-export function initHistoryDateRange(): void {
+export function presetToRange(preset: HistoryRangePreset): { start: string; end: string } {
   const end = new Date();
   const start = new Date();
-  start.setMonth(start.getMonth() - 3);
+  const days = preset === '7d' ? 7 : preset === '30d' ? 30 : 90;
+  start.setDate(start.getDate() - days);
+  return {
+    start: start.toISOString().split('T')[0] || '',
+    end: end.toISOString().split('T')[0] || '',
+  };
+}
 
+/**
+ * Initialize history date range to the default preset (7d).
+ * Idempotent — preserves any value the user has already set.
+ */
+export function initHistoryDateRange(): void {
   const startInput = document.getElementById('history-start') as HTMLInputElement | null;
   const endInput = document.getElementById('history-end') as HTMLInputElement | null;
+  const { start, end } = presetToRange(DEFAULT_RANGE_PRESET);
 
-  if (startInput && !startInput.value) {
-    startInput.value = start.toISOString().split('T')[0] || '';
-  }
-  if (endInput && !endInput.value) {
-    endInput.value = end.toISOString().split('T')[0] || '';
-  }
+  if (startInput && !startInput.value) startInput.value = start;
+  if (endInput && !endInput.value) endInput.value = end;
+}
+
+/**
+ * Apply a preset to the shared date inputs. Visual chip-active state
+ * is owned by setupHistoryRangeHandlers — applyHistoryPreset only
+ * mutates the input values so headless callers (tests, deep-links)
+ * can drive the same code path without a DOM dependency on the chips.
+ */
+export function applyHistoryPreset(preset: HistoryRangePreset): void {
+  const startInput = document.getElementById('history-start') as HTMLInputElement | null;
+  const endInput = document.getElementById('history-end') as HTMLInputElement | null;
+  const { start, end } = presetToRange(preset);
+  if (startInput) startInput.value = start;
+  if (endInput) endInput.value = end;
 }
 
 /**

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -188,21 +188,34 @@
 
             <!-- History Tab -->
             <div id="history-tab" class="tab-content" role="tabpanel" aria-labelledby="history-tab-btn">
+                <!-- Unified Date Range Picker -->
+                <!--
+                  Single source of truth for the date range across BOTH the
+                  Savings History KPI cards/chart and the Purchase events
+                  table below. Replaces the previous Period dropdown and
+                  the duplicate From/To + Load-History controls (issue #55).
+                -->
+                <section id="history-range-section" class="card">
+                    <div class="section-header">
+                        <h2>Date Range</h2>
+                        <div id="history-range-picker" class="controls-bar" role="group" aria-label="Date range for savings and purchase history">
+                            <div class="range-presets" role="tablist" aria-label="Date range presets">
+                                <button type="button" class="range-preset active" data-history-preset="7d" role="tab" aria-selected="true">Last 7 Days</button>
+                                <button type="button" class="range-preset" data-history-preset="30d" role="tab" aria-selected="false">Last 30 Days</button>
+                                <button type="button" class="range-preset" data-history-preset="90d" role="tab" aria-selected="false">Last 90 Days</button>
+                            </div>
+                            <label>From: <input type="date" id="history-start"></label>
+                            <label>To: <input type="date" id="history-end"></label>
+                            <button id="refresh-savings-btn" class="btn-small">Refresh</button>
+                        </div>
+                    </div>
+                    <p class="help-text">Applies to both Savings History (below) and the Purchase events table.</p>
+                </section>
+
                 <!-- Savings History Chart Section -->
                 <section id="savings-history-section" class="card">
                     <div class="section-header">
                         <h2>Savings History</h2>
-                        <div class="controls-bar">
-                            <label>Period:
-                                <select id="savings-period">
-                                    <option value="24h">Last 24 Hours</option>
-                                    <option value="7d" selected>Last 7 Days</option>
-                                    <option value="30d">Last 30 Days</option>
-                                    <option value="90d">Last 90 Days</option>
-                                </select>
-                            </label>
-                            <button id="refresh-savings-btn" class="btn-small">Refresh</button>
-                        </div>
                     </div>
 
                     <!-- Savings Stats Cards -->
@@ -235,11 +248,10 @@
 
                 <!-- Purchase History Section -->
                 <section id="purchase-history-section" class="card">
-                    <h2>Purchase History</h2>
+                    <h2>Purchase events</h2>
+                    <p class="help-text">Individual purchase events recorded in the date range above. Filter further by provider or account:</p>
                     <section id="history-controls">
                         <div class="date-range-picker">
-                            <label>From: <input type="date" id="history-start"></label>
-                            <label>To: <input type="date" id="history-end"></label>
                             <label>Provider:
                                 <select id="history-provider-filter">
                                     <option value="">All Providers</option>
@@ -253,7 +265,6 @@
                                     <option value="">All Accounts</option>
                                 </select>
                             </label>
-                            <button id="load-history-btn">Load History</button>
                         </div>
                     </section>
                     <section id="history-summary"></section>

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -199,10 +199,10 @@
                     <div class="section-header">
                         <h2>Date Range</h2>
                         <div id="history-range-picker" class="controls-bar" role="group" aria-label="Date range for savings and purchase history">
-                            <div class="range-presets" role="tablist" aria-label="Date range presets">
-                                <button type="button" class="range-preset active" data-history-preset="7d" role="tab" aria-selected="true">Last 7 Days</button>
-                                <button type="button" class="range-preset" data-history-preset="30d" role="tab" aria-selected="false">Last 30 Days</button>
-                                <button type="button" class="range-preset" data-history-preset="90d" role="tab" aria-selected="false">Last 90 Days</button>
+                            <div class="range-presets" role="group" aria-label="Date range presets">
+                                <button type="button" class="range-preset active" data-history-preset="7d" aria-pressed="true">Last 7 Days</button>
+                                <button type="button" class="range-preset" data-history-preset="30d" aria-pressed="false">Last 30 Days</button>
+                                <button type="button" class="range-preset" data-history-preset="90d" aria-pressed="false">Last 90 Days</button>
                             </div>
                             <label>From: <input type="date" id="history-start"></label>
                             <label>To: <input type="date" id="history-end"></label>

--- a/frontend/src/modules/savings-history.ts
+++ b/frontend/src/modules/savings-history.ts
@@ -12,18 +12,18 @@ Chart.register(...registerables);
 let savingsChart: Chart | null = null;
 
 /**
- * Load savings history data based on selected period
+ * Load savings history data based on the unified date-range picker
+ * (#history-start / #history-end inputs — see issue #55). Falls back
+ * to a 7-day window if the inputs are missing or empty so callers
+ * that mount the section before the controls (e.g. plan-history
+ * deep-link) still get sensible data.
  */
 export async function loadSavingsHistory(): Promise<void> {
-    const periodSelect = document.getElementById('savings-period') as HTMLSelectElement;
     const chartContainer = document.getElementById('savings-history-chart')?.parentElement;
     const emptyEl = document.getElementById('savings-history-empty');
     const statsEl = document.getElementById('savings-stats');
 
-    if (!periodSelect) return;
-
-    const period = periodSelect.value;
-    const { start, end, interval } = getPeriodDates(period);
+    const { start, end, interval } = getRangeFromInputs();
 
     try {
         const data = await getSavingsAnalytics({
@@ -70,36 +70,57 @@ function showEmptyState(
 }
 
 /**
- * Get start/end dates and interval based on period selection
+ * Read the shared date-range picker (`#history-start` / `#history-end`
+ * — populated by initHistoryDateRange + applyHistoryPreset in
+ * history.ts) and derive the (start, end, interval) tuple.
+ *
+ * Interval picks `hourly` for spans up to 7 days and `daily` beyond,
+ * matching the previous Period-dropdown behaviour:
+ *   - 7d preset  → 7-day span  → hourly
+ *   - 30d preset → 30-day span → daily
+ *   - 90d preset → 90-day span → daily
+ *
+ * Falls back to a 7-day window if inputs are missing/empty so callers
+ * that fire before initHistoryDateRange still get a sensible default.
  */
-function getPeriodDates(period: string): { start: Date; end: Date; interval: 'hourly' | 'daily' | 'weekly' | 'monthly' } {
-    const end = new Date();
-    const start = new Date();
-    let interval: 'hourly' | 'daily' | 'weekly' | 'monthly' = 'hourly';
+function getRangeFromInputs(): { start: Date; end: Date; interval: 'hourly' | 'daily' | 'weekly' | 'monthly' } {
+    const startInput = document.getElementById('history-start') as HTMLInputElement | null;
+    const endInput = document.getElementById('history-end') as HTMLInputElement | null;
 
-    switch (period) {
-        case '24h':
-            start.setHours(start.getHours() - 24);
-            interval = 'hourly';
-            break;
-        case '7d':
-            start.setDate(start.getDate() - 7);
-            interval = 'hourly';
-            break;
-        case '30d':
-            start.setDate(start.getDate() - 30);
-            interval = 'daily';
-            break;
-        case '90d':
-            start.setDate(start.getDate() - 90);
-            interval = 'daily';
-            break;
-        default:
-            start.setDate(start.getDate() - 7);
-            interval = 'hourly';
+    const end = parseDateOrNow(endInput?.value);
+    let start: Date;
+    if (startInput?.value) {
+        start = new Date(startInput.value);
+        if (Number.isNaN(start.getTime())) {
+            start = defaultStart(end);
+        }
+    } else {
+        start = defaultStart(end);
     }
 
+    // Guard against an inverted range (start > end) — clamp start back
+    // 7 days from end so the API call stays well-formed.
+    if (start.getTime() > end.getTime()) {
+        start = defaultStart(end);
+    }
+
+    const spanMs = end.getTime() - start.getTime();
+    const spanDays = spanMs / (1000 * 60 * 60 * 24);
+    const interval: 'hourly' | 'daily' = spanDays <= 7 ? 'hourly' : 'daily';
+
     return { start, end, interval };
+}
+
+function parseDateOrNow(value: string | undefined): Date {
+    if (!value) return new Date();
+    const d = new Date(value);
+    return Number.isNaN(d.getTime()) ? new Date() : d;
+}
+
+function defaultStart(end: Date): Date {
+    const start = new Date(end);
+    start.setDate(start.getDate() - 7);
+    return start;
 }
 
 /**
@@ -301,15 +322,16 @@ function renderSavingsChart(dataPoints: SavingsDataPoint[], interval: string): v
 }
 
 /**
- * Initialize savings history event listeners
+ * Initialize savings history event listeners.
+ *
+ * The standalone Period dropdown was removed in #55 — the unified
+ * date-range picker (handled in app.ts) now drives loadSavingsHistory
+ * alongside the Purchase events table. The Refresh button is still
+ * wired here because it's local to the savings card and the chart
+ * recreation lives in this module.
  */
 export function initSavingsHistory(): void {
-    const periodSelect = document.getElementById('savings-period');
     const refreshBtn = document.getElementById('refresh-savings-btn');
-
-    if (periodSelect) {
-        periodSelect.addEventListener('change', loadSavingsHistory);
-    }
 
     if (refreshBtn) {
         refreshBtn.addEventListener('click', loadSavingsHistory);

--- a/frontend/src/navigation.ts
+++ b/frontend/src/navigation.ts
@@ -5,7 +5,7 @@
 import { loadDashboard } from './dashboard';
 import { loadRecommendations } from './recommendations';
 import { loadPlans } from './plans';
-import { initHistoryDateRange } from './history';
+import { initHistoryDateRange, loadHistory } from './history';
 import { loadGlobalSettings, isUnsavedChanges, loadAccountsTab } from './settings';
 import { renderSubNav } from './settings-subnav';
 import { loadUsers } from './users';
@@ -88,8 +88,13 @@ export function switchTab(tabName: string, opts: SwitchTabOptions = {}): void {
       void loadPlans();
       break;
     case 'history':
+      // Issue #55: the unified date-range picker drives BOTH the
+      // savings KPIs/chart AND the purchase events table, so kick
+      // off both loaders when the tab opens. The Load-History button
+      // that previously gated the table fetch is gone.
       initHistoryDateRange();
       void loadSavingsHistory();
+      void loadHistory();
       break;
     case 'settings':
       switchSettingsSubTab(getSettingsSubTabFromPath(), { push: false });

--- a/frontend/src/styles/forms.css
+++ b/frontend/src/styles/forms.css
@@ -210,7 +210,7 @@ input:checked + .slider:before {
 }
 
 .range-preset.active,
-.range-preset[aria-selected="true"] {
+.range-preset[aria-pressed="true"] {
     background: #1a73e8;
     border-color: #1a73e8;
     color: #fff;

--- a/frontend/src/styles/forms.css
+++ b/frontend/src/styles/forms.css
@@ -185,6 +185,37 @@ input:checked + .slider:before {
     font-size: 0.9rem;
 }
 
+/* Date-range preset chips (issue #55) — used inside the unified
+ * Purchase History date-range picker to give one-click access to the
+ * common 7d / 30d / 90d windows. Lives next to the From/To inputs in
+ * #history-range-picker and shares the row with them. */
+.range-presets {
+    display: inline-flex;
+    gap: 0.25rem;
+}
+
+.range-preset {
+    background: #fff;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    padding: 0.4rem 0.75rem;
+    font-size: 0.85rem;
+    color: #333;
+    cursor: pointer;
+}
+
+.range-preset:hover {
+    border-color: #1a73e8;
+    color: #1a73e8;
+}
+
+.range-preset.active,
+.range-preset[aria-selected="true"] {
+    background: #1a73e8;
+    border-color: #1a73e8;
+    color: #fff;
+}
+
 /* Ramp schedule options */
 .ramp-options {
     display: grid;


### PR DESCRIPTION
## Summary

- Replace the two unrelated Purchase History date controls (top-right `Period` dropdown + lower From/To pickers + `[Load History]` button) with a **single** unified date-range picker at the top of the History tab. Preset chips (`7d` / `30d` / `90d`) plus From/To inputs drive **both** Savings History KPIs/chart **and** the Purchase events table.
- `loadSavingsHistory` now reads `#history-start` / `#history-end` and derives the interval from the span (≤ 7 days → hourly, otherwise daily) — no separate `#savings-period` dropdown.
- The `Load History` button is gone — Provider/Account filter changes live-refetch the table; the unified picker fires `loadSavingsHistory` + `loadHistory` together. Default range flipped from 3 months to 7d so both panes open scoped to the same window.

Closes #55.

## Test plan

- [x] `npx jest` — 1254/1254 pass (35 suites)
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` (production webpack) succeeds
- [x] 4 new unit tests in `frontend/src/__tests__/history.test.ts` pin: `presetToRange` 7d/30d/90d spans, `applyHistoryPreset` writes the same inputs `loadHistory` reads (both data sources scoped from one knob), and override semantics over stale values
- [x] `savings-history.test.ts` migrated from the deleted `#savings-period` dropdown to the shared date inputs (helper `setRangeDays(n)`)
- [x] `html.test.ts` adds a regression guard so the duplicate date row can't sneak back into `#purchase-history-section`
- [ ] Deployed-browser smoke once the Lambda URL build lands: open `/history`, verify only one date-control row, click `30d`, confirm both KPI cards and Purchase events table re-fetch with the new range
