### PR TITLE
perf(common): extend ComputeDetails with VCPU + MemoryGB

### DIFF
--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -242,20 +242,40 @@ type Region struct {
 	DisplayName string       `json:"display_name"`
 }
 
-// ComputeDetails represents compute-specific details (EC2, VM, Compute Engine)
+// ComputeDetails represents compute-specific details (EC2, VM, Compute Engine).
+//
+// VCPU + MemoryGB are populated by per-provider catalogue lookups when
+// available (Azure: armcompute.ResourceSKU.Capabilities; AWS:
+// ec2:DescribeInstanceTypes; GCP: machine-type catalogue). They are
+// optional — converters that don't yet wire a catalogue leave them at the
+// zero value, and the JSON tag uses omitempty so unknown values don't
+// pollute the API payload.
 type ComputeDetails struct {
-	InstanceType string `json:"instance_type"`
-	Platform     string `json:"platform"` // linux, windows
-	Tenancy      string `json:"tenancy"`  // default, dedicated, host
-	Scope        string `json:"scope"`    // regional, zonal
+	InstanceType string  `json:"instance_type"`
+	Platform     string  `json:"platform"`            // linux, windows
+	Tenancy      string  `json:"tenancy"`             // default, dedicated, host
+	Scope        string  `json:"scope"`               // regional, zonal
+	VCPU         int     `json:"vcpu,omitempty"`      // 0 = unknown
+	MemoryGB     float64 `json:"memory_gb,omitempty"` // 0 = unknown
 }
 
 func (d ComputeDetails) GetServiceType() ServiceType {
 	return ServiceCompute
 }
 
+// GetDetailDescription returns a short human description of the compute
+// recommendation. The base form is "<platform>/<tenancy>"; when both VCPU
+// and MemoryGB are populated (>0) the size is appended as
+// " (<vcpu> vCPU / <memory> GB)" to give the UI a one-line summary
+// without forcing the caller to inspect the struct.
 func (d ComputeDetails) GetDetailDescription() string {
-	return d.Platform + "/" + d.Tenancy
+	base := d.Platform + "/" + d.Tenancy
+	if d.VCPU > 0 && d.MemoryGB > 0 {
+		// %g trims trailing zeros (16 GB, not 16.000000 GB) but keeps
+		// fractional sizes (e.g. 0.5 GB for the smallest Azure SKUs).
+		return fmt.Sprintf("%s (%d vCPU / %g GB)", base, d.VCPU, d.MemoryGB)
+	}
+	return base
 }
 
 // DatabaseDetails represents database-specific details (RDS, Azure SQL, Cloud SQL)

--- a/pkg/common/types_test.go
+++ b/pkg/common/types_test.go
@@ -115,6 +115,51 @@ func TestComputeDetails_GetDetailDescription(t *testing.T) {
 			},
 			expected: "windows/dedicated",
 		},
+		{
+			// vCPU alone is insufficient — both fields must be populated for
+			// the size suffix to appear, otherwise we'd surface "16 vCPU /
+			// 0 GB" which is misleading.
+			name: "VCPU populated but MemoryGB zero — base description only",
+			details: ComputeDetails{
+				Platform: "linux",
+				Tenancy:  "default",
+				VCPU:     16,
+			},
+			expected: "linux/default",
+		},
+		{
+			// Symmetric guard for the MemoryGB-only case.
+			name: "MemoryGB populated but VCPU zero — base description only",
+			details: ComputeDetails{
+				Platform: "linux",
+				Tenancy:  "default",
+				MemoryGB: 32,
+			},
+			expected: "linux/default",
+		},
+		{
+			// Whole-number GB renders without trailing zeros (16 GB,
+			// not 16.000000 GB).
+			name: "Both fields populated — integer memory",
+			details: ComputeDetails{
+				Platform: "linux",
+				Tenancy:  "default",
+				VCPU:     4,
+				MemoryGB: 16,
+			},
+			expected: "linux/default (4 vCPU / 16 GB)",
+		},
+		{
+			// Fractional GB (Azure has 0.5 GB SKUs) renders verbatim.
+			name: "Both fields populated — fractional memory",
+			details: ComputeDetails{
+				Platform: "linux",
+				Tenancy:  "default",
+				VCPU:     1,
+				MemoryGB: 0.5,
+			},
+			expected: "linux/default (1 vCPU / 0.5 GB)",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Adds `VCPU int` + `MemoryGB float64` (both `omitempty`) to
`common.ComputeDetails` so per-provider catalogue lookups can enrich compute
recommendations with sizing data. Foundation work for the deferred Azure /
AWS / GCP compute SKU enrichment tracked in #82.

`GetDetailDescription` now appends `" (N vCPU / M GB)"` when both values
are populated; the existing `"platform/tenancy"` form is preserved when
either is zero (so today's call sites stay unchanged).

## Scope decision — schema-only foundation

This PR intentionally lands **only** the shared-type schema + matcher
formatting + tests. Per-provider catalogue wiring is out of scope:

- **Azure**: PR #81 (`perf/azure-batched-sku-lookup`) introduces the
  `cachedSKULookup` helper for cache/cosmos/database. Compute was scoped
  back from #81 because these struct fields didn't exist yet. With the
  schema in place, a follow-up PR can wire compute on top of #81 once it
  merges. Filing the wiring against an unmerged PR here would create a
  rebase/merge dependency that's better tracked as a separate issue.
- **AWS**: `ce.EC2InstanceDetails` (Cost-Explorer) has no vCPU/Memory
  fields. Populating would require a new `ec2:DescribeInstanceTypes`
  caller + region-scoped catalogue cache + mocks/tests — substantial
  net-new code, separate follow-up.
- **GCP**: no compute recommendation converter exists today. N/A until one
  is added.
- **Frontend**: `api.Recommendation` (TS) has no `details` field and the
  detail drawer renders a hard-coded list. Surfacing the new fields needs
  separate API serializer + UI changes; tracked as a follow-up once at
  least one provider populates the fields.

The schema change is the prerequisite that unblocks every one of those
follow-ups.

## Changes

- `pkg/common/types.go::ComputeDetails` gains `VCPU` + `MemoryGB`
  (`omitempty`) with a doc comment explaining the catalogue-source
  contract.
- `ComputeDetails.GetDetailDescription()` appends the size suffix when
  both fields are > 0; uses `%g` so `16 GB` renders without trailing
  zeros while `0.5 GB` (smallest Azure SKU) renders verbatim.
- `pkg/common/types_test.go` adds 4 table rows covering VCPU-only,
  MemoryGB-only (both fall back to base form), integer GB, and
  fractional GB.

## Test plan

- [x] `go build ./...` (root + `pkg/`)
- [x] `go test ./...` (root)
- [x] `go test ./...` from `pkg/`
- [x] Pre-commit hooks (gofmt, govet, gosec, gocyclo, etc.) all green
- [x] Existing `ComputeDetails` consumers (Azure converter, AWS parser,
      cmd/main.go switch) continue compiling — no field is removed and
      `omitempty` keeps the JSON payload unchanged when fields aren't
      populated

## Follow-up issues (to file post-merge)

- Wire Azure compute to `cachedSKULookup` after #81 merges
- AWS EC2 catalogue lookup via `DescribeInstanceTypes`
- Frontend: add `details` to `api.Recommendation` + render in the detail
  drawer

Refs #82


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Compute details now display vCPU and memory sizing information alongside platform and tenancy data when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->