### PR TITLE
chore(repo): graphify integration + mark #33 retention as resolved

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ security-audit-swarm/
 
 # Generated docs (security runbooks etc.)
 docs/
+
+# Graphify knowledge graph output — regenerated locally, not committed
+graphify-out/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,6 +244,26 @@ Key rules:
 
 Directory structure: `~/.claude/agent-comms/{messages,locks,status}`
 
+## Knowledge graph (graphify)
+
+**This project uses the graphify knowledge graph at `graphify-out/` — always consult it for architecture/codebase questions, and (re)build it when missing or stale.**
+
+Rules, in priority order:
+
+1. **Before answering architecture or codebase questions**: read `graphify-out/GRAPH_REPORT.md` for god nodes + community structure, and `graphify-out/wiki/index.md` for a navigable summary. The graph often surfaces helpers/utilities that grep misses because names don't overlap.
+2. **If `graphify-out/` is missing**: build it FIRST before doing any non-trivial exploration. Command (from the repo root):
+
+   ```bash
+   /Users/cristi/Dropbox_Maestral/devel/graphify/.venv/bin/python3 \
+     -c "from graphify.watch import _rebuild_code; from pathlib import Path; _rebuild_code(Path('.'))"
+   ```
+
+   Runs for ~1–3 minutes on this repo; run it in the background (`run_in_background: true`) so you can start reading other things while it finishes.
+3. **After modifying code files in a session**: re-run the same command to keep the graph current. The installed `PreToolUse` hook in `.claude/settings.json` handles this automatically for Write/Edit/MultiEdit, but the hook has a 5-second timeout — on a large edit batch the rebuild may be skipped; run the command manually in that case.
+4. **Never edit code you haven't mapped** when the graph is available. Prefer graph-assisted navigation over raw grep for cross-cutting questions ("who calls X", "where is Y implemented", "what would break if I rename Z").
+
+If `graphify` is not on PATH, the binary is at `/Users/cristi/bin/graphify`. The `graphify claude install` subcommand re-registers the PreToolUse hook if it's been removed.
+
 ## Support
 
 - Documentation: <https://github.com/ruvnet/claude-flow>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,15 +254,15 @@ Rules, in priority order:
 2. **If `graphify-out/` is missing**: build it FIRST before doing any non-trivial exploration. Command (from the repo root):
 
    ```bash
-   /Users/cristi/Dropbox_Maestral/devel/graphify/.venv/bin/python3 \
+   "${GRAPHIFY_PYTHON:-python3}" \
      -c "from graphify.watch import _rebuild_code; from pathlib import Path; _rebuild_code(Path('.'))"
    ```
 
-   Runs for ~1–3 minutes on this repo; run it in the background (`run_in_background: true`) so you can start reading other things while it finishes.
+   Set `GRAPHIFY_PYTHON` to your graphify venv's Python interpreter (`<graphify-checkout>/.venv/bin/python3`); falls back to `python3` if the package is installed system-wide. Runs for ~1–3 minutes on this repo; run it in the background (`run_in_background: true`) so you can start reading other things while it finishes.
 3. **After modifying code files in a session**: re-run the same command to keep the graph current. The installed `PreToolUse` hook in `.claude/settings.json` handles this automatically for Write/Edit/MultiEdit, but the hook has a 5-second timeout — on a large edit batch the rebuild may be skipped; run the command manually in that case.
 4. **Never edit code you haven't mapped** when the graph is available. Prefer graph-assisted navigation over raw grep for cross-cutting questions ("who calls X", "where is Y implemented", "what would break if I rename Z").
 
-If `graphify` is not on PATH, the binary is at `/Users/cristi/bin/graphify`. The `graphify claude install` subcommand re-registers the PreToolUse hook if it's been removed.
+If `graphify` is not on PATH, locate your local install (typically `~/bin/graphify` or your venv's `bin/`). The `graphify claude install` subcommand re-registers the PreToolUse hook if it's been removed.
 
 ## Support
 

--- a/known_issues/33_executions_retention_cleanup.md
+++ b/known_issues/33_executions_retention_cleanup.md
@@ -2,50 +2,52 @@
 
 **Surfaced during:** 2026-04-23 follow-up audit — Failed + Expired rows now persist and surface in History
 **Related commits:** `32f9e4ffc` (pending-in-history), `b44283746` (failed + expired states)
-**Status:** ✔️ Resolved — `internal/server/handler.go::handleCleanupExpiredRecords` (line 153) calls `CleanupOldExecutions(ctx, 30)` with a 30-day retention. Wired as the `TaskCleanupExpiredRecords` scheduled task type and triggered by the EventBridge rule `cleanup_schedule` in `terraform/modules/compute/aws/cleanup-lambda/main.tf:98` (plus Azure cleanup-function and Container Apps scheduled task). Verified 2026-04-25.
+**Status:** ✔️ Resolved — verified 2026-04-25.
 
-## Problem
+## Resolution
 
-Before the merge of non-completed executions into History (`32f9e4ffc`
-and `b44283746`), only `completed` purchases surfaced via
-`purchase_history` — which is itself pruned in its own SQL. Now
-`purchase_executions` rows in `pending` / `notified` / `failed` /
-`expired` states also render on every `/api/history` request, and those
-stick around until something calls `CleanupOldExecutions`.
+`internal/server/handler.go::handleCleanupExpiredRecords` (line 153) calls
+`CleanupOldExecutions(ctx, 30)` with a 30-day retention. Wired as the
+`TaskCleanupExpiredRecords` scheduled task type and triggered by:
 
-The store interface exposes
-`CleanupOldExecutions(ctx, retentionDays) (int64, error)` and a Postgres
-implementation (`internal/config/store_postgres.go`) runs the expected
-`DELETE FROM purchase_executions WHERE …`. What we have not verified is
-whether **any** scheduled job actually calls it. `grep -rn
-CleanupOldExecutions internal/` currently shows only the interface +
-implementation + tests; no caller.
+- **AWS:** EventBridge rule `cleanup_schedule` in
+  `terraform/modules/compute/aws/cleanup-lambda/main.tf:98`
+- **Azure:** dedicated cleanup Function App
+- **Container Apps:** scheduled task
 
-If no caller exists, the table grows unbounded:
+The `CleanupOldExecutions` Postgres implementation in
+`internal/config/store_postgres.go` runs the expected
+`DELETE FROM purchase_executions WHERE …`, so the table is now bounded
+on every supported deployment target.
 
-- a high-volume tenant with one failed purchase per day (common when
-  FROM_EMAIL is misconfigured — see `33pz7pom…` before `b3e17719b`)
-  will accumulate a thousand failed rows a year;
-- History render then pulls the full non-completed set every page load
-  (capped at `config.DefaultListLimit = 100`, so UX degrades gracefully,
-  but the DB write amplification from `expireIfStale` transitioning
-  hundreds of stale rows on a single page view is still a concern).
+## Original problem (historical context)
 
-## Proposed resolution
+Before the merge of non-completed executions into History
+(`32f9e4ffc` and `b44283746`), only `completed` purchases surfaced via
+`purchase_history` — which is itself pruned in its own SQL. After those
+commits, `purchase_executions` rows in `pending` / `notified` / `failed`
+/ `expired` states also render on every `/api/history` request, and
+those rows would have stuck around indefinitely without a cleanup
+caller.
 
-1. **Audit** — confirm whether a scheduled Lambda/job calls
-   `CleanupOldExecutions`. If yes, capture the cadence + retention in a
-   code comment on the interface method.
-2. **If no caller** — add one. Natural home is the existing
-   `internal/scheduler/` package alongside the scheduled recommendation
-   collector. Retention ~90 days covers "I need to see what failed last
-   quarter" without ballooning the table.
-3. **Metrics** — emit a CloudWatch metric for the count of non-completed
-   executions so we can alarm before the table becomes a performance
-   issue, not after.
+At the time this issue was filed, `grep -rn CleanupOldExecutions
+internal/` showed only the interface + implementation + tests; no
+caller. The concern was that, left unbounded, a high-volume tenant with
+one failed purchase per day (common when FROM_EMAIL is misconfigured —
+see `33pz7pom…` before `b3e17719b`) would accumulate a thousand failed
+rows a year, eventually amplifying writes during `expireIfStale`
+transitions on every History page load.
 
-## Why not now
+The wiring discovered above (handleCleanupExpiredRecords →
+TaskCleanupExpiredRecords → cleanup_schedule) closes that gap. The
+30-day retention is shorter than the 90-day window originally proposed
+but matches what the cleanup-lambda Terraform actually configures, and
+is sufficient for "what failed last week" debugging without ballooning
+the table.
 
-Nothing is broken yet — the first production deployment of `b44283746`
-hasn't even completed. Tagging this so the next ops review of the
-scheduler catches it before the growth curve matters.
+## Future improvements (not blocking)
+
+- **Metrics** — emit a CloudWatch metric for the count of non-completed
+  executions so we can alarm before the table becomes a performance
+  issue, not after. Tracked separately if it matters; not part of this
+  issue's resolution.

--- a/known_issues/33_executions_retention_cleanup.md
+++ b/known_issues/33_executions_retention_cleanup.md
@@ -2,7 +2,7 @@
 
 **Surfaced during:** 2026-04-23 follow-up audit — Failed + Expired rows now persist and surface in History
 **Related commits:** `32f9e4ffc` (pending-in-history), `b44283746` (failed + expired states)
-**Status:** ops unknown — need to confirm cleanup cadence before failed/expired rows pile up.
+**Status:** ✔️ Resolved — `internal/server/handler.go::handleCleanupExpiredRecords` (line 153) calls `CleanupOldExecutions(ctx, 30)` with a 30-day retention. Wired as the `TaskCleanupExpiredRecords` scheduled task type and triggered by the EventBridge rule `cleanup_schedule` in `terraform/modules/compute/aws/cleanup-lambda/main.tf:98` (plus Azure cleanup-function and Container Apps scheduled task). Verified 2026-04-25.
 
 ## Problem
 


### PR DESCRIPTION
## Summary

Two doc-only commits, both housekeeping:

1. **`chore(repo): add graphify knowledge-graph integration`** —
   `.gitignore` excludes `graphify-out/` (regenerated locally) and
   `CLAUDE.md` documents the rebuild command + when to run it. Mirrors
   the global `~/.claude/CLAUDE.md` guidance for this project so future
   Claude sessions consult the graph instead of grepping blind.
2. **`docs(known-issues): mark #33 executions retention cleanup as resolved`** —
   Re-verified `handleCleanupExpiredRecords` calls `CleanupOldExecutions`
   with 30-day retention, dispatched via the `cleanup` scheduled task and
   triggered by the AWS `cleanup_schedule` EventBridge rule (Azure + ACA
   equivalents present). Line-number drift fixed (97 → 98).

No code or behaviour changes. Zero file pre-commit hooks fired (no Go,
no frontend, no migrations) — only end-of-files / markdown lint / secret
scans.

## Test plan

- [x] `git diff` reviewed — only the three intended files
- [x] `pre-commit run --files .gitignore CLAUDE.md known_issues/33_executions_retention_cleanup.md` — all checks pass on commit
- [x] `terraform/modules/compute/aws/cleanup-lambda/main.tf:98` confirmed contains `aws_cloudwatch_event_rule "cleanup_schedule"`
- [x] `internal/server/handler.go:153` confirmed calls `CleanupOldExecutions(ctx, retentionDays)` with `retentionDays = 30`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Execution data cleanup process documented and operationally verified with a 30-day retention policy.
  * Added architecture reference guide workflow for knowledge graph navigation.

* **Chores**
  * Updated version control exclusion patterns for build artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->