### PR TITLE
docs(specs): multi-account execution draft spec

### DIFF
--- a/specs/multi-account-execution/README.md
+++ b/specs/multi-account-execution/README.md
@@ -1,0 +1,61 @@
+<!-- markdownlint-disable MD040 MD060 -->
+# Spec: Multi-Account Execution
+
+**Status**: Draft
+**Created**: 2026-04-02
+**Authors**: Engineering
+
+## Problem Statement
+
+CUDly currently manages a single AWS account (via IAM role), a single Azure subscription, and a single GCP project. Organizations using CUDly at scale run workloads across dozens or hundreds of cloud accounts. Cost-optimization tooling that cannot see all accounts simultaneously cannot produce accurate recommendations, cannot purchase commitments across an org, and forces users to log in separately to each account.
+
+This feature enables CUDly to:
+
+1. Manage any number of cloud accounts/subscriptions per provider
+2. Collect recommendations and purchase commitments across all accounts in parallel
+3. Display aggregated or per-account data in every view
+4. Apply service-level settings globally or override them per account
+
+## Scope
+
+All three supported cloud providers are in scope:
+
+- **AWS**: EC2, RDS, ElastiCache, OpenSearch, Redshift, Savings Plans — across any number of AWS accounts
+- **Azure**: VM, SQL, Cosmos DB reservations — across any number of Azure subscriptions
+- **GCP**: Compute, Cloud SQL committed use discounts — across any number of GCP projects
+
+## Document Index
+
+| Document | Contents |
+|----------|----------|
+| [data-model.md](./data-model.md) | New DB tables, column additions to existing tables, migration strategy |
+| [api.md](./api.md) | New REST endpoints + modifications to existing endpoints |
+| [backend.md](./backend.md) | Credential resolution, org discovery, parallel execution engine, service config cascade |
+| [frontend.md](./frontend.md) | Settings UI (account CRUD), filter changes, plan account association, state model |
+| [security.md](./security.md) | Credential encryption, access control, audit logging, input validation |
+| [iac.md](./iac.md) | Terraform changes: Secrets Manager key, Lambda IAM policies, env vars for all environments |
+| [acceptance.md](./acceptance.md) | BDD-style acceptance scenarios (the definition of done) |
+| [tasks.md](./tasks.md) | Ordered implementation tasks with file paths, dependencies, and test requirements |
+
+## Key Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| AWS auth modes | `access_keys`, `role_arn`, `bastion` | Covers all real-world patterns: simple dev accounts, cross-account role delegation, AWS Organizations with a central hub |
+| Bastion pattern | One hub account (keys or role) assumes roles in N target accounts | Standard AWS Organizations security model; avoids giving CUDly direct keys to every account |
+| AWS Org discovery | Add org root/management account → CUDly calls Organizations API to list member accounts | No separate discovery step; the management account IS the discovery mechanism |
+| Service override cascade | Sparse: `NULL` fields in account override inherit the global default | Minimises configuration duplication; operators set global sensible defaults and only override what differs per account |
+| Plan ↔ Account relationship | Many-to-many via `plan_accounts` join table | One plan can fan out across multiple accounts; one account can participate in multiple plans |
+| Parallel execution | Backend goroutine fan-out per account; per-account errors are isolated | Failure in one account does not block others; results collected and tagged with `cloud_account_id` |
+| Credential storage | AES-256-GCM encrypted blob in `account_credentials` table; key loaded from AWS Secrets Manager (ARN via `CREDENTIAL_ENCRYPTION_KEY_SECRET_ARN` env) in prod; direct hex env var for local dev | Consistent with existing project secret management pattern; encryption key never in plaintext Lambda env |
+
+## Glossary
+
+| Term | Definition |
+|------|-----------|
+| **Cloud Account** | A single AWS account, Azure subscription, or GCP project managed by CUDly |
+| **Bastion Account** | An AWS account whose credentials CUDly holds directly and uses to assume roles in other (target) accounts |
+| **Org Root Account** | An AWS management account that has AWS Organizations access; used to discover member accounts |
+| **Service Override** | A per-account, per-service config value that overrides the global default |
+| **Plan Fan-out** | The process of executing a single purchase plan concurrently across all accounts it targets |
+| **Effective Config** | The merged config for (account, provider, service): account overrides applied on top of global defaults |

--- a/specs/multi-account-execution/acceptance.md
+++ b/specs/multi-account-execution/acceptance.md
@@ -1,0 +1,359 @@
+<!-- markdownlint-disable MD040 MD060 -->
+# Acceptance Criteria
+
+BDD-style scenarios using Given / When / Then.
+Each scenario maps to one or more automated tests or manual verification steps.
+
+---
+
+## A. Account CRUD
+
+### A-1: Create an AWS account with Role ARN
+
+**Given** no cloud accounts are configured
+**When** I POST `/api/accounts` with:
+
+```json
+{
+  "name": "Prod-US",
+  "provider": "aws",
+  "external_id": "123456789012",
+  "aws_auth_mode": "role_arn",
+  "aws_role_arn": "arn:aws:iam::123456789012:role/CUDly"
+}
+```
+
+**Then** the response is `201` with the created account object
+**And** `GET /api/accounts` returns the account in the list
+**And** `credentials_configured` is `false` (no credentials provided yet)
+
+---
+
+### A-2: Create account with inline credentials
+
+**Given** a valid account payload
+**When** I include `credentials: { "access_key_id": "...", "secret_access_key": "..." }` in the POST (inline credentials on create; `type` is inferred from `aws_auth_mode = "access_keys"`)
+**Then** the account is created AND credentials are stored
+**And** `credentials_configured` is `true`
+**And** the credentials are NOT returned in any subsequent GET response
+
+---
+
+### A-2a: provider and external_id are immutable
+
+**Given** account X exists with `provider=aws, external_id=123456789012`
+**When** I PUT `/api/accounts/X.id` with `{ "provider": "azure" }` in the body
+**Then** response is `400` with an error describing that `provider` is immutable
+**And** account X is unchanged
+
+---
+
+### A-3: Duplicate external_id is rejected
+
+**Given** account with `provider=aws, external_id=123456789012` exists
+**When** I POST another account with the same `(provider, external_id)`
+**Then** the response is `409 Conflict`
+
+---
+
+### A-4: Bastion chain not allowed
+
+**Given** account A has `aws_auth_mode = 'bastion'`
+**When** I create account B with `aws_auth_mode = 'bastion'` and `aws_bastion_id = A.id`
+**Then** the response is `400` with error `"bastion chaining is not supported"`
+
+---
+
+### A-5: Delete account cascades correctly
+
+**Given** account X exists with service overrides and purchase history
+**When** I DELETE `/api/accounts/X.id`
+**Then** response is `204`
+**And** `account_credentials` rows for X are deleted
+**And** `account_service_overrides` rows for X are deleted
+**And** `purchase_history` rows for X retain their data but have `cloud_account_id = NULL`
+
+---
+
+### A-6: Delete bastion account blocked by dependents
+
+**Given** account B is used as bastion by accounts C and D
+**When** I DELETE `/api/accounts/B.id`
+**Then** the response is `409` with a message listing accounts C and D
+**And** account B still exists
+
+---
+
+## B. Credential Management
+
+### B-1: Credentials are never returned
+
+**Given** credentials are stored for account X
+**When** I GET `/api/accounts/X.id`
+**Then** the response body does NOT contain `access_key_id`, `secret_access_key`, `client_secret`, `private_key`, or any credential value
+**And** `credentials_configured: true` is present
+
+---
+
+### B-2: Test credentials — success
+
+**Given** account X has valid credentials stored
+**When** I POST `/api/accounts/X.id/test`
+**Then** response is `200` with `{ "ok": true, "caller_identity": "..." }`
+**And** no credential values appear in the response or server logs
+
+---
+
+### B-3: Test credentials — failure
+
+**Given** account X has invalid/expired credentials
+**When** I POST `/api/accounts/X.id/test`
+**Then** response is `200` (not `5xx`) with `{ "ok": false, "error": "..." }`
+**And** the error message does NOT contain the credential value
+
+---
+
+### B-3a: Test credentials — no credentials configured
+
+**Given** account X exists but has no credentials stored
+**When** I POST `/api/accounts/X.id/test`
+**Then** response is `200` (not `404`) with `{ "ok": false, "error": "no credentials configured" }`
+
+---
+
+### B-4: Overwrite credentials
+
+**Given** credentials are already stored for account X
+**When** I POST `/api/accounts/X.id/credentials` with new credential values
+**Then** response is `204`
+**And** old encrypted blob is replaced in `account_credentials`
+**And** test connectivity returns success with the new credentials
+
+---
+
+## C. Service Overrides
+
+### C-1: Global default is used when no override exists
+
+**Given** global service config: `{ provider: "aws", service: "ec2", term: 3, coverage: 80 }`
+**And** account X has no override for `aws/ec2`
+**When** recommendations are collected for account X
+**Then** the effective config used for EC2 is `term=3, coverage=80`
+
+---
+
+### C-2: Account override takes precedence for set fields
+
+**Given** global: `{ term: 3, coverage: 80 }`
+**And** account X has override: `{ term: 1 }` (coverage not set)
+**When** recommendations are collected for account X
+**Then** the effective config is `term=1, coverage=80` (term overridden, coverage inherited)
+
+---
+
+### C-3: Deleting an override reverts to global
+
+**Given** account X has override `{ term: 1 }` for `aws/ec2`
+**When** I DELETE `/api/accounts/X.id/service-overrides/aws/ec2`
+**Then** response is `204`
+**And** effective config for account X / EC2 reverts to global default
+
+---
+
+## D. Multi-Account Filtering
+
+### D-1: Filter recommendations by account
+
+**Given** accounts A (`123...`) and B (`234...`) have separate recommendations
+**When** I GET `/api/recommendations?account_ids=A.id`
+**Then** only recommendations from account A are returned
+**And** recommendations from account B are absent
+
+---
+
+### D-2: Filter dashboard by multiple accounts
+
+**Given** accounts A, B, C each have savings data
+**When** I GET `/api/dashboard/summary?account_ids=A.id,B.id`
+**Then** the summary aggregates A and B only
+**And** C's data is excluded
+
+---
+
+### D-3: No account filter returns all accounts
+
+**Given** accounts A, B, C exist
+**When** I GET `/api/recommendations` (no `account_ids` param)
+**Then** recommendations from all three accounts are returned
+
+---
+
+### D-4: Filtering by disabled account returns empty
+
+**Given** account D exists but `enabled = false`
+**When** I GET `/api/recommendations` (no filter)
+**Then** recommendations from account D are NOT included
+(Disabled accounts are excluded from all data collection)
+
+---
+
+## E. Plan Fan-out
+
+### E-1: Plan targeting two accounts creates two execution records
+
+**Given** plan P targets accounts A and B
+**When** the plan executes
+**Then** two rows are inserted in `purchase_executions`: one with `cloud_account_id = A.id`, one with `cloud_account_id = B.id`
+**And** both executions proceed in parallel (goroutines; verified via execution timestamps being close)
+
+---
+
+### E-2: One account failure does not fail others
+
+**Given** plan P targets accounts A (valid credentials) and B (invalid credentials)
+**When** the plan executes
+**Then** account A's execution completes successfully
+**And** account B's execution is marked `failed` with an error message
+**And** account A's execution record is unaffected by B's failure
+
+---
+
+### E-3: Plan with empty account list targets all provider accounts
+
+**Given** plan P has services with keys like `"aws:ec2"` (provider derived at runtime as `aws`) and no entries in `plan_accounts`
+**And** three AWS accounts are enabled (A, B, C)
+**When** the plan executes
+**Then** three execution records are created (one per account)
+
+---
+
+### E-4: Plan filtered to provider — only that provider's accounts run
+
+**Given** plan P has services with keys like `"aws:ec2"` (provider derived as `aws`)
+**And** accounts A (AWS), B (AWS), C (Azure) are enabled
+**When** `PUT /api/plans/P.id/accounts` is called with `[A.id, B.id, C.id]`
+**Then** the API returns `400` because C is not an AWS account
+**And** no accounts are associated
+
+---
+
+## F. Org Discovery
+
+### F-1: Discovery creates accounts for new members
+
+**Given** org root account R is configured with valid credentials
+**And** Organizations has member accounts M1, M2, M3
+**And** M1 already exists in `cloud_accounts`
+**When** I POST `/api/accounts/discover-org` with `org_root_account_id = R.id`
+**Then** response is `200` with `{ "discovered": 3, "created": 2, "skipped": 1 }`
+**And** M2 and M3 are created with `enabled = false`
+**And** M1 is untouched (skipped)
+
+---
+
+### F-2: Non-admin cannot trigger discovery
+
+**Given** user has role `user` (not `admin`)
+**When** I POST `/api/accounts/discover-org`
+**Then** response is `403 Forbidden`
+
+---
+
+### F-3: Discovery from non-org-root is rejected
+
+**Given** account X has `aws_is_org_root = false`
+**When** I POST `/api/accounts/discover-org` with `org_root_account_id = X.id`
+**Then** response is `400` with a descriptive error
+
+---
+
+## G. Frontend — Settings UI
+
+### G-1: Account appears in list after creation
+
+**Given** the Settings tab is open, AWS provider enabled
+**When** I click "+ Add Account" and fill in valid details
+**And** I click "Save Account"
+**Then** the new account appears in the `#aws-account-list` without page reload
+**And** the row shows the account name, Account ID, and auth mode badge
+
+---
+
+### G-2: Credentials status updates after saving credentials
+
+**Given** account X shows "⚠ No credentials"
+**When** I click "Credentials" and save valid credentials
+**Then** the row updates to "✓ Credentials set"
+
+---
+
+### G-3: Test button shows inline success/error
+
+**Given** account X has credentials configured
+**When** I click "Test"
+**Then** a non-blocking notification appears: "✓ Connected as arn:aws:iam::..." or "✗ Test failed: [reason]"
+**And** the page does not navigate away
+
+---
+
+### G-4: Overrides panel expands inline
+
+**Given** account X is shown in the account list
+**When** I click "Overrides"
+**Then** a panel expands below the account row showing service rows
+**And** rows with active overrides show "(override)" badge
+**And** rows without overrides show "(global)" badge
+
+---
+
+## H. Frontend — Filtering
+
+### H-1: Account filter is populated on tab load
+
+**Given** three AWS accounts are configured
+**When** I navigate to the Recommendations tab
+**Then** the `#recommendations-account-filter` select contains "All Accounts" plus the three account names
+
+---
+
+### H-2: Provider filter change updates account list
+
+**Given** the provider filter is set to "All"
+**And** the account filter shows AWS + Azure accounts
+**When** I change the provider filter to "AWS"
+**Then** the account filter is repopulated with AWS accounts only
+
+---
+
+### H-3: Multi-account selection is passed to API
+
+**Given** accounts A and B are selected in the account filter
+**When** recommendations reload
+**Then** the API request includes `account_ids=A.id,B.id`
+
+---
+
+## I. Backward Compatibility
+
+### I-1: Existing purchase history is unaffected
+
+**Given** purchase history records exist with `cloud_account_id = NULL` (pre-migration)
+**When** I GET `/api/history` with no filters
+**Then** old records are included in the response
+**And** their `cloud_account_id` field is absent or null
+
+---
+
+### I-2: Existing config endpoints still work
+
+**Given** multi-account feature is deployed
+**When** I GET `/api/config`
+**Then** the response is identical to pre-deployment (no breaking changes to existing config shape)
+
+---
+
+### I-3: Single-account workflow unchanged
+
+**Given** only one AWS account is configured
+**When** using any existing feature (recommendations, history, plans)
+**Then** the behavior is identical to pre-deployment with no account filter applied

--- a/specs/multi-account-execution/api.md
+++ b/specs/multi-account-execution/api.md
@@ -1,0 +1,403 @@
+<!-- markdownlint-disable MD040 MD060 -->
+# API Design
+
+All new endpoints are under the existing `/api` prefix and follow the same auth middleware, error response format, and permission model as current endpoints.
+
+---
+
+## Cloud Accounts Endpoints
+
+### `GET /api/accounts`
+
+List all configured cloud accounts. Returns metadata only — no credential material.
+
+**Query params:**
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `provider` | string | Filter by provider: `aws`, `azure`, `gcp` |
+| `enabled` | bool | Filter by enabled status |
+| `search` | string | Substring match on `name` or `external_id` |
+
+**Response `200`:**
+
+```json
+{
+  "accounts": [
+    {
+      "id": "uuid",
+      "name": "Prod-US",
+      "description": "Production US account",
+      "contact_email": "infra@example.com",
+      "enabled": true,
+      "provider": "aws",
+      "external_id": "123456789012",
+      "aws_auth_mode": "role_arn",
+      "aws_role_arn": "arn:aws:iam::123456789012:role/CUDly",
+      "aws_is_org_root": false,
+      "credentials_configured": true,
+      "created_at": "2026-01-01T00:00:00Z",
+      "updated_at": "2026-01-01T00:00:00Z"
+    }
+  ]
+}
+```
+
+---
+
+### `POST /api/accounts`
+
+Create a new cloud account. Credentials can be included inline and are stored encrypted.
+
+**Request body:**
+
+```json
+{
+  "name": "Prod-US",
+  "description": "Production US account",
+  "contact_email": "infra@example.com",
+  "enabled": true,
+  "provider": "aws",
+  "external_id": "123456789012",
+  "aws_auth_mode": "role_arn",
+  "aws_role_arn": "arn:aws:iam::123456789012:role/CUDly",
+  "aws_external_id": "cudly-external-123",
+
+  "credentials": {
+    "access_key_id": "AKIA...",         // only for aws_auth_mode = access_keys
+    "secret_access_key": "..."          // only for aws_auth_mode = access_keys
+  }
+}
+```
+
+For Azure:
+
+```json
+{
+  "provider": "azure",
+  "name": "Azure Prod",
+  "external_id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "azure_subscription_id": "xxxxxxxx-...",
+  "azure_tenant_id": "yyyyyyyy-...",
+  "azure_client_id": "zzzzzzzz-...",
+  "credentials": {
+    "client_secret": "..."
+  }
+}
+```
+
+For GCP:
+
+```json
+{
+  "provider": "gcp",
+  "name": "GCP Analytics",
+  "external_id": "my-project-123",
+  "gcp_project_id": "my-project-123",
+  "credentials": {
+    "service_account_json": "{ \"type\": \"service_account\", ... }"
+  }
+}
+```
+
+**Response `201`:** Created account object (same shape as GET, no credential material).
+
+**Validation errors `400`:**
+
+- `provider` not in `{aws, azure, gcp}`
+- `aws_auth_mode = role_arn` but no `aws_role_arn` provided
+- `aws_auth_mode = bastion` but no `aws_bastion_id` or bastion account not found
+- Duplicate `(provider, external_id)` → `409 Conflict`
+
+---
+
+### `GET /api/accounts/:id`
+
+Get a single account. Never returns credential material.
+
+**Response `200`:** Same shape as list item.
+**Response `404`:** Account not found.
+
+---
+
+### `PUT /api/accounts/:id`
+
+Update account metadata. Does not touch credentials.
+
+**Request body:** Same fields as POST, minus `credentials`, `provider`, and `external_id`. `provider` and `external_id` are immutable after creation; the server returns `400` if either is included in the PUT body.
+**Response `200`:** Updated account.
+
+---
+
+### `DELETE /api/accounts/:id`
+
+Delete account and cascade-delete its credentials and service overrides. Purchase history records retain the account name as a string but FK becomes `NULL`.
+
+**Response `204`:** No content.
+**Response `409`:** Account is referenced as bastion by other accounts (caller must re-assign those first).
+
+On delete, CUDly applies `ON DELETE CASCADE` to `account_credentials` and `account_service_overrides`, and `ON DELETE SET NULL` to `cloud_account_id` in `purchase_history`, `purchase_executions`, `savings_snapshots`, and `ri_exchange_history`. The `account_id VARCHAR(20)` column (cloud provider's raw account ID) is retained unchanged in those tables.
+
+---
+
+### `POST /api/accounts/:id/credentials`
+
+Replace credentials for an account. Write-only — returns no credential data.
+
+**Request body:**
+
+AWS access keys:
+
+```json
+{
+  "type": "aws_access_keys",
+  "access_key_id": "AKIA...",
+  "secret_access_key": "..."
+}
+```
+
+Azure client secret:
+
+```json
+{
+  "type": "azure_client_secret",
+  "client_secret": "..."
+}
+```
+
+GCP service account:
+
+```json
+{
+  "type": "gcp_service_account",
+  "service_account_json": "{ \"type\": \"service_account\", ... }"
+}
+```
+
+**Response `204`:** No content.
+
+---
+
+### `POST /api/accounts/:id/test`
+
+Test connectivity using the account's stored credentials. Makes a minimal read-only API call:
+
+- AWS: `sts:GetCallerIdentity`
+- Azure: `GET /subscriptions/{id}` (read subscription metadata)
+- GCP: `resourcemanager.projects.get`
+
+**Response `200`:**
+
+```json
+{
+  "ok": true,
+  "caller_identity": "arn:aws:iam::123456789012:role/CUDly"
+}
+```
+
+**Response `200`** (failure — connection error is not an HTTP error):
+
+```json
+{
+  "ok": false,
+  "error": "NoCredentialProviders: no valid providers in chain"
+}
+```
+
+**Response `200`** (no credentials stored — not a 404; credentials absence is a soft failure):
+
+```json
+{ "ok": false, "error": "no credentials configured" }
+```
+
+**Response `404`:** Account not found.
+
+---
+
+### `GET /api/accounts/:id/service-overrides`
+
+List all service overrides for an account.
+
+**Response `200`:**
+
+```json
+{
+  "overrides": [
+    {
+      "id": "uuid",
+      "account_id": "uuid",
+      "provider": "aws",
+      "service": "ec2",
+      "term": 1,
+      "coverage": 60.0
+    }
+  ]
+}
+```
+
+Fields not overridden are omitted from the response (callers should merge with global defaults client-side or use the resolved-config endpoint).
+
+---
+
+### `PUT /api/accounts/:id/service-overrides/:provider/:service`
+
+Create or replace a service override for an account. This is a **full-replace** operation: all override columns are set to the values provided in the request body; any field absent from the body is written as `NULL` (meaning "inherit from global default"). To update one field without resetting others, the caller must include the full desired override in the body.
+
+**Request body (all fields optional):**
+
+```json
+{
+  "enabled": true,
+  "term": 1,
+  "payment": "all-upfront",
+  "coverage": 60.0,
+  "ramp_schedule": "immediate",
+  "include_regions": ["us-east-1", "eu-west-1"],
+  "exclude_engines": ["aurora-mysql"]
+}
+```
+
+**Response `200`:** Saved override (sparse — only explicitly-set fields returned).
+
+---
+
+### `DELETE /api/accounts/:id/service-overrides/:provider/:service`
+
+Delete override, reverting to global default.
+
+**Response `204`:** No content.
+
+---
+
+### `POST /api/accounts/discover-org`
+
+Trigger AWS Organizations member account discovery using a configured org-root account. Idempotent: existing accounts matching discovered external IDs are skipped; new ones are created with `enabled = false` pending user review.
+
+**Request body:**
+
+```json
+{
+  "org_root_account_id": "uuid"
+}
+```
+
+**Response `200`:**
+
+```json
+{
+  "discovered": 14,
+  "created": 3,
+  "skipped": 11,
+  "accounts": [
+    { "name": "Member-Acct-A", "external_id": "111122223333", "created": true },
+    ...
+  ]
+}
+```
+
+**Response `400`:** `aws_is_org_root = false` for the referenced account (account exists but is not an org root).
+**Response `404`:** `org_root_account_id` references an account that does not exist.
+**Response `403`:** Caller is not an admin.
+
+---
+
+## Plan ↔ Account Association
+
+### `GET /api/plans/:id/accounts`
+
+List accounts associated with a plan.
+
+**Required permission:** `view` on `accounts`.
+
+**Response `200`:**
+
+```json
+{
+  "account_ids": ["uuid1", "uuid2"],
+  "accounts": [
+    { "id": "uuid1", "name": "Prod-US", "provider": "aws", "external_id": "123..." }
+  ]
+}
+```
+
+---
+
+### `PUT /api/plans/:id/accounts`
+
+Replace the full account list for a plan. Send an empty array to target all accounts for the plan's provider.
+
+**Required permission:** `update` on `accounts`.
+
+**Request body:**
+
+```json
+{
+  "account_ids": ["uuid1", "uuid2"]
+}
+```
+
+**Validation:** All referenced `account_ids` must exist and their `provider` must match the plan's provider (derived from the plan's `services` map keys — e.g. a key of `"aws:ec2"` means provider `aws`).
+**Response `200`:** Same as GET response above.
+
+---
+
+## Modifications to Existing Endpoints
+
+The following endpoints gain an optional `account_ids` query parameter.
+
+**`account_ids`**: comma-separated list of `cloud_accounts.id` UUIDs. Omitting the param (or passing `account_ids=`) returns data for **all** accounts.
+
+### Dashboard
+
+```
+GET /api/dashboard/summary?provider=aws&account_ids=uuid1,uuid2
+GET /api/dashboard/upcoming?account_ids=uuid1
+```
+
+### Recommendations
+
+```
+GET /api/recommendations?provider=aws&account_ids=uuid1&service=ec2&region=us-east-1
+```
+
+### History
+
+```
+GET /api/history?provider=aws&account_ids=uuid1,uuid2&start=2026-01-01&end=2026-03-31
+GET /api/history/analytics?account_ids=uuid1&interval=monthly
+GET /api/history/breakdown?dimension=service&account_ids=uuid1
+```
+
+---
+
+## Error Response Format
+
+Unchanged from current pattern — a single `error` string key, no code field:
+
+```json
+{
+  "error": "account not found"
+}
+```
+
+Standard HTTP status codes apply: `400` validation, `401` unauthenticated, `403` unauthorized, `404` not found, `409` conflict, `500` internal.
+
+Error types are signalled via `NewClientError(code, message)` (defined in `internal/api/handler_router.go`). For example, `NewClientError(404, "account not found")` produces `{"error": "account not found"}` with HTTP 404. Any unhandled Go error maps to `500 {"error": "Internal server error"}`.
+
+---
+
+## Permissions
+
+New resource type `accounts` added to the permission model:
+
+| Action | Resource | Description |
+|--------|----------|-------------|
+| `view` | `accounts` | List and GET accounts |
+| `create` | `accounts` | Create new accounts |
+| `update` | `accounts` | Edit metadata and service overrides |
+| `delete` | `accounts` | Delete accounts |
+| `manage_credentials` | `accounts` | Write credentials to an account |
+| `test_credentials` | `accounts` | Test account connectivity |
+| `discover_org` | `accounts` | Trigger org discovery (admin only) |
+
+The `allowed_accounts` constraint on existing permissions continues to work: a user with `view` on `recommendations` and `allowed_accounts: ["uuid1"]` only sees recommendations from account `uuid1`.

--- a/specs/multi-account-execution/backend.md
+++ b/specs/multi-account-execution/backend.md
@@ -1,0 +1,365 @@
+<!-- markdownlint-disable MD040 MD060 -->
+# Backend Architecture
+
+## Package Structure
+
+```
+internal/
+  credentials/         ← NEW: credential encryption + resolution
+    cipher.go          ← AES-256-GCM encrypt/decrypt primitives
+    store.go           ← save/load encrypted blobs from account_credentials
+    resolver.go        ← decrypt + return provider-specific credential structs
+    cipher_test.go
+    resolver_test.go
+
+  accounts/            ← NEW: account-level business logic
+    org_discovery.go   ← AWS Organizations member-account discovery
+    org_discovery_test.go
+
+  execution/           ← NEW: parallel multi-account fan-out engine
+    executor.go        ← Executor interface + per-account executor
+    fanout.go          ← FanOut: concurrently runs a function across N accounts
+    collector.go       ← aggregates tagged per-account results
+    fanout_test.go
+
+  config/
+    types.go           ← ADD: CloudAccount, AccountServiceOverride, CloudAccountFilter
+    interfaces.go      ← ADD: new store method signatures
+    store_postgres.go  ← ADD: implementations for new StoreInterface methods
+                          NOTE: does NOT implement credentials.CredentialStore —
+                          that would create a circular import (credentials→config→credentials)
+    resolver.go        ← ADD: ResolveServiceConfig (cascade logic)
+
+  api/
+    handler_accounts.go    ← NEW: HTTP handlers for /api/accounts/* routes
+    handler_accounts_test.go
+    handler.go             ← MODIFY: add credStore credentials.CredentialStore to Handler struct
+    types.go               ← MODIFY: add CredentialStore to HandlerConfig
+    router.go              ← MODIFY: register new routes (existing table-driven router)
+    handler_recommendations.go ← MODIFY: add account_ids filter to recommendations handler
+    handler_dashboard.go   ← MODIFY: add account_ids filter
+    handler_history.go     ← MODIFY: add account_ids filter to history handler
+    handler_analytics.go   ← MODIFY: add account_ids filter to analytics handlers
+    -- NOTE: internal/server/handler.go is for SCHEDULED TASK dispatch only,
+    --       not HTTP routing. HTTP routing lives entirely in internal/api/.
+
+  server/
+    app.go                 ← MODIFY: add CredentialStore field to Application, initialise from
+                             credentials.NewCredentialStore(pool, encKey) in DB connect path
+```
+
+---
+
+## Credential Management (`internal/credentials/`)
+
+### `cipher.go`
+
+```go
+package credentials
+
+// Encrypt encrypts plaintext using AES-256-GCM.
+// Returns "<base64(nonce)>.<base64(ciphertext)>".
+func Encrypt(key []byte, plaintext []byte) (string, error)
+
+// Decrypt reverses Encrypt.
+func Decrypt(key []byte, blob string) ([]byte, error)
+
+// KeyFromEnv loads the 32-byte AES encryption key using the following priority order:
+//   1. CREDENTIAL_ENCRYPTION_KEY_SECRET_ARN set → call secretsmanager.GetSecretValue(arn),
+//      treat returned string as 64-char hex key; cache result for Lambda lifetime.
+//   2. CREDENTIAL_ENCRYPTION_KEY set → decode as 64-char hex key directly (local dev / non-AWS).
+//   3. Neither set → use hardcoded dev-only key; logs WARN "using insecure dev credential key".
+func KeyFromEnv() ([]byte, error)
+```
+
+Key format: `CREDENTIAL_ENCRYPTION_KEY` env var must be a 64-character hex string (32 bytes). Generate with: `openssl rand -hex 32`.
+
+### `store.go`
+
+**Import note**: `internal/credentials` imports `internal/config` (for `CloudAccount`). It must NOT be imported by `internal/config` — that would create a circular dependency. The concrete `CredentialStore` implementation lives here in `internal/credentials/store.go` and takes a `*pgxpool.Pool` directly (same mechanism `store_postgres.go` uses), keeping the packages independent.
+
+```go
+type CredentialStore interface {
+    // SaveCredential encrypts and stores credential material.
+    SaveCredential(ctx context.Context, accountID string, credType string, payload []byte) error
+
+    // DeleteCredential removes stored credential material.
+    DeleteCredential(ctx context.Context, accountID string, credType string) error
+
+    // HasCredential returns true if credential material exists for the account+type.
+    HasCredential(ctx context.Context, accountID string, credType string) (bool, error)
+
+    // LoadRaw decrypts and returns raw credential bytes.
+    // Only called by resolver.go — not for application use.
+    // Must be exported (uppercase) since the concrete struct is in the same package
+    // (pgCredentialStore) but callers across packages need the interface.
+    LoadRaw(ctx context.Context, accountID string, credType string) ([]byte, error)
+}
+
+// NewCredentialStore creates a CredentialStore backed by the account_credentials table.
+// Takes a *pgxpool.Pool directly — does not go through StoreInterface.
+func NewCredentialStore(pool *pgxpool.Pool, encKey []byte) CredentialStore
+```
+
+### `resolver.go`
+
+```go
+// AWSCredentials holds resolved AWS access credentials.
+// Note: for role-based auth modes (role_arn, bastion) this struct is not used;
+// callers use ResolveAWSCredentialProvider which returns an aws.CredentialsProvider.
+type AWSCredentials struct {
+    AccessKeyID     string
+    SecretAccessKey string
+}
+
+func (c *AWSCredentials) String() string { return "[REDACTED]" }
+
+// AzureCredentials holds resolved Azure service principal credentials.
+type AzureCredentials struct {
+    ClientSecret string
+}
+
+func (c *AzureCredentials) String() string { return "[REDACTED]" }
+
+// STSClient is the minimal STS interface needed for role assumption.
+// Satisfied by *sts.Client from github.com/aws/aws-sdk-go-v2/service/sts.
+type STSClient interface {
+    AssumeRole(ctx context.Context, params *sts.AssumeRoleInput, optFns ...func(*sts.Options)) (*sts.AssumeRoleOutput, error)
+}
+
+// ResolveAWSCredentialProvider returns an aws.CredentialsProvider for the given account.
+//
+// Logic per auth mode:
+//   access_keys: decrypt blob → static credentials provider
+//   role_arn:    use ambient credentials (instance role/env) → STS AssumeRole
+//   bastion:     resolve bastion account creds first → STS AssumeRole into target account
+//
+// The returned provider is safe to use for the duration of one API call.
+// Callers should NOT cache the returned provider across requests.
+func ResolveAWSCredentialProvider(
+    ctx context.Context,
+    account *config.CloudAccount,
+    store CredentialStore,
+    stsClient STSClient,
+) (aws.CredentialsProvider, error)
+
+// ResolveAzureCredentials decrypts and returns the Azure client secret.
+func ResolveAzureCredentials(ctx context.Context, account *config.CloudAccount, store CredentialStore) (*AzureCredentials, error)
+
+// ResolveGCPCredentials decrypts and returns the GCP service account JSON.
+func ResolveGCPCredentials(ctx context.Context, account *config.CloudAccount, store CredentialStore) ([]byte, error)
+```
+
+**Bastion chain resolution (AWS)**:
+
+1. Load the hub account (`cloud_accounts.aws_bastion_id`).
+2. Resolve hub account's credentials (either access_keys or role_arn — bastion accounts cannot themselves be bastions).
+3. Use hub credentials to call `sts:AssumeRole` with `aws_role_arn` of the target account and optional `aws_external_id`.
+4. Return a `aws.CredentialsProvider` wrapping the assumed-role session token.
+
+---
+
+## Org Discovery (`internal/accounts/org_discovery.go`)
+
+```go
+// DiscoverOrgAccounts calls AWS Organizations ListAccounts using the management
+// account's credentials and returns a slice of CloudAccount records (not yet persisted).
+// Caller is responsible for deduplication and saving.
+func DiscoverOrgAccounts(
+    ctx context.Context,
+    mgmtAccount *config.CloudAccount,
+    credStore credentials.CredentialStore,
+) ([]config.CloudAccount, error)
+```
+
+Implementation:
+
+1. Resolve credentials for `mgmtAccount` using the credentials package.
+2. Create an `organizations.Client` with those credentials.
+3. Call `organizations.ListAccounts` (paginated).
+4. Map each member account to a `CloudAccount` struct with:
+   - `Provider = "aws"`
+   - `ExternalID = member.Id`
+   - `Name = *member.Name`
+   - `Enabled = false` (operator must review and enable)
+   - `AWSAuthMode = "bastion"` (default: assume they'll use the org root as bastion)
+   - `AWSBastionID = mgmtAccount.ID`
+5. Return slice — caller saves to DB with `CreateCloudAccount`, skipping duplicates by `(provider, external_id)`.
+
+---
+
+## Parallel Execution Engine (`internal/execution/`)
+
+### `executor.go`
+
+```go
+// AccountContext bundles an account with its resolved credentials for one execution.
+type AccountContext struct {
+    Account     config.CloudAccount
+    AWSProvider aws.CredentialsProvider   // non-nil for AWS accounts
+    AzureCreds  *credentials.AzureCredentials // non-nil for Azure
+    GCPKeyJSON  []byte                    // non-nil for GCP
+}
+
+// PrepareAccountContext resolves credentials and returns an AccountContext.
+// This is the only function that calls the credentials package.
+func PrepareAccountContext(ctx context.Context, account config.CloudAccount, credStore credentials.CredentialStore) (*AccountContext, error)
+```
+
+### `fanout.go`
+
+```go
+// FanOutResult wraps the result of one account's execution with its account context.
+type FanOutResult[T any] struct {
+    Account config.CloudAccount
+    Result  T
+    Err     error
+}
+
+// FanOut runs fn concurrently for each account with a configurable parallelism limit
+// (default: 10). Results are collected in a slice ordered by account ID (deterministic
+// for testing — sort by account ID after all goroutines complete).
+//
+// Implementation note: do NOT use errgroup.WithContext — that cancels the shared context
+// on the first error, which would abort in-flight goroutines for other accounts.
+// Instead use sync.WaitGroup + a buffered semaphore channel for the parallelism cap,
+// and capture each account's error in its own FanOutResult.Err.
+//
+// A failure in one account's fn does NOT affect others.
+// Each error is captured in FanOutResult.Err.
+func FanOut[T any](
+    ctx context.Context,
+    accounts []config.CloudAccount,
+    maxParallel int,
+    fn func(context.Context, AccountContext) (T, error),
+    credStore credentials.CredentialStore,
+) []FanOutResult[T]
+```
+
+**Parallelism limit**: Controlled by `CUDLY_MAX_ACCOUNT_PARALLELISM` env var, default `10`. This prevents overwhelming AWS API rate limits when running across many accounts simultaneously.
+
+### `collector.go`
+
+```go
+// AggregatedRecommendations merges per-account recommendation slices into one slice,
+// adding Account metadata to each item.
+func AggregatedRecommendations(results []FanOutResult[[]config.RecommendationRecord]) []config.RecommendationRecord
+
+// AggregatedPurchaseHistory merges per-account history slices.
+func AggregatedPurchaseHistory(results []FanOutResult[[]config.PurchaseHistoryRecord]) []config.PurchaseHistoryRecord
+```
+
+---
+
+## Service Config Cascade (`internal/config/resolver.go`)
+
+```go
+// ResolveServiceConfig merges an account-level sparse override on top of the
+// global service config. Any nil pointer in override inherits from global.
+// Returns a fully-populated ServiceConfig (no nil fields).
+func ResolveServiceConfig(global *ServiceConfig, override *AccountServiceOverride) *ServiceConfig {
+    if override == nil {
+        return global
+    }
+    result := *global // copy
+    if override.Enabled      != nil { result.Enabled      = *override.Enabled }
+    if override.Term         != nil { result.Term         = *override.Term }
+    if override.Payment      != nil { result.Payment      = *override.Payment }
+    if override.Coverage     != nil { result.Coverage     = *override.Coverage }
+    if override.RampSchedule != nil { result.RampSchedule = *override.RampSchedule }
+    if override.IncludeEngines != nil { result.IncludeEngines = override.IncludeEngines }
+    if override.ExcludeEngines != nil { result.ExcludeEngines = override.ExcludeEngines }
+    if override.IncludeRegions != nil { result.IncludeRegions = override.IncludeRegions }
+    if override.ExcludeRegions != nil { result.ExcludeRegions = override.ExcludeRegions }
+    if override.IncludeTypes   != nil { result.IncludeTypes   = override.IncludeTypes }
+    if override.ExcludeTypes   != nil { result.ExcludeTypes   = override.ExcludeTypes }
+    return &result
+}
+```
+
+---
+
+## Store Interface Additions (`internal/config/interfaces.go`)
+
+```go
+// Cloud Account management
+CreateCloudAccount(ctx context.Context, account *CloudAccount) error
+GetCloudAccount(ctx context.Context, id string) (*CloudAccount, error)
+UpdateCloudAccount(ctx context.Context, account *CloudAccount) error
+DeleteCloudAccount(ctx context.Context, id string) error
+ListCloudAccounts(ctx context.Context, filter CloudAccountFilter) ([]CloudAccount, error)
+
+// Account service overrides
+GetAccountServiceOverride(ctx context.Context, accountID, provider, service string) (*AccountServiceOverride, error)
+SaveAccountServiceOverride(ctx context.Context, override *AccountServiceOverride) error
+DeleteAccountServiceOverride(ctx context.Context, accountID, provider, service string) error
+ListAccountServiceOverrides(ctx context.Context, accountID string) ([]AccountServiceOverride, error)
+
+// Plan ↔ Account association
+SetPlanAccounts(ctx context.Context, planID string, accountIDs []string) error
+GetPlanAccounts(ctx context.Context, planID string) ([]CloudAccount, error)
+```
+
+---
+
+## Purchase Plan Execution Changes
+
+Current flow is triggered via `app.Purchase.ProcessScheduledPurchases(ctx)` (called from
+`internal/server/handler.go:handleProcessScheduledPurchases`). The implementation lives in:
+
+- `internal/purchase/manager.go` — `ProcessScheduledPurchases` orchestrates the flow
+- `internal/purchase/execution.go` — per-plan execution logic
+
+New flow — changes required in `internal/purchase/execution.go`:
+
+```
+ProcessScheduledPurchases(ctx):
+  for each plan:
+    1. Derive plan's provider: iterate plan.Services map keys (format "provider:service",
+       e.g. "aws:ec2") and extract the provider. In practice the frontend always sends a
+       single provider, so take the first distinct provider found.
+    2. Load plan accounts from plan_accounts (if empty: load all enabled accounts
+       matching that derived provider)
+    3. For each account: PrepareAccountContext(ctx, account, credStore)
+    4. FanOut(ctx, accountContexts, fn=executeForAccount)
+    5. For each FanOutResult:
+         a. Create purchase_execution row tagged with cloud_account_id
+         b. If Err != nil: mark execution failed, log, continue
+         c. If ok: execute purchases against account's cloud API
+    6. Aggregate and return summary
+```
+
+**Note on `PurchasePlan.Provider`**: The `PurchasePlan` struct (`internal/config/types.go`) has no direct `provider` field. Provider is embedded in the `Services` map keys (e.g. `"aws:ec2"`). Do not add a `provider` column to `purchase_plans` as part of this feature; derive it from the services map at runtime.
+
+The `purchase_executions` table now has a `cloud_account_id` column so each execution row is linked to the specific account it ran against.
+
+---
+
+## Modified Handler: `account_ids` Filtering
+
+The existing handlers in `internal/api/` use a Lambda Function URL request model, not
+`*http.Request`. Query parameter extraction uses the Lambda event:
+
+```go
+// parseAccountIDs extracts and validates the account_ids query param from a Lambda request.
+// Returns nil slice (= all accounts) if param is absent or empty.
+// Add this helper to internal/api/handler.go or a shared helpers file.
+func parseAccountIDs(req *events.LambdaFunctionURLRequest) ([]string, error) {
+    raw := req.QueryStringParameters["account_ids"]
+    if raw == "" {
+        return nil, nil
+    }
+    parts := strings.Split(raw, ",")
+    ids := make([]string, 0, len(parts))
+    for _, part := range parts {
+        id := strings.TrimSpace(part)
+        if _, err := uuid.Parse(id); err != nil {
+            return nil, fmt.Errorf("invalid account_id %q: %w", id, err)
+        }
+        ids = append(ids, id)
+    }
+    return ids, nil
+}
+```
+
+History queries that currently filter by `account_id VARCHAR(20)` (raw AWS account ID) will also support filtering by `cloud_account_id UUID` for multi-account scenarios. The existing single-account behavior is preserved when `account_ids` is absent.

--- a/specs/multi-account-execution/data-model.md
+++ b/specs/multi-account-execution/data-model.md
@@ -1,0 +1,329 @@
+<!-- markdownlint-disable MD040 MD060 -->
+# Data Model
+
+## Overview
+
+Four new tables are introduced. Four existing tables gain a nullable FK column (`cloud_account_id`) for forward-compatible account attribution. All changes are backward-compatible: existing rows keep working with `cloud_account_id = NULL` (interpreted as "legacy / pre-migration record").
+
+Migration file: `internal/database/postgres/migrations/000011_cloud_accounts.up.sql`
+
+---
+
+## New Tables
+
+### `cloud_accounts`
+
+Central registry for every managed cloud account/subscription/project.
+
+```sql
+CREATE TABLE cloud_accounts (
+    id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+
+    -- Display / metadata
+    name            VARCHAR(255) NOT NULL,
+    description     TEXT,
+    contact_email   VARCHAR(255),
+    enabled         BOOLEAN NOT NULL DEFAULT true,
+
+    -- Provider identification
+    provider        VARCHAR(32) NOT NULL
+                    CHECK (provider IN ('aws', 'azure', 'gcp')),
+    external_id     VARCHAR(255) NOT NULL,
+    -- external_id meaning per provider:
+    --   aws:   12-digit AWS account ID  (e.g. "123456789012")
+    --   azure: Azure subscription UUID  (e.g. "xxxxxxxx-xxxx-...")
+    --   gcp:   GCP project ID           (e.g. "my-project-123")
+
+    -- ── AWS-specific ─────────────────────────────────────────
+    aws_auth_mode   VARCHAR(32)
+                    CHECK (aws_auth_mode IN ('access_keys', 'role_arn', 'bastion')),
+    aws_role_arn    VARCHAR(512),        -- for role_arn and bastion modes
+    aws_external_id VARCHAR(255),        -- ExternalId for STS AssumeRole (optional)
+    aws_bastion_id  UUID                 -- for bastion mode: FK to the hub account
+                    REFERENCES cloud_accounts(id) ON DELETE SET NULL,
+    aws_is_org_root BOOLEAN NOT NULL DEFAULT false,
+    -- When true: CUDly treats this as an AWS Organizations management account
+    -- and can discover member accounts via the Organizations API.
+
+    -- ── Azure-specific ───────────────────────────────────────
+    azure_subscription_id   VARCHAR(36),
+    azure_tenant_id         VARCHAR(36),
+    azure_client_id         VARCHAR(36),    -- non-secret; client_secret stored in account_credentials
+
+    -- ── GCP-specific ─────────────────────────────────────────
+    gcp_project_id      VARCHAR(255),
+    gcp_client_email    VARCHAR(255),       -- non-secret; private_key stored in account_credentials
+
+    -- Audit
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_by  UUID REFERENCES users(id) ON DELETE SET NULL,
+
+    UNIQUE(provider, external_id)
+);
+
+CREATE TRIGGER update_cloud_accounts_updated_at
+    BEFORE UPDATE ON cloud_accounts
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE INDEX idx_cloud_accounts_provider ON cloud_accounts(provider) WHERE enabled = true;
+CREATE INDEX idx_cloud_accounts_org_root ON cloud_accounts(aws_is_org_root) WHERE aws_is_org_root = true;
+```
+
+**Constraints:**
+
+- `aws_bastion_id` must not reference an account that itself has `aws_auth_mode = 'bastion'` — enforced at application layer (prevents chaining).
+- When `aws_auth_mode = 'role_arn'` or `'bastion'`, `aws_role_arn` must be non-null — validated on write.
+- When `provider = 'azure'`, `azure_subscription_id` and `azure_tenant_id` must be non-null — validated on write.
+
+**`external_id` vs provider-specific ID fields:**
+`external_id` is the provider-agnostic unique key used for deduplication (`UNIQUE(provider, external_id)`). For Azure and GCP, `external_id` duplicates the provider-specific field:
+
+- Azure: `external_id` = `azure_subscription_id` (both are the subscription UUID). On create/update, if both are provided they must match; if only `external_id` is provided, the handler sets `azure_subscription_id = external_id` automatically.
+- GCP: `external_id` = `gcp_project_id` (both are the project ID string). Same derivation rule applies.
+- AWS: `external_id` is the 12-digit AWS account ID; there is no separate `aws_account_id` column (not needed — the account ID is not provider-specific secret data).
+
+---
+
+### `account_credentials`
+
+Stores encrypted credential material. Never returned via GET responses.
+
+```sql
+CREATE TABLE account_credentials (
+    id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    account_id      UUID NOT NULL
+                    REFERENCES cloud_accounts(id) ON DELETE CASCADE,
+    credential_type VARCHAR(32) NOT NULL,
+    -- Allowed values and the JSON structure they encrypt:
+    --
+    --  'aws_access_keys'       → {"access_key_id": "...", "secret_access_key": "..."}
+    --  'azure_client_secret'   → {"client_secret": "..."}
+    --  'gcp_service_account'   → full service account JSON blob
+    --
+    encrypted_blob  TEXT NOT NULL,
+    -- AES-256-GCM ciphertext, base64url-encoded.
+    -- Format: <base64(nonce)>.<base64(ciphertext)>
+    -- Key source: loaded by KeyFromEnv() — see iac.md and security.md for full load order
+    --   (prod: CREDENTIAL_ENCRYPTION_KEY_SECRET_ARN → Secrets Manager;
+    --    dev:  CREDENTIAL_ENCRYPTION_KEY env var directly)
+
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    UNIQUE(account_id, credential_type)
+);
+
+CREATE TRIGGER update_account_credentials_updated_at
+    BEFORE UPDATE ON account_credentials
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+```
+
+**Note**: `account_credentials` has no SELECT-returning API endpoint. The application only reads it server-side to resolve credentials before making cloud API calls.
+
+---
+
+### `account_service_overrides`
+
+Per-account sparse overrides for service configuration. `NULL` in any column means "inherit from global `service_configs`".
+
+```sql
+CREATE TABLE account_service_overrides (
+    id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    account_id      UUID NOT NULL
+                    REFERENCES cloud_accounts(id) ON DELETE CASCADE,
+    provider        VARCHAR(32) NOT NULL,
+    service         VARCHAR(64) NOT NULL,
+
+    -- All override fields are nullable; NULL = inherit global default
+    enabled         BOOLEAN,
+    term            INTEGER,                -- years: 1 or 3
+    payment         VARCHAR(32),            -- no-upfront / partial-upfront / all-upfront
+    coverage        DECIMAL(5,2),           -- 0–100
+    ramp_schedule   VARCHAR(32),
+    include_engines TEXT[],
+    exclude_engines TEXT[],
+    include_regions TEXT[],
+    exclude_regions TEXT[],
+    include_types   TEXT[],
+    exclude_types   TEXT[],
+
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    UNIQUE(account_id, provider, service)
+);
+
+CREATE TRIGGER update_account_service_overrides_updated_at
+    BEFORE UPDATE ON account_service_overrides
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE INDEX idx_aso_account ON account_service_overrides(account_id);
+```
+
+**Cascade resolution logic** (implemented in `internal/config/resolver.go`):
+
+```
+effectiveConfig(account, provider, service):
+  global = service_configs WHERE provider=? AND service=?
+  override = account_service_overrides WHERE account_id=? AND provider=? AND service=?
+  IF override IS NULL: return global
+  RETURN {
+    enabled:         COALESCE(override.enabled,         global.enabled),
+    term:            COALESCE(override.term,            global.term),
+    payment:         COALESCE(override.payment,         global.payment),
+    coverage:        COALESCE(override.coverage,        global.coverage),
+    ramp_schedule:   COALESCE(override.ramp_schedule,   global.ramp_schedule),
+    include_engines: COALESCE(override.include_engines, global.include_engines),
+    ... etc
+  }
+```
+
+---
+
+### `plan_accounts`
+
+Many-to-many join: which cloud accounts a purchase plan targets.
+
+```sql
+CREATE TABLE plan_accounts (
+    plan_id     UUID NOT NULL REFERENCES purchase_plans(id) ON DELETE CASCADE,
+    account_id  UUID NOT NULL REFERENCES cloud_accounts(id) ON DELETE CASCADE,
+    PRIMARY KEY (plan_id, account_id)
+);
+
+CREATE INDEX idx_plan_accounts_account ON plan_accounts(account_id);
+```
+
+**Behaviour when the list is empty**: A plan with no rows in `plan_accounts` targets **all enabled accounts** for its configured provider. This is the default for backward compatibility with plans created before multi-account support.
+
+---
+
+## Existing Table Modifications
+
+The following tables gain a nullable `cloud_account_id` column so that new records can be attributed to a specific managed account. Existing rows default to `NULL` (no attribution required).
+
+### `purchase_history`
+
+```sql
+ALTER TABLE purchase_history
+    ADD COLUMN cloud_account_id UUID REFERENCES cloud_accounts(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_purchase_history_cloud_account
+    ON purchase_history(cloud_account_id) WHERE cloud_account_id IS NOT NULL;
+```
+
+### `purchase_executions`
+
+```sql
+ALTER TABLE purchase_executions
+    ADD COLUMN cloud_account_id UUID REFERENCES cloud_accounts(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_purchase_executions_cloud_account
+    ON purchase_executions(cloud_account_id) WHERE cloud_account_id IS NOT NULL;
+```
+
+### `savings_snapshots`
+
+```sql
+ALTER TABLE savings_snapshots
+    ADD COLUMN cloud_account_id UUID REFERENCES cloud_accounts(id) ON DELETE SET NULL;
+```
+
+### `ri_exchange_history`
+
+```sql
+ALTER TABLE ri_exchange_history
+    ADD COLUMN cloud_account_id UUID REFERENCES cloud_accounts(id) ON DELETE SET NULL;
+```
+
+**Note on `account_id VARCHAR(20)`**: These columns are kept as-is. They store the raw cloud-provider account identifier (AWS 12-digit ID, Azure subscription GUID, etc.) and are still populated for all new records. `cloud_account_id` is the normalized FK into CUDly's own registry.
+
+---
+
+## Migration File Structure
+
+```
+internal/database/postgres/migrations/
+  000011_cloud_accounts.up.sql    ← creates the 4 new tables, adds FK columns, creates indexes
+  000011_cloud_accounts.down.sql  ← drops indexes, removes FK columns, drops tables in reverse order
+```
+
+Down migration order (reverse dependency):
+
+1. `DROP TABLE plan_accounts`
+2. `DROP TABLE account_service_overrides`
+3. `DROP TABLE account_credentials`
+4. Remove FK columns from `purchase_history`, `purchase_executions`, `savings_snapshots`, `ri_exchange_history`
+5. `DROP TABLE cloud_accounts`
+
+---
+
+## Go Type Additions (`internal/config/types.go`)
+
+```go
+// CloudAccount represents a single managed cloud account/subscription/project.
+type CloudAccount struct {
+    ID           string    `json:"id"`
+    Name         string    `json:"name"`
+    Description  string    `json:"description,omitempty"`
+    ContactEmail string    `json:"contact_email,omitempty"`
+    Enabled      bool      `json:"enabled"`
+    Provider     string    `json:"provider"`
+    ExternalID   string    `json:"external_id"`
+
+    // AWS
+    AWSAuthMode    string  `json:"aws_auth_mode,omitempty"`
+    AWSRoleARN     string  `json:"aws_role_arn,omitempty"`
+    AWSExternalID  string  `json:"aws_external_id,omitempty"`
+    AWSBastionID   string  `json:"aws_bastion_id,omitempty"`
+    AWSIsOrgRoot   bool    `json:"aws_is_org_root,omitempty"`
+
+    // Azure
+    AzureSubscriptionID string `json:"azure_subscription_id,omitempty"`
+    AzureTenantID       string `json:"azure_tenant_id,omitempty"`
+    AzureClientID       string `json:"azure_client_id,omitempty"`
+
+    // GCP
+    GCPProjectID    string `json:"gcp_project_id,omitempty"`
+    GCPClientEmail  string `json:"gcp_client_email,omitempty"`
+
+    // Derived (not stored)
+    CredentialsConfigured bool   `json:"credentials_configured"`
+    BastionAccountName    string `json:"bastion_account_name,omitempty"`
+
+    CreatedAt time.Time  `json:"created_at"`
+    UpdatedAt time.Time  `json:"updated_at"`
+    CreatedBy string     `json:"created_by,omitempty"`
+}
+
+// CloudAccountFilter for ListCloudAccounts queries.
+type CloudAccountFilter struct {
+    Provider  *string
+    Enabled   *bool
+    Search    string  // substring match on name or external_id
+    BastionID *string // return accounts whose aws_bastion_id = *BastionID; used by delete handler
+}
+
+// AccountServiceOverride is a sparse per-account override on top of the global ServiceConfig.
+// Nil pointer fields inherit the global value.
+type AccountServiceOverride struct {
+    ID           string    `json:"id"`
+    AccountID    string    `json:"account_id"`
+    Provider     string    `json:"provider"`
+    Service      string    `json:"service"`
+    Enabled      *bool     `json:"enabled,omitempty"`
+    Term         *int      `json:"term,omitempty"`
+    Payment      *string   `json:"payment,omitempty"`
+    Coverage     *float64  `json:"coverage,omitempty"`
+    RampSchedule *string   `json:"ramp_schedule,omitempty"`
+    IncludeEngines []string `json:"include_engines,omitempty"`
+    ExcludeEngines []string `json:"exclude_engines,omitempty"`
+    IncludeRegions []string `json:"include_regions,omitempty"`
+    ExcludeRegions []string `json:"exclude_regions,omitempty"`
+    IncludeTypes   []string `json:"include_types,omitempty"`
+    ExcludeTypes   []string `json:"exclude_types,omitempty"`
+    CreatedAt time.Time `json:"created_at"`
+    UpdatedAt time.Time `json:"updated_at"`
+}
+```

--- a/specs/multi-account-execution/frontend.md
+++ b/specs/multi-account-execution/frontend.md
@@ -1,0 +1,571 @@
+<!-- markdownlint-disable MD040 MD060 -->
+# Frontend Design
+
+## Overview
+
+The frontend changes fall into four areas:
+
+1. **Settings Tab** — account CRUD UI per provider (AWS / Azure / GCP)
+2. **Service Override UI** — per-account overrides for service defaults
+3. **Filter bar additions** — account multi-select in Dashboard, Recommendations, History, Plans
+4. **Plan account association** — account selector in plan create/edit modal
+
+All changes are backward-compatible: if no accounts are configured, the UI behaves identically to today.
+
+---
+
+## State Model Changes
+
+### `frontend/src/api/types.ts`
+
+Add `CloudAccount` here — it is an API response type, consistent with all other API response shapes (`AzureCredentials`, `GCPCredentials`, `Plan`, `PurchaseHistory`, etc.) that live in `frontend/src/api/types.ts`.
+
+```typescript
+// New type — add to frontend/src/api/types.ts
+export interface CloudAccount {
+  id: string;
+  name: string;
+  description?: string;
+  contact_email?: string;
+  enabled: boolean;
+  provider: Provider;
+  external_id: string;
+
+  // AWS-specific (may be absent for Azure/GCP)
+  aws_auth_mode?: 'access_keys' | 'role_arn' | 'bastion';
+  aws_role_arn?: string;
+  aws_external_id?: string;
+  aws_bastion_id?: string;
+  aws_is_org_root?: boolean;
+  bastion_account_name?: string;  // resolved display name
+
+  // Azure-specific
+  azure_subscription_id?: string;
+  azure_tenant_id?: string;
+  azure_client_id?: string;
+
+  // GCP-specific
+  gcp_project_id?: string;
+  gcp_client_email?: string;
+
+  credentials_configured: boolean;
+  created_at: string;
+  updated_at: string;
+}
+```
+
+### `frontend/src/types.ts`
+
+Only the `AppState` interface needs modification here (not `CloudAccount`):
+
+```typescript
+// Add currentAccountIDs to AppState
+export interface AppState {
+  currentUser: api.User | null;
+  currentProvider: api.Provider | 'all';
+  currentAccountIDs: string[];           // ← NEW: selected account UUIDs; [] = all accounts
+  currentRecommendations: api.Recommendation[];
+  selectedRecommendations: Set<number>;
+  savingsChart: Chart | null;
+}
+```
+
+### `frontend/src/state.ts`
+
+```typescript
+// Add getter/setter pair
+export function getCurrentAccountIDs(): string[] {
+  return state.currentAccountIDs;
+}
+export function setCurrentAccountIDs(ids: string[]): void {
+  state.currentAccountIDs = ids;
+}
+```
+
+---
+
+## New Types: `frontend/src/api/types.ts` additions
+
+Add these alongside `CloudAccount`:
+
+```typescript
+// Request/response types for accounts API — add to frontend/src/api/types.ts
+
+export interface CreateAccountRequest {
+  name: string;
+  description?: string;
+  contact_email?: string;
+  enabled: boolean;
+  provider: Provider;
+  external_id: string;
+  // AWS
+  aws_auth_mode?: 'access_keys' | 'role_arn' | 'bastion';
+  aws_role_arn?: string;
+  aws_external_id?: string;
+  aws_bastion_id?: string;
+  aws_is_org_root?: boolean;
+  // Azure
+  azure_subscription_id?: string;
+  azure_tenant_id?: string;
+  azure_client_id?: string;
+  // GCP
+  gcp_project_id?: string;
+  // Inline credentials (optional — inferred from auth_mode; no "type" field needed here)
+  credentials?: {
+    access_key_id?: string;        // aws_auth_mode=access_keys
+    secret_access_key?: string;    // aws_auth_mode=access_keys
+    client_secret?: string;        // azure
+    service_account_json?: string; // gcp
+  };
+}
+
+// provider and external_id are immutable after creation — server rejects changes to them.
+// Omit them from UpdateAccountRequest to make the type honest and prevent accidental sends.
+export type UpdateAccountRequest = Omit<CreateAccountRequest, 'credentials' | 'provider' | 'external_id'>;
+
+export interface AccountCredentials {
+  type: 'aws_access_keys' | 'azure_client_secret' | 'gcp_service_account';
+  access_key_id?: string;
+  secret_access_key?: string;
+  client_secret?: string;
+  service_account_json?: string;
+}
+
+export interface AccountServiceOverride {
+  id: string;
+  account_id: string;
+  provider: string;
+  service: string;
+  enabled?: boolean;
+  term?: number;
+  payment?: string;
+  coverage?: number;
+  ramp_schedule?: string;
+  include_regions?: string[];
+  exclude_regions?: string[];
+  include_engines?: string[];
+  exclude_engines?: string[];
+  include_types?: string[];
+  exclude_types?: string[];
+}
+
+export type ServiceOverrideFields = Omit<AccountServiceOverride, 'id' | 'account_id' | 'provider' | 'service'>;
+
+export interface OrgDiscoveryResult {
+  discovered: number;
+  created: number;
+  skipped: number;
+  accounts: Array<{ name: string; external_id: string; created: boolean }>;
+}
+
+export interface PlanAccountsResponse {
+  account_ids: string[];
+  accounts: Array<Pick<CloudAccount, 'id' | 'name' | 'provider' | 'external_id'>>;
+}
+```
+
+---
+
+## New API Module: `frontend/src/api/accounts.ts`
+
+`listAccounts` unwraps the `{ "accounts": [...] }` API wrapper and returns the array directly
+(same pattern as existing API functions).
+
+```typescript
+export async function listAccounts(provider?: Provider): Promise<CloudAccount[]>
+  // calls GET /api/accounts?provider=... → unwraps response.accounts
+export async function createAccount(data: CreateAccountRequest): Promise<CloudAccount>
+export async function updateAccount(id: string, data: UpdateAccountRequest): Promise<CloudAccount>
+export async function deleteAccount(id: string): Promise<void>
+export async function saveAccountCredentials(id: string, creds: AccountCredentials): Promise<void>
+export async function testAccountCredentials(id: string): Promise<{ ok: boolean; error?: string; caller_identity?: string }>
+export async function listAccountServiceOverrides(id: string): Promise<AccountServiceOverride[]>
+  // unwraps response.overrides
+export async function saveAccountServiceOverride(id: string, provider: string, service: string, override: Partial<ServiceOverrideFields>): Promise<AccountServiceOverride>
+export async function deleteAccountServiceOverride(id: string, provider: string, service: string): Promise<void>
+export async function discoverOrgAccounts(orgRootAccountId: string): Promise<OrgDiscoveryResult>
+export async function getPlanAccounts(planId: string): Promise<PlanAccountsResponse>
+export async function setPlanAccounts(planId: string, accountIds: string[]): Promise<PlanAccountsResponse>
+```
+
+---
+
+## Settings Tab: Account Management Section
+
+### Placement in `index.html`
+
+Inside each provider fieldset (`#aws-settings`, `#azure-settings`, `#gcp-settings`), add an **Accounts** sub-section **before** the existing "Service Defaults" heading:
+
+```html
+<!-- Inside #aws-settings fieldset, before <h4 class="subsection-title">Service Defaults</h4> -->
+<h4 class="subsection-title">
+  Accounts
+  <button type="button" class="btn btn-small btn-primary" id="aws-add-account-btn">+ Add Account</button>
+</h4>
+<div class="account-list" id="aws-account-list">
+  <!-- Rendered dynamically by settings.ts using safe DOM methods (textContent / appendChild) -->
+  <p class="empty-state" id="aws-no-accounts">No AWS accounts configured.</p>
+</div>
+```
+
+Repeat for `#azure-account-list` and `#gcp-account-list`.
+
+### Account Row (rendered by JS via DOM methods — no raw HTML injection)
+
+Each row is built with `document.createElement` / `textContent` to prevent XSS:
+
+```
+[Account Name]  [external_id]  [auth-mode badge]  [✓ Credentials set | ⚠ No credentials]
+  [Test]  [Credentials]  [Overrides]  [Edit]  [Delete]
+```
+
+Button `data-account-id` attributes drive click handlers (no inline event attributes).
+
+---
+
+## Modals
+
+### Notes on existing modal patterns
+
+Existing modals (`#azure-creds-modal`, `#gcp-creds-modal`) use class `modal hidden` (NOT `modal-overlay hidden`).
+Their close buttons use id pattern `close-X-modal-btn` with class `btn-secondary`.
+New account modals must follow the same pattern to be consistent with `app.ts` event binding.
+
+### AWS Account Modal (`#aws-account-modal`)
+
+Dynamic form — shows different credential fields based on selected auth mode via CSS class toggling.
+
+```
+┌─ Add AWS Account ──────────────────────────────────────────┐
+│ Name *                 [_________________________]          │
+│ AWS Account ID *       [_________________________]          │
+│ Description            [_________________________]          │
+│ Contact Email          [_________________________]          │
+│ Auth Mode *            [▼ Role ARN              ]          │
+│ ─── Role ARN ─────────────────────────────────────────     │
+│ Role ARN *             [arn:aws:iam::...         ]          │
+│ External ID            [_________________________]          │
+│ ─── (if Access Keys selected) ────────────────────         │
+│ Access Key ID *        [_________________________]          │
+│ Secret Access Key *    [_________________________]          │
+│ ─── (if Bastion selected) ─────────────────────────        │
+│ Bastion Account *      [▼ Select bastion account]          │
+│ Role ARN in Target *   [arn:aws:iam::...         ]          │
+│ External ID            [_________________________]          │
+│                                                             │
+│ [ ] This is an AWS Organizations root account              │
+│     (enables member account discovery)                      │
+│                                                             │
+│              [Cancel]  [Save Account]                       │
+└─────────────────────────────────────────────────────────────┘
+```
+
+Modal HTML structure (matching existing pattern — class `modal hidden`, close button id `close-X-modal-btn`):
+
+```html
+<div id="aws-account-modal" class="modal hidden">
+  <div class="modal-content modal-wide">
+    <h2 id="aws-account-modal-title">Add AWS Account</h2>
+    <div id="aws-account-error" class="error hidden"></div>
+    <form id="aws-account-form"><!-- fields --></form>
+    <button type="button" class="btn-secondary" id="close-aws-account-modal-btn">Cancel</button>
+  </div>
+</div>
+```
+
+Auth mode sections use `hidden` CSS class toggled by JS (same pattern as provider settings sections in `settings.ts`).
+
+### Azure Subscription Modal (`#azure-account-modal`)
+
+```
+┌─ Add Azure Subscription ───────────────────────────────────┐
+│ Name *                 [_________________________]          │
+│ Subscription ID *      [xxxxxxxx-xxxx-xxxx-xxxx-]          │
+│ Tenant ID *            [yyyyyyyy-xxxx-xxxx-xxxx-]          │
+│ Client ID *            [zzzzzzzz-xxxx-xxxx-xxxx-]          │
+│ Client Secret *        [_________________________]          │
+│ Description            [_________________________]          │
+│ Contact Email          [_________________________]          │
+│              [Cancel]  [Save Subscription]                  │
+└─────────────────────────────────────────────────────────────┘
+```
+
+HTML: `<div id="azure-account-modal" class="modal hidden">` / close btn `id="close-azure-account-modal-btn"`
+
+### GCP Project Modal (`#gcp-account-modal`)
+
+```
+┌─ Add GCP Project ──────────────────────────────────────────┐
+│ Name *                 [_________________________]          │
+│ GCP Project ID *       [my-project-123           ]          │
+│ Description            [_________________________]          │
+│ Contact Email          [_________________________]          │
+│ Service Account JSON * [                         ]          │
+│                        [   paste JSON here...   ]          │
+│                        [                         ]          │
+│              [Cancel]  [Save Project]                       │
+└─────────────────────────────────────────────────────────────┘
+```
+
+HTML: `<div id="gcp-account-modal" class="modal hidden">` / close btn `id="close-gcp-account-modal-btn"`
+
+### Credentials-Only Modal (`#account-creds-modal`)
+
+Used when "Credentials" button is clicked on an existing account:
+
+```
+┌─ Update Credentials: {account name} ───────────────────────┐
+│  [provider-specific credential fields only]                 │
+│              [Cancel]  [Save Credentials]                   │
+└─────────────────────────────────────────────────────────────┘
+```
+
+HTML: `<div id="account-creds-modal" class="modal hidden">` / close btn `id="close-account-creds-modal-btn"`
+
+---
+
+## Service Overrides UI
+
+Clicking "Overrides" on an account row expands an inline override panel below that row:
+
+```
+  ▼ Service Overrides for Prod-US
+  ┌────────────────────┬──────────────────┬──────────────────────┐
+  │ Service            │ Term             │ Coverage             │
+  ├────────────────────┼──────────────────┼──────────────────────┤
+  │ EC2                │ 1yr (override)   │ 60% (override) [Edit]│
+  │ RDS                │ 3yr (global)     │ 80% (global)   [Edit]│
+  │ ElastiCache        │ 3yr (global)     │ 80% (global)   [Edit]│
+  └────────────────────┴──────────────────┴──────────────────────┘
+  [+ Add Override]
+```
+
+"Edit" opens a compact inline form for that service row. "Reset to global" (shown for overridden rows) calls `DELETE /api/accounts/:id/service-overrides/:provider/:service`.
+
+---
+
+## Filter Bar Changes
+
+### HTML additions (per tab)
+
+**Existing controls bars** (confirmed in HTML):
+
+- `#dashboard-controls` → has `#dashboard-provider-filter`
+- `#recommendations-controls` → has `#recommendations-provider-filter`, `#service-filter`
+- `#history-controls` → has `#history-provider-filter`, `#history-start`, `#history-end`
+- Plans tab → **no existing controls bar**; a new `<section id="plans-controls">` must be added
+
+Add after the existing provider filter `<select>` in Dashboard, Recommendations, and History:
+
+```html
+<label>Account:
+  <select id="dashboard-account-filter" multiple size="1">
+    <option value="">All Accounts</option>
+    <!-- dynamically populated via DOM methods -->
+  </select>
+</label>
+```
+
+For Plans, add a new controls section before the plans list:
+
+```html
+<section id="plans-controls">
+  <div class="controls-bar">
+    <div class="filter-group">
+      <label>Provider:
+        <select id="plans-provider-filter">
+          <option value="">All Providers</option>
+          <option value="aws">AWS</option>
+          <option value="azure">Azure</option>
+          <option value="gcp">GCP</option>
+        </select>
+      </label>
+      <label>Account:
+        <select id="plans-account-filter" multiple size="1">
+          <option value="">All Accounts</option>
+        </select>
+      </label>
+    </div>
+  </div>
+</section>
+```
+
+The account select is populated dynamically when:
+
+- The tab loads (fetch all accounts)
+- The provider filter changes (re-fetch filtered accounts for that provider)
+
+An empty selection means "all accounts" — no `account_ids` param is sent to the API.
+
+Element IDs:
+
+- `#dashboard-account-filter`
+- `#recommendations-account-filter`
+- `#history-account-filter`
+- `#plans-account-filter`
+
+### JS changes (shared utility in `utils.ts`)
+
+```typescript
+// populateAccountFilter: fetches accounts and rebuilds <select> options using DOM methods.
+// Preserves existing selection state.
+export async function populateAccountFilter(
+  select: HTMLSelectElement,
+  provider: string
+): Promise<void> {
+  const accounts = await api.listAccounts(provider !== 'all' ? provider as api.Provider : undefined);
+  const existing = state.getCurrentAccountIDs();
+
+  // Clear and rebuild using DOM methods (not innerHTML) to avoid XSS
+  while (select.options.length > 1) select.remove(1); // keep "All Accounts"
+
+  // Only show enabled accounts in filter bars — disabled accounts don't contribute data
+  for (const acct of accounts.filter(a => a.enabled)) {
+    const opt = document.createElement('option');
+    opt.value = acct.id;
+    opt.textContent = `${acct.name} (${acct.external_id})`;
+    if (existing.includes(acct.id)) opt.selected = true;
+    select.appendChild(opt);
+  }
+}
+```
+
+In each tab module, after provider filter setup:
+
+```typescript
+const accountFilter = document.getElementById('dashboard-account-filter') as HTMLSelectElement | null;
+if (accountFilter) {
+  void populateAccountFilter(accountFilter, state.getCurrentProvider());
+  accountFilter.addEventListener('change', () => {
+    const selected = Array.from(accountFilter.selectedOptions)
+      .map(o => o.value)
+      .filter(v => v !== '');
+    state.setCurrentAccountIDs(selected);
+    void loadDashboard();
+  });
+}
+```
+
+### API filter type additions (`frontend/src/api/types.ts`)
+
+```typescript
+export interface RecommendationFilters {
+  provider?: Provider | 'all';
+  service?: string;
+  region?: string;
+  minSavings?: number;
+  accountIDs?: string[];    // ← NEW
+}
+
+export interface HistoryFilters {
+  start?: string;
+  end?: string;
+  provider?: Provider;
+  planId?: string;
+  accountIDs?: string[];    // ← NEW
+}
+
+export interface SavingsAnalyticsFilters {
+  start?: string;
+  end?: string;
+  interval?: 'hourly' | 'daily' | 'weekly' | 'monthly';  // preserve existing literal union
+  provider?: Provider;                                    // preserve existing Provider type
+  service?: string;
+  accountIDs?: string[];    // ← NEW
+}
+```
+
+Serialization in API client functions:
+
+```typescript
+if (filters.accountIDs?.length) params.set('account_ids', filters.accountIDs.join(','));
+```
+
+---
+
+## Plan Account Association
+
+### Plan Create/Edit Modal additions
+
+After the existing provider/service fields, add a new **Target Accounts** section:
+
+```
+Target Accounts
+  Search: [____________________] [Add]
+  ┌─────────────────────────────────────────────┐
+  │ Prod-US (123456789012) [AWS]       [Remove] │
+  │ Staging (234567890123) [AWS]       [Remove] │
+  └─────────────────────────────────────────────┘
+  Tip: Leave empty to target all accounts for the selected provider.
+```
+
+Implementation in `plans.ts`:
+
+1. On plan modal open: call `getPlanAccounts(planId)` and populate the list (empty for create).
+2. Search input calls `listAccounts(provider)` and filters client-side by name/ID substring.
+3. "Add" appends to in-memory list (deduplicated by ID).
+4. "Remove" deletes from in-memory list.
+5. On plan save: call `setPlanAccounts(planId, accountIds)` after the plan PUT/POST succeeds.
+
+### Plan List Display
+
+Add an "Accounts" column to the plans table:
+
+```
+| Name      | Provider | Service | Accounts             | Status  |
+|-----------|----------|---------|----------------------|---------|
+| Prod Plan | AWS      | EC2     | 2 accounts           | Enabled |
+| All-AWS   | AWS      | RDS     | All AWS accounts     | Enabled |
+```
+
+"N accounts" text has a `title` attribute (tooltip) listing the account names — set via `element.title = names.join(', ')` (no HTML injection).
+
+---
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `frontend/src/types.ts` | Add `AppState.currentAccountIDs` only |
+| `frontend/src/api/types.ts` | Add `CloudAccount` type; add `accountIDs` to filter types |
+| `frontend/src/api/index.ts` | Re-export from new `accounts.ts` module |
+| `frontend/src/state.ts` | Add `currentAccountIDs` state + accessors |
+| `frontend/src/index.html` | Account list sections in settings, account filter selects in tab controls, all account modals |
+| `frontend/src/settings.ts` | Account CRUD handlers, service override handlers, org discovery |
+| `frontend/src/dashboard.ts` | Account filter setup + pass accountIDs to API |
+| `frontend/src/recommendations.ts` | Account filter setup + pass accountIDs to API |
+| `frontend/src/history.ts` | Account filter setup + pass accountIDs to API |
+| `frontend/src/plans.ts` | Account association UI in plan modal |
+| `frontend/src/utils.ts` | Add `populateAccountFilter` shared utility |
+
+## New Files
+
+| File | Purpose |
+|------|---------|
+| `frontend/src/api/accounts.ts` | All cloud account API calls |
+| `frontend/src/__tests__/api-accounts.test.ts` | Unit tests for accounts API functions (mocked fetch) |
+| `frontend/src/__tests__/settings-accounts.test.ts` | Unit tests for settings account CRUD handlers |
+
+## CSS Notes
+
+**Classes that need to be added** (confirmed absent in existing stylesheets):
+
+- `.account-list` — container for the account rows in settings; style similarly to `.service-defaults-grid`
+- `.account-row` — individual account row; use flex layout consistent with `.setting-row`
+- `.account-row-info` / `.account-row-actions` — left/right sections within a row
+- `.account-auth-badge` — small badge for auth mode; style similarly to `.provider-badge` but neutral colour
+
+**Classes that already exist and should be reused** (confirmed in CSS):
+
+- `.modal hidden` — existing modal pattern (note: class is `modal`, toggle is `hidden`)
+- `.modal-content.modal-wide` — wide modal variant, used for Azure/GCP creds modals
+- `.provider-badge` (with `.aws`, `.azure`, `.gcp` variants)
+- `.credential-status` (with `.configured` variant)
+- `.btn`, `.btn-small`, `.btn-primary`, `.btn-secondary`, `.btn-danger`
+- `.controls-bar`, `.filter-group` — existing filter bar layout
+- `.hidden` — utility class for show/hide toggles
+- `.error` — error message display
+
+## Rendering Pattern Note
+
+Existing frontend code (e.g., `history.ts`, `plans.ts`) renders table rows via template literals in `container.innerHTML` with `escapeHtml()` for all user-supplied values. New account-rendering code in `settings.ts` should use DOM methods (`createElement`, `textContent`, `appendChild`) for account rows that mix static structure with user-controlled data (account names, external IDs). This is a stricter approach than the existing pattern but appropriate for settings where account metadata is displayed.

--- a/specs/multi-account-execution/iac.md
+++ b/specs/multi-account-execution/iac.md
@@ -1,0 +1,322 @@
+<!-- markdownlint-disable MD040 MD060 -->
+# Infrastructure as Code Changes
+
+All Terraform changes follow the existing project conventions: modules under `terraform/modules/`, environment configs under `terraform/environments/{aws,azure,gcp}/`.
+
+---
+
+## AWS Environment (`terraform/environments/aws/`)
+
+### New secret: credential encryption key
+
+The existing project creates all secrets through the `modules/secrets/aws` module (invoked in `terraform/environments/aws/secrets.tf` with `create_jwt_secret = true`, etc.). The credential encryption key follows the same pattern.
+
+**Step 1 — Add module variable to `terraform/modules/secrets/aws/variables.tf`:**
+
+```hcl
+variable "create_credential_encryption_key" {
+  description = "Whether to create a Secrets Manager secret for the credential encryption key"
+  type        = bool
+  default     = false  # Opt-in; environments without multi-account can skip
+}
+
+variable "credential_encryption_key" {
+  description = "AES-256-GCM key for account credential encryption (64-char hex = 32 bytes). Generate: openssl rand -hex 32"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+```
+
+**Step 2 — Add resource to `terraform/modules/secrets/aws/main.tf`** (following existing `aws_secretsmanager_secret` patterns in that file):
+
+```hcl
+resource "aws_secretsmanager_secret" "credential_encryption_key" {
+  count                   = var.create_credential_encryption_key ? 1 : 0
+  name_prefix             = "${var.stack_name}-credential-enc-key-"
+  description             = "AES-256-GCM key for encrypting cloud account credentials"
+  recovery_window_in_days = var.secret_recovery_window_days
+
+  tags = merge(var.common_tags, {
+    Name      = "${var.stack_name}-credential-enc-key"
+    ManagedBy = "terraform"
+  })
+}
+
+resource "aws_secretsmanager_secret_version" "credential_encryption_key" {
+  count         = var.create_credential_encryption_key ? 1 : 0
+  secret_id     = aws_secretsmanager_secret.credential_encryption_key[0].id
+  secret_string = var.credential_encryption_key
+
+  lifecycle {
+    ignore_changes = [secret_string]  # Allow out-of-band rotation without Terraform drift
+  }
+}
+```
+
+**Step 3 — Add output to `terraform/modules/secrets/aws/outputs.tf`** (following the existing `secret_env_vars` output pattern):
+
+```hcl
+output "credential_encryption_key_secret_arn" {
+  value       = var.create_credential_encryption_key ? aws_secretsmanager_secret.credential_encryption_key[0].arn : ""
+  description = "ARN of the credential encryption key secret; empty string if not created"
+}
+```
+
+**Step 4 — Enable in `terraform/environments/aws/secrets.tf`** (update the existing `module "secrets"` invocation):
+
+```hcl
+module "secrets" {
+  source = "../../modules/secrets/aws"
+  # ... existing args ...
+  create_credential_encryption_key = true
+  credential_encryption_key        = var.credential_encryption_key
+}
+```
+
+**Step 5 — Add `credential_encryption_key` variable to `terraform/environments/aws/variables.tf`:**
+
+```hcl
+variable "credential_encryption_key" {
+  description = "AES-256-GCM key for account credential encryption (64-char hex = 32 bytes). Generate: openssl rand -hex 32"
+  type        = string
+  sensitive   = true
+  # No default — must be explicitly set; for local dev use CREDENTIAL_ENCRYPTION_KEY env var directly
+}
+```
+
+Pass the secret ARN as an env var to the Lambda module in `terraform/environments/aws/compute.tf`:
+
+```hcl
+additional_env_vars = merge(
+  {
+    STATIC_DIR                           = "/app/static"
+    DASHBOARD_URL                        = local.dashboard_url
+    CORS_ALLOWED_ORIGIN                  = local.dashboard_url != "" ? local.dashboard_url : "*"
+    FROM_EMAIL                           = "noreply@${var.subdomain_zone_name}"
+    CREDENTIAL_ENCRYPTION_KEY_SECRET_ARN = module.secrets.credential_encryption_key_secret_arn
+    CUDLY_MAX_ACCOUNT_PARALLELISM        = var.max_account_parallelism
+  },
+  var.additional_env_vars
+)
+```
+
+Add `max_account_parallelism` variable to `variables.tf`:
+
+```hcl
+variable "max_account_parallelism" {
+  description = "Maximum number of cloud accounts to process in parallel during plan fan-out"
+  type        = number
+  default     = 10
+}
+```
+
+---
+
+## Lambda IAM Policy Updates (`terraform/modules/compute/aws/lambda/main.tf`)
+
+### 1. Add encryption key secret to `secretsmanager:GetSecretValue`
+
+Update the existing `aws_iam_role_policy.secrets_access` to include the new secret ARN. Add a new variable:
+
+```hcl
+variable "credential_encryption_key_secret_arn" {
+  description = "ARN of the credential encryption key secret in Secrets Manager"
+  type        = string
+  default     = ""
+}
+```
+
+Update the policy resource:
+
+```hcl
+resource "aws_iam_role_policy" "secrets_access" {
+  ...
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = ["secretsmanager:GetSecretValue"]
+        Resource = compact([
+          var.database_password_secret_arn,
+          "${var.database_password_secret_arn}*",
+          var.admin_password_secret_arn,
+          var.admin_password_secret_arn != "" ? "${var.admin_password_secret_arn}*" : "",
+          var.credential_encryption_key_secret_arn,             # ← NEW
+          var.credential_encryption_key_secret_arn != "" ? "${var.credential_encryption_key_secret_arn}*" : "",
+        ])
+      },
+      ...
+    ]
+  })
+}
+```
+
+### 2. Add `sts:AssumeRole` for cross-account credential resolution
+
+New IAM policy block in `terraform/modules/compute/aws/lambda/main.tf`:
+
+```hcl
+variable "enable_cross_account_sts" {
+  description = "Allow Lambda to assume roles in remote AWS accounts (required for multi-account support)"
+  type        = bool
+  default     = false
+}
+
+resource "aws_iam_role_policy" "cross_account_sts" {
+  count = var.enable_cross_account_sts ? 1 : 0
+
+  name_prefix = "${var.stack_name}-cross-account-sts-"
+  role        = aws_iam_role.lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["sts:AssumeRole"]
+        Resource = "arn:aws:iam::*:role/*"
+        # Recommended: scope to a naming convention in production to reduce blast radius:
+        # Resource = "arn:aws:iam::*:role/CUDly*"
+        # Note: No ExternalId condition is applied at the IAM level because Lambda assumes
+        # roles on behalf of many target accounts, each with its own ExternalId.
+        # ExternalId validation is enforced at the application layer in resolver.go:
+        # the stored aws_external_id is always passed in AssumeRoleInput.ExternalId,
+        # so only the configured target account (whose trust policy requires that ExternalId)
+        # can be assumed.
+      }
+    ]
+  })
+}
+```
+
+Enable in `terraform/environments/aws/compute.tf` (hardcoded `true` for now — both capabilities are required for multi-account support; set to `false` to disable in environments that don't need it):
+
+```hcl
+module "compute_lambda" {
+  ...
+  enable_cross_account_sts             = true
+  credential_encryption_key_secret_arn = module.secrets.credential_encryption_key_secret_arn
+}
+```
+
+### 3. Add `organizations:ListAccounts` for org discovery
+
+New IAM policy block — only needed when org discovery is enabled:
+
+```hcl
+variable "enable_org_discovery" {
+  description = "Allow Lambda to call AWS Organizations ListAccounts for member account discovery"
+  type        = bool
+  default     = false
+}
+
+resource "aws_iam_role_policy" "org_discovery" {
+  count = var.enable_org_discovery ? 1 : 0
+
+  name_prefix = "${var.stack_name}-org-discovery-"
+  role        = aws_iam_role.lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["organizations:ListAccounts", "organizations:DescribeOrganization"]
+        Resource = "*"  # Organizations API does not support resource-level restrictions
+      }
+    ]
+  })
+}
+```
+
+Enable in `terraform/environments/aws/compute.tf` (alongside `enable_cross_account_sts`):
+
+```hcl
+module "compute_lambda" {
+  ...
+  enable_org_discovery = true
+}
+```
+
+---
+
+## Azure Environment (`terraform/environments/azure/`)
+
+Add to `terraform/environments/azure/secrets.tf`:
+
+```hcl
+resource "azurerm_key_vault_secret" "credential_encryption_key" {
+  name         = "${local.stack_name}-credential-enc-key"
+  value        = var.credential_encryption_key  # 64-char hex
+  key_vault_id = module.secrets.key_vault_id
+
+  tags = local.common_tags
+}
+```
+
+**Key loading for Azure**: The application's `KeyFromEnv()` only handles `CREDENTIAL_ENCRYPTION_KEY_SECRET_ARN` (AWS Secrets Manager). For Azure, the container entrypoint or init container retrieves the Key Vault secret and injects it as the `CREDENTIAL_ENCRYPTION_KEY` environment variable before starting the app. Pass the Key Vault secret URI to the container so the startup script can resolve it, or use Azure's [Key Vault references in App Service/Container Apps](https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references) to surface it as an env var automatically.
+
+---
+
+## GCP Environment (`terraform/environments/gcp/`)
+
+Add to GCP secrets module invocation:
+
+```hcl
+additional_secrets = {
+  "credential-enc-key" = {
+    value       = var.credential_encryption_key
+    description = "AES-256-GCM key for account credential encryption"
+  }
+}
+```
+
+**Key loading for GCP**: Same pattern as Azure — `KeyFromEnv()` does not call GCP Secret Manager directly. The container entrypoint retrieves the secret (via `gcloud secrets versions access latest --secret=credential-enc-key`) and sets it as `CREDENTIAL_ENCRYPTION_KEY` before the app starts, or use GCP's [Secret Manager env var injection](https://cloud.google.com/run/docs/configuring/secrets) for Cloud Run to surface it automatically as `CREDENTIAL_ENCRYPTION_KEY`.
+
+---
+
+## Application Change: Secret Manager–aware key loading
+
+`internal/credentials/cipher.go:KeyFromEnv()` must be updated to support the ARN-based pattern:
+
+```
+Load order:
+1. If CREDENTIAL_ENCRYPTION_KEY_SECRET_ARN is set:
+     → call secretsmanager.GetSecretValue(arn) → use returned string as hex key
+     → cache in memory for the Lambda lifetime (loaded once at cold start)
+2. Else if CREDENTIAL_ENCRYPTION_KEY is set:
+     → use directly (hex key; for local dev / non-AWS environments)
+3. Else:
+     → use hardcoded dev key; log WARN "using insecure dev credential key"
+```
+
+This preserves local-dev ergonomics (no Secrets Manager needed) while mandating SM in production.
+
+---
+
+## `dev.tfvars.example` Additions
+
+Document new required variables in `terraform/environments/aws/dev.tfvars.example`:
+
+```hcl
+# Multi-account credential encryption key (generate with: openssl rand -hex 32)
+# In CI/CD, set this from a secrets vault rather than committing to tfvars.
+credential_encryption_key = "REPLACE_WITH_64_CHAR_HEX_STRING"
+
+# Maximum concurrent account connections during plan fan-out (default: 10)
+max_account_parallelism = 10
+```
+
+Note: `enable_cross_account_sts` and `enable_org_discovery` are **not** environment-level variables. They are hardcoded as `true` in `compute.tf` (passed directly to the Lambda module). To disable them for a specific environment, edit `compute.tf` for that environment.
+
+---
+
+## Summary of new env vars (all environments)
+
+| Env var | Set by | Purpose |
+|---------|--------|---------|
+| `CREDENTIAL_ENCRYPTION_KEY_SECRET_ARN` | Terraform → Lambda env | ARN of SM secret holding the 32-byte AES key |
+| `CREDENTIAL_ENCRYPTION_KEY` | Direct (local dev only) | 64-char hex key, bypasses SM for local use |
+| `CUDLY_MAX_ACCOUNT_PARALLELISM` | Terraform → Lambda env | Fan-out goroutine cap (default: 10) |

--- a/specs/multi-account-execution/security.md
+++ b/specs/multi-account-execution/security.md
@@ -1,0 +1,188 @@
+<!-- markdownlint-disable MD040 MD060 -->
+# Security Model
+
+## Credential Storage
+
+### Encryption
+
+All sensitive credential values (AWS secret access keys, Azure client secrets, GCP service account private keys) are stored encrypted in the `account_credentials` table.
+
+**Algorithm**: AES-256-GCM (authenticated encryption — provides both confidentiality and integrity).
+
+**Format**: `<base64url(nonce)>.<base64url(ciphertext)>` where:
+
+- `nonce` is a randomly generated 12-byte value (unique per encryption operation)
+- `ciphertext` includes the GCM authentication tag appended
+
+**Key management**:
+
+| Environment | Key Source | Behaviour |
+|-------------|-----------|-----------|
+| Production (AWS) | `CREDENTIAL_ENCRYPTION_KEY_SECRET_ARN` env var → AWS Secrets Manager `GetSecretValue` | ARN set via Terraform `compute.tf`; secret created in `secrets.tf`. See `iac.md`. |
+| Staging/CI (AWS) | Same SM-based pattern with a staging-specific secret | Separate Secrets Manager secret per environment |
+| Non-AWS / local dev | `CREDENTIAL_ENCRYPTION_KEY` env var (64-char hex = 32 bytes) | Used directly when SM ARN is absent; bypasses Secrets Manager for local ergonomics |
+| Fallback (dev only) | Neither env var set | Hardcoded dev-only key; logs `WARN: using insecure dev credential key — do not use in production` |
+
+Load order in `internal/credentials/cipher.go:KeyFromEnv()`:
+
+1. If `CREDENTIAL_ENCRYPTION_KEY_SECRET_ARN` is set → call `secretsmanager.GetSecretValue(arn)`, use returned string as hex key (cached for Lambda lifetime)
+2. Else if `CREDENTIAL_ENCRYPTION_KEY` is set → use directly
+3. Else → hardcoded dev key + `WARN` log
+
+**Key rotation**: To rotate the encryption key, a `RotateCredentials(oldKey, newKey)` utility function will decrypt all blobs with `oldKey` and re-encrypt with `newKey`. This is a maintenance operation requiring downtime or a migration job.
+
+---
+
+## Credential Access Patterns
+
+### Write-only API
+
+Credential material is never returned in any API response:
+
+- `GET /api/accounts/:id` returns `credentials_configured: bool` only
+- `GET /api/accounts` list — same
+- `POST /api/accounts/:id/credentials` — returns `204 No Content`
+
+The only code path that decrypts credentials is the server-side resolution in `internal/credentials/resolver.go`, called immediately before making a cloud API call and not persisted in memory beyond that call.
+
+### Test endpoint constraints
+
+`POST /api/accounts/:id/test`:
+
+- Resolves credentials in memory for the duration of the test call
+- Makes one lightweight, read-only cloud API call
+- Logs the result (success/failure) but **never logs credential values or session tokens**
+- Returns `{ ok: bool, error?: string }` — never the credential itself
+- **Rate limiting**: Limited to 10 calls per account per minute (enforced server-side via a sliding window counter in the handler). Returns `429 Too Many Requests` when exceeded. This prevents the endpoint from being used to probe or brute-force credential validity at scale.
+
+### Logging policy
+
+- Credential fields are never included in structured log output
+- `fmt.Errorf` wrapping credential operations must not include credential values in error messages
+- The `AWSCredentials`, `AzureCredentials`, and GCP JSON structs must implement `String() string` returning `"[REDACTED]"` to prevent accidental logging via `%v`
+
+---
+
+## Bastion Chain Depth Limit
+
+To prevent misconfiguration creating circular or deep credential chains:
+
+1. An account with `aws_auth_mode = 'bastion'` cannot itself be set as the `aws_bastion_id` of another bastion account — validated on `POST /api/accounts` and `PUT /api/accounts/:id`.
+2. Maximum chain depth: 1 (bastion → target). A bastion account can only use `access_keys` or `role_arn` auth modes, not `bastion`.
+3. This is enforced both in the API handler (returns `400` with error `"bastion chaining is not supported"`) and in `resolver.go` (returns an error if attempted at runtime).
+
+---
+
+## Input Validation
+
+### ARN Format Validation
+
+When a user provides `aws_role_arn` (for `role_arn` or `bastion` auth modes), the handler must validate the format before storing:
+
+- Regex: `^arn:aws:iam::\d{12}:role/[\w+=,.@/-]+$`
+- Max length: 512 characters
+- Returns `400 Bad Request` with a descriptive message if invalid
+
+`aws_external_id`, if provided, must be 2–1224 characters (AWS constraint) and contain only printable ASCII (no control characters).
+
+### GCP Service Account JSON
+
+GCP credentials are a JSON key file. The handler must:
+
+- Enforce a maximum payload size of 64 KB to prevent memory exhaustion
+- Validate that the blob is valid JSON before encrypting
+- Returns `400 Bad Request` on size or JSON parse failure
+
+### Account ID Format
+
+`external_id` (AWS account ID / Azure subscription ID / GCP project ID):
+
+- AWS: exactly 12 digits (`^\d{12}$`)
+- Azure: UUID format (`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+- GCP: 6–30 lowercase alphanumeric + hyphens, must start with a letter (`^[a-z][a-z0-9-]{5,29}$`)
+
+---
+
+## AWS Role Trust Policy Recommendations
+
+When users configure a `role_arn` or bastion target, CUDly validates the ARN format but cannot validate that the trust policy allows assumption. The UI should display a recommended trust policy template for users to apply in their target accounts:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": { "AWS": "arn:aws:iam::{CUDLY_ACCOUNT_ID}:role/{CUDLY_ROLE}" },
+    "Action": "sts:AssumeRole",
+    "Condition": {
+      "StringEquals": { "sts:ExternalId": "{EXTERNAL_ID}" }
+    }
+  }]
+}
+```
+
+The ExternalId condition is strongly recommended (shown in UI) but not enforced (some orgs manage it differently).
+
+---
+
+## Access Control
+
+### Existing permission model extension
+
+The existing `groups.permissions` JSONB array is extended with a new resource type `accounts`:
+
+```json
+[
+  { "action": "view",               "resource": "accounts" },
+  { "action": "create",             "resource": "accounts" },
+  { "action": "update",             "resource": "accounts" },
+  { "action": "delete",             "resource": "accounts" },
+  { "action": "manage_credentials", "resource": "accounts" },
+  { "action": "test_credentials",   "resource": "accounts" },
+  { "action": "discover_org",       "resource": "accounts" }
+]
+```
+
+`discover_org` requires `role = 'admin'` in addition to the permission (defence in depth).
+
+### Existing `allowed_accounts` constraint
+
+The existing `Permission.constraints.accounts` field (already in the DB schema) now resolves against `cloud_accounts.id` UUIDs. A user with:
+
+```json
+{ "action": "view", "resource": "recommendations", "constraints": { "accounts": ["uuid1"] } }
+```
+
+can only see recommendations filtered to `account_ids=uuid1`.
+
+---
+
+## Audit Logging
+
+The following events are logged at `INFO` level with structured fields (no credential values):
+
+| Event | Fields logged |
+|-------|--------------|
+| Account created | `account_id`, `provider`, `external_id`, `created_by` |
+| Account updated | `account_id`, `changed_fields` (list of field names, no values for sensitive fields) |
+| Account deleted | `account_id`, `deleted_by` |
+| Credentials saved | `account_id`, `credential_type`, `updated_by` |
+| Credentials test | `account_id`, `result` (ok/fail), `error` (no credential content) |
+| Org discovery | `org_root_account_id`, `discovered`, `created`, `triggered_by` |
+
+---
+
+## Threat Model
+
+| Threat | Mitigation |
+|--------|-----------|
+| DB compromise exposes all cloud credentials | AES-256-GCM encryption; attacker needs both DB access AND `CREDENTIAL_ENCRYPTION_KEY` |
+| Credential exfiltration via API | Write-only credential endpoint; GET responses never include credential material |
+| Bastion account misuse grants access to all member accounts | Bastion chain depth limit of 1; ExternalId recommended; IAM role requires explicit trust policy |
+| XSS → credential theft | Credentials never rendered in DOM; account names/IDs rendered with `textContent` (not raw HTML) |
+| SSRF via "test credentials" | Test endpoint is tightly scoped to known cloud SDK calls; no user-controlled URLs in the call path |
+| Insider threat / privilege escalation | `manage_credentials` and `discover_org` are separate permissions; full audit log; admin role required for org discovery |
+| Credential logging | All credential structs implement `String() = "[REDACTED]"`; structured log review required during code review |
+| Abuse of test endpoint to probe credential validity | Rate limit: 10 calls/account/minute; returns `429` when exceeded |
+| Malformed ARN or GCP JSON causes panic/memory issue | ARN regex + length validation; GCP JSON validated + capped at 64 KB before encrypting |
+| Encryption key exposure in Lambda logs/env | Key loaded from Secrets Manager (not plaintext env); never logged; `KeyFromEnv()` returns `[]byte`, not string |

--- a/specs/multi-account-execution/tasks.md
+++ b/specs/multi-account-execution/tasks.md
@@ -1,0 +1,432 @@
+<!-- markdownlint-disable MD040 MD060 -->
+# Implementation Tasks
+
+Tasks are ordered by dependency. Each phase can begin once the previous phase's tasks are complete. Within a phase, tasks can be parallelised where noted.
+
+Commit strategy: one atomic commit per task (or per logical sub-task if a task is large). Each commit must pass `make full-test` and `npm test`.
+
+---
+
+## Phase 1 — Data Layer
+
+These tasks establish the foundation that everything else depends on.
+
+### Task 1.1: DB Migration
+
+**Files to create:**
+
+- `internal/database/postgres/migrations/000011_cloud_accounts.up.sql`
+- `internal/database/postgres/migrations/000011_cloud_accounts.down.sql`
+
+**What to do:** Write the migration as specified in `data-model.md`. Include all four new tables (`cloud_accounts`, `account_credentials`, `account_service_overrides`, `plan_accounts`), the FK column additions on existing tables, all indexes, and the `updated_at` triggers.
+
+**Verification:** `make migrate-up` on a clean test DB; `make migrate-down` brings it back to state 000010; `make migrate-up` again leaves schema identical.
+
+---
+
+### Task 1.2: Go Type Definitions
+
+**Files to modify:**
+
+- `internal/config/types.go`
+
+**What to do:** Add `CloudAccount`, `CloudAccountFilter`, `AccountServiceOverride` structs as specified in `data-model.md` (Go type additions section). Add `CloudAccountID *string` field to: `PurchaseHistoryRecord`, `PurchaseExecution`, `RIExchangeRecord`, and `RecommendationRecord` (needed so aggregated multi-account recommendations can be tagged with the originating account UUID). Note: existing structs carry `dynamodbav` struct tags — add `db:"cloud_account_id"` or omit tags since pgx uses positional scanning, not tag-based.
+
+**Verification:** `go build ./...` passes with no new errors.
+
+---
+
+### Task 1.3: Store Interface Extension
+
+**Files to modify:**
+
+- `internal/config/interfaces.go`
+
+**What to do:** Add new method signatures to `StoreInterface` as listed in `backend.md` (Store Interface Additions section). The mock is hand-written (no generator) — add the new mock methods to `internal/mocks/stores.go` following the existing `testify/mock` pattern in that file (e.g. `func (m *MockConfigStore) CreateCloudAccount(ctx context.Context, account *config.CloudAccount) error { ... }`).
+
+**Verification:** `go build ./...` passes; existing mock still compiles (update mock if needed).
+
+---
+
+### Task 1.4: Credential Encryption Package
+
+**Files to create:**
+
+- `internal/credentials/cipher.go`
+- `internal/credentials/cipher_test.go`
+- `internal/credentials/store.go`
+- `internal/credentials/resolver.go`
+- `internal/credentials/resolver_test.go`
+
+**What to do:** Implement AES-256-GCM encrypt/decrypt, the `CredentialStore` interface backed by `account_credentials` table, and the `ResolveAWSCredentialProvider` / `ResolveAzureCredentials` / `ResolveGCPCredentials` functions as specified in `backend.md`.
+
+Ensure all structs have `String() string` returning `"[REDACTED]"`.
+
+**Tests:** Round-trip encrypt/decrypt, resolver for each auth mode (mock STS client), dev key fallback behaviour, `CREDENTIAL_ENCRYPTION_KEY_SECRET_ARN` path (mock `secretsmanager.GetSecretValue`).
+
+**Verification:** `go test ./internal/credentials/...` — all pass.
+
+---
+
+### Task 1.5: Service Config Resolver
+
+**Files to create:**
+
+- `internal/config/resolver.go`
+- `internal/config/resolver_test.go`
+
+**What to do:** Implement `ResolveServiceConfig(global, override)` as specified in `backend.md`. Table-driven tests covering: no override (returns global), partial override (sparse merge), full override.
+
+**Verification:** `go test ./internal/config/... -run TestResolveServiceConfig`
+
+---
+
+### Task 1.6: Store Implementation (Cloud Accounts)
+
+**Files to modify:**
+
+- `internal/config/store_postgres.go`
+
+**What to do:** Implement the new `StoreInterface` methods: `CreateCloudAccount`, `GetCloudAccount`, `UpdateCloudAccount`, `DeleteCloudAccount`, `ListCloudAccounts`, `GetAccountServiceOverride`, `SaveAccountServiceOverride`, `DeleteAccountServiceOverride`, `ListAccountServiceOverrides`, `SetPlanAccounts`, `GetPlanAccounts`.
+
+Do NOT implement `CredentialStore` here — that lives in `internal/credentials/store.go` to avoid a circular import (`credentials` imports `config`; `config` must not import `credentials`).
+
+Follow the existing CRUD pattern: parameterised queries, `nullStringFromString` helpers for nullable fields, helper `queryXxx` functions for row scanning.
+
+**Verification:** `go test ./internal/config/... -tags integration` (requires test DB).
+
+---
+
+## Phase 2 — Backend API
+
+Can begin once Phase 1 is complete.
+
+### Task 2.1: Account HTTP Handlers
+
+**Files to create:**
+
+- `internal/api/handler_accounts.go`
+- `internal/api/handler_accounts_test.go`
+
+**Files to modify:**
+
+- `internal/api/types.go` — add `CredentialStore credentials.CredentialStore` field to `HandlerConfig`
+- `internal/api/handler.go` — add `credStore credentials.CredentialStore` field to `Handler` struct; assign from config in `NewHandler`
+- `internal/server/app.go` — add `CredentialStore credentials.CredentialStore` to `Application`; initialise via `credentials.NewCredentialStore(pool, key)` in the DB connect path
+
+**Context:** HTTP handlers in this project live in `internal/api/handler_*.go`, NOT in `internal/server/`. The `internal/server/handler.go` is for *scheduled task* dispatch only. All Lambda Function URL request handling goes through `internal/api/`.
+
+**What to do:** Implement all handlers from `api.md`:
+
+- `handleListAccounts`, `handleCreateAccount`, `handleGetAccount`, `handleUpdateAccount`, `handleDeleteAccount`
+- `handleSaveAccountCredentials`, `handleTestAccountCredentials`
+- `handleListAccountServiceOverrides`, `handleSaveAccountServiceOverride`, `handleDeleteAccountServiceOverride`
+- `handleDiscoverOrgAccounts`
+- `handleGetPlanAccounts`, `handleSetPlanAccounts`
+
+Follow existing handler pattern: method on `*Handler`, takes `*events.LambdaFunctionURLRequest`, returns `(any, error)`. Use `NewClientError(code, msg)` for all 4xx errors including 404 (e.g. `NewClientError(404, "account not found")`). The `errNotFound` sentinel and `notFoundError{}` type are router-internal (for unmatched routes) — do not use them in handlers. Never return Go errors as HTTP 500 — always wrap.
+
+**Verification:** Unit tests with mock store: `go test ./internal/api/... -run TestAccounts`
+
+---
+
+### Task 2.2: Route Registration
+
+**Files to modify:**
+
+- `internal/api/router.go` — add new routes to `registerRoutes()` slice
+
+**What to do:** Register all new `/api/accounts/*` and `/api/plans/:id/accounts` routes using the existing `Route{ExactPath/PathPrefix/PathSuffix, Method, Handler}` struct pattern. Add `parseAccountIDs` helper to `internal/api/handler.go`. Wire `account_ids` param into existing handlers: look up the handler functions in `handler_recommendations.go`, `handler_dashboard.go`, `handler_history.go`, and `handler_analytics.go` and add account_ids extraction using `parseAccountIDs(req)`. (`handler_config.go` handles service config only — no account_ids needed there.)
+
+**Note on route ordering:** Exact-path routes must be registered before prefix/suffix routes in the slice to avoid shadowing — match the ordering pattern already established in `router.go`. Specifically, `POST /api/accounts/discover-org` must be registered as an `ExactPath` route before any `PathPrefix: "/api/accounts/"` POST routes.
+
+**Note on multi-segment variable paths:** The current router's `extractParams` produces a single `params["id"]` — the path segment between `PathPrefix` and `PathSuffix`. For the service override routes (`PUT/DELETE /api/accounts/:id/service-overrides/:provider/:service`), the path can't be expressed with a fixed suffix because `:provider/:service` varies. Register these as `{PathPrefix: "/api/accounts/", Method: "PUT"/"DELETE"}` with no suffix, which causes `params["id"]` to be the full tail (e.g. `"<uuid>/service-overrides/aws/ec2"`). The handler must detect the `/service-overrides/` segment and split accordingly:
+
+```go
+parts := strings.SplitN(params["id"], "/service-overrides/", 2)
+accountID := parts[0]                    // uuid
+providerService := strings.SplitN(parts[1], "/", 2)  // ["aws", "ec2"]
+```
+
+Handlers for simple `PUT /api/accounts/:id` (no service-overrides in path) must be registered with a priority check so the dispatcher skips accounts whose params["id"] contains `/service-overrides/`.
+
+**Verification:** `go test ./internal/api/...`; existing handler tests still pass.
+
+---
+
+### Task 2.3: Org Discovery Implementation
+
+**Files to create:**
+
+- `internal/accounts/org_discovery.go`
+- `internal/accounts/org_discovery_test.go`
+
+**What to do:** Implement `DiscoverOrgAccounts` as specified in `backend.md`. Use paginated `organizations.ListAccounts`. Map results to `CloudAccount` structs with `enabled=false` and `aws_auth_mode='bastion'` defaulting to the management account as bastion.
+
+**Tests:** Mock Organizations client; test pagination, account mapping, idempotency (existing accounts skipped).
+
+**Verification:** `go test ./internal/accounts/...`
+
+---
+
+## Phase 3 — Execution Engine
+
+Can begin once Phase 1 is complete (parallel with Phase 2).
+
+### Task 3.1: Fan-Out Engine
+
+**Files to create:**
+
+- `internal/execution/executor.go`
+- `internal/execution/fanout.go`
+- `internal/execution/collector.go`
+- `internal/execution/fanout_test.go`
+
+**What to do:** Implement `PrepareAccountContext`, `FanOut[T]` (generic, with `sync.WaitGroup` + buffered semaphore for parallelism — NOT `errgroup.WithContext`; see `backend.md` for rationale), and aggregation helpers as specified in `backend.md`.
+
+**Tests:** Table-driven tests: all succeed, one fails, all fail, parallelism limit respected (mock executors with artificial delay).
+
+**Verification:** `go test ./internal/execution/... -race` (race detector must pass).
+
+---
+
+### Task 3.2: Wire Fan-Out into Plan Execution
+
+**Files to modify:**
+
+- `internal/purchase/execution.go` — per-plan execution logic (confirmed location)
+- `internal/purchase/manager.go` — `ProcessScheduledPurchases` which calls execution
+
+**What to do:** Change plan execution to:
+
+1. Derive plan's provider from `plan.Services` map keys (format `"provider:service"`). `PurchasePlan` has no direct `provider` field.
+2. Load `plan_accounts` for the plan (or all enabled `cloud_accounts` matching the derived provider if `plan_accounts` is empty).
+3. Call `FanOut(ctx, accounts, maxParallel, fn, credStore)` — `FanOut` calls `PrepareAccountContext` internally per goroutine (do NOT call PrepareAccountContext externally before FanOut). Use `sync.WaitGroup` + semaphore (not `errgroup.WithContext`).
+4. For each `FanOutResult`: create one `purchase_execution` row with `cloud_account_id` set; on `FanOutResult.Err != nil`, mark execution failed and log.
+
+**Verification:** Existing plan execution tests pass; new tests for multi-account fan-out.
+
+---
+
+## Phase 4 — Frontend: Accounts Management
+
+Can begin once Phase 2 Task 2.1 is complete (API endpoints available).
+
+### Task 4.1: Accounts API Module
+
+**Files to create:**
+
+- `frontend/src/api/accounts.ts`
+
+**Files to modify:**
+
+- `frontend/src/api/index.ts` (re-export)
+- `frontend/src/api/types.ts` (add `CloudAccount` type here — it's an API response type; also add `accountIDs` to filter types)
+
+**What to do:** Implement all functions from `frontend.md` (New API Module section). Follow existing `apiRequest` pattern.
+
+**Verification:** `npm test` — add `frontend/src/__tests__/api-accounts.test.ts` with mocked fetch.
+
+---
+
+### Task 4.2: State and Type Changes
+
+**Files to modify:**
+
+- `frontend/src/types.ts` (add `AppState.currentAccountIDs` only — `CloudAccount` goes in `api/types.ts`)
+- `frontend/src/state.ts` (add `currentAccountIDs` getter/setter, initialise to `[]`)
+
+**Verification:** `npm test` — existing tests pass; `currentAccountIDs` defaults to `[]`.
+
+---
+
+### Task 4.3: Settings HTML — Account Sections and Modals
+
+**Files to modify:**
+
+- `frontend/src/index.html`
+
+**What to do:** Add the following to `index.html`:
+
+- Inside each provider fieldset (`#aws-settings`, `#azure-settings`, `#gcp-settings`), insert an Accounts sub-section **above** the existing `<h4 class="subsection-title">Service Defaults</h4>` heading. Each sub-section contains an account list `<div id="aws-account-list">` (etc.) and an "+ Add Account" button.
+- Add `#aws-account-modal`, `#azure-account-modal`, `#gcp-account-modal` modal overlays as siblings of the existing modals (`#azure-creds-modal`, `#gcp-creds-modal`). Use `class="modal hidden"` + inner `class="modal-content modal-wide"`. Cancel button pattern: `class="btn-secondary"` with id `close-aws-account-modal-btn` etc. (see `frontend.md` Modals section).
+- Add `#account-creds-modal` for updating credentials on existing accounts (same modal structure).
+
+Auth mode sections in the AWS modal use the existing `hidden` class toggle pattern.
+
+---
+
+### Task 4.4: Settings TypeScript — Account CRUD
+
+**Files to modify:**
+
+- `frontend/src/settings.ts`
+
+**What to do:** Implement:
+
+- `loadAccountsList(provider)` — fetch + render account rows using DOM methods
+- `setupAccountHandlers()` — event delegation on account list for Test / Credentials / Overrides / Edit / Delete buttons
+- `openAddAccountModal(provider)` / `openEditAccountModal(account)`
+- `handleAccountSave(e)` — validate + call createAccount or updateAccount
+- `handleDeleteAccount(accountId)` — confirm + call deleteAccount + refresh list
+- `handleTestCredentials(accountId)` — call testAccountCredentials + show inline result
+- `openCredsModal(account)` + `handleCredsSave` — save credentials via saveAccountCredentials
+- `toggleOverridesPanel(accountId)` — expand/collapse override sub-panel
+- Override CRUD: load overrides, render table, handle edit/reset
+
+**Verification:** `npm test` — add `frontend/src/__tests__/settings-accounts.test.ts`.
+
+---
+
+## Phase 5 — Frontend: Filters
+
+Can begin once Task 4.1 and 4.2 are complete.
+
+### Task 5.1: Filter HTML Additions
+
+**Files to modify:**
+
+- `frontend/src/index.html`
+
+**What to do:** Add account filter `<select>` elements to the controls bars of each tab:
+
+- `#dashboard-account-filter` — inside `#dashboard-controls .controls-bar` (existing controls bar at line ~36)
+- `#recommendations-account-filter` — inside `#recommendations-controls .controls-bar` (existing)
+- `#history-account-filter` — inside `#history-controls` (existing)
+- `#plans-account-filter` — the plans tab has **no existing controls bar**; create `<section id="plans-controls">` with a `.controls-bar` before `#plans-header` (see `frontend.md` for the HTML)
+
+Add the `populateAccountFilter` utility to `frontend/src/utils.ts`.
+
+---
+
+### Task 5.2: Wire Account Filters in Tab Modules
+
+**Files to modify:**
+
+- `frontend/src/dashboard.ts`
+- `frontend/src/recommendations.ts`
+- `frontend/src/history.ts`
+
+**What to do:** In each module's setup function, add account filter population and change handler (see `frontend.md` JS changes section). Pass `state.getCurrentAccountIDs()` to API calls via the `accountIDs` filter field.
+
+**Verification:** `npm test` — existing tests pass; add filter-passing assertion to each module's test.
+
+---
+
+### Task 5.3: Update API Client Functions to Pass `account_ids`
+
+**Files to modify:**
+
+- `frontend/src/api/recommendations.ts`
+- `frontend/src/api/history.ts`
+- `frontend/src/api/dashboard.ts`
+
+**What to do:** Serialize `accountIDs` as `account_ids=uuid1,uuid2` query param when present.
+
+**Verification:** `npm test`
+
+---
+
+## Phase 6 — Frontend: Plans
+
+Can begin once Task 4.1, 4.2 are complete.
+
+### Task 6.1: Plan Account Association UI
+
+**Files to modify:**
+
+- `frontend/src/plans.ts`
+- `frontend/src/index.html` (plan modal additions + plans-controls section)
+
+**What to do:**
+
+- Add `<section id="plans-controls">` with `.controls-bar` before the plans list in `index.html` (see `frontend.md` Filter Bar section — Plans tab has no existing controls bar; create the entire section including `#plans-provider-filter` and `#plans-account-filter`)
+- Add Target Accounts section to plan create/edit modal (see `frontend.md`)
+- On plan modal open: call `getPlanAccounts(planId)` for existing plans
+- Search + Add + Remove logic (DOM-based, no raw HTML injection)
+- On plan save: call `setPlanAccounts(planId, accountIds)` after plan save succeeds
+- Plan list: add Accounts column showing count or "All accounts"; use `element.title` for tooltip
+
+**Verification:** `npm test`
+
+---
+
+## Phase 7 — Integration and Cleanup
+
+### Task 7.1: End-to-End Smoke Test Script
+
+**What to do:** Write a manual test runbook (or automated integration test) covering:
+
+1. Create AWS account (role_arn)
+2. Save credentials
+3. Test credentials
+4. Set service override
+5. Create plan targeting account
+6. Trigger recommendations refresh
+7. Verify recommendations show account name
+8. Check history filter by account
+
+---
+
+### Task 7.2: Known Issues Update
+
+**Files to modify:**
+
+- `known-issues.md` (if it exists at project root)
+
+**What to do:** Add any discovered issues during implementation. Remove any pre-existing issues that this feature resolves.
+
+---
+
+### Task 7.3: Documentation
+
+**Files to modify:**
+
+- `docs/DEVELOPMENT.md` — add local-dev instructions: set `CREDENTIAL_ENCRYPTION_KEY` (64-char hex from `openssl rand -hex 32`); note that production uses `CREDENTIAL_ENCRYPTION_KEY_SECRET_ARN` instead
+- `docs/DEPLOYMENT.md` — add migration step 000011; document all new env vars (`CREDENTIAL_ENCRYPTION_KEY_SECRET_ARN`, `CUDLY_MAX_ACCOUNT_PARALLELISM`); reference `iac.md` for Terraform changes
+
+---
+
+### Task 7.4: IaC Changes
+
+**Reference:** `specs/multi-account-execution/iac.md`
+
+**Files to modify/create:**
+
+- `terraform/modules/secrets/aws/variables.tf` — add `create_credential_encryption_key` (bool, default false) and `credential_encryption_key` (sensitive string) variables
+- `terraform/modules/secrets/aws/main.tf` — add `aws_secretsmanager_secret.credential_encryption_key` + version resource (count-gated on `var.create_credential_encryption_key`)
+- `terraform/modules/secrets/aws/outputs.tf` — add `credential_encryption_key_secret_arn` output
+- `terraform/environments/aws/secrets.tf` — update existing `module "secrets"` invocation to add `create_credential_encryption_key = true` and `credential_encryption_key = var.credential_encryption_key`
+- `terraform/environments/aws/variables.tf` — add `credential_encryption_key` (sensitive, no default) and `max_account_parallelism` (default: 10)
+- `terraform/environments/aws/compute.tf` — add `CREDENTIAL_ENCRYPTION_KEY_SECRET_ARN` (set to `module.secrets.credential_encryption_key_secret_arn`) and `CUDLY_MAX_ACCOUNT_PARALLELISM` to `additional_env_vars`; pass `enable_cross_account_sts = true`, `enable_org_discovery = true`, `credential_encryption_key_secret_arn = module.secrets.credential_encryption_key_secret_arn` to the Lambda module
+- `terraform/modules/compute/aws/lambda/main.tf` — add `credential_encryption_key_secret_arn` variable; update `secrets_access` policy to include it; add `cross_account_sts` IAM policy (conditioned on `enable_cross_account_sts`); add `org_discovery` IAM policy (conditioned on `enable_org_discovery`)
+- `terraform/environments/aws/dev.tfvars.example` — document the two new variables (`credential_encryption_key`, `max_account_parallelism`)
+- `terraform/environments/azure/secrets.tf` — add `azurerm_key_vault_secret.credential_encryption_key`
+- `terraform/environments/gcp/` — add `credential-enc-key` to secrets module invocation
+
+**Verification:** `terraform validate` + `terraform plan` in a dev environment shows only the new resources and IAM policy changes; `terraform apply` succeeds; Lambda can call `secretsmanager:GetSecretValue` on the new secret ARN.
+
+---
+
+## Dependency Graph
+
+```
+Task 1.1 (migration)
+  └─► Task 1.2 (types)
+        └─► Task 1.3 (interface)
+              ├─► Task 1.4 (credentials pkg) ──► Task 3.1 (fanout) ──► Task 3.2 (wire)
+              ├─► Task 1.5 (resolver)
+              └─► Task 1.6 (store impl)
+                    └─► Task 2.1 (handlers) ──► Task 2.2 (routes) ──► Task 2.3 (org discovery)
+                          └─► Task 4.1 (FE api module)
+                                ├─► Task 4.2 (FE state)
+                                │     ├─► Task 4.3 (FE HTML)
+                                │     │     └─► Task 4.4 (FE settings.ts)
+                                │     ├─► Task 5.1 (filter HTML)
+                                │     │     └─► Task 5.2 (filter JS)
+                                │     │           └─► Task 5.3 (API params)
+                                │     └─► Task 6.1 (plans UI)
+                                └─► Task 7.x (integration/docs)
+
+Task 7.4 (IaC) — independent of all code tasks; can be done in parallel with any phase
+```


### PR DESCRIPTION
## Summary

Adds `specs/multi-account-execution/` — design doc set covering CUDly's planned move from one-account-per-provider to N-accounts-per-provider across AWS / Azure / GCP. Status: **Draft** (created 2026-04-02).

Nine documents, doc-only, no code changes:

| File | Contents |
|------|----------|
| `README.md`     | Problem statement, scope, document index |
| `acceptance.md` | Gherkin-style acceptance criteria |
| `api.md`        | REST surface changes (account CRUD, overrides) |
| `backend.md`    | Handler + scheduler + collection-pipeline impacts |
| `data-model.md` | New DB tables, column additions, migration plan |
| `frontend.md`   | UI flows (account list, per-account dashboards) |
| `iac.md`        | Terraform module changes for multi-account federation |
| `security.md`   | Credential storage, audit log, scoped tokens |
| `tasks.md`      | Phased implementation plan, one atomic commit per task |

## Why this PR is just docs

No implementation has shipped yet — the live scheduler still collects per-provider, not per-account-per-provider. Recent shipped work (`32f9e4ffc` history pending, `b44283746` failed/expired states, `b3fe6e225` Azure scheduler dedupe) was scoped to keep the existing single-account model working; this spec is the substrate the next implementation phase will land against.

Landing the spec early means subsequent feature PRs can reference it without re-deriving the design every time.

## Markdownlint note

The repo's markdownlint config defaults to "consistent" table-column style and "language-required" fenced code blocks. The spec was authored before the rules tightened; rather than reflow ~20 tables and tag every fenced block, each file opens with a `<!-- markdownlint-disable MD040 MD060 -->` directive scoped to that file. When the spec stops being draft and graduates to canonical docs, those can come off and the tables/code blocks can be normalised in the same pass.

## Test plan

- [x] No hardcoded secrets: `grep` for `AKIA|client_secret|private_key|password` returned only schema field names and example placeholders (`AKIA...`).
- [x] Pre-commit hooks pass (markdownlint clean with the per-file disable).
- [x] Word/line counts match expectation: 3,030 lines, ~111 KB across 9 files.
