### PR TITLE
chore(tests): parallelize pkg/errors test files

### DIFF
--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -8,7 +8,9 @@ import (
 )
 
 func TestNotFoundError(t *testing.T) {
+	t.Parallel()
 	t.Run("with resource and ID", func(t *testing.T) {
+		t.Parallel()
 		err := NewNotFoundError("User", "123")
 		assert.Equal(t, "User not found: 123", err.Error())
 		assert.Equal(t, "User", err.Resource)
@@ -16,22 +18,26 @@ func TestNotFoundError(t *testing.T) {
 	})
 
 	t.Run("with resource only", func(t *testing.T) {
+		t.Parallel()
 		err := &NotFoundError{Resource: "Config"}
 		assert.Equal(t, "Config not found", err.Error())
 	})
 
 	t.Run("with custom message", func(t *testing.T) {
+		t.Parallel()
 		err := NewNotFoundErrorWithMessage("custom not found message")
 		assert.Equal(t, "custom not found message", err.Error())
 	})
 
 	t.Run("Is comparison", func(t *testing.T) {
+		t.Parallel()
 		err := NewNotFoundError("User", "123")
 		target := &NotFoundError{}
 		assert.True(t, errors.Is(err, target))
 	})
 
 	t.Run("IsNotFoundError helper", func(t *testing.T) {
+		t.Parallel()
 		err := NewNotFoundError("User", "123")
 		assert.True(t, IsNotFoundError(err))
 		assert.False(t, IsNotFoundError(errors.New("other error")))
@@ -39,7 +45,9 @@ func TestNotFoundError(t *testing.T) {
 }
 
 func TestValidationError(t *testing.T) {
+	t.Parallel()
 	t.Run("with field and message", func(t *testing.T) {
+		t.Parallel()
 		err := NewValidationError("email", "invalid format")
 		assert.Equal(t, "validation error on field 'email': invalid format", err.Error())
 		assert.Equal(t, "email", err.Field)
@@ -47,17 +55,20 @@ func TestValidationError(t *testing.T) {
 	})
 
 	t.Run("without field", func(t *testing.T) {
+		t.Parallel()
 		err := &ValidationError{Message: "general validation error"}
 		assert.Equal(t, "validation error: general validation error", err.Error())
 	})
 
 	t.Run("Is comparison", func(t *testing.T) {
+		t.Parallel()
 		err := NewValidationError("field", "message")
 		target := &ValidationError{}
 		assert.True(t, errors.Is(err, target))
 	})
 
 	t.Run("IsValidationError helper", func(t *testing.T) {
+		t.Parallel()
 		err := NewValidationError("field", "message")
 		assert.True(t, IsValidationError(err))
 		assert.False(t, IsValidationError(errors.New("other error")))
@@ -65,24 +76,29 @@ func TestValidationError(t *testing.T) {
 }
 
 func TestAuthenticationError(t *testing.T) {
+	t.Parallel()
 	t.Run("with reason", func(t *testing.T) {
+		t.Parallel()
 		err := NewAuthenticationError("invalid token")
 		assert.Equal(t, "authentication failed: invalid token", err.Error())
 		assert.Equal(t, "invalid token", err.Reason)
 	})
 
 	t.Run("without reason", func(t *testing.T) {
+		t.Parallel()
 		err := &AuthenticationError{}
 		assert.Equal(t, "authentication failed", err.Error())
 	})
 
 	t.Run("Is comparison", func(t *testing.T) {
+		t.Parallel()
 		err := NewAuthenticationError("reason")
 		target := &AuthenticationError{}
 		assert.True(t, errors.Is(err, target))
 	})
 
 	t.Run("IsAuthenticationError helper", func(t *testing.T) {
+		t.Parallel()
 		err := NewAuthenticationError("reason")
 		assert.True(t, IsAuthenticationError(err))
 		assert.False(t, IsAuthenticationError(errors.New("other error")))
@@ -90,7 +106,9 @@ func TestAuthenticationError(t *testing.T) {
 }
 
 func TestAuthorizationError(t *testing.T) {
+	t.Parallel()
 	t.Run("with action and resource", func(t *testing.T) {
+		t.Parallel()
 		err := NewAuthorizationError("delete", "users")
 		assert.Equal(t, "not authorized to delete on users", err.Error())
 		assert.Equal(t, "delete", err.Action)
@@ -98,17 +116,20 @@ func TestAuthorizationError(t *testing.T) {
 	})
 
 	t.Run("without details", func(t *testing.T) {
+		t.Parallel()
 		err := &AuthorizationError{}
 		assert.Equal(t, "not authorized", err.Error())
 	})
 
 	t.Run("Is comparison", func(t *testing.T) {
+		t.Parallel()
 		err := NewAuthorizationError("action", "resource")
 		target := &AuthorizationError{}
 		assert.True(t, errors.Is(err, target))
 	})
 
 	t.Run("IsAuthorizationError helper", func(t *testing.T) {
+		t.Parallel()
 		err := NewAuthorizationError("action", "resource")
 		assert.True(t, IsAuthorizationError(err))
 		assert.False(t, IsAuthorizationError(errors.New("other error")))
@@ -116,7 +137,9 @@ func TestAuthorizationError(t *testing.T) {
 }
 
 func TestConflictError(t *testing.T) {
+	t.Parallel()
 	t.Run("with resource and ID", func(t *testing.T) {
+		t.Parallel()
 		err := NewConflictError("User", "john@example.com")
 		assert.Equal(t, "User already exists: john@example.com", err.Error())
 		assert.Equal(t, "User", err.Resource)
@@ -124,22 +147,26 @@ func TestConflictError(t *testing.T) {
 	})
 
 	t.Run("with resource only", func(t *testing.T) {
+		t.Parallel()
 		err := &ConflictError{Resource: "Plan"}
 		assert.Equal(t, "Plan already exists", err.Error())
 	})
 
 	t.Run("with custom message", func(t *testing.T) {
+		t.Parallel()
 		err := &ConflictError{Message: "custom conflict message"}
 		assert.Equal(t, "custom conflict message", err.Error())
 	})
 
 	t.Run("Is comparison", func(t *testing.T) {
+		t.Parallel()
 		err := NewConflictError("resource", "id")
 		target := &ConflictError{}
 		assert.True(t, errors.Is(err, target))
 	})
 
 	t.Run("IsConflictError helper", func(t *testing.T) {
+		t.Parallel()
 		err := NewConflictError("resource", "id")
 		assert.True(t, IsConflictError(err))
 		assert.False(t, IsConflictError(errors.New("other error")))
@@ -147,24 +174,29 @@ func TestConflictError(t *testing.T) {
 }
 
 func TestRateLimitError(t *testing.T) {
+	t.Parallel()
 	t.Run("with retry after", func(t *testing.T) {
+		t.Parallel()
 		err := NewRateLimitError(60)
 		assert.Equal(t, "rate limit exceeded, retry after 60 seconds", err.Error())
 		assert.Equal(t, 60, err.RetryAfter)
 	})
 
 	t.Run("without retry after", func(t *testing.T) {
+		t.Parallel()
 		err := &RateLimitError{}
 		assert.Equal(t, "rate limit exceeded", err.Error())
 	})
 
 	t.Run("Is comparison", func(t *testing.T) {
+		t.Parallel()
 		err := NewRateLimitError(30)
 		target := &RateLimitError{}
 		assert.True(t, errors.Is(err, target))
 	})
 
 	t.Run("IsRateLimitError helper", func(t *testing.T) {
+		t.Parallel()
 		err := NewRateLimitError(30)
 		assert.True(t, IsRateLimitError(err))
 		assert.False(t, IsRateLimitError(errors.New("other error")))
@@ -172,7 +204,9 @@ func TestRateLimitError(t *testing.T) {
 }
 
 func TestServiceError(t *testing.T) {
+	t.Parallel()
 	t.Run("with service and error", func(t *testing.T) {
+		t.Parallel()
 		underlying := errors.New("connection refused")
 		err := NewServiceError("AWS", underlying)
 		assert.Equal(t, "AWS service error: connection refused", err.Error())
@@ -181,29 +215,34 @@ func TestServiceError(t *testing.T) {
 	})
 
 	t.Run("without underlying error", func(t *testing.T) {
+		t.Parallel()
 		err := &ServiceError{Service: "Azure"}
 		assert.Equal(t, "Azure service error", err.Error())
 	})
 
 	t.Run("Unwrap", func(t *testing.T) {
+		t.Parallel()
 		underlying := errors.New("timeout")
 		err := NewServiceError("GCP", underlying)
 		assert.Equal(t, underlying, err.Unwrap())
 	})
 
 	t.Run("errors.Is with wrapped error", func(t *testing.T) {
+		t.Parallel()
 		underlying := errors.New("timeout")
 		err := NewServiceError("AWS", underlying)
 		assert.True(t, errors.Is(err, underlying))
 	})
 
 	t.Run("Is comparison", func(t *testing.T) {
+		t.Parallel()
 		err := NewServiceError("service", nil)
 		target := &ServiceError{}
 		assert.True(t, errors.Is(err, target))
 	})
 
 	t.Run("IsServiceError helper", func(t *testing.T) {
+		t.Parallel()
 		err := NewServiceError("service", nil)
 		assert.True(t, IsServiceError(err))
 		assert.False(t, IsServiceError(errors.New("other error")))
@@ -211,39 +250,49 @@ func TestServiceError(t *testing.T) {
 }
 
 func TestSentinelErrors(t *testing.T) {
+	t.Parallel()
 	t.Run("ErrNotFound", func(t *testing.T) {
+		t.Parallel()
 		assert.Equal(t, "not found", ErrNotFound.Error())
 	})
 
 	t.Run("ErrUnauthorized", func(t *testing.T) {
+		t.Parallel()
 		assert.Equal(t, "unauthorized", ErrUnauthorized.Error())
 	})
 
 	t.Run("ErrForbidden", func(t *testing.T) {
+		t.Parallel()
 		assert.Equal(t, "forbidden", ErrForbidden.Error())
 	})
 
 	t.Run("ErrInvalidInput", func(t *testing.T) {
+		t.Parallel()
 		assert.Equal(t, "invalid input", ErrInvalidInput.Error())
 	})
 
 	t.Run("ErrConflict", func(t *testing.T) {
+		t.Parallel()
 		assert.Equal(t, "conflict", ErrConflict.Error())
 	})
 
 	t.Run("ErrInternalError", func(t *testing.T) {
+		t.Parallel()
 		assert.Equal(t, "internal error", ErrInternalError.Error())
 	})
 }
 
 func TestWrappedErrors(t *testing.T) {
+	t.Parallel()
 	t.Run("wrapped NotFoundError", func(t *testing.T) {
+		t.Parallel()
 		inner := NewNotFoundError("Resource", "id")
 		wrapped := errors.Join(errors.New("context"), inner)
 		assert.True(t, IsNotFoundError(wrapped))
 	})
 
 	t.Run("wrapped ValidationError", func(t *testing.T) {
+		t.Parallel()
 		inner := NewValidationError("field", "msg")
 		wrapped := errors.Join(errors.New("context"), inner)
 		assert.True(t, IsValidationError(wrapped))


### PR DESCRIPTION
## Summary

Incremental sweep of issue #58: enable Go test parallelism in `pkg/errors/`.

- Added `t.Parallel()` to every top-level `Test*` function (9) and every `t.Run` sub-test (40) in `pkg/errors/errors_test.go` — 49 `t.Parallel()` calls total.
- Pure value-type tests with no shared mutable state, no env vars, no package-level fixtures, no table-driven loops; race-safety required no other refactors.
- Verified clean under `go test -race -count=2 ./errors/...` from the `pkg/` submodule; `=== PAUSE` / `=== CONT` lines in verbose output confirm the parallel scheduler is engaged.

## Test plan

- [x] `cd pkg && go test -race -count=2 -v ./errors/...` passes twice cleanly
- [x] Pre-commit hooks (gosec, trivy, lint, go test) pass
- [ ] CI green on push

Refs #58 (issue stays OPEN — incremental sweep, more packages still pending).
