### PR TITLE
a11y(modals): keyboard focus trap + ESC-to-close + focus restoration

### DIFF
--- a/frontend/src/__tests__/modal.test.ts
+++ b/frontend/src/__tests__/modal.test.ts
@@ -227,6 +227,17 @@ function mountAccountModalDOM(): { trigger: HTMLButtonElement; modal: HTMLDivEle
   return { trigger, modal };
 }
 
+// Each test mounts its own DOM via buildModal/mountPlanModalDOM/
+// mountAccountModalDOM, all of which append to document.body. Reset
+// between tests so a failure mid-test doesn't leak elements (or the
+// active focus they own) into the next one. replaceChildren() rather
+// than innerHTML to keep the file free of XSS-flagged sinks (the
+// project's security hook flags any innerHTML write, even on test
+// scaffolding — see the mountPlanModalDOM comment above).
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
 describe('modal focus-trap helper', () => {
   describe('openModal', () => {
     test('removes hidden class', () => {

--- a/frontend/src/__tests__/modal.test.ts
+++ b/frontend/src/__tests__/modal.test.ts
@@ -6,7 +6,7 @@
  * engages end-to-end through the production show/hide path.
  */
 
-import { openModal, closeModal } from '../modal';
+import { openModal, closeModal, FOCUSABLE_SELECTOR } from '../modal';
 
 // ----- Mocks for the call-site integration tests -----
 // plans.openCreatePlanModal touches state and a few helpers; mock them
@@ -410,10 +410,9 @@ describe('focus trap engages on real call sites', () => {
     // Focus should be inside the modal.
     expect(modal.contains(document.activeElement)).toBe(true);
 
-    // Tab from the last focusable wraps to first.
-    const focusables = modal.querySelectorAll<HTMLElement>(
-      'a[href], button:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
-    );
+    // Tab from the last focusable wraps to first. Reuses the canonical
+    // selector exported from modal.ts so it can't drift from the impl.
+    const focusables = modal.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
     expect(focusables.length).toBeGreaterThan(1);
     const last = focusables[focusables.length - 1]!;
     const first = focusables[0]!;

--- a/frontend/src/__tests__/modal.test.ts
+++ b/frontend/src/__tests__/modal.test.ts
@@ -1,0 +1,436 @@
+/**
+ * Tests for the modal focus-trap helper (issue #56). Covers the keyboard
+ * trap, ESC-to-close, focus restoration on close, and the initialFocus
+ * option. Also exercises two representative real call sites
+ * (openCreatePlanModal + the account modal DOM) to confirm the trap
+ * engages end-to-end through the production show/hide path.
+ */
+
+import { openModal, closeModal } from '../modal';
+
+// ----- Mocks for the call-site integration tests -----
+// plans.openCreatePlanModal touches state and a few helpers; mock them
+// so the test stays focused on the focus-trap behaviour rather than
+// re-validating plan business logic.
+jest.mock('../state', () => ({
+  getSelectedRecommendationIDs: jest.fn(() => new Set()),
+  getRecommendations: jest.fn(() => []),
+}));
+jest.mock('../api', () => ({
+  listAccounts: jest.fn(() => Promise.resolve([])),
+  getConfig: jest.fn(() => Promise.resolve({})),
+}));
+jest.mock('../commitmentOptions', () => ({
+  populateTermSelect: jest.fn(),
+  populatePaymentSelect: jest.fn(),
+  isValidCombination: jest.fn(() => true),
+  normalizePaymentValue: jest.fn((v: string) => v),
+  fetchAndPopulateCommitmentOptions: jest.fn(() => Promise.resolve()),
+}));
+jest.mock('../federation', () => ({ initFederationPanel: jest.fn() }));
+jest.mock('../settings-subnav', () => ({ reflectDirtyState: jest.fn() }));
+jest.mock('../confirmDialog', () => ({ confirmDialog: jest.fn(() => Promise.resolve(true)) }));
+
+// ----- Test helpers -----
+
+function dispatchKey(target: Element, key: string, opts: KeyboardEventInit = {}): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true, ...opts });
+  target.dispatchEvent(event);
+  return event;
+}
+
+/**
+ * Build a minimal modal with three buttons + a focusable trigger
+ * outside it.
+ */
+function buildModal(): { modal: HTMLDivElement; trigger: HTMLButtonElement; first: HTMLButtonElement; mid: HTMLButtonElement; last: HTMLButtonElement } {
+  const trigger = document.createElement('button');
+  trigger.id = 'trigger';
+  trigger.textContent = 'Open';
+  document.body.appendChild(trigger);
+
+  const modal = document.createElement('div');
+  modal.id = 'm';
+  modal.className = 'modal hidden';
+  modal.setAttribute('role', 'dialog');
+  modal.setAttribute('aria-modal', 'true');
+  const first = document.createElement('button');
+  first.id = 'first';
+  first.textContent = 'first';
+  const mid = document.createElement('button');
+  mid.id = 'mid';
+  mid.textContent = 'mid';
+  const last = document.createElement('button');
+  last.id = 'last';
+  last.textContent = 'last';
+  modal.append(first, mid, last);
+  document.body.appendChild(modal);
+
+  return { modal, trigger, first, mid, last };
+}
+
+/**
+ * Build the production-shaped plan-modal DOM (subset). We use
+ * createElement rather than the innerHTML shorthand so the test file
+ * stays free of XSS-flagged sinks (the security hook flags any
+ * innerHTML write, even on test scaffolding).
+ */
+function mountPlanModalDOM(): HTMLButtonElement {
+  const trigger = document.createElement('button');
+  trigger.id = 'new-plan-btn';
+  trigger.textContent = 'New Plan';
+  document.body.appendChild(trigger);
+
+  const modal = document.createElement('div');
+  modal.id = 'plan-modal';
+  modal.className = 'modal hidden';
+  modal.setAttribute('role', 'dialog');
+  modal.setAttribute('aria-modal', 'true');
+
+  const content = document.createElement('div');
+  content.className = 'modal-content';
+
+  const h2 = document.createElement('h2');
+  h2.id = 'plan-modal-title';
+  h2.textContent = 'Create Purchase Plan';
+  content.appendChild(h2);
+
+  const form = document.createElement('form');
+  form.id = 'plan-form';
+
+  const mkInput = (id: string, type = 'text', value = ''): HTMLInputElement => {
+    const i = document.createElement('input');
+    i.type = type;
+    i.id = id;
+    if (value) i.value = value;
+    return i;
+  };
+  const mkSelect = (id: string, optValue: string, optText: string): HTMLSelectElement => {
+    const s = document.createElement('select');
+    s.id = id;
+    const opt = document.createElement('option');
+    opt.value = optValue;
+    opt.textContent = optText;
+    s.appendChild(opt);
+    return s;
+  };
+  const mkRadio = (name: string, value: string, checked = false): HTMLInputElement => {
+    const r = document.createElement('input');
+    r.type = 'radio';
+    r.name = name;
+    r.value = value;
+    r.checked = checked;
+    return r;
+  };
+
+  form.append(
+    mkInput('plan-id', 'hidden'),
+    mkInput('plan-name', 'text'),
+  );
+  const desc = document.createElement('textarea');
+  desc.id = 'plan-description';
+  form.appendChild(desc);
+  form.append(
+    mkSelect('plan-provider', 'aws', 'AWS'),
+    mkSelect('plan-service', 'ec2', 'EC2'),
+    mkSelect('plan-term', '1', '1y'),
+    mkSelect('plan-payment', 'no_upfront', 'No Upfront'),
+    mkInput('plan-coverage', 'number', '80'),
+    mkRadio('ramp-schedule', 'immediate', true),
+    mkRadio('ramp-schedule', 'custom'),
+  );
+
+  const customRamp = document.createElement('div');
+  customRamp.id = 'custom-ramp-config';
+  customRamp.append(
+    mkInput('ramp-step-percent', 'number', '20'),
+    mkInput('ramp-interval-days', 'number', '7'),
+  );
+  form.appendChild(customRamp);
+
+  form.append(
+    mkInput('plan-auto-purchase', 'checkbox'),
+    mkInput('plan-notify-days', 'number', '3'),
+    mkInput('plan-enabled', 'checkbox'),
+    mkInput('plan-account-ids', 'hidden'),
+    mkInput('plan-account-search', 'text'),
+  );
+  const suggestions = document.createElement('div');
+  suggestions.id = 'plan-account-suggestions';
+  suggestions.className = 'hidden';
+  form.appendChild(suggestions);
+  const selected = document.createElement('div');
+  selected.id = 'plan-accounts-selected';
+  form.appendChild(selected);
+
+  const submitBtn = document.createElement('button');
+  submitBtn.type = 'submit';
+  submitBtn.textContent = 'Save';
+  form.appendChild(submitBtn);
+
+  const cancelBtn = document.createElement('button');
+  cancelBtn.type = 'button';
+  cancelBtn.id = 'close-plan-modal-btn';
+  cancelBtn.textContent = 'Cancel';
+  form.appendChild(cancelBtn);
+
+  content.appendChild(form);
+  modal.appendChild(content);
+  document.body.appendChild(modal);
+
+  return trigger;
+}
+
+function mountAccountModalDOM(): { trigger: HTMLButtonElement; modal: HTMLDivElement } {
+  const trigger = document.createElement('button');
+  trigger.id = 'add-account-btn';
+  trigger.textContent = 'Add Account';
+  document.body.appendChild(trigger);
+
+  const modal = document.createElement('div');
+  modal.id = 'account-modal';
+  modal.className = 'modal hidden';
+  modal.setAttribute('role', 'dialog');
+  modal.setAttribute('aria-modal', 'true');
+
+  const content = document.createElement('div');
+  content.className = 'modal-content';
+
+  const h2 = document.createElement('h2');
+  h2.id = 'account-modal-title';
+  h2.textContent = 'Add Account';
+  content.appendChild(h2);
+
+  const form = document.createElement('form');
+  form.id = 'account-form';
+  const idInput = document.createElement('input');
+  idInput.type = 'hidden';
+  idInput.id = 'account-id';
+  const nameInput = document.createElement('input');
+  nameInput.type = 'text';
+  nameInput.id = 'account-name';
+  const externalIdInput = document.createElement('input');
+  externalIdInput.type = 'text';
+  externalIdInput.id = 'account-external-id';
+  const submit = document.createElement('button');
+  submit.type = 'submit';
+  submit.textContent = 'Save';
+  const cancel = document.createElement('button');
+  cancel.type = 'button';
+  cancel.id = 'close-account-modal-btn';
+  cancel.textContent = 'Cancel';
+  form.append(idInput, nameInput, externalIdInput, submit, cancel);
+  content.appendChild(form);
+  modal.appendChild(content);
+  document.body.appendChild(modal);
+
+  return { trigger, modal };
+}
+
+describe('modal focus-trap helper', () => {
+  describe('openModal', () => {
+    test('removes hidden class', () => {
+      const { modal } = buildModal();
+      openModal(modal);
+      expect(modal.classList.contains('hidden')).toBe(false);
+    });
+
+    test('focuses first focusable when no initialFocus is given', () => {
+      const { modal, first } = buildModal();
+      openModal(modal);
+      expect(document.activeElement).toBe(first);
+    });
+
+    test('honours initialFocus option (HTMLElement)', () => {
+      const { modal, mid } = buildModal();
+      openModal(modal, { initialFocus: mid });
+      expect(document.activeElement).toBe(mid);
+    });
+
+    test('honours initialFocus option (selector string)', () => {
+      const { modal, last } = buildModal();
+      openModal(modal, { initialFocus: '#last' });
+      expect(document.activeElement).toBe(last);
+    });
+  });
+
+  describe('focus trap', () => {
+    test('Tab from last focusable wraps to first', () => {
+      const { modal, first, last } = buildModal();
+      openModal(modal);
+      last.focus();
+      expect(document.activeElement).toBe(last);
+
+      const evt = dispatchKey(last, 'Tab');
+      expect(evt.defaultPrevented).toBe(true);
+      expect(document.activeElement).toBe(first);
+    });
+
+    test('Shift+Tab from first focusable wraps to last', () => {
+      const { modal, first, last } = buildModal();
+      openModal(modal);
+      first.focus();
+      expect(document.activeElement).toBe(first);
+
+      const evt = dispatchKey(first, 'Tab', { shiftKey: true });
+      expect(evt.defaultPrevented).toBe(true);
+      expect(document.activeElement).toBe(last);
+    });
+
+    test('Tab in the middle is allowed through (browser handles native focus advance)', () => {
+      const { modal, first } = buildModal();
+      openModal(modal);
+      first.focus();
+
+      const evt = dispatchKey(first, 'Tab');
+      // We only intercept at the edges; mid-stream Tab is the browser's
+      // job, so the helper must not preventDefault here.
+      expect(evt.defaultPrevented).toBe(false);
+    });
+
+    test('focus that escaped the modal subtree is pulled back on Tab', () => {
+      const { modal, first, trigger } = buildModal();
+      openModal(modal);
+      // Simulate focus escaping (e.g. user clicked outside the modal).
+      trigger.focus();
+      expect(document.activeElement).toBe(trigger);
+
+      // The keydown still has to arrive on the modal for the trap to
+      // fire — that's the point of attaching the listener to the modal
+      // root, so dispatch the event on the modal here.
+      const evt = dispatchKey(modal, 'Tab');
+      expect(evt.defaultPrevented).toBe(true);
+      expect(document.activeElement).toBe(first);
+    });
+  });
+
+  describe('Escape', () => {
+    test('Escape calls closeModal (modal becomes hidden)', () => {
+      const { modal } = buildModal();
+      openModal(modal);
+      expect(modal.classList.contains('hidden')).toBe(false);
+
+      const evt = dispatchKey(modal, 'Escape');
+      expect(evt.defaultPrevented).toBe(true);
+      expect(modal.classList.contains('hidden')).toBe(true);
+    });
+
+    test('non-Escape, non-Tab keys are ignored', () => {
+      const { modal, first } = buildModal();
+      openModal(modal);
+      first.focus();
+
+      const evt = dispatchKey(first, 'a');
+      expect(evt.defaultPrevented).toBe(false);
+      expect(modal.classList.contains('hidden')).toBe(false);
+    });
+  });
+
+  describe('focus restoration', () => {
+    test('focus returns to the trigger on close', () => {
+      const { modal, trigger } = buildModal();
+      trigger.focus();
+      expect(document.activeElement).toBe(trigger);
+
+      openModal(modal);
+      expect(document.activeElement).not.toBe(trigger);
+
+      closeModal(modal);
+      expect(document.activeElement).toBe(trigger);
+    });
+
+    test('skips restoration when the trigger has been removed from the DOM', () => {
+      const { modal, trigger } = buildModal();
+      trigger.focus();
+      openModal(modal);
+      // Simulate the trigger being unmounted while the modal was open.
+      trigger.remove();
+      // No throw, no jump anywhere weird — focus stays on whatever the
+      // browser fell back to (jsdom: body).
+      expect(() => closeModal(modal)).not.toThrow();
+      expect(modal.classList.contains('hidden')).toBe(true);
+    });
+  });
+
+  describe('teardown', () => {
+    test('keydown handler is removed on close — Escape after close is a no-op', () => {
+      const { modal } = buildModal();
+      openModal(modal);
+      closeModal(modal);
+      expect(modal.classList.contains('hidden')).toBe(true);
+
+      // Re-add to a clean state so we can observe whether the listener
+      // is still wired.
+      modal.classList.remove('hidden');
+      const evt = dispatchKey(modal, 'Escape');
+      expect(evt.defaultPrevented).toBe(false);
+      // The class stays as we left it — the trap didn't re-hide it.
+      expect(modal.classList.contains('hidden')).toBe(false);
+    });
+
+    test('opening twice on the same element does not stack listeners', () => {
+      const { modal, trigger } = buildModal();
+      trigger.focus();
+      openModal(modal);
+      // Snapshot whatever ended up focused after the first open — that
+      // becomes the trigger recorded by the second open() call.
+      const intermediate = document.activeElement as HTMLElement;
+      openModal(modal);
+      closeModal(modal);
+      expect(document.activeElement).toBe(intermediate);
+    });
+  });
+});
+
+// ----- Call-site integration tests -----
+
+describe('focus trap engages on real call sites', () => {
+  test('openNewPlanModal — opens modal, traps focus, ESC closes', async () => {
+    const trigger = mountPlanModalDOM();
+    trigger.focus();
+
+    // Lazy-import so the jest.mock setup at top-of-file is in effect.
+    const plans = await import('../plans');
+    plans.openNewPlanModal();
+
+    const modal = document.getElementById('plan-modal') as HTMLDivElement;
+    expect(modal.classList.contains('hidden')).toBe(false);
+
+    // Focus should be inside the modal.
+    expect(modal.contains(document.activeElement)).toBe(true);
+
+    // Tab from the last focusable wraps to first.
+    const focusables = modal.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+    );
+    expect(focusables.length).toBeGreaterThan(1);
+    const last = focusables[focusables.length - 1]!;
+    const first = focusables[0]!;
+    last.focus();
+    dispatchKey(last, 'Tab');
+    expect(document.activeElement).toBe(first);
+
+    // ESC closes and restores focus to the trigger.
+    dispatchKey(modal, 'Escape');
+    expect(modal.classList.contains('hidden')).toBe(true);
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  test('account modal — openModal directly engages trap on the same DOM shape', () => {
+    const { trigger, modal } = mountAccountModalDOM();
+    trigger.focus();
+
+    // The settings.openCreateAccountModal flow does provider-specific
+    // population we don't need to re-execute here — the contract under
+    // test is "openModal is what the call site uses", which we
+    // exercise by calling it the same way settings.ts now does.
+    openModal(modal);
+    expect(modal.classList.contains('hidden')).toBe(false);
+    expect(modal.contains(document.activeElement)).toBe(true);
+
+    // ESC closes and restores focus.
+    dispatchKey(modal, 'Escape');
+    expect(modal.classList.contains('hidden')).toBe(true);
+    expect(document.activeElement).toBe(trigger);
+  });
+});

--- a/frontend/src/apikeys.ts
+++ b/frontend/src/apikeys.ts
@@ -7,6 +7,7 @@ import type { APIKeyInfo, CreateAPIKeyResponse } from './types';
 import { formatDateTime } from './utils';
 import { confirmDialog } from './confirmDialog';
 import { showToast } from './toast';
+import { openModal, closeModal } from './modal';
 
 // State for modal management
 let currentApiKeys: APIKeyInfo[] = [];
@@ -133,7 +134,7 @@ export function showCreateKeyModal(): void {
   if (expiresCheckbox) expiresCheckbox.checked = false;
   if (expiresAtField) expiresAtField.classList.add('hidden');
 
-  modal.classList.remove('hidden');
+  openModal(modal);
 }
 
 /**
@@ -141,7 +142,7 @@ export function showCreateKeyModal(): void {
  */
 export function closeCreateKeyModal(): void {
   const modal = document.getElementById('create-apikey-modal');
-  if (modal) modal.classList.add('hidden');
+  if (modal) closeModal(modal);
 }
 
 /**
@@ -240,7 +241,7 @@ export function showKeyCreatedModal(apiKey: string): void {
   `;
 
   document.body.appendChild(modal);
-  modal.classList.remove('hidden');
+  openModal(modal);
 
   // Setup copy button
   const copyBtn = document.getElementById('copy-apikey-btn');
@@ -260,10 +261,13 @@ export function showKeyCreatedModal(apiKey: string): void {
     });
   }
 
-  // Setup close button
+  // Setup close button. closeModal first so the focus trap is torn
+  // down and focus is restored to the original trigger; then remove
+  // the dynamically-injected element from the DOM.
   const closeBtn = document.getElementById('close-apikey-created-btn');
   if (closeBtn) {
     closeBtn.addEventListener('click', () => {
+      closeModal(modal);
       modal.remove();
     });
   }

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -18,6 +18,7 @@ import { setupRIExchangeHandlers, saveAutomationSettings } from './riexchange';
 import { showToast } from './toast';
 import { confirmDialog } from './confirmDialog';
 import { handlePurchaseDeeplink } from './purchases-deeplink';
+import { closeModal } from './modal';
 
 /**
  * Initialize app
@@ -205,7 +206,7 @@ function setupButtonHandlers(): void {
   if (closeSelectRecsBtn) {
     closeSelectRecsBtn.addEventListener('click', () => {
       const modal = document.getElementById('select-recommendations-modal');
-      if (modal) modal.classList.add('hidden');
+      if (modal) closeModal(modal);
     });
   }
 

--- a/frontend/src/auth.ts
+++ b/frontend/src/auth.ts
@@ -5,6 +5,7 @@
 import * as api from './api';
 import * as state from './state';
 import { escapeHtml } from './utils';
+import { openModal, closeModal } from './modal';
 
 // Login rate limiting
 let lastLoginAttempt = 0;
@@ -693,14 +694,15 @@ async function openProfileModal(): Promise<void> {
   (document.getElementById('profile-confirm-password') as HTMLInputElement).value = '';
 
   // Show modal
-  modal.classList.remove('hidden');
+  openModal(modal);
 }
 
 /**
  * Close profile modal
  */
 function closeProfileModal(): void {
-  document.getElementById('profile-modal')?.classList.add('hidden');
+  const modal = document.getElementById('profile-modal');
+  if (modal) closeModal(modal);
 }
 
 /**

--- a/frontend/src/groups/groupModals.ts
+++ b/frontend/src/groups/groupModals.ts
@@ -8,6 +8,7 @@ import { currentEditingGroup, setCurrentEditingGroup } from './state';
 import { availableGroups } from '../users/state';
 import { escapeHtml, showError, showSuccess } from '../users/utils';
 import { loadUsers } from '../users/userActions';
+import { openModal, closeModal } from '../modal';
 
 // Module-level state for the duplicate modal — holds the source group so
 // saveDuplicateGroup doesn't need another lookup.
@@ -34,7 +35,7 @@ export function openCreateGroupModal(): void {
     permissionsList.innerHTML = '';
   }
 
-  modal.classList.remove('hidden');
+  openModal(modal);
 }
 
 /**
@@ -59,7 +60,7 @@ export async function openEditGroupModal(groupId: string): Promise<void> {
     // Render existing permissions
     renderPermissions(group.permissions);
 
-    modal.classList.remove('hidden');
+    openModal(modal);
   } catch (error) {
     console.error('Failed to load group:', error);
     showError('Failed to load group details');
@@ -72,7 +73,7 @@ export async function openEditGroupModal(groupId: string): Promise<void> {
 export function closeGroupModal(): void {
   const modal = document.getElementById('group-modal');
   if (modal) {
-    modal.classList.add('hidden');
+    closeModal(modal);
   }
   setCurrentEditingGroup(null);
 }
@@ -395,7 +396,7 @@ export async function openDuplicateGroupModal(groupId: string): Promise<void> {
     if (accountsList) renderDuplicateAccountsList(accountsList, accounts);
     if (providerFilter && accountsList) renderDuplicateProviderPills(providerFilter, accountsList);
 
-    modal.classList.remove('hidden');
+    openModal(modal);
   } catch (error) {
     console.error('Failed to open duplicate group modal:', error);
     showError('Failed to load group details');
@@ -407,7 +408,7 @@ export async function openDuplicateGroupModal(groupId: string): Promise<void> {
  */
 export function closeDuplicateGroupModal(): void {
   const modal = document.getElementById('group-duplicate-modal');
-  if (modal) modal.classList.add('hidden');
+  if (modal) closeModal(modal);
   duplicateSourceGroup = null;
 }
 

--- a/frontend/src/modal.ts
+++ b/frontend/src/modal.ts
@@ -14,7 +14,13 @@
  * established show/hide convention without touching the stylesheet.
  */
 
-const FOCUSABLE_SELECTOR = [
+/**
+ * Single source of truth for "what counts as a focusable element inside a
+ * modal". Exported so the integration test in `modal.test.ts` can import
+ * the same selector instead of duplicating the string and silently drifting
+ * if the canonical list changes.
+ */
+export const FOCUSABLE_SELECTOR = [
   'a[href]',
   'button:not([disabled])',
   'input:not([disabled]):not([type="hidden"])',

--- a/frontend/src/modal.ts
+++ b/frontend/src/modal.ts
@@ -1,0 +1,167 @@
+/**
+ * Accessible modal helpers — keyboard focus trap, ESC-to-close, and focus
+ * restoration for any element used as a dialog. ARIA semantics
+ * (`role="dialog"`, `aria-modal="true"`) live in the markup; this file is
+ * the keyboard layer that the original ARIA fix deliberately deferred
+ * (issue #56).
+ *
+ * Usage:
+ *   openModal(modalEl);          // shows + traps + focuses first focusable
+ *   openModal(modalEl, { initialFocus: '#some-input' });
+ *   closeModal(modalEl);         // hides + releases trap + restores focus
+ *
+ * The helper toggles the existing `.hidden` CSS class so it slots into the
+ * established show/hide convention without touching the stylesheet.
+ */
+
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled]):not([type="hidden"])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+interface ModalState {
+  trigger: Element | null;
+  keydownHandler: (e: KeyboardEvent) => void;
+}
+
+// WeakMap so a removed modal element doesn't leak its handler reference.
+// Avoids stomping on `dataset` (which would survive in the DOM after
+// closeModal and confuse anything that inspects it).
+const openModals = new WeakMap<HTMLElement, ModalState>();
+
+/**
+ * Whether `el` is currently visible enough to focus. We deliberately
+ * avoid `offsetParent` because jsdom (and some headless layout cases)
+ * returns null for elements that are perfectly visible to a real user.
+ * Instead we walk ancestors looking for an explicit hide signal —
+ * `hidden`, `display: none`, `visibility: hidden`, or the project's
+ * `.hidden` utility class. This stays correct in real browsers while
+ * letting jsdom-based tests find focusables inside our modals.
+ */
+function isVisible(el: HTMLElement): boolean {
+  let node: HTMLElement | null = el;
+  while (node) {
+    if (node.hidden) return false;
+    if (node.classList.contains('hidden')) return false;
+    const style = getComputedStyle(node);
+    if (style.display === 'none' || style.visibility === 'hidden') return false;
+    node = node.parentElement;
+  }
+  return true;
+}
+
+function getFocusables(root: HTMLElement): HTMLElement[] {
+  const nodes = Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+  return nodes.filter(n => !n.hasAttribute('disabled') && isVisible(n));
+}
+
+function resolveInitialFocus(
+  el: HTMLElement,
+  initialFocus: HTMLElement | string | undefined,
+  focusables: HTMLElement[],
+): HTMLElement | null {
+  if (initialFocus) {
+    const target =
+      typeof initialFocus === 'string'
+        ? el.querySelector<HTMLElement>(initialFocus)
+        : initialFocus;
+    if (target) return target;
+  }
+  return focusables[0] ?? null;
+}
+
+/**
+ * Show a modal: clear `.hidden`, install the focus trap + ESC handler,
+ * record the previously focused element so closeModal can restore it,
+ * then focus either `opts.initialFocus` or the first focusable inside.
+ *
+ * Calling openModal twice on the same element is safe — the previous
+ * trap is torn down before the new one wires up, so the trigger
+ * recorded for restoration matches the most recent open() call.
+ */
+export function openModal(
+  el: HTMLElement,
+  opts?: { initialFocus?: HTMLElement | string },
+): void {
+  // Re-opening: tear down the prior trap so we don't stack listeners
+  // and so the recorded trigger reflects the latest opener.
+  if (openModals.has(el)) {
+    teardown(el);
+  }
+
+  const trigger = document.activeElement;
+
+  el.classList.remove('hidden');
+
+  const keydownHandler = (e: KeyboardEvent): void => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      closeModal(el);
+      return;
+    }
+
+    if (e.key !== 'Tab') return;
+
+    // Re-query on each Tab — the modal body can change (e.g. a form
+    // toggles a fieldset visible) between open and the user's tab.
+    const focusables = getFocusables(el);
+    if (focusables.length === 0) {
+      e.preventDefault();
+      return;
+    }
+
+    const first = focusables[0]!;
+    const last = focusables[focusables.length - 1]!;
+    const active = document.activeElement as HTMLElement | null;
+
+    // Wrap when the active element is at (or has slipped past) the edge.
+    // Checking active not in focusables covers the case where focus
+    // somehow escaped the modal subtree — pull it back to a sensible end.
+    if (e.shiftKey) {
+      if (active === first || !el.contains(active)) {
+        e.preventDefault();
+        last.focus();
+      }
+    } else {
+      if (active === last || !el.contains(active)) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  };
+
+  el.addEventListener('keydown', keydownHandler);
+  openModals.set(el, { trigger, keydownHandler });
+
+  const focusables = getFocusables(el);
+  const initialTarget = resolveInitialFocus(el, opts?.initialFocus, focusables);
+  initialTarget?.focus();
+}
+
+/**
+ * Hide a modal: add `.hidden`, detach the trap handler, and restore
+ * focus to the element that triggered openModal. No-op (apart from
+ * adding `.hidden`) if the element wasn't opened via openModal — keeps
+ * legacy code paths that call closeModal directly from a callback safe.
+ */
+export function closeModal(el: HTMLElement): void {
+  const state = openModals.get(el);
+  teardown(el);
+  el.classList.add('hidden');
+
+  const trigger = state?.trigger as HTMLElement | null | undefined;
+  if (trigger && typeof trigger.focus === 'function' && document.contains(trigger)) {
+    trigger.focus();
+  }
+}
+
+function teardown(el: HTMLElement): void {
+  const state = openModals.get(el);
+  if (!state) return;
+  el.removeEventListener('keydown', state.keydownHandler);
+  openModals.delete(el);
+}

--- a/frontend/src/plans.ts
+++ b/frontend/src/plans.ts
@@ -11,6 +11,7 @@ import type { PlansResponse, LocalPlan, SavePlanData } from './types';
 import { viewPlanHistory } from './history';
 import type { PlannedPurchase } from './api';
 import { populateTermSelect, populatePaymentSelect, isValidCombination, normalizePaymentValue } from './commitmentOptions';
+import { openModal, closeModal } from './modal';
 
 /**
  * Load plans and planned purchases
@@ -464,7 +465,8 @@ async function editPlan(planId: string): Promise<void> {
     }
 
     void setupPlanAccountsSection(backendPlan.id);
-    document.getElementById('plan-modal')?.classList.remove('hidden');
+    const planModal = document.getElementById('plan-modal');
+    if (planModal) openModal(planModal);
   } catch (error) {
     console.error('Failed to load plan:', error);
     showToast({ message: 'Failed to load plan details', kind: 'error' });
@@ -554,7 +556,8 @@ export async function savePlan(e: Event): Promise<void> {
  * Close plan modal
  */
 export function closePlanModal(): void {
-  document.getElementById('plan-modal')?.classList.add('hidden');
+  const planModal = document.getElementById('plan-modal');
+  if (planModal) closeModal(planModal);
 }
 
 // Selected accounts for the plan modal
@@ -692,7 +695,8 @@ export function openCreatePlanModal(): void {
 
   void setupPlanAccountsSection();
 
-  document.getElementById('plan-modal')?.classList.remove('hidden');
+  const planModal = document.getElementById('plan-modal');
+  if (planModal) openModal(planModal);
 }
 
 /**
@@ -712,7 +716,8 @@ export function openNewPlanModal(): void {
 
   void setupPlanAccountsSection();
 
-  document.getElementById('plan-modal')?.classList.remove('hidden');
+  const planModal = document.getElementById('plan-modal');
+  if (planModal) openModal(planModal);
 }
 
 /**
@@ -937,7 +942,8 @@ function updateCustomConfigFromPreset(rampSchedule: string): void {
  * Close purchase modal
  */
 export function closePurchaseModal(): void {
-  document.getElementById('purchase-modal')?.classList.add('hidden');
+  const purchaseModal = document.getElementById('purchase-modal');
+  if (purchaseModal) closeModal(purchaseModal);
 }
 
 /**
@@ -989,13 +995,22 @@ async function openAddPurchasesModal(planId: string, planName: string): Promise<
   // Add event listeners
   document.getElementById('add-purchases-cancel')?.addEventListener('click', closeAddPurchasesModal);
   document.getElementById('add-purchases-form')?.addEventListener('submit', (e) => void handleAddPurchases(e));
+
+  // Engage focus trap + Escape handler. The modal element itself is
+  // removed from the DOM on close (see closeAddPurchasesModal) instead
+  // of just toggling .hidden, so the closeModal call there is what
+  // actually triggers focus restoration to the trigger.
+  openModal(modal);
 }
 
 /**
- * Close add purchases modal
+ * Close add purchases modal — restore focus first (closeModal), then
+ * remove the dynamically-injected element from the DOM.
  */
 function closeAddPurchasesModal(): void {
-  document.getElementById('add-purchases-modal')?.remove();
+  const modal = document.getElementById('add-purchases-modal');
+  if (modal) closeModal(modal);
+  modal?.remove();
 }
 
 /**

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -10,6 +10,7 @@ import { getRecommendationsFreshness } from './api/recommendations';
 import { showToast } from './toast';
 import { isPaymentSupported, type Provider as CompatProvider } from './lib/purchase-compatibility';
 import type { RecommendationsResponse, LocalRecommendation, RecommendationsSummary } from './types';
+import { openModal } from './modal';
 
 // Module state for current purchase modal recommendations
 let currentPurchaseRecommendations: LocalRecommendation[] = [];
@@ -737,7 +738,7 @@ function openFanOutModal(
     container.appendChild(renderFanOutBucketSection(b));
   }
 
-  modal.classList.remove('hidden');
+  openModal(modal);
 }
 
 function computeFanOutTotals(buckets: FanOutBucket[]): { totalCount: number; totalUpfront: number; totalSavings: number } {
@@ -926,7 +927,8 @@ export function openPurchaseModal(recommendations: LocalRecommendation[]): void 
     </div>
   `;
 
-  document.getElementById('purchase-modal')?.classList.remove('hidden');
+  const purchaseModal = document.getElementById('purchase-modal');
+  if (purchaseModal) openModal(purchaseModal);
 }
 
 /**

--- a/frontend/src/riexchange.ts
+++ b/frontend/src/riexchange.ts
@@ -16,6 +16,7 @@ import type {
   RIExchangeHistoryRecord,
   OfferingOption,
 } from './api';
+import { openModal, closeModal } from './modal';
 
 // Module state
 let currentRIs: ConvertibleRI[] = [];
@@ -476,10 +477,10 @@ export function openExchangeModal(riId: string, count: number, suggestedTargetTy
   content.appendChild(btnRow);
 
   // Show modal
-  modal.classList.remove('hidden');
+  openModal(modal);
 
   cancelBtn.addEventListener('click', () => {
-    modal.classList.add('hidden');
+    closeModal(modal);
   });
 
   quoteBtn.addEventListener('click', () => {
@@ -571,7 +572,7 @@ export function openExchangeModal(riId: string, count: number, suggestedTargetTy
       modalQuoteReq = null;
 
       setTimeout(() => {
-        modal.classList.add('hidden');
+        closeModal(modal);
         void loadConvertibleRIs();
         void loadExchangeHistory();
       }, 2000);

--- a/frontend/src/settings.ts
+++ b/frontend/src/settings.ts
@@ -9,6 +9,7 @@ import { confirmDialog } from './confirmDialog';
 import { reflectDirtyState } from './settings-subnav';
 import { showToast } from './toast';
 import { isValidCombination } from './commitmentOptions';
+import { openModal, closeModal } from './modal';
 
 type AccountProvider = 'aws' | 'azure' | 'gcp';
 
@@ -597,7 +598,7 @@ export function openAccountModal(provider: AccountProvider, account?: api.CloudA
     updateGCPAuthModeFields(gcpMode);
   }
 
-  modal.classList.remove('hidden');
+  openModal(modal);
 }
 
 /**
@@ -774,7 +775,7 @@ async function populateBastionAccountDropdown(selectedId?: string): Promise<void
  */
 function closeAccountModal(): void {
   const modal = document.getElementById('account-modal');
-  modal?.classList.add('hidden');
+  if (modal) closeModal(modal);
   accountModalOnSave = undefined;
 }
 

--- a/frontend/src/users/userModals.ts
+++ b/frontend/src/users/userModals.ts
@@ -10,6 +10,7 @@ import {
 } from './state';
 import { escapeHtml, showError, showSuccess } from './utils';
 import { loadUsers } from './userActions';
+import { openModal, closeModal } from '../modal';
 
 /**
  * Open create user modal
@@ -36,7 +37,7 @@ export function openCreateUserModal(): void {
   // Populate groups dropdown
   populateGroupsDropdown();
 
-  modal.classList.remove('hidden');
+  openModal(modal);
 }
 
 /**
@@ -68,7 +69,7 @@ export async function openEditUserModal(userId: string): Promise<void> {
     // Populate and select groups
     populateGroupsDropdown(user.groups);
 
-    modal.classList.remove('hidden');
+    openModal(modal);
   } catch (error) {
     console.error('Failed to load user:', error);
     showError('Failed to load user details');
@@ -81,7 +82,7 @@ export async function openEditUserModal(userId: string): Promise<void> {
 export function closeUserModal(): void {
   const modal = document.getElementById('user-modal');
   if (modal) {
-    modal.classList.add('hidden');
+    closeModal(modal);
   }
   setCurrentEditingUser(null);
 }


### PR DESCRIPTION
## Summary

- Adds `frontend/src/modal.ts` with `openModal()` / `closeModal()` — focus trap (Tab/Shift+Tab wrap), ESC-to-close, and focus restoration to the triggering element on close. Optional `initialFocus` accepts an `HTMLElement` or selector string.
- Migrates every `.hidden`-class modal show/hide site through the helper: `plan-modal`, `purchase-modal`, `select-recommendations-modal`, `account-modal`, `create-apikey-modal`, `apikey-created-modal`, `user-modal`, `group-modal`, `group-duplicate-modal`, `profile-modal`, `ri-exchange-modal`, plus the dynamically-injected `add-purchases-modal` (close path now restores focus before the element is removed from the DOM).
- 16 new unit + integration tests in `frontend/src/__tests__/modal.test.ts` covering the keyboard contract and two real call sites (`openNewPlanModal` + the account modal DOM shape). Full suite (1267 tests) green; `tsc --noEmit` and production webpack build clean.

ARIA semantics (`role="dialog"`, `aria-modal="true"`) were already in place — this PR is the keyboard layer the original ARIA fix deliberately deferred.

Closes #56.

## Test plan

- [x] `npx jest` — 1267 tests pass, 36 suites
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — production bundle compiles
- [ ] Deployed verification: open New Plan modal, Tab past the last focusable, confirm wrap; press ESC, confirm modal closes and focus returns to the "New Plan" trigger button. Repeat for Add Account modal.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Modal keyboard navigation: Tab/Shift+Tab focus trapping, Escape to close, and customizable initial focus with focus restoration.

* **Refactor**
  * Centralized modal open/close behavior across the app for consistent lifecycle handling.

* **Bug Fixes**
  * Safe teardown on close (no-op after close), robust reopen behavior without stacking handlers, and restored focus even if trigger was removed.

* **Tests**
  * Added end-to-end tests covering keyboard handling, focus management, open/close, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->