### PR TITLE
fix(security): narrow IAM Resource="*" on ECS/ECR/CloudFront/KMS/SES

### DIFF
--- a/terraform/environments/aws/ci-cd-permissions/policy_compute.tf
+++ b/terraform/environments/aws/ci-cd-permissions/policy_compute.tf
@@ -69,7 +69,11 @@ resource "aws_iam_policy" "compute" {
         Resource = "arn:aws:events:*:*:rule/cudly-*"
       },
       {
-        Sid    = "ECR"
+        # ECR repository-scoped actions: every action that takes a
+        # repository ARN is restricted to cudly-* repositories. This
+        # prevents the deploy SA from poisoning, deleting, or exfiltrating
+        # images in unrelated ECR repositories sharing the same account.
+        Sid    = "ECRRepositoryScoped"
         Effect = "Allow"
         Action = [
           "ecr:BatchCheckLayerAvailability",
@@ -81,7 +85,6 @@ resource "aws_iam_policy" "compute" {
           "ecr:DeleteRepository",
           "ecr:DeleteRepositoryPolicy",
           "ecr:DescribeRepositories",
-          "ecr:GetAuthorizationToken",
           "ecr:GetDownloadUrlForLayer",
           "ecr:GetLifecyclePolicy",
           "ecr:GetRepositoryPolicy",
@@ -96,21 +99,46 @@ resource "aws_iam_policy" "compute" {
           "ecr:UntagResource",
           "ecr:UploadLayerPart",
         ]
+        Resource = "arn:aws:ecr:*:*:repository/cudly-*"
+      },
+      {
+        # ECR token endpoint — does not take a resource ARN and is
+        # account-wide by design. Required for `docker login` against ECR.
+        Sid      = "ECRGetAuthorizationToken"
+        Effect   = "Allow"
+        Action   = ["ecr:GetAuthorizationToken"]
         Resource = "*"
       },
       {
-        Sid    = "CloudFrontFrontend"
+        # CloudFront create + read actions don't take a resource ARN at
+        # the API level (a distribution's ARN is only known after create).
+        # Read actions are also broad because terraform plan needs to
+        # enumerate resources. Mutating actions are gated below.
+        Sid    = "CloudFrontCreateAndRead"
         Effect = "Allow"
         Action = [
           "cloudfront:CreateDistribution",
           "cloudfront:CreateFunction",
-          "cloudfront:DeleteDistribution",
-          "cloudfront:DeleteFunction",
           "cloudfront:DescribeFunction",
           "cloudfront:GetDistribution",
           "cloudfront:GetDistributionConfig",
           "cloudfront:GetFunction",
           "cloudfront:ListTagsForResource",
+        ]
+        Resource = "*"
+      },
+      {
+        # CloudFront mutations are restricted to distributions/functions
+        # tagged Project=CUDly. The Terraform aws_cloudfront_distribution
+        # resource sets this tag at creation time (see modules/frontend/aws),
+        # so subsequent Update/Delete/Tag/Untag operations against
+        # CUDly-owned distributions succeed while attempts to mutate any
+        # third-party distribution sharing the account are denied.
+        Sid    = "CloudFrontMutateTaggedOnly"
+        Effect = "Allow"
+        Action = [
+          "cloudfront:DeleteDistribution",
+          "cloudfront:DeleteFunction",
           "cloudfront:PublishFunction",
           "cloudfront:TagResource",
           "cloudfront:UntagResource",
@@ -118,6 +146,11 @@ resource "aws_iam_policy" "compute" {
           "cloudfront:UpdateFunction",
         ]
         Resource = "*"
+        Condition = {
+          StringEquals = {
+            "aws:ResourceTag/Project" = "CUDly"
+          }
+        }
       },
       {
         Sid    = "CloudWatchAlarms"
@@ -133,28 +166,55 @@ resource "aws_iam_policy" "compute" {
         Resource = "arn:aws:cloudwatch:*:*:alarm:cudly-*"
       },
       {
-        Sid    = "ECSFargate"
+        # ECS resource-scoped actions: cluster, service, and task ARNs
+        # all match cudly-* prefix. RegisterTaskDefinition cannot take a
+        # specific ARN at registration time and is split below.
+        Sid    = "ECSFargateResourceScoped"
         Effect = "Allow"
         Action = [
           "ecs:CreateCluster",
           "ecs:CreateService",
           "ecs:DeleteCluster",
           "ecs:DeleteService",
-          "ecs:DeregisterTaskDefinition",
           "ecs:DescribeClusters",
           "ecs:DescribeServices",
-          "ecs:DescribeTaskDefinition",
-          "ecs:ListTagsForResource",
           "ecs:ListTasks",
           "ecs:PutClusterCapacityProviders",
           "ecs:StopTask",
-          "ecs:RegisterTaskDefinition",
           "ecs:TagResource",
           "ecs:UntagResource",
           "ecs:UpdateCluster",
           "ecs:UpdateService",
         ]
+        Resource = [
+          "arn:aws:ecs:*:*:cluster/cudly-*",
+          "arn:aws:ecs:*:*:service/cudly-*/*",
+          "arn:aws:ecs:*:*:task/cudly-*/*",
+          "arn:aws:ecs:*:*:task-definition/cudly-*:*",
+        ]
+      },
+      {
+        # ECS task-definition + tag-listing actions don't take a specific
+        # ARN at API level. RegisterTaskDefinition has no resource;
+        # DeregisterTaskDefinition + DescribeTaskDefinition take a
+        # task-definition ARN that we constrain to cudly-*.
+        # ListTagsForResource takes any ARN type but is read-only.
+        Sid    = "ECSFargateAccountWide"
+        Effect = "Allow"
+        Action = [
+          "ecs:RegisterTaskDefinition",
+          "ecs:ListTagsForResource",
+        ]
         Resource = "*"
+      },
+      {
+        Sid    = "ECSFargateTaskDefinition"
+        Effect = "Allow"
+        Action = [
+          "ecs:DeregisterTaskDefinition",
+          "ecs:DescribeTaskDefinition",
+        ]
+        Resource = "arn:aws:ecs:*:*:task-definition/cudly-*:*"
       },
       {
         Sid    = "ELBFargate"
@@ -213,24 +273,36 @@ resource "aws_iam_policy" "compute" {
         Resource = "*"
       },
       {
-        # KMS asymmetric signing key for the CUDly OIDC issuer.
-        # Broad KMS management perms scoped to Describe/Tag/Alias
-        # actions required by terraform-aws-provider on key create
-        # and update. Resource is "*" because KMS key ARNs are only
-        # known after creation.
-        Sid    = "KMSSigningKey"
+        # KMS create + read-only actions don't accept a key ARN at API
+        # level (key ARNs are only known after CreateKey). Read-only
+        # actions are also broad because terraform plan needs to
+        # enumerate key state.
+        Sid    = "KMSCreateAndRead"
         Effect = "Allow"
         Action = [
           "kms:CreateAlias",
           "kms:CreateKey",
-          "kms:DeleteAlias",
           "kms:DescribeKey",
-          "kms:DisableKey",
-          "kms:EnableKey",
           "kms:GetKeyPolicy",
           "kms:GetKeyRotationStatus",
           "kms:ListAliases",
           "kms:ListResourceTags",
+        ]
+        Resource = "*"
+      },
+      {
+        # KMS mutating + destructive actions are gated on the key being
+        # tagged Project=CUDly. The CUDly OIDC signing key is tagged at
+        # creation by Terraform (see modules/security/aws/kms_signing.tf).
+        # Without this gate the deploy SA could schedule deletion or
+        # disable any KMS key in the account, causing denial of service
+        # for unrelated workloads.
+        Sid    = "KMSMutateTaggedOnly"
+        Effect = "Allow"
+        Action = [
+          "kms:DeleteAlias",
+          "kms:DisableKey",
+          "kms:EnableKey",
           "kms:PutKeyPolicy",
           "kms:ScheduleKeyDeletion",
           "kms:TagResource",
@@ -239,6 +311,11 @@ resource "aws_iam_policy" "compute" {
           "kms:UpdateKeyDescription",
         ]
         Resource = "*"
+        Condition = {
+          StringEquals = {
+            "aws:ResourceTag/Project" = "CUDly"
+          }
+        }
       },
     ]
   })

--- a/terraform/environments/aws/ci-cd-permissions/policy_compute.tf
+++ b/terraform/environments/aws/ci-cd-permissions/policy_compute.tf
@@ -261,6 +261,12 @@ resource "aws_iam_policy" "compute" {
         Resource = "*"
       },
       {
+        # CI deploy SA configures email identities (verify domain,
+        # rotate DKIM, tag) but does NOT send mail — that path lives
+        # in the Lambda runtime role (modules/compute/aws/lambda).
+        # ses:SendEmail intentionally excluded here per CR pass-3
+        # nitpick — adding it would let a leaked deploy SA exfiltrate
+        # via mail without unlocking any deploy capability.
         Sid    = "SES"
         Effect = "Allow"
         Action = [
@@ -268,7 +274,6 @@ resource "aws_iam_policy" "compute" {
           "ses:DeleteEmailIdentity",
           "ses:GetEmailIdentity",
           "ses:PutEmailIdentityDkimSigningAttributes",
-          "ses:SendEmail",
           "ses:TagResource",
           "ses:UntagResource",
         ]

--- a/terraform/environments/aws/ci-cd-permissions/policy_compute.tf
+++ b/terraform/environments/aws/ci-cd-permissions/policy_compute.tf
@@ -128,22 +128,22 @@ resource "aws_iam_policy" "compute" {
         Resource = "*"
       },
       {
-        # CloudFront mutations are restricted to distributions/functions
+        # CloudFront distribution mutations are restricted to distributions
         # tagged Project=CUDly. The Terraform aws_cloudfront_distribution
         # resource sets this tag at creation time (see modules/frontend/aws),
         # so subsequent Update/Delete/Tag/Untag operations against
         # CUDly-owned distributions succeed while attempts to mutate any
         # third-party distribution sharing the account are denied.
+        # Function mutations live in policy_compute_b.tf — the function
+        # resource type does not support aws:ResourceTag per the AWS
+        # Service Authorization Reference, so it needs ARN scoping.
         Sid    = "CloudFrontMutateTaggedOnly"
         Effect = "Allow"
         Action = [
           "cloudfront:DeleteDistribution",
-          "cloudfront:DeleteFunction",
-          "cloudfront:PublishFunction",
           "cloudfront:TagResource",
           "cloudfront:UntagResource",
           "cloudfront:UpdateDistribution",
-          "cloudfront:UpdateFunction",
         ]
         Resource = "*"
         Condition = {
@@ -169,6 +169,9 @@ resource "aws_iam_policy" "compute" {
         # ECS resource-scoped actions: cluster, service, and task ARNs
         # all match cudly-* prefix. RegisterTaskDefinition cannot take a
         # specific ARN at registration time and is split below.
+        # ecs:ListTasks does NOT support resource-level permissions per
+        # the AWS Service Authorization Reference; it lives in
+        # policy_compute_b.tf gated by an ecs:cluster condition.
         Sid    = "ECSFargateResourceScoped"
         Effect = "Allow"
         Action = [
@@ -178,7 +181,6 @@ resource "aws_iam_policy" "compute" {
           "ecs:DeleteService",
           "ecs:DescribeClusters",
           "ecs:DescribeServices",
-          "ecs:ListTasks",
           "ecs:PutClusterCapacityProviders",
           "ecs:StopTask",
           "ecs:TagResource",
@@ -277,10 +279,14 @@ resource "aws_iam_policy" "compute" {
         # level (key ARNs are only known after CreateKey). Read-only
         # actions are also broad because terraform plan needs to
         # enumerate key state.
+        # kms:CreateAlias is NOT here — alias actions act on alias
+        # resources, and the aws:ResourceTag/Project gate below applies
+        # only to keys (aliases inherit no IAM-visible tags). Alias
+        # operations live in policy_compute_b.tf scoped by alias-ARN
+        # prefix.
         Sid    = "KMSCreateAndRead"
         Effect = "Allow"
         Action = [
-          "kms:CreateAlias",
           "kms:CreateKey",
           "kms:DescribeKey",
           "kms:GetKeyPolicy",
@@ -297,17 +303,18 @@ resource "aws_iam_policy" "compute" {
         # Without this gate the deploy SA could schedule deletion or
         # disable any KMS key in the account, causing denial of service
         # for unrelated workloads.
+        # Alias mutations (DeleteAlias/UpdateAlias) live in
+        # policy_compute_b.tf — the aws:ResourceTag condition does not
+        # match alias resources.
         Sid    = "KMSMutateTaggedOnly"
         Effect = "Allow"
         Action = [
-          "kms:DeleteAlias",
           "kms:DisableKey",
           "kms:EnableKey",
           "kms:PutKeyPolicy",
           "kms:ScheduleKeyDeletion",
           "kms:TagResource",
           "kms:UntagResource",
-          "kms:UpdateAlias",
           "kms:UpdateKeyDescription",
         ]
         Resource = "*"

--- a/terraform/environments/aws/ci-cd-permissions/policy_compute.tf
+++ b/terraform/environments/aws/ci-cd-permissions/policy_compute.tf
@@ -279,11 +279,10 @@ resource "aws_iam_policy" "compute" {
         # level (key ARNs are only known after CreateKey). Read-only
         # actions are also broad because terraform plan needs to
         # enumerate key state.
-        # kms:CreateAlias is NOT here — alias actions act on alias
-        # resources, and the aws:ResourceTag/Project gate below applies
-        # only to keys (aliases inherit no IAM-visible tags). Alias
-        # operations live in policy_compute_b.tf scoped by alias-ARN
-        # prefix.
+        # kms:CreateAlias is NOT here — it moved to KMSMutateTaggedOnly
+        # below (key-side check, tag-gated) and policy_compute_b.tf
+        # KMSAliasMutate (alias-side check, ARN-scoped). KMS evaluates
+        # alias actions against both the alias and the target key.
         Sid    = "KMSCreateAndRead"
         Effect = "Allow"
         Action = [
@@ -303,18 +302,24 @@ resource "aws_iam_policy" "compute" {
         # Without this gate the deploy SA could schedule deletion or
         # disable any KMS key in the account, causing denial of service
         # for unrelated workloads.
-        # Alias mutations (DeleteAlias/UpdateAlias) live in
-        # policy_compute_b.tf — the aws:ResourceTag condition does not
-        # match alias resources.
+        # Alias mutations (CreateAlias/DeleteAlias/UpdateAlias) appear
+        # here because AWS KMS evaluates these actions against BOTH the
+        # alias and the target key resource — this statement covers the
+        # key-side check (tag-gated). The alias-side check lives in
+        # policy_compute_b.tf KMSAliasMutate (ARN-scoped because aliases
+        # have no IAM-visible tags).
         Sid    = "KMSMutateTaggedOnly"
         Effect = "Allow"
         Action = [
+          "kms:CreateAlias",
+          "kms:DeleteAlias",
           "kms:DisableKey",
           "kms:EnableKey",
           "kms:PutKeyPolicy",
           "kms:ScheduleKeyDeletion",
           "kms:TagResource",
           "kms:UntagResource",
+          "kms:UpdateAlias",
           "kms:UpdateKeyDescription",
         ]
         Resource = "*"

--- a/terraform/environments/aws/ci-cd-permissions/policy_compute.tf
+++ b/terraform/environments/aws/ci-cd-permissions/policy_compute.tf
@@ -110,22 +110,37 @@ resource "aws_iam_policy" "compute" {
         Resource = "*"
       },
       {
-        # CloudFront create + read actions don't take a resource ARN at
-        # the API level (a distribution's ARN is only known after create).
-        # Read actions are also broad because terraform plan needs to
-        # enumerate resources. Mutating actions are gated below.
+        # CloudFront create + distribution-read actions don't take a
+        # resource ARN at the API level (a distribution's ARN is only
+        # known after create, and CreateFunction has no resource type
+        # per the AWS Service Authorization Reference). Read actions
+        # against distributions are also broad because terraform plan
+        # needs to enumerate resources. Mutating actions are gated
+        # below; function reads are scoped in CloudFrontFnRead.
         Sid    = "CloudFrontCreateAndRead"
         Effect = "Allow"
         Action = [
           "cloudfront:CreateDistribution",
           "cloudfront:CreateFunction",
-          "cloudfront:DescribeFunction",
           "cloudfront:GetDistribution",
           "cloudfront:GetDistributionConfig",
-          "cloudfront:GetFunction",
           "cloudfront:ListTagsForResource",
         ]
         Resource = "*"
+      },
+      {
+        # CloudFront DescribeFunction/GetFunction support the
+        # function resource type per the AWS Service Authorization
+        # Reference, so scope them to CUDly-owned functions to match
+        # the ARN scoping used by CloudFrontFnMutate in
+        # policy_compute_b.tf.
+        Sid    = "CloudFrontFnRead"
+        Effect = "Allow"
+        Action = [
+          "cloudfront:DescribeFunction",
+          "cloudfront:GetFunction",
+        ]
+        Resource = "arn:aws:cloudfront::*:function/cudly-*"
       },
       {
         # CloudFront distribution mutations are restricted to distributions

--- a/terraform/environments/aws/ci-cd-permissions/policy_compute_b.tf
+++ b/terraform/environments/aws/ci-cd-permissions/policy_compute_b.tf
@@ -1,0 +1,69 @@
+# Second compute-permissions policy. This file exists because the main
+# `aws_iam_policy.compute` is at AWS's 6144-char managed-policy limit;
+# additional ARN-scoped statements (added in response to a CodeRabbit
+# review of fix/iam-resource-wildcards) wouldn't fit there without
+# evicting unrelated existing grants. Each statement here corrects a
+# scoping bug that the AWS service authorization reference forced us to
+# split out of `policy_compute.tf`:
+#
+#  - CloudFrontFnMutate: cloudfront:DeleteFunction/PublishFunction/
+#    UpdateFunction operate on the `function` resource type which does
+#    not support aws:ResourceTag, so tag-gating them is a no-op. ARN
+#    scope used instead.
+#
+#  - ECSListTasks: ecs:ListTasks does not support resource-level
+#    permissions, so Resource must be "*". The ecs:cluster condition
+#    key restricts it to CUDly clusters.
+#
+#  - KMSAliasMutate: kms:CreateAlias/DeleteAlias/UpdateAlias act on
+#    alias resources, but aws:ResourceTag/Project gates only key
+#    resources (aliases inherit nothing). ARN scope used instead.
+
+resource "aws_iam_policy" "compute_b" {
+  name        = "cudly-deploy-compute-b"
+  description = "CUDly Terraform deploy: ARN-scoped statements split out of compute policy due to size"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "CloudFrontFnMutate"
+        Effect = "Allow"
+        Action = [
+          "cloudfront:DeleteFunction",
+          "cloudfront:PublishFunction",
+          "cloudfront:UpdateFunction",
+        ]
+        Resource = "arn:aws:cloudfront::*:function/cudly-*"
+      },
+      {
+        Sid    = "ECSListTasks"
+        Effect = "Allow"
+        Action = [
+          "ecs:ListTasks",
+        ]
+        Resource = "*"
+        Condition = {
+          ArnLike = {
+            "ecs:cluster" = "arn:aws:ecs:*:*:cluster/cudly-*"
+          }
+        }
+      },
+      {
+        Sid    = "KMSAliasMutate"
+        Effect = "Allow"
+        Action = [
+          "kms:CreateAlias",
+          "kms:DeleteAlias",
+          "kms:UpdateAlias",
+        ]
+        Resource = "arn:aws:kms:*:*:alias/cudly-*"
+      },
+    ]
+  })
+
+  tags = {
+    Project   = "CUDly"
+    ManagedBy = "terraform"
+  }
+}

--- a/terraform/environments/aws/ci-cd-permissions/policy_compute_b.tf
+++ b/terraform/environments/aws/ci-cd-permissions/policy_compute_b.tf
@@ -17,7 +17,10 @@
 #
 #  - KMSAliasMutate: kms:CreateAlias/DeleteAlias/UpdateAlias act on
 #    alias resources, but aws:ResourceTag/Project gates only key
-#    resources (aliases inherit nothing). ARN scope used instead.
+#    resources (aliases inherit nothing). KMS evaluates these actions
+#    against BOTH the alias and the target key, so the alias-side
+#    check lives here (ARN-scoped) and the key-side check lives in
+#    policy_compute.tf KMSMutateTaggedOnly (tag-gated to CUDly keys).
 
 resource "aws_iam_policy" "compute_b" {
   name        = "cudly-deploy-compute-b"

--- a/terraform/environments/aws/ci-cd-permissions/role.tf
+++ b/terraform/environments/aws/ci-cd-permissions/role.tf
@@ -47,6 +47,11 @@ resource "aws_iam_role_policy_attachment" "compute" {
   policy_arn = aws_iam_policy.compute.arn
 }
 
+resource "aws_iam_role_policy_attachment" "compute_b" {
+  role       = aws_iam_role.cudly_deploy.name
+  policy_arn = aws_iam_policy.compute_b.arn
+}
+
 resource "aws_iam_role_policy_attachment" "data" {
   role       = aws_iam_role.cudly_deploy.name
   policy_arn = aws_iam_policy.data.arn

--- a/terraform/modules/compute/aws/lambda/main.tf
+++ b/terraform/modules/compute/aws/lambda/main.tf
@@ -230,10 +230,16 @@ resource "aws_iam_role_policy" "secrets_access" {
 # where SES walks up the identity hierarchy and evaluates IAM against the
 # verified parent's ARN (identity/leanercloud.com). Enumerating every
 # ancestor the operator might verify would work on paper but drifts every
-# time the SES identity tree is reorganised; `*` defers the real check to
-# SES itself (which still rejects sends from unverified identities at the
-# service layer). Configuration-set access stays scoped to ${stack_name}*
-# so a compromised Lambda can't touch unrelated stacks' config sets.
+# time the SES identity tree is reorganised.
+#
+# To still narrow the blast radius (a compromised Lambda must not be able
+# to spoof emails from arbitrary verified identities in the same account),
+# the SendEmail/SendRawEmail actions are gated by a `ses:FromAddress`
+# condition restricting the From header to *@${var.email_from_domain}.
+# SES enforces FromAddress on the wire, so this prevents phishing from
+# unrelated identities even though the resource ARN remains broad.
+# Configuration-set access stays scoped to ${stack_name}* so a compromised
+# Lambda can't touch unrelated stacks' config sets either.
 #
 # Only attached when var.email_from_domain is set — deployments without email
 # notifications don't get any SES permissions at all.
@@ -247,11 +253,25 @@ resource "aws_iam_role_policy" "ses_access" {
     Version = "2012-10-17"
     Statement = [
       {
-        Sid    = "SendFromAnyVerifiedIdentity"
+        Sid    = "SendFromCUDlyDomain"
         Effect = "Allow"
         Action = [
           "ses:SendEmail",
           "ses:SendRawEmail",
+        ]
+        Resource = "*"
+        Condition = {
+          StringLike = {
+            "ses:FromAddress" = "*@${var.email_from_domain}"
+          }
+        }
+      },
+      {
+        # Read-only SES status checks for healthchecks and quota
+        # introspection. No spoofing risk — these don't send mail.
+        Sid    = "SESReadOnly"
+        Effect = "Allow"
+        Action = [
           "ses:GetAccount",
           "ses:GetEmailIdentity",
         ]


### PR DESCRIPTION
## Summary

Closes 5 HIGH findings from the security review (H4–H8). Each `Resource = "*"` on the deploy SA / runtime Lambda role now uses the tightest scope AWS IAM allows for the action, with a `Project=CUDly` tag condition where the API doesn't accept a resource ARN at create time.

| Finding | Service | Approach |
|---|---|---|
| **H4** | ECS | Split into resource-scoped (`cluster/cudly-*`, `service/cudly-*/*`, `task-definition/cudly-*:*`), account-wide read (RegisterTaskDefinition + tags), and task-def-scoped Describe/Deregister. |
| **H5** | SES SendEmail | Resource stays `*` (SES walks identity hierarchy — see existing comment), but new `ses:FromAddress` `StringLike` condition restricts send to `*@${var.email_from_domain}`. Read-only actions split into their own statement. |
| **H6** | ECR | Repository ARNs scoped to `arn:aws:ecr:*:*:repository/cudly-*`. `GetAuthorizationToken` split (account-wide token endpoint, no resource ARN). |
| **H7** | CloudFront | Create+Read stay `*` (ARN unknown at create), but mutate (Update/Delete/Tag) requires `aws:ResourceTag/Project = "CUDly"`. |
| **H8** | KMS | Same pattern as CloudFront: read/create stay broad, but mutate (ScheduleKeyDeletion, DisableKey, PutKeyPolicy, etc.) requires `aws:ResourceTag/Project = "CUDly"`. |

## ⚠ Operator action required

`terraform/environments/aws/ci-cd-permissions/` is a bootstrap module per the CLAUDE.md CI/CD IAM split — applied manually by a privileged human, not by the CI workflow itself. After merging this PR, re-apply that directory out of band:

```bash
cd terraform/environments/aws/ci-cd-permissions
terraform plan
terraform apply
```

Until that re-apply happens, the deploy SA still has the old (broader) grants and nothing breaks. After re-apply, any drift detection on third-party resources sharing the same account that the deploy SA happens to have been touching becomes visible — that's the fix taking effect.

## Test plan

- [x] `terraform fmt -check` clean.
- [x] `terraform validate` green for `environments/aws/ci-cd-permissions/`.
- [x] No runtime code paths touched — Go test suite unaffected.
- [ ] **Operator (post-merge)**: `terraform plan` against the bootstrap module in a sandbox account; confirm no live CUDly resources hit "access denied"; then re-apply in prod.
- [ ] **Operator (post-merge)**: smoke-test a CUDly redeploy (Lambda push, ECR push, CloudFront update) to confirm the deploy SA still works for legitimate operations.

## Follow-up PR

PR5 (supply chain) — independent of this PR.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tightened ECR, CloudFront, ECS and KMS permissions into resource- and tag-scoped statements; destructive/mutation actions now require the project tag.
  * Restricted SES send permissions to the project email domain and added read-only SES access for account/identity info; removed broad send allowance.
  * Added and attached a supplemental managed IAM policy to split large permission sets and enable finer-grained mutation scopes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->