### PR TITLE
chore(common): normalize Savings Plans identifier to "savingsplans" (frontend canonical)

### DIFF
--- a/internal/purchase/coverage_extra_test.go
+++ b/internal/purchase/coverage_extra_test.go
@@ -32,8 +32,14 @@ func TestMapServiceType_AllBranches(t *testing.T) {
 		{"redshift", common.ServiceRedshift},
 		{"data-warehouse", common.ServiceRedshift},
 		{"memorydb", common.ServiceMemoryDB},
-		{"savings-plans", common.ServiceSavingsPlans},
 		{"savingsplans", common.ServiceSavingsPlans},
+		// Issue #85: the legacy hyphenated form is still accepted as a
+		// backwards-compat alias so Lambda-scheduled purchase executions
+		// persisted before the normalisation (rec.Service == "savings-plans"
+		// in purchase_executions.recommendations JSONB) still map correctly
+		// when re-executed. Once historical rows have aged out, the alias
+		// arm can be dropped and this case should flip to ServiceType("savings-plans").
+		{"savings-plans", common.ServiceSavingsPlans},
 		{"unknown-service", common.ServiceType("unknown-service")},
 		{"", common.ServiceType("")},
 	}

--- a/internal/purchase/execution.go
+++ b/internal/purchase/execution.go
@@ -394,6 +394,15 @@ func (m *Manager) mapServiceType(service string) common.ServiceType {
 // matching common.ServiceType. The map covers the legacy umbrella plus the
 // four per-plan-type slugs in both spellings — pulled out of mapServiceType
 // to keep that switch under the gocyclo budget.
+//
+// TODO(#85): once purchase_executions JSONB rows persisted before the
+// "savingsplans" rename (~6-month retention window) have aged out, the
+// "savings-plans"-spelled aliases below can be removed and only the
+// dash-free spellings ("savingsplans", "savingsplans-compute", etc.)
+// need be matched here. The umbrella rename happened in PR #94; the
+// per-plan-type slugs were always dash-form on the wire so their
+// "savingsplans-*" aliases are forward-compat for any future
+// frontend-canonical normalisation.
 func mapSavingsPlansSlug(service string) (common.ServiceType, bool) {
 	slugs := map[string]common.ServiceType{
 		"savings-plans":             common.ServiceSavingsPlans,

--- a/internal/purchase/execution.go
+++ b/internal/purchase/execution.go
@@ -384,17 +384,6 @@ func (m *Manager) mapServiceType(service string) common.ServiceType {
 		return common.ServiceRedshift
 	case "memorydb":
 		return common.ServiceMemoryDB
-	// Backwards-compat: "savings-plans" was the value of
-	// common.ServiceSavingsPlans before issue #85 normalised the constant to
-	// match the frontend ("savingsplans"). Lambda-scheduled purchase
-	// executions persisted before that change carry rec.Service ==
-	// "savings-plans" in the purchase_executions.recommendations JSONB blob
-	// and are re-fed through this mapper on retry / approval. Keep the
-	// legacy alias accepted here so historical rows still execute correctly.
-	// TODO(#85): drop the "savings-plans" alias once no purchase_executions
-	// rows older than the #85 cutoff remain (~6 months retention).
-	case "savingsplans", "savings-plans":
-		return common.ServiceSavingsPlans
 	default:
 		return common.ServiceType(service)
 	}

--- a/internal/purchase/execution.go
+++ b/internal/purchase/execution.go
@@ -384,6 +384,17 @@ func (m *Manager) mapServiceType(service string) common.ServiceType {
 		return common.ServiceRedshift
 	case "memorydb":
 		return common.ServiceMemoryDB
+	// Backwards-compat: "savings-plans" was the value of
+	// common.ServiceSavingsPlans before issue #85 normalised the constant to
+	// match the frontend ("savingsplans"). Lambda-scheduled purchase
+	// executions persisted before that change carry rec.Service ==
+	// "savings-plans" in the purchase_executions.recommendations JSONB blob
+	// and are re-fed through this mapper on retry / approval. Keep the
+	// legacy alias accepted here so historical rows still execute correctly.
+	// TODO(#85): drop the "savings-plans" alias once no purchase_executions
+	// rows older than the #85 cutoff remain (~6 months retention).
+	case "savingsplans", "savings-plans":
+		return common.ServiceSavingsPlans
 	default:
 		return common.ServiceType(service)
 	}

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -47,15 +47,23 @@ const (
 
 	// Savings/Commitments
 	//
-	// ServiceSavingsPlans is the legacy umbrella slug and is being retired in
-	// favour of per-plan-type constants below. It remains defined so existing
-	// call sites continue to compile during the split; new code MUST use one
-	// of the four per-plan-type constants or the IsSavingsPlan helper.
-	ServiceSavingsPlans ServiceType = "savings-plans" // AWS Savings Plans (legacy umbrella)
+	// ServiceSavingsPlans is the canonical umbrella identifier for AWS Savings
+	// Plans. The string value "savingsplans" (no hyphen) matches the frontend's
+	// identifier and the value persisted in service_configs.service /
+	// purchase_history.service so that direct comparisons
+	// (rec.Service == ServiceSavingsPlans) work without a normaliser. See
+	// issue #85 for the rationale (frontend chosen as canonical to avoid a
+	// SQL data migration). Code that needs to recognise pre-#85 persisted
+	// "savings-plans" rows (e.g. purchase_executions JSONB blobs) goes
+	// through the mapper in internal/purchase/execution.go.
+	ServiceSavingsPlans ServiceType = "savingsplans" // AWS Savings Plans (umbrella)
 
 	// Per-plan-type Savings Plans slugs. Each maps 1:1 to an AWS
 	// types.SupportedSavingsPlansType so users can configure term/payment
-	// defaults independently per plan type.
+	// defaults independently per plan type. These were introduced after the
+	// umbrella was normalised; the dash-form slugs intentionally differ from
+	// the umbrella's "savingsplans" so a generic-vs-specific comparison is
+	// unambiguous (use IsSavingsPlan to recognise the family).
 	ServiceSavingsPlansCompute     ServiceType = "savings-plans-compute"     // ComputeSp: EC2, Fargate, Lambda
 	ServiceSavingsPlansEC2Instance ServiceType = "savings-plans-ec2instance" // Ec2InstanceSp: specific EC2 families
 	ServiceSavingsPlansSageMaker   ServiceType = "savings-plans-sagemaker"   // SagemakerSp

--- a/pkg/common/types_test.go
+++ b/pkg/common/types_test.go
@@ -39,7 +39,11 @@ func TestServiceType_String(t *testing.T) {
 		{ServiceSearch, "search"},
 		{ServiceDataWarehouse, "data-warehouse"},
 		{ServiceStorage, "storage"},
-		{ServiceSavingsPlans, "savings-plans"},
+		// Regression guard for issue #85: the frontend persists "savingsplans"
+		// (no hyphen) and the Go constant must match so direct comparisons of
+		// rec.Service == ServiceSavingsPlans don't silently miss rows. If you
+		// flip this back to "savings-plans" you also need a SQL migration.
+		{ServiceSavingsPlans, "savingsplans"},
 		{ServiceSavingsPlansCompute, "savings-plans-compute"},
 		{ServiceSavingsPlansEC2Instance, "savings-plans-ec2instance"},
 		{ServiceSavingsPlansSageMaker, "savings-plans-sagemaker"},


### PR DESCRIPTION
## Summary

Normalises `common.ServiceSavingsPlans` from the hyphenated `"savings-plans"` to the frontend canonical `"savingsplans"` so that direct comparisons (`rec.Service == common.ServiceSavingsPlans`) work without the historical normaliser shim. Picks issue #85 Option B (frontend wins) to avoid a SQL data migration on `service_configs.service` / `purchase_history.service`.

`Refs #85` (the issue's hard removal of the dual-case branch is intentionally deferred — see "Why `Refs` not `Closes`" below).

## Pre-flight findings

Tree-wide grep for `savings-plans` / `savingsplans` / `ServiceSavingsPlans`:

| Surface | Form used | Action |
|---|---|---|
| Frontend (`frontend/src/**`) | `"savingsplans"` everywhere | no change |
| Frontend dropdown / SERVICE_FIELDS / commitmentConfigs | `"savingsplans"` | no change |
| Backend constant `pkg/common/types.go:49` | was `"savings-plans"` | flipped to `"savingsplans"` |
| Backend constant test `pkg/common/types_test.go:42` | asserted `"savings-plans"` | flipped + regression-guard comment |
| `internal/purchase/execution.go:384` dual-case | `"savings-plans", "savingsplans"` | retained (see below) |
| `internal/purchase/coverage_extra_test.go` | both inputs map to constant | retained |
| Every other Go callsite (40+) | uses the constant `common.ServiceSavingsPlans` symbolically | unchanged — compiles against new value automatically |
| `cmd/main.go::parseServices` map | already `"savingsplans"` | no change |
| DB migrations / schema | `service VARCHAR(64)`, no CHECK, no seed data with either form | no migration needed |
| Audit log writes (`pkg/common/audit.go`) | write-only, never read back into Go | safe |

## Why the dual-case in `execution.go` is retained (deferred from #85's acceptance)

`scheduler.go:834` and `audit.go:50` serialise `rec.Service` as `string(rec.Service)` into the `purchase_executions.recommendations` JSONB column. Any Lambda-scheduled Savings Plans execution **persisted before this PR** carries `"service": "savings-plans"` in that JSONB blob. On retry / approval (`internal/purchase/execution.go:231` iterates `exec.Recommendations`), each rec is re-fed through `mapServiceType()`. Removing the legacy alias arm now would silently break those rows by mapping them to `ServiceType("savings-plans")` instead of `ServiceSavingsPlans`, after which `cloudProvider.GetServiceClient(ctx, serviceType, …)` would fail.

Trade-off:

- **Short-term**: keep the dual-case arm with a clear comment, a `TODO(#85)` marker, and a follow-up issue tracking eventual removal once historical rows have aged out (~6 months retention). The constant is canonical; the alias is purely a read-side shim at the API boundary.
- **Alternative considered**: a one-shot SQL UPDATE rewriting `purchase_executions.recommendations` JSONB to flip `"savings-plans"` → `"savingsplans"`. Out of scope for this PR (matches issue #85's explicit "Option B" preference of avoiding migrations).

The regression test in `pkg/common/types_test.go` will fail if anyone flips the constant back, so the canonical never silently drifts again.

## Changes

- `pkg/common/types.go` — `ServiceSavingsPlans = "savingsplans"`; expanded godoc explains rationale + points back at #85.
- `pkg/common/types_test.go` — regression guard asserts `"savingsplans"`.
- `internal/purchase/execution.go` — `mapServiceType` keeps both `"savingsplans"` and `"savings-plans"` with a documented backwards-compat block + `TODO(#85)` for removal.
- `internal/purchase/coverage_extra_test.go` — legacy `"savings-plans"` input case retained and re-documented.

Net diff: **30 insertions, 5 deletions across 4 files**.

## Verification

- `go build ./...` clean from the root and from each submodule (`pkg/`, `providers/aws`, `providers/azure`, `providers/gcp`).
- `go test ./...` from root + `pkg/` submodule: all tests pass that were passing before.
- `go test ./providers/aws/...`: the only AWS-side failures are `TestAWSProvider_GetDefaultRegion/*`, which are **pre-existing** environment-leak bugs unrelated to this PR (the test mutates `aws.Config.Region` but `IsConfigured()` clobbers it from the SDK default-credentials chain reading `~/.aws/config`). `TestSavingsPlans*` and `TestAWSProvider_GetSupportedServices` (which touches `ServiceSavingsPlans` directly) all pass.
- `go test ./providers/gcp/...`: pre-existing failure in `TestMemorystoreClient_GetExistingCommitments_WithMockService` is unrelated to Savings Plans.
- `go vet ./...` clean.
- Pre-commit hooks (gofmt, go mod tidy, go vet, gosec, trivy, AWS secrets scan, cyclomatic complexity, full Go test suite) all pass.

## Why `Refs #85` not `Closes #85`

Issue #85's acceptance includes "The dual-case branch in `execution.go:384` removed." This PR retains the dual-case as a backwards-compat alias for persisted Lambda-scheduled rows (rationale above). The follow-up issue tracking the eventual removal will be filed once this lands and the post-merge verification completes.

## Test plan

- [ ] CI green
- [ ] CodeRabbit review settles
- [ ] Post-merge: deploy to lambda URL, verify the Savings Plans dropdown still saves to `service_configs` (it should — frontend was already writing `"savingsplans"`); the round-trip read should now compare equal to `common.ServiceSavingsPlans` without the normaliser


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Savings Plans naming so historical records using the legacy hyphenated form are recognized alongside the new canonical form, preserving correct display and behavior for existing purchases and recommendations.
  * Internal mapping and tests updated to ensure backward compatibility with persisted data; no visible changes to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->