### PR TITLE
fix(commitmentopts): swap MemoryDB probe target to db.r6g.large (closes #61)

### DIFF
--- a/internal/commitmentopts/probe.go
+++ b/internal/commitmentopts/probe.go
@@ -30,24 +30,26 @@ const pageSize int32 = 100
 // a purchase so their cost is irrelevant; what matters is that AWS
 // actually has offerings to return for them.
 //
-// probeTargetMemoryDB carries an empirical risk: MemoryDB reserved-node
-// coverage has historically skewed to db.r6g.* tiers, and db.t4g.small may
-// return an empty offerings list in some regions. If that happens the
-// orchestrating Service still persists the run (so we don't re-probe in a
-// hot loop) and the frontend silently falls back to hardcoded MemoryDB
-// rules. Switching to db.r6g.large would be the safe alternative once a
-// human with AWS creds confirms via:
+// probeTargetMemoryDB is db.r6g.large because db.t4g.small returns an
+// empty offerings list — verified 2026-04-25 in us-east-1:
 //
-//	aws memorydb describe-reserved-nodes-offerings \
+//	$ aws memorydb describe-reserved-nodes-offerings \
 //	    --region us-east-1 --node-type db.t4g.small
+//	{ "ReservedNodesOfferings": [] }
 //
-// Tracked in github.com/LeanerCloud/CUDly#61.
+//	$ aws memorydb describe-reserved-nodes-offerings \
+//	    --region us-east-1 --node-type db.r6g.large
+//	# 6 offerings: 1yr/3yr × all/partial/no-upfront
+//
+// MemoryDB's reserved-node coverage is skewed to db.r6g.* tiers, so
+// picking the smallest one in that family gives us the full term ×
+// payment matrix while keeping the probe target stable.
 const (
 	probeTargetRDS         = "db.t3.micro"
 	probeTargetElastiCache = "cache.t3.micro"
 	probeTargetOpenSearch  = "t3.small.search"
 	probeTargetRedshift    = "dc2.large"
-	probeTargetMemoryDB    = "db.t4g.small"
+	probeTargetMemoryDB    = "db.r6g.large"
 	probeTargetEC2         = "t3.micro"
 )
 
@@ -371,7 +373,7 @@ type MemoryDBProber struct {
 // Service returns "memorydb".
 func (p *MemoryDBProber) Service() string { return "memorydb" }
 
-// Probe returns the combos for db.t4g.small.
+// Probe returns the combos for db.r6g.large.
 func (p *MemoryDBProber) Probe(ctx context.Context, cfg aws.Config) ([]Combo, error) {
 	client := p.client(cfg)
 	raw, err := walkPaginated(ctx, p.Service(), func(ctx context.Context, token *string) ([]rawOffer, *string, error) {


### PR DESCRIPTION
Closes #61.

## Verification (2026-04-25, `us-east-1`)

```
$ aws memorydb describe-reserved-nodes-offerings --region us-east-1 --node-type db.t4g.small
{ "ReservedNodesOfferings": [] }

$ aws memorydb describe-reserved-nodes-offerings --region us-east-1 --node-type db.r6g.large
# 6 offerings: 1yr/3yr × {all-upfront, partial-upfront, no-upfront}
```

The current probe target `db.t4g.small` returns zero offerings, so in production the MemoryDB probe was silently persisting an empty combo set and the frontend was always falling back to its hardcoded MemoryDB rules — defeating the dynamic-overlay design for that one service.

## Change

- `probeTargetMemoryDB` switches from `db.t4g.small` to `db.r6g.large` (smallest tier in the family MemoryDB actually covers with reserved nodes; full 6-combo matrix).
- The shared comment on `probeTarget*` is rewritten to embed the verification commands and their output, so a future revisitor doesn't have to re-derive the rationale.
- The MemoryDBProber docstring is updated to match the new target.

Tests reference the constant by name (not the literal string), so no test changes are needed.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/commitmentopts/...` green
- [ ] Once merged + deployed, the next cold cache fill will probe `db.r6g.large` and `/api/commitment-options` will start returning a `memorydb` entry. Existing deploys with the empty-combos cache will continue serving stale-but-graceful-fallback until the singleton run row is cleared (one-time DB op).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated MemoryDB probe infrastructure to verify instance type compatibility and coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->