### PR TITLE
feat(settings): create-override modal for AWS account overrides (closes #104)

### DIFF
--- a/frontend/src/__tests__/settings-accounts.test.ts
+++ b/frontend/src/__tests__/settings-accounts.test.ts
@@ -146,6 +146,24 @@ function buildAccountsDOM(): void {
   modal.appendChild(form);
   modal.appendChild(btn('close-account-modal-btn'));
   document.body.appendChild(modal);
+
+  // ── Override modal (issue #104) ────────────────────────────
+  const overrideModal = div('override-modal', 'modal hidden');
+  const overrideForm = el('form', {}, 'override-form');
+  overrideForm.appendChild(input('override-account-id', 'hidden'));
+  overrideForm.appendChild(input('override-provider', 'hidden'));
+  overrideForm.appendChild(select('override-service', []));
+  overrideForm.appendChild(select('override-term', ['', '1', '3']));
+  overrideForm.appendChild(select('override-payment', ['', 'no-upfront', 'partial-upfront', 'all-upfront']));
+  overrideForm.appendChild(input('override-coverage', 'number'));
+  const overrideErr = el('p', {}, 'override-form-error');
+  overrideForm.appendChild(overrideErr);
+  const overrideSubmit = el('button', { type: 'submit' }) as HTMLButtonElement;
+  overrideSubmit.textContent = 'Save override';
+  overrideForm.appendChild(overrideSubmit);
+  overrideModal.appendChild(overrideForm);
+  overrideModal.appendChild(btn('close-override-modal-btn'));
+  document.body.appendChild(overrideModal);
 }
 
 // ---------------------------------------------------------------------------
@@ -563,5 +581,226 @@ describe('Overrides panel — AWS payment selector', () => {
     const panel = await openOverridesPanel('acc-1');
     expect(panel.querySelector('select.override-payment-select')).toBeNull();
     expect(panel.textContent).toContain('all-upfront');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Override creation modal — issue #104
+// ---------------------------------------------------------------------------
+
+describe('Create-override modal', () => {
+  /**
+   * Click the "Service overrides" expander button on an AWS account row to
+   * trigger loadOverridesPanel, then return the panel + override-modal DOM
+   * for further interaction.
+   */
+  async function expandOverridesPanel(accountId = 'acc-1'): Promise<{ panel: HTMLElement; modal: HTMLElement }> {
+    (api.listAccounts as jest.Mock).mockResolvedValue([
+      { id: accountId, name: 'Prod', provider: 'aws', external_id: '111', enabled: true },
+    ]);
+    await loadAccountsForProvider('aws');
+    const overridesBtn = document.querySelector(
+      `button[aria-label="Service overrides for Prod (111)"]`,
+    ) as HTMLButtonElement | null;
+    expect(overridesBtn).not.toBeNull();
+    overridesBtn!.click();
+    await new Promise(r => setTimeout(r, 0));
+    const panel = document.querySelector('.account-overrides-panel') as HTMLElement | null;
+    expect(panel).not.toBeNull();
+    const modal = document.getElementById('override-modal') as HTMLElement | null;
+    expect(modal).not.toBeNull();
+    return { panel: panel!, modal: modal! };
+  }
+
+  beforeEach(() => {
+    buildAccountsDOM();
+    setupSettingsHandlers();
+    jest.clearAllMocks();
+  });
+
+  test('empty-state auto-opens the override modal', async () => {
+    (api.listAccountServiceOverrides as jest.Mock).mockResolvedValue([]);
+
+    const { modal } = await expandOverridesPanel('acc-1');
+
+    expect(modal.classList.contains('hidden')).toBe(false);
+    // Service dropdown should be populated with all 7 AWS service options.
+    const svcSelect = document.getElementById('override-service') as HTMLSelectElement;
+    const values = Array.from(svcSelect.options).map(o => o.value);
+    expect(values).toEqual(['ec2', 'rds', 'elasticache', 'opensearch', 'redshift', 'savingsplans', 'sagemaker']);
+  });
+
+  test('populated panel shows an Add override button that opens the modal', async () => {
+    (api.listAccountServiceOverrides as jest.Mock).mockResolvedValue([
+      { id: 'o1', account_id: 'acc-1', provider: 'aws', service: 'ec2', term: 1 },
+    ]);
+
+    const { panel, modal } = await expandOverridesPanel('acc-1');
+    // The auto-open path must NOT fire when overrides already exist.
+    expect(modal.classList.contains('hidden')).toBe(true);
+
+    const addBtn = Array.from(panel.querySelectorAll('button')).find(b => b.textContent === 'Add override');
+    expect(addBtn).toBeDefined();
+    addBtn!.click();
+    expect(modal.classList.contains('hidden')).toBe(false);
+
+    // ec2 already has an override; the dropdown excludes it.
+    const svcSelect = document.getElementById('override-service') as HTMLSelectElement;
+    const values = Array.from(svcSelect.options).map(o => o.value);
+    expect(values).not.toContain('ec2');
+    expect(values).toContain('rds');
+  });
+
+  test('submit sends only the fields the user filled in (sparse PUT)', async () => {
+    (api.listAccountServiceOverrides as jest.Mock).mockResolvedValue([]);
+    (api.saveAccountServiceOverride as jest.Mock).mockResolvedValue({
+      id: 'o-new', account_id: 'acc-1', provider: 'aws', service: 'rds', payment: 'no-upfront',
+    });
+
+    await expandOverridesPanel('acc-1');
+
+    (document.getElementById('override-service') as HTMLSelectElement).value = 'rds';
+    (document.getElementById('override-payment') as HTMLSelectElement).value = 'no-upfront';
+    // term + coverage left blank → omitted from the request
+
+    const form = document.getElementById('override-form') as HTMLFormElement;
+    form.dispatchEvent(new Event('submit', { cancelable: true }));
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(api.saveAccountServiceOverride).toHaveBeenCalledTimes(1);
+    expect(api.saveAccountServiceOverride).toHaveBeenCalledWith(
+      'acc-1', 'aws', 'rds', { payment: 'no-upfront' },
+    );
+  });
+
+  test('coercion: term parses to int, coverage parses to number', async () => {
+    (api.listAccountServiceOverrides as jest.Mock).mockResolvedValue([]);
+    (api.saveAccountServiceOverride as jest.Mock).mockResolvedValue({});
+
+    await expandOverridesPanel('acc-1');
+    (document.getElementById('override-service') as HTMLSelectElement).value = 'ec2';
+    (document.getElementById('override-term') as HTMLSelectElement).value = '3';
+    (document.getElementById('override-payment') as HTMLSelectElement).value = 'all-upfront';
+    (document.getElementById('override-coverage') as HTMLInputElement).value = '85';
+
+    (document.getElementById('override-form') as HTMLFormElement).dispatchEvent(
+      new Event('submit', { cancelable: true }),
+    );
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(api.saveAccountServiceOverride).toHaveBeenCalledWith(
+      'acc-1', 'aws', 'ec2',
+      { term: 3, payment: 'all-upfront', coverage: 85 },
+    );
+  });
+
+  test('blocks submit when no field is set (would be a no-op override)', async () => {
+    (api.listAccountServiceOverrides as jest.Mock).mockResolvedValue([]);
+
+    await expandOverridesPanel('acc-1');
+    (document.getElementById('override-service') as HTMLSelectElement).value = 'ec2';
+    // All three override fields left blank.
+
+    (document.getElementById('override-form') as HTMLFormElement).dispatchEvent(
+      new Event('submit', { cancelable: true }),
+    );
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(api.saveAccountServiceOverride).not.toHaveBeenCalled();
+    const errEl = document.getElementById('override-form-error');
+    expect(errEl?.textContent).toContain('Set at least one');
+  });
+
+  test('blocks submit when coverage is out of range', async () => {
+    (api.listAccountServiceOverrides as jest.Mock).mockResolvedValue([]);
+
+    await expandOverridesPanel('acc-1');
+    (document.getElementById('override-service') as HTMLSelectElement).value = 'ec2';
+    (document.getElementById('override-coverage') as HTMLInputElement).value = '150';
+
+    (document.getElementById('override-form') as HTMLFormElement).dispatchEvent(
+      new Event('submit', { cancelable: true }),
+    );
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(api.saveAccountServiceOverride).not.toHaveBeenCalled();
+    const errEl = document.getElementById('override-form-error');
+    expect(errEl?.textContent).toContain('Coverage must be between 0 and 100');
+  });
+
+  test('save success closes the modal and reloads the panel', async () => {
+    (api.listAccountServiceOverrides as jest.Mock)
+      .mockResolvedValueOnce([])  // initial empty
+      .mockResolvedValueOnce([    // after save reload
+        { id: 'o-new', account_id: 'acc-1', provider: 'aws', service: 'rds', payment: 'all-upfront' },
+      ]);
+    (api.saveAccountServiceOverride as jest.Mock).mockResolvedValue({});
+
+    const { modal } = await expandOverridesPanel('acc-1');
+    (document.getElementById('override-service') as HTMLSelectElement).value = 'rds';
+    (document.getElementById('override-payment') as HTMLSelectElement).value = 'all-upfront';
+
+    (document.getElementById('override-form') as HTMLFormElement).dispatchEvent(
+      new Event('submit', { cancelable: true }),
+    );
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(modal.classList.contains('hidden')).toBe(true);
+    expect(api.listAccountServiceOverrides).toHaveBeenCalledTimes(2);
+  });
+
+  test('cancel button closes the modal without calling the API', async () => {
+    (api.listAccountServiceOverrides as jest.Mock).mockResolvedValue([]);
+
+    const { modal } = await expandOverridesPanel('acc-1');
+    expect(modal.classList.contains('hidden')).toBe(false);
+
+    (document.getElementById('close-override-modal-btn') as HTMLButtonElement).click();
+    expect(modal.classList.contains('hidden')).toBe(true);
+    expect(api.saveAccountServiceOverride).not.toHaveBeenCalled();
+  });
+
+  test('non-AWS account: empty state shows passive text, no modal auto-open, no Add button', async () => {
+    (api.listAccounts as jest.Mock).mockResolvedValue([
+      { id: 'az-1', name: 'AzureProd', provider: 'azure', external_id: 'sub-x', enabled: true },
+    ]);
+    (api.listAccountServiceOverrides as jest.Mock).mockResolvedValue([]);
+
+    await loadAccountsForProvider('azure');
+    const overridesBtn = document.querySelector(
+      `button[aria-label="Service overrides for AzureProd (sub-x)"]`,
+    ) as HTMLButtonElement;
+    overridesBtn.click();
+    await new Promise(r => setTimeout(r, 0));
+
+    const panel = document.querySelector('.account-overrides-panel') as HTMLElement;
+    const modal = document.getElementById('override-modal') as HTMLElement;
+
+    // Modal must NOT have auto-opened for a non-AWS account.
+    expect(modal.classList.contains('hidden')).toBe(true);
+
+    // No Add override button on non-AWS for now (issue #104 follow-up).
+    const addBtn = Array.from(panel.querySelectorAll('button')).find(b => b.textContent === 'Add override');
+    expect(addBtn).toBeUndefined();
+
+    // Passive empty-state copy is what they see.
+    expect(panel.textContent).toContain('No service overrides set');
+  });
+
+  test('all services already overridden disables submit', async () => {
+    const all = ['ec2', 'rds', 'elasticache', 'opensearch', 'redshift', 'savingsplans', 'sagemaker'];
+    (api.listAccountServiceOverrides as jest.Mock).mockResolvedValue(
+      all.map((service, i) => ({
+        id: `o-${i}`, account_id: 'acc-1', provider: 'aws', service, term: 1,
+      })),
+    );
+
+    const { panel, modal } = await expandOverridesPanel('acc-1');
+    const addBtn = Array.from(panel.querySelectorAll('button')).find(b => b.textContent === 'Add override');
+    addBtn!.click();
+    expect(modal.classList.contains('hidden')).toBe(false);
+
+    const submitBtn = modal.querySelector('button[type="submit"]') as HTMLButtonElement;
+    expect(submitBtn.disabled).toBe(true);
   });
 });

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -991,6 +991,46 @@
         </div>
 
         <!-- Cloud Account Modal -->
+        <div id="override-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="override-modal-title">
+            <div class="modal-content">
+                <h2 id="override-modal-title">Add service override</h2>
+                <p class="help-text">Per-account override that takes precedence over the global service defaults. Only AWS services are supported today.</p>
+                <form id="override-form">
+                    <input type="hidden" id="override-account-id">
+                    <input type="hidden" id="override-provider" value="aws">
+
+                    <label>Service:
+                        <select id="override-service" required></select>
+                    </label>
+                    <label>Term:
+                        <select id="override-term">
+                            <option value="">Inherit (use global default)</option>
+                            <option value="1">1 Year</option>
+                            <option value="3">3 Years</option>
+                        </select>
+                    </label>
+                    <label>Payment:
+                        <select id="override-payment">
+                            <option value="">Inherit (use global default)</option>
+                            <option value="no-upfront">No Upfront</option>
+                            <option value="partial-upfront">Partial Upfront</option>
+                            <option value="all-upfront">All Upfront</option>
+                        </select>
+                    </label>
+                    <label>Coverage (%):
+                        <input type="number" id="override-coverage" min="0" max="100" step="1" placeholder="Inherit (use global default)">
+                    </label>
+
+                    <p class="help-text" id="override-form-error" role="alert"></p>
+
+                    <div class="modal-buttons">
+                        <button type="button" id="close-override-modal-btn">Cancel</button>
+                        <button type="submit" class="primary">Save override</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+
         <div id="account-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="account-modal-title">
             <div class="modal-content modal-wide">
                 <h2 id="account-modal-title">Add Account</h2>

--- a/frontend/src/settings.ts
+++ b/frontend/src/settings.ts
@@ -397,7 +397,7 @@ function renderAccountsList(
     overridesPanel.className = 'account-overrides-panel hidden';
     overridesBtn.addEventListener('click', () => {
       const hidden = overridesPanel.classList.toggle('hidden');
-      if (!hidden) void loadOverridesPanel(account.id, overridesPanel);
+      if (!hidden) void loadOverridesPanel(account.id, overridesPanel, account.provider);
     });
     actionsTd.appendChild(overridesBtn);
 
@@ -436,6 +436,20 @@ const AWS_PAYMENT_OPTIONS: ReadonlyArray<{ value: string; label: string }> = [
   { value: 'partial-upfront', label: 'Partial Upfront' },
   { value: 'all-upfront',     label: 'All Upfront' },
 ];
+
+// AWS services that can carry a per-account override. Mirrors the AWS-only
+// entries in SERVICE_FIELDS \u2014 Azure/GCP override creation is a follow-up
+// (issue #104) since the backend payment/term semantics differ per provider.
+const AWS_OVERRIDE_SERVICES: ReadonlyArray<{ value: string; label: string }> = [
+  { value: 'ec2',          label: 'EC2 (Reserved Instances)' },
+  { value: 'rds',          label: 'RDS' },
+  { value: 'elasticache',  label: 'ElastiCache' },
+  { value: 'opensearch',   label: 'OpenSearch' },
+  { value: 'redshift',     label: 'Redshift' },
+  { value: 'savingsplans', label: 'Savings Plans' },
+  { value: 'sagemaker',    label: 'SageMaker Savings Plans' },
+];
+
 
 /**
  * Build the per-row Payment <select> for the overrides panel. Issue #23.
@@ -518,7 +532,10 @@ async function handlePaymentOverrideChange(
       message: `Payment override updated for ${override.provider}/${override.service}.`,
       kind: 'success',
     });
-    await loadOverridesPanel(accountId, panel);
+    // The inline payment selector only renders for AWS rows (per the
+    // o.provider === 'aws' guard in loadOverridesPanel's row loop), so
+    // override.provider is always 'aws' at this call site — cast is safe.
+    await loadOverridesPanel(accountId, panel, override.provider as AccountProvider);
   } catch (err) {
     select.value = previous;
     showToast({
@@ -531,20 +548,63 @@ async function handlePaymentOverrideChange(
 }
 
 /**
- * Load and render the service overrides panel for an account
+ * Load and render the service overrides panel for an account.
+ *
+ * Empty state (no overrides yet for this account) auto-opens the create
+ * modal \u2014 the previous "No service overrides set." text was a dead-end
+ * because there was no UI affordance to create one. See issue #104.
+ *
+ * Populated state: render the existing table + an "Add override" button at
+ * the top so users can add another override for a different service.
+ *
+ * The Add Override flow is AWS-only for now; Azure/GCP keep the read-only
+ * empty-state text since their per-product term/payment semantics differ
+ * (issue #104 follow-up tracks Azure/GCP modal support).
  */
-async function loadOverridesPanel(accountId: string, panel: HTMLElement): Promise<void> {
+async function loadOverridesPanel(accountId: string, panel: HTMLElement, provider: AccountProvider): Promise<void> {
   panel.textContent = 'Loading\u2026';
   try {
     const overrides = await api.listAccountServiceOverrides(accountId);
     panel.textContent = '';
+
+    const canCreate = provider === 'aws';
+
     if (!overrides || overrides.length === 0) {
       const msg = document.createElement('p');
       msg.className = 'help-text';
-      msg.textContent = 'No service overrides set. All services use global defaults.';
+      msg.textContent = canCreate
+        ? 'No service overrides yet for this account.'
+        : 'No service overrides set. All services use global defaults.';
       panel.appendChild(msg);
+      if (canCreate) {
+        // No overrides yet \u2014 auto-open the modal so the user lands directly
+        // on the create flow instead of staring at empty-state text. The
+        // button stays in the panel as a fallback if the user cancels and
+        // wants to retry without re-expanding the row.
+        const addBtn = document.createElement('button');
+        addBtn.type = 'button';
+        addBtn.className = 'btn btn-small';
+        addBtn.textContent = 'Add override';
+        addBtn.addEventListener('click', () => {
+          openOverrideModal(accountId, provider, overrides ?? [], panel);
+        });
+        panel.appendChild(addBtn);
+        openOverrideModal(accountId, provider, [], panel);
+      }
       return;
     }
+
+    if (canCreate) {
+      const addBtn = document.createElement('button');
+      addBtn.type = 'button';
+      addBtn.className = 'btn btn-small';
+      addBtn.textContent = 'Add override';
+      addBtn.addEventListener('click', () => {
+        openOverrideModal(accountId, provider, overrides, panel);
+      });
+      panel.appendChild(addBtn);
+    }
+
     const table = document.createElement('table');
     table.className = 'overrides-table';
     const thead = table.createTHead();
@@ -593,7 +653,7 @@ async function loadOverridesPanel(accountId: string, panel: HTMLElement): Promis
         if (!ok) return;
         try {
           await api.deleteAccountServiceOverride(accountId, o.provider, o.service);
-          await loadOverridesPanel(accountId, panel);
+          await loadOverridesPanel(accountId, panel, provider);
         } catch (err) {
           showToast({ message: `Failed to reset override: ${(err as Error).message}`, kind: 'error' });
         }
@@ -664,6 +724,142 @@ async function testAccount(accountId: string, accountLabel: string, btn: HTMLBut
       btn.textContent = original;
       btn.disabled = false;
     }, 3000);
+  }
+}
+
+// State carried from openOverrideModal → submitOverrideForm so the form
+// handler knows which account/provider/panel it belongs to without
+// inspecting the DOM. Cleared on close so it can't leak across opens.
+let overrideModalContext: { accountId: string; provider: string; panel: HTMLElement } | null = null;
+
+/**
+ * Open the create-override modal for a specific account.
+ *
+ * `existingOverrides` is used to filter the service dropdown so users
+ * can't pick a service that already has an override for this account
+ * (the backend would UPSERT, silently overwriting the existing values —
+ * users should use the panel's Reset + re-create flow for that, not the
+ * Add flow).
+ *
+ * Issue #104.
+ */
+function openOverrideModal(
+  accountId: string,
+  provider: string,
+  existingOverrides: api.AccountServiceOverride[],
+  panel: HTMLElement,
+): void {
+  const modal = document.getElementById('override-modal');
+  if (!modal) return;
+
+  overrideModalContext = { accountId, provider, panel };
+
+  setInputValue('override-account-id', accountId);
+  setInputValue('override-provider', provider);
+
+  // Reset form fields to defaults each open so a previous cancelled
+  // session doesn't bleed values forward.
+  setInputValue('override-term', '');
+  setInputValue('override-payment', '');
+  setInputValue('override-coverage', '');
+  const errEl = document.getElementById('override-form-error');
+  if (errEl) errEl.textContent = '';
+
+  // Populate the service dropdown, excluding services this account already
+  // has an override for. AWS-only for now (issue #104 follow-up tracks
+  // Azure/GCP).
+  const used = new Set(
+    existingOverrides
+      .filter(o => o.provider === provider)
+      .map(o => o.service),
+  );
+  const select = document.getElementById('override-service') as HTMLSelectElement | null;
+  if (select) {
+    select.replaceChildren();
+    const available = AWS_OVERRIDE_SERVICES.filter(s => !used.has(s.value));
+    if (available.length === 0) {
+      const opt = document.createElement('option');
+      opt.value = '';
+      opt.textContent = 'All services already have overrides';
+      opt.disabled = true;
+      select.appendChild(opt);
+      const submitBtn = modal.querySelector<HTMLButtonElement>('button[type="submit"]');
+      if (submitBtn) submitBtn.disabled = true;
+    } else {
+      for (const { value, label } of available) {
+        const opt = document.createElement('option');
+        opt.value = value;
+        opt.textContent = label;
+        select.appendChild(opt);
+      }
+      const submitBtn = modal.querySelector<HTMLButtonElement>('button[type="submit"]');
+      if (submitBtn) submitBtn.disabled = false;
+    }
+  }
+
+  modal.classList.remove('hidden');
+}
+
+function closeOverrideModal(): void {
+  const modal = document.getElementById('override-modal');
+  modal?.classList.add('hidden');
+  overrideModalContext = null;
+}
+
+/**
+ * Submit the create-override form. Sends a sparse PUT — fields left blank
+ * (term/payment/coverage = "Inherit") are omitted so the backend's
+ * applyOverrideScalars treats them as "unset → inherit global default".
+ */
+async function submitOverrideForm(e: Event): Promise<void> {
+  e.preventDefault();
+  const ctx = overrideModalContext;
+  if (!ctx) return;
+
+  const service = (byId<HTMLSelectElement>('override-service')?.value ?? '').trim();
+  if (!service) return;
+
+  const termRaw = (byId<HTMLSelectElement>('override-term')?.value ?? '').trim();
+  const paymentRaw = (byId<HTMLSelectElement>('override-payment')?.value ?? '').trim();
+  const coverageRaw = (byId<HTMLInputElement>('override-coverage')?.value ?? '').trim();
+
+  const req: api.AccountServiceOverrideRequest = {};
+  if (termRaw !== '') req.term = parseInt(termRaw, 10);
+  if (paymentRaw !== '') req.payment = paymentRaw;
+  if (coverageRaw !== '') {
+    const n = Number(coverageRaw);
+    if (!Number.isFinite(n) || n < 0 || n > 100) {
+      const errEl = document.getElementById('override-form-error');
+      if (errEl) errEl.textContent = 'Coverage must be between 0 and 100.';
+      return;
+    }
+    req.coverage = n;
+  }
+
+  if (Object.keys(req).length === 0) {
+    // The backend would happily store an all-null override row, but it'd
+    // be a no-op semantically — no field overrides anything. Block at the
+    // UI to avoid silent confusion.
+    const errEl = document.getElementById('override-form-error');
+    if (errEl) errEl.textContent = 'Set at least one of Term, Payment, or Coverage.';
+    return;
+  }
+
+  const submitBtn = document.querySelector<HTMLButtonElement>('#override-form button[type="submit"]');
+  if (submitBtn) submitBtn.disabled = true;
+  try {
+    await api.saveAccountServiceOverride(ctx.accountId, ctx.provider, service, req);
+    showToast({
+      message: `Override created for ${ctx.provider}/${service}.`,
+      kind: 'success',
+    });
+    closeOverrideModal();
+    await loadOverridesPanel(ctx.accountId, ctx.panel, ctx.provider as AccountProvider);
+  } catch (err) {
+    const errEl = document.getElementById('override-form-error');
+    if (errEl) errEl.textContent = `Failed to create override: ${(err as Error).message}`;
+  } finally {
+    if (submitBtn) submitBtn.disabled = false;
   }
 }
 
@@ -1167,6 +1363,22 @@ export function setupSettingsHandlers(signal?: AbortSignal): void {
   const accountModal = document.getElementById('account-modal');
   accountModal?.addEventListener('click', (e) => {
     if (e.target === accountModal) closeAccountModal();
+  }, { signal });
+
+  // Override modal — submit, cancel, click-outside-to-dismiss (issue #104).
+  document.getElementById('override-form')?.addEventListener(
+    'submit',
+    (e) => void submitOverrideForm(e),
+    { signal },
+  );
+  document.getElementById('close-override-modal-btn')?.addEventListener(
+    'click',
+    closeOverrideModal,
+    { signal },
+  );
+  const overrideModal = document.getElementById('override-modal');
+  overrideModal?.addEventListener('click', (e) => {
+    if (e.target === overrideModal) closeOverrideModal();
   }, { signal });
 }
 


### PR DESCRIPTION
Closes #104.

## Summary

Settings → Accounts → Service overrides had no UI to create an override — empty accounts saw "No service overrides set." with no path forward, and PR #72's inline payment editor inherited the same dead end (it edits existing rows; nobody could create the first row except via direct curl to `PUT /api/accounts/:id/service-overrides/:provider/:service`).

This PR adds the missing create flow as a modal:

- **Empty-state auto-open**: clicking "Service overrides" on an AWS account that has zero overrides immediately surfaces the create modal — no dead-end empty state.
- **Populated-state "Add override" button** at the top of the existing table for adding more overrides on different services.
- **Service dropdown** filters out services that already have an override for this account, so users can't accidentally UPSERT-overwrite an existing row.
- **Sparse PUT**: Term / Payment / Coverage default to "Inherit"; only filled fields are sent, so the backend's `applyOverrideScalars` treats unset fields as "use global default".
- **Validation**: blocks no-op overrides (no field set) and out-of-range coverage (must be 0–100).
- **Non-AWS accounts** (Azure/GCP) keep their existing read-only empty-state text and gain neither the Add button nor the auto-open. Per-provider term/payment semantics differ enough that a follow-up under #104 will track the modal expansion once the AWS UX settles.

## How it interacts with PR #72

PR #72 makes the **Payment** column on existing override rows editable via an inline `<select>`. This PR creates the rows in the first place. They're complementary — together they give users the full create+edit lifecycle in the UI without needing to know the API shape. Both modify `frontend/src/settings.ts` but in different code regions (PR #72 inside `loadOverridesPanel`'s table cells; this PR adds the modal handlers + an `Add override` button + the empty-state auto-open path), so a clean rebase should produce a small mechanical merge.

## Test plan

- [x] `npx jest src/__tests__/settings-accounts.test.ts` — 10 new tests + 22 existing = 32/32 pass. Coverage:
  - Empty-state auto-opens the modal for AWS
  - Populated panel shows Add override button which opens the modal
  - Service dropdown excludes already-overridden services
  - Sparse PUT semantics (only filled fields sent)
  - Term/coverage type coercion (string → int/number)
  - No-fields rejection (would be a no-op override)
  - Coverage out-of-range rejection (0–100)
  - Save success closes modal + reloads panel
  - Cancel button closes without API call
  - All-services-used disables submit
  - Non-AWS account: empty state stays passive, no auto-open, no Add button
- [x] `npx jest` — full frontend suite (1265 tests) green
- [x] `npm run typecheck` clean
- [x] `npm run build` (production webpack) clean
- [ ] Smoke after deploy: navigate Settings → Accounts → expand an AWS account with no overrides → confirm modal auto-opens; create one → confirm row appears; click Add override → confirm dropdown excludes the just-created service.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)
