### PR TITLE
feat(settings): per-plan-type Savings Plans configuration (closes #22)

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -126,7 +126,12 @@ func ApplyCoverage(recs []common.Recommendation, coverage float64) []common.Reco
 	for _, rec := range recs {
 		adjusted := rec
 
-		// For Savings Plans, reduce the hourly commitment instead of count
+		// For Savings Plans, reduce the hourly commitment instead of count.
+		// If the type assertion fails (defensive — Details should always
+		// be *SavingsPlanDetails for SP recs), preserve the recommendation
+		// at its original values rather than silently dropping it. A
+		// missing-Details record is a logged anomaly, not a reason to
+		// erase coverage from the run.
 		if common.IsSavingsPlan(rec.Service) {
 			if details, ok := rec.Details.(*common.SavingsPlanDetails); ok {
 				newDetails := *details // Copy the struct
@@ -134,8 +139,10 @@ func ApplyCoverage(recs []common.Recommendation, coverage float64) []common.Reco
 				adjusted.Details = &newDetails
 				// Also adjust the estimated savings proportionally
 				adjusted.EstimatedSavings = rec.EstimatedSavings * coverage / 100
-				result = append(result, adjusted)
+			} else {
+				AppLogger.Printf("WARNING: SP recommendation for service %q has unexpected Details type %T; passing through unscaled\n", rec.Service, rec.Details)
 			}
+			result = append(result, adjusted)
 			continue
 		}
 

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -127,7 +127,7 @@ func ApplyCoverage(recs []common.Recommendation, coverage float64) []common.Reco
 		adjusted := rec
 
 		// For Savings Plans, reduce the hourly commitment instead of count
-		if rec.Service == common.ServiceSavingsPlans {
+		if common.IsSavingsPlan(rec.Service) {
 			if details, ok := rec.Details.(*common.SavingsPlanDetails); ok {
 				newDetails := *details // Copy the struct
 				newDetails.HourlyCommitment = newDetails.HourlyCommitment * coverage / 100

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -132,23 +132,44 @@ var toolCfg = Config{}
 
 // validateFlags is now defined in validators.go
 
-// parseServices converts service names to ServiceType
+// parseServices converts service names to ServiceType. The legacy
+// "savingsplans" / "sp" aliases fan out to all four per-plan-type SP slugs so
+// existing CLI scripts that pass --services savingsplans keep covering every
+// plan type. Specific slugs (savingsplans-compute, etc.) are also accepted for
+// targeted runs.
 func parseServices(serviceNames []string) []common.ServiceType {
 	var result []common.ServiceType
+	allSPSlugs := []common.ServiceType{
+		common.ServiceSavingsPlansCompute,
+		common.ServiceSavingsPlansEC2Instance,
+		common.ServiceSavingsPlansSageMaker,
+		common.ServiceSavingsPlansDatabase,
+	}
 	serviceMap := map[string]common.ServiceType{
-		"rds":           common.ServiceRDS,
-		"elasticache":   common.ServiceElastiCache,
-		"ec2":           common.ServiceEC2,
-		"opensearch":    common.ServiceOpenSearch,
-		"elasticsearch": common.ServiceOpenSearch, // Legacy alias maps to OpenSearch
-		"redshift":      common.ServiceRedshift,
-		"memorydb":      common.ServiceMemoryDB,
-		"savingsplans":  common.ServiceSavingsPlans,
-		"sp":            common.ServiceSavingsPlans, // Short alias
+		"rds":                       common.ServiceRDS,
+		"elasticache":               common.ServiceElastiCache,
+		"ec2":                       common.ServiceEC2,
+		"opensearch":                common.ServiceOpenSearch,
+		"elasticsearch":             common.ServiceOpenSearch, // Legacy alias maps to OpenSearch
+		"redshift":                  common.ServiceRedshift,
+		"memorydb":                  common.ServiceMemoryDB,
+		"savingsplans-compute":      common.ServiceSavingsPlansCompute,
+		"savingsplans-ec2instance":  common.ServiceSavingsPlansEC2Instance,
+		"savingsplans-sagemaker":    common.ServiceSavingsPlansSageMaker,
+		"savingsplans-database":     common.ServiceSavingsPlansDatabase,
+		"savings-plans-compute":     common.ServiceSavingsPlansCompute,
+		"savings-plans-ec2instance": common.ServiceSavingsPlansEC2Instance,
+		"savings-plans-sagemaker":   common.ServiceSavingsPlansSageMaker,
+		"savings-plans-database":    common.ServiceSavingsPlansDatabase,
 	}
 
 	for _, name := range serviceNames {
-		if service, ok := serviceMap[strings.ToLower(name)]; ok {
+		key := strings.ToLower(name)
+		if key == "savingsplans" || key == "savings-plans" || key == "sp" {
+			result = append(result, allSPSlugs...)
+			continue
+		}
+		if service, ok := serviceMap[key]; ok {
 			result = append(result, service)
 		} else {
 			log.Printf("Warning: Unknown service '%s', skipping", name)
@@ -167,7 +188,10 @@ func getAllServices() []common.ServiceType {
 		common.ServiceOpenSearch,
 		common.ServiceRedshift,
 		common.ServiceMemoryDB,
-		common.ServiceSavingsPlans,
+		common.ServiceSavingsPlansCompute,
+		common.ServiceSavingsPlansEC2Instance,
+		common.ServiceSavingsPlansSageMaker,
+		common.ServiceSavingsPlansDatabase,
 	}
 }
 
@@ -186,8 +210,15 @@ func createServiceClient(service common.ServiceType, cfg aws.Config) provider.Se
 		return redshift.NewClient(cfg)
 	case common.ServiceMemoryDB:
 		return memorydb.NewClient(cfg)
-	case common.ServiceSavingsPlans:
-		return savingsplans.NewClient(cfg)
+	case common.ServiceSavingsPlansCompute,
+		common.ServiceSavingsPlansEC2Instance,
+		common.ServiceSavingsPlansSageMaker,
+		common.ServiceSavingsPlansDatabase:
+		pt, ok := savingsplans.PlanTypeForServiceType(service)
+		if !ok {
+			return nil
+		}
+		return savingsplans.NewClient(cfg, pt)
 	default:
 		return nil
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -137,8 +137,20 @@ var toolCfg = Config{}
 // existing CLI scripts that pass --services savingsplans keep covering every
 // plan type. Specific slugs (savingsplans-compute, etc.) are also accepted for
 // targeted runs.
+//
+// Duplicates are silently dropped via a `seen` set so combinations like
+// `--services savingsplans,savingsplans-compute` don't double-process Compute
+// SP through both the fan-out path and the explicit-slug path.
 func parseServices(serviceNames []string) []common.ServiceType {
 	var result []common.ServiceType
+	seen := make(map[common.ServiceType]struct{})
+	add := func(service common.ServiceType) {
+		if _, ok := seen[service]; ok {
+			return
+		}
+		seen[service] = struct{}{}
+		result = append(result, service)
+	}
 	allSPSlugs := []common.ServiceType{
 		common.ServiceSavingsPlansCompute,
 		common.ServiceSavingsPlansEC2Instance,
@@ -166,11 +178,13 @@ func parseServices(serviceNames []string) []common.ServiceType {
 	for _, name := range serviceNames {
 		key := strings.ToLower(name)
 		if key == "savingsplans" || key == "savings-plans" || key == "sp" {
-			result = append(result, allSPSlugs...)
+			for _, service := range allSPSlugs {
+				add(service)
+			}
 			continue
 		}
 		if service, ok := serviceMap[key]; ok {
-			result = append(result, service)
+			add(service)
 		} else {
 			log.Printf("Warning: Unknown service '%s', skipping", name)
 		}

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -86,7 +86,10 @@ func TestGetAllServices(t *testing.T) {
 		common.ServiceOpenSearch,
 		common.ServiceRedshift,
 		common.ServiceMemoryDB,
-		common.ServiceSavingsPlans,
+		common.ServiceSavingsPlansCompute,
+		common.ServiceSavingsPlansEC2Instance,
+		common.ServiceSavingsPlansSageMaker,
+		common.ServiceSavingsPlansDatabase,
 	}
 
 	assert.Equal(t, expected, services)
@@ -218,9 +221,33 @@ func TestCreateServiceClient(t *testing.T) {
 			expectNil: false,
 		},
 		{
-			name:      "Savings Plans service",
-			service:   common.ServiceSavingsPlans,
+			name:      "Compute Savings Plans service",
+			service:   common.ServiceSavingsPlansCompute,
 			expectNil: false,
+		},
+		{
+			name:      "EC2 Instance Savings Plans service",
+			service:   common.ServiceSavingsPlansEC2Instance,
+			expectNil: false,
+		},
+		{
+			name:      "SageMaker Savings Plans service",
+			service:   common.ServiceSavingsPlansSageMaker,
+			expectNil: false,
+		},
+		{
+			name:      "Database Savings Plans service",
+			service:   common.ServiceSavingsPlansDatabase,
+			expectNil: false,
+		},
+		{
+			// Legacy umbrella slug is no longer dispatched to a client — the
+			// per-plan-type slugs above carry the actual work. Keep the case
+			// to lock the contract: createServiceClient returns nil for the
+			// umbrella so the caller knows to fan out.
+			name:      "Savings Plans umbrella service (legacy, returns nil)",
+			service:   common.ServiceSavingsPlans,
+			expectNil: true,
 		},
 		{
 			name:      "Unknown service",

--- a/cmd/multi_service_filters.go
+++ b/cmd/multi_service_filters.go
@@ -27,7 +27,7 @@ func processRecommendation(rec common.Recommendation, cfg Config, instanceVersio
 	// Filter to only recommendations for the current region being processed
 	// This prevents duplicating recommendations across all regions
 	// Skip this filter for Savings Plans as they are account-level, not regional
-	if currentRegion != "" && rec.Region != currentRegion && rec.Service != common.ServiceSavingsPlans {
+	if currentRegion != "" && rec.Region != currentRegion && !common.IsSavingsPlan(rec.Service) {
 		return rec, false
 	}
 

--- a/cmd/multi_service_helpers.go
+++ b/cmd/multi_service_helpers.go
@@ -43,11 +43,28 @@ func getServiceDisplayName(service common.ServiceType) string {
 		return "Redshift"
 	case common.ServiceMemoryDB:
 		return "MemoryDB"
-	case common.ServiceSavingsPlans:
-		return "Savings Plans"
-	default:
-		return string(service)
 	}
+	if name, ok := savingsPlanDisplayName(service); ok {
+		return name
+	}
+	return string(service)
+}
+
+// savingsPlanDisplayName returns a friendly label for the four per-plan-type
+// SP slugs and the legacy umbrella. Hoisted out of getServiceDisplayName to
+// keep the main switch under the gocyclo limit; using a small lookup map
+// instead of a five-arm switch also makes adding a fifth plan type a
+// one-line change.
+func savingsPlanDisplayName(service common.ServiceType) (string, bool) {
+	labels := map[common.ServiceType]string{
+		common.ServiceSavingsPlans:            "Savings Plans",
+		common.ServiceSavingsPlansCompute:     "Compute Savings Plans",
+		common.ServiceSavingsPlansEC2Instance: "EC2 Instance Savings Plans",
+		common.ServiceSavingsPlansSageMaker:   "SageMaker Savings Plans",
+		common.ServiceSavingsPlansDatabase:    "Database Savings Plans",
+	}
+	name, ok := labels[service]
+	return name, ok
 }
 
 // getAllAWSRegions retrieves all available AWS regions
@@ -232,7 +249,7 @@ func determineRegionsForService(ctx context.Context, awsCfg aws.Config, recClien
 	}
 
 	// Savings Plans are account-level, not regional - only query once
-	if service == common.ServiceSavingsPlans {
+	if common.IsSavingsPlan(service) {
 		AppLogger.Printf("🌍 Fetching account-level Savings Plans recommendations...\n")
 		return []string{"us-east-1"}, nil // Single query for account-level data
 	}

--- a/cmd/multi_service_stats.go
+++ b/cmd/multi_service_stats.go
@@ -102,7 +102,7 @@ func separateAndAggregateStats(serviceStats map[common.ServiceType]ServiceProces
 	aggregates := riAggregateStats{}
 
 	for service, stats := range serviceStats {
-		if service == common.ServiceSavingsPlans {
+		if common.IsSavingsPlan(service) {
 			spStats = stats
 		} else {
 			riStats[service] = stats

--- a/cmd/multi_service_stats.go
+++ b/cmd/multi_service_stats.go
@@ -101,9 +101,28 @@ func separateAndAggregateStats(serviceStats map[common.ServiceType]ServiceProces
 	riStats := make(map[common.ServiceType]ServiceProcessingStats)
 	aggregates := riAggregateStats{}
 
+	// Aggregate Savings Plans stats across all matching slugs (legacy
+	// umbrella + the four per-plan-type slugs from issue #22). Pre-split,
+	// only one SP slug existed so a plain assignment was correct; post-
+	// split, multiple SP slugs can land in serviceStats and Go map
+	// iteration order is non-deterministic, so a last-write-wins
+	// assignment would discard data unpredictably. Sum the relevant
+	// counters into spStats so the printed Savings Plans summary
+	// reflects every plan type's contribution.
 	for service, stats := range serviceStats {
 		if common.IsSavingsPlan(service) {
-			spStats = stats
+			if spStats.Service == "" {
+				spStats.Service = common.ServiceSavingsPlans
+			}
+			if stats.RegionsProcessed > spStats.RegionsProcessed {
+				spStats.RegionsProcessed = stats.RegionsProcessed
+			}
+			spStats.RecommendationsFound += stats.RecommendationsFound
+			spStats.RecommendationsSelected += stats.RecommendationsSelected
+			spStats.InstancesProcessed += stats.InstancesProcessed
+			spStats.SuccessfulPurchases += stats.SuccessfulPurchases
+			spStats.FailedPurchases += stats.FailedPurchases
+			spStats.TotalEstimatedSavings += stats.TotalEstimatedSavings
 		} else {
 			riStats[service] = stats
 			aggregates.recommendations += stats.RecommendationsSelected

--- a/cmd/multi_service_stats_helpers.go
+++ b/cmd/multi_service_stats_helpers.go
@@ -21,7 +21,7 @@ func categorizeSPRecommendations(recommendations []common.Recommendation) SPType
 	breakdown := SPTypeBreakdown{}
 
 	for _, rec := range recommendations {
-		if rec.Service == common.ServiceSavingsPlans {
+		if common.IsSavingsPlan(rec.Service) {
 			if details, ok := rec.Details.(*common.SavingsPlanDetails); ok {
 				switch details.PlanType {
 				case "Compute":
@@ -100,7 +100,7 @@ func collectSPSavings(recommendations []common.Recommendation) SPSavingsByType {
 	savings := SPSavingsByType{}
 
 	for _, rec := range recommendations {
-		if rec.Service == common.ServiceSavingsPlans {
+		if common.IsSavingsPlan(rec.Service) {
 			if details, ok := rec.Details.(*common.SavingsPlanDetails); ok {
 				switch details.PlanType {
 				case "EC2Instance":

--- a/cmd/multi_service_test.go
+++ b/cmd/multi_service_test.go
@@ -333,9 +333,11 @@ func TestProcessService_SavingsPlansAccountLevel(t *testing.T) {
 
 	mockClient := &MockRecommendationsClient{}
 
-	// Savings Plans should only query us-east-1 once (account-level)
+	// Savings Plans should only query us-east-1 once (account-level). Use the
+	// per-plan-type Compute slug now that the legacy umbrella has been
+	// retired from createServiceClient dispatch.
 	params := common.RecommendationParams{
-		Service:        common.ServiceSavingsPlans,
+		Service:        common.ServiceSavingsPlansCompute,
 		Region:         "us-east-1",
 		PaymentOption:  "all-upfront",
 		Term:           "3yr",
@@ -344,12 +346,12 @@ func TestProcessService_SavingsPlansAccountLevel(t *testing.T) {
 		ExcludeSPTypes: toolCfg.ExcludeSPTypes,
 	}
 	mockRecs := []common.Recommendation{
-		{Service: common.ServiceSavingsPlans, ResourceType: "ComputeSP", Count: 1, Region: "us-east-1", EstimatedSavings: 1000},
+		{Service: common.ServiceSavingsPlansCompute, ResourceType: "ComputeSP", Count: 1, Region: "us-east-1", EstimatedSavings: 1000},
 	}
 	mockClient.On("GetRecommendations", ctx, params).Return(mockRecs, nil)
 
 	accountCache := NewAccountAliasCache(awsCfg)
-	recs, results := processService(ctx, awsCfg, mockClient, accountCache, common.ServiceSavingsPlans, true, toolCfg, engineVersionData{})
+	recs, results := processService(ctx, awsCfg, mockClient, accountCache, common.ServiceSavingsPlansCompute, true, toolCfg, engineVersionData{})
 
 	// Should get recommendations
 	assert.NotEmpty(t, recs)

--- a/docs/smoke-test-multi-account.sh
+++ b/docs/smoke-test-multi-account.sh
@@ -83,10 +83,14 @@ fi
 # ---------------------------------------------------------------------------
 # Step 4: Set a service override
 # ---------------------------------------------------------------------------
-step "4. Set service override (aws/savingsplans: disable auto-collect)"
+step "4. Set service override (aws/savings-plans-compute: disable auto-collect)"
 
+# Note: with the per-plan-type SP split (issue #22 follow-up), Savings
+# Plans are addressed per plan type. We disable auto-collect on the
+# Compute SP card here; replace with savings-plans-{ec2instance,
+# sagemaker,database} to target other plan types.
 curl -sf -X PUT \
-  "${BASE_URL}/api/accounts/${ACCOUNT_ID}/service-overrides/aws/savingsplans" \
+  "${BASE_URL}/api/accounts/${ACCOUNT_ID}/service-overrides/aws/savings-plans-compute" \
   "${HDR[@]}" -d '{
     "auto_collect": false,
     "notification_days_before": 14
@@ -105,7 +109,7 @@ step "5. Create a plan and associate account"
 
 PLAN_JSON=$(curl -sf "${BASE_URL}/api/plans" "${HDR[@]}" -d '{
   "name": "smoke-test-plan",
-  "services": {"aws:savingsplans": {"term": "1yr", "payment": "all_upfront"}},
+  "services": {"aws:savings-plans-compute": {"term": "1yr", "payment": "all_upfront"}},
   "enabled": true
 }')
 PLAN_ID=$(echo "${PLAN_JSON}" | jq -r '.id')

--- a/frontend/src/__tests__/commitmentOptions.test.ts
+++ b/frontend/src/__tests__/commitmentOptions.test.ts
@@ -187,6 +187,24 @@ describe('commitmentOptions', () => {
         expect(isValidCombination('aws', 'savingsplans', 1, 'no-upfront')).toBe(true);
         expect(isValidCombination('aws', 'savingsplans', 3, 'no-upfront')).toBe(true);
       });
+
+      // Issue #22 follow-up: per-plan-type SP slugs fall through the
+      // _default arm of getCommitmentConfig (no per-key entry needed),
+      // so all 6 (term × payment) combos are valid for each. This test
+      // pins that behaviour so a future change to the _default
+      // fallback can't silently restrict SP saves.
+      it.each([
+        'savings-plans-compute',
+        'savings-plans-ec2instance',
+        'savings-plans-sagemaker',
+        'savings-plans-database',
+      ])('should return true for all %s combinations (24 total: 4 keys × 6 combos)', (service) => {
+        for (const term of [1, 3]) {
+          for (const payment of ['no-upfront', 'partial-upfront', 'all-upfront']) {
+            expect(isValidCombination('aws', service, term, payment)).toBe(true);
+          }
+        }
+      });
     });
 
     describe('AWS services with 3yr no-upfront restriction', () => {

--- a/frontend/src/__tests__/settings-accounts.test.ts
+++ b/frontend/src/__tests__/settings-accounts.test.ts
@@ -624,10 +624,15 @@ describe('Create-override modal', () => {
     const { modal } = await expandOverridesPanel('acc-1');
 
     expect(modal.classList.contains('hidden')).toBe(false);
-    // Service dropdown should be populated with all 7 AWS service options.
+    // Service dropdown should be populated with all 9 AWS service options
+    // (5 RIs + 4 per-plan-type SP slugs after the issue #22 follow-up).
     const svcSelect = document.getElementById('override-service') as HTMLSelectElement;
     const values = Array.from(svcSelect.options).map(o => o.value);
-    expect(values).toEqual(['ec2', 'rds', 'elasticache', 'opensearch', 'redshift', 'savingsplans', 'sagemaker']);
+    expect(values).toEqual([
+      'ec2', 'rds', 'elasticache', 'opensearch', 'redshift',
+      'savings-plans-compute', 'savings-plans-ec2instance',
+      'savings-plans-sagemaker', 'savings-plans-database',
+    ]);
   });
 
   test('populated panel shows an Add override button that opens the modal', async () => {
@@ -788,7 +793,13 @@ describe('Create-override modal', () => {
   });
 
   test('all services already overridden disables submit', async () => {
-    const all = ['ec2', 'rds', 'elasticache', 'opensearch', 'redshift', 'savingsplans', 'sagemaker'];
+    // Mirrors AWS_OVERRIDE_SERVICES post-issue-#22-follow-up: 5 RI services
+    // plus the four per-plan-type SP slugs.
+    const all = [
+      'ec2', 'rds', 'elasticache', 'opensearch', 'redshift',
+      'savings-plans-compute', 'savings-plans-ec2instance',
+      'savings-plans-sagemaker', 'savings-plans-database',
+    ];
     (api.listAccountServiceOverrides as jest.Mock).mockResolvedValue(
       all.map((service, i) => ({
         id: `o-${i}`, account_id: 'acc-1', provider: 'aws', service, term: 1,

--- a/frontend/src/__tests__/settings.test.ts
+++ b/frontend/src/__tests__/settings.test.ts
@@ -81,17 +81,23 @@ describe('Settings Module', () => {
         <select id="aws-elasticache-term"><option value="1">1</option><option value="3">3</option></select>
         <select id="aws-opensearch-term"><option value="1">1</option><option value="3">3</option></select>
         <select id="aws-redshift-term"><option value="1">1</option><option value="3">3</option></select>
-        <select id="aws-savingsplans-term"><option value="1">1</option><option value="3">3</option></select>
-        <!-- Issue #22: SageMaker per-service card (its own SP type). Lambda
-             intentionally omitted — it has no standalone SP, only Compute SP. -->
-        <select id="aws-sagemaker-term"><option value="1">1</option><option value="3">3</option></select>
+        <!-- Issue #22 follow-up: per-plan-type Savings Plans cards
+             (Compute / EC2 Instance / SageMaker / Database). The earlier
+             umbrella savingsplans and PR #71 sagemaker cards have
+             been replaced. -->
+        <select id="aws-savings-plans-compute-term"><option value="1">1</option><option value="3">3</option></select>
+        <select id="aws-savings-plans-ec2instance-term"><option value="1">1</option><option value="3">3</option></select>
+        <select id="aws-savings-plans-sagemaker-term"><option value="1">1</option><option value="3">3</option></select>
+        <select id="aws-savings-plans-database-term"><option value="1">1</option><option value="3">3</option></select>
         <select id="aws-ec2-payment"><option value="no-upfront">No</option><option value="partial-upfront">Partial</option><option value="all-upfront">All</option></select>
         <select id="aws-rds-payment"><option value="no-upfront">No</option><option value="partial-upfront">Partial</option><option value="all-upfront">All</option></select>
         <select id="aws-elasticache-payment"><option value="no-upfront">No</option><option value="partial-upfront">Partial</option><option value="all-upfront">All</option></select>
         <select id="aws-opensearch-payment"><option value="no-upfront">No</option><option value="partial-upfront">Partial</option><option value="all-upfront">All</option></select>
         <select id="aws-redshift-payment"><option value="no-upfront">No</option><option value="partial-upfront">Partial</option><option value="all-upfront">All</option></select>
-        <select id="aws-savingsplans-payment"><option value="no-upfront">No</option><option value="partial-upfront">Partial</option><option value="all-upfront">All</option></select>
-        <select id="aws-sagemaker-payment"><option value="no-upfront">No</option><option value="partial-upfront">Partial</option><option value="all-upfront">All</option></select>
+        <select id="aws-savings-plans-compute-payment"><option value="no-upfront">No</option><option value="partial-upfront">Partial</option><option value="all-upfront">All</option></select>
+        <select id="aws-savings-plans-ec2instance-payment"><option value="no-upfront">No</option><option value="partial-upfront">Partial</option><option value="all-upfront">All</option></select>
+        <select id="aws-savings-plans-sagemaker-payment"><option value="no-upfront">No</option><option value="partial-upfront">Partial</option><option value="all-upfront">All</option></select>
+        <select id="aws-savings-plans-database-payment"><option value="no-upfront">No</option><option value="partial-upfront">Partial</option><option value="all-upfront">All</option></select>
         <!-- Azure term selects -->
         <select id="azure-vm-term"><option value="1">1</option><option value="3">3</option></select>
         <select id="azure-sql-term"><option value="1">1</option><option value="3">3</option></select>
@@ -112,11 +118,11 @@ describe('Settings Module', () => {
     (document.getElementById('setting-default-payment') as HTMLSelectElement).value = 'all-upfront';
     // Mirror the same baseline onto every per-service select so the cascade
     // diff only reports genuinely-changed rows.
-    ['aws-ec2-term','aws-rds-term','aws-elasticache-term','aws-opensearch-term','aws-redshift-term','aws-savingsplans-term','aws-sagemaker-term','azure-vm-term','azure-sql-term','azure-cosmos-term','gcp-compute-term','gcp-sql-term'].forEach(id => {
+    ['aws-ec2-term','aws-rds-term','aws-elasticache-term','aws-opensearch-term','aws-redshift-term','aws-savings-plans-compute-term','aws-savings-plans-ec2instance-term','aws-savings-plans-sagemaker-term','aws-savings-plans-database-term','azure-vm-term','azure-sql-term','azure-cosmos-term','gcp-compute-term','gcp-sql-term'].forEach(id => {
       const el = document.getElementById(id) as HTMLSelectElement | null;
       if (el) el.value = '3';
     });
-    ['aws-ec2-payment','aws-rds-payment','aws-elasticache-payment','aws-opensearch-payment','aws-redshift-payment','aws-savingsplans-payment','aws-sagemaker-payment'].forEach(id => {
+    ['aws-ec2-payment','aws-rds-payment','aws-elasticache-payment','aws-opensearch-payment','aws-redshift-payment','aws-savings-plans-compute-payment','aws-savings-plans-ec2instance-payment','aws-savings-plans-sagemaker-payment','aws-savings-plans-database-payment'].forEach(id => {
       const el = document.getElementById(id) as HTMLSelectElement | null;
       if (el) el.value = 'all-upfront';
     });
@@ -510,18 +516,23 @@ describe('Settings Module', () => {
       expect(api.updateConfig).toHaveBeenCalled();
     });
 
-    // Issue #22: SageMaker has its own SP type, so it gets a dedicated
-    // purchasing-defaults card. Verify the card exists in the canonical
-    // index.html (so the deployed UI actually renders it) and that the
-    // save flow round-trips edits to the per-service config endpoint.
-    // Lambda is intentionally absent — it has no standalone SP product.
-    test('SageMaker card present in index.html with term and payment selects (issue #22)', () => {
+    // Issue #22 follow-up: AWS Savings Plans split into four per-plan-type
+    // cards (Compute / EC2 Instance / SageMaker / Database). Each gets
+    // a dedicated card in index.html so users can pin term/payment per
+    // workload independently. Lambda is intentionally absent — it has no
+    // standalone SP product (Lambda commitments roll into Compute SP).
+    test('four per-plan-type SP cards present in index.html (issue #22)', () => {
       const fs = require('fs') as typeof import('fs');
       const path = require('path') as typeof import('path');
       const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf-8');
+      expect(html).toMatch(/<h5>\s*Compute Savings Plans\s*<\/h5>/);
+      expect(html).toMatch(/<h5>\s*EC2 Instance Savings Plans\s*<\/h5>/);
       expect(html).toMatch(/<h5>\s*SageMaker Savings Plans\s*<\/h5>/);
-      expect(html).toMatch(/id="aws-sagemaker-term"/);
-      expect(html).toMatch(/id="aws-sagemaker-payment"/);
+      expect(html).toMatch(/<h5>\s*Database Savings Plans\s*<\/h5>/);
+      for (const planType of ['compute', 'ec2instance', 'sagemaker', 'database']) {
+        expect(html).toMatch(new RegExp(`id="aws-savings-plans-${planType}-term"`));
+        expect(html).toMatch(new RegExp(`id="aws-savings-plans-${planType}-payment"`));
+      }
     });
 
     test('no Lambda card in index.html — Lambda has no standalone SP, only Compute SP (issue #22)', () => {
@@ -534,21 +545,22 @@ describe('Settings Module', () => {
       expect(html).not.toMatch(/id="aws-lambda-payment"/);
     });
 
-    test('saveGlobalSettings sends per-service SageMaker term and payment (issue #22)', async () => {
+    test('saveGlobalSettings sends per-plan-type SP term and payment (issue #22)', async () => {
       (api.updateConfig as jest.Mock).mockResolvedValue({});
       (api.updateServiceConfig as jest.Mock).mockClear().mockResolvedValue(undefined);
       window.alert = jest.fn();
 
-      // User pins SageMaker to 1yr / no-upfront while leaving the global
-      // default at 3yr / all-upfront.
-      (document.getElementById('aws-sagemaker-term') as HTMLSelectElement).value = '1';
-      (document.getElementById('aws-sagemaker-payment') as HTMLSelectElement).value = 'no-upfront';
+      // User pins SageMaker SP to 1yr / no-upfront while leaving Compute
+      // SP at the global default (3yr / all-upfront, matching the seeded
+      // baseline from beforeEach).
+      (document.getElementById('aws-savings-plans-sagemaker-term') as HTMLSelectElement).value = '1';
+      (document.getElementById('aws-savings-plans-sagemaker-payment') as HTMLSelectElement).value = 'no-upfront';
 
       const event = { preventDefault: jest.fn() } as unknown as Event;
       await saveGlobalSettings(event);
 
       const call = (api.updateServiceConfig as jest.Mock).mock.calls.find(
-        ([provider, service]) => provider === 'aws' && service === 'sagemaker',
+        ([provider, service]) => provider === 'aws' && service === 'savings-plans-sagemaker',
       );
       expect(call).toBeDefined();
       const cfg = call![2];
@@ -556,7 +568,7 @@ describe('Settings Module', () => {
       expect(cfg.payment).toBe('no-upfront');
     });
 
-    test('calls updateServiceConfig once per service field (16 calls)', async () => {
+    test('calls updateServiceConfig once per service field (18 calls)', async () => {
       (api.updateConfig as jest.Mock).mockResolvedValue({});
       (api.updateServiceConfig as jest.Mock).mockResolvedValue(undefined);
       window.alert = jest.fn();
@@ -564,10 +576,13 @@ describe('Settings Module', () => {
       const event = { preventDefault: jest.fn() } as unknown as Event;
       await saveGlobalSettings(event);
 
-      // 7 AWS (ec2, rds, elasticache, opensearch, redshift, savingsplans,
-      // sagemaker — last one added per issue #22) + 5 Azure
-      // (vm, sql, cosmosdb, redis, search) + 4 GCP.
-      expect(api.updateServiceConfig).toHaveBeenCalledTimes(16);
+      // 5 AWS RIs (ec2, rds, elasticache, opensearch, redshift) + 4 AWS
+      // SP (compute, ec2instance, sagemaker, database) + 5 Azure (vm,
+      // sql, cosmosdb, redis, search) + 4 GCP (compute, sql, memorystore,
+      // storage). Pre-rev-2 was 16 (1 umbrella SP + 1 sagemaker, plus 5
+      // RIs); the SP split replaced those two with four per-plan-type
+      // entries, net +2.
+      expect(api.updateServiceConfig).toHaveBeenCalledTimes(18);
     });
   }); // end saveGlobalSettings
 
@@ -887,15 +902,50 @@ describe('Settings Module', () => {
       },
     );
 
-    test('SageMaker 3yr keeps "no-upfront" visible (issue #22 — no service-level restriction)', async () => {
+    // Empty-state regression: on a fresh install where no per-product
+    // service_configs rows exist (e.g., right after migration 000040 ran
+    // but before any user save), loadGlobalSettings must not blow up,
+    // and the four SP card selects must remain present + interactable.
+    // This protects against a regression where the load path tried to
+    // touch a missing service entry and threw, leaving the cards in a
+    // broken state. The selects keep their HTML-default values (3 /
+    // all-upfront) per the existing per-service load semantics — the
+    // wider "apply globalCfg.default_term / default_payment to empty
+    // selects" cascade is OUT OF SCOPE for this PR (see plan §6.5).
+    test('per-plan-type SP cards remain interactable when no service rows exist (issue #22 follow-up)', async () => {
       (api.getConfig as jest.Mock).mockResolvedValue({
-        global: { enabled_providers: ['aws'], default_term: 3, default_payment: 'no-upfront', default_coverage: 80 },
-        services: [{ provider: 'aws', service: 'sagemaker', term: 3, payment: 'no-upfront' }],
+        global: { enabled_providers: ['aws'], default_term: 1, default_payment: 'no-upfront', default_coverage: 80 },
+        services: [], // no per-service overrides
       });
       setupSettingsHandlers();
       await loadGlobalSettings();
 
-      const payment = document.getElementById('aws-sagemaker-payment') as HTMLSelectElement;
+      for (const planType of ['compute', 'ec2instance', 'sagemaker', 'database']) {
+        const term = document.getElementById(`aws-savings-plans-${planType}-term`) as HTMLSelectElement;
+        const payment = document.getElementById(`aws-savings-plans-${planType}-payment`) as HTMLSelectElement;
+        expect(term).not.toBeNull();
+        expect(payment).not.toBeNull();
+        // Cards keep the HTML-default 3yr/all-upfront baseline (matching
+        // the existing umbrella card's pre-rev-2 behaviour).
+        expect(term.value).toBe('3');
+        expect(payment.value).toBe('all-upfront');
+        // All 6 (term × payment) combos remain selectable on the new
+        // SP keys via the _default fallback in commitmentOptions.
+        expect(optVisible(payment, 'no-upfront')).toBe(true);
+        expect(optVisible(payment, 'partial-upfront')).toBe(true);
+        expect(optVisible(payment, 'all-upfront')).toBe(true);
+      }
+    });
+
+    test('SageMaker 3yr keeps "no-upfront" visible (issue #22 — no service-level restriction)', async () => {
+      (api.getConfig as jest.Mock).mockResolvedValue({
+        global: { enabled_providers: ['aws'], default_term: 3, default_payment: 'no-upfront', default_coverage: 80 },
+        services: [{ provider: 'aws', service: 'savings-plans-sagemaker', term: 3, payment: 'no-upfront' }],
+      });
+      setupSettingsHandlers();
+      await loadGlobalSettings();
+
+      const payment = document.getElementById('aws-savings-plans-sagemaker-payment') as HTMLSelectElement;
       expect(optVisible(payment, 'no-upfront')).toBe(true);
       expect(optVisible(payment, 'partial-upfront')).toBe(true);
       expect(optVisible(payment, 'all-upfront')).toBe(true);

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -109,7 +109,12 @@
                                         <option value="opensearch">OpenSearch</option>
                                         <option value="memorydb">MemoryDB</option>
                                         <option value="redshift">Redshift</option>
-                                        <option value="savingsplans">Savings Plans</option>
+                                    </optgroup>
+                                    <optgroup label="Savings Plans">
+                                        <option value="savings-plans-compute">Compute SP</option>
+                                        <option value="savings-plans-ec2instance">EC2 Instance SP</option>
+                                        <option value="savings-plans-sagemaker">SageMaker SP</option>
+                                        <option value="savings-plans-database">Database SP</option>
                                     </optgroup>
                                     <optgroup label="Azure">
                                         <option value="vm">Virtual Machines</option>
@@ -484,16 +489,28 @@
                                 <label>Payment: <select id="aws-redshift-payment"><option value="no-upfront">No Upfront</option><option value="partial-upfront">Partial</option><option value="all-upfront" selected>All Upfront</option></select></label>
                             </div>
                             <div class="service-default-card">
-                                <h5>Savings Plans</h5>
-                                <p class="service-default-hint">Compute (EC2, Fargate, Lambda), EC2 Instance, and Database (RDS) plans share these defaults. SageMaker is its own SP type — see card below.</p>
-                                <label>Term: <select id="aws-savingsplans-term"><option value="1">1 Year</option><option value="3" selected>3 Years</option></select></label>
-                                <label>Payment: <select id="aws-savingsplans-payment"><option value="no-upfront">No Upfront</option><option value="partial-upfront">Partial</option><option value="all-upfront" selected>All Upfront</option></select></label>
+                                <h5>Compute Savings Plans</h5>
+                                <p class="service-default-hint">EC2, Fargate, Lambda — most flexible</p>
+                                <label>Term: <select id="aws-savings-plans-compute-term"><option value="1">1 Year</option><option value="3" selected>3 Years</option></select></label>
+                                <label>Payment: <select id="aws-savings-plans-compute-payment"><option value="no-upfront">No Upfront</option><option value="partial-upfront">Partial</option><option value="all-upfront" selected>All Upfront</option></select></label>
+                            </div>
+                            <div class="service-default-card">
+                                <h5>EC2 Instance Savings Plans</h5>
+                                <p class="service-default-hint">EC2 only, region-locked — deepest discount</p>
+                                <label>Term: <select id="aws-savings-plans-ec2instance-term"><option value="1">1 Year</option><option value="3" selected>3 Years</option></select></label>
+                                <label>Payment: <select id="aws-savings-plans-ec2instance-payment"><option value="no-upfront">No Upfront</option><option value="partial-upfront">Partial</option><option value="all-upfront" selected>All Upfront</option></select></label>
                             </div>
                             <div class="service-default-card">
                                 <h5>SageMaker Savings Plans</h5>
-                                <p class="service-default-hint">SageMaker Savings Plans are a distinct SP product (separate from Compute SP). These defaults narrow SageMaker recommendations independently of the umbrella Savings Plans card.</p>
-                                <label>Term: <select id="aws-sagemaker-term"><option value="1">1 Year</option><option value="3" selected>3 Years</option></select></label>
-                                <label>Payment: <select id="aws-sagemaker-payment"><option value="no-upfront">No Upfront</option><option value="partial-upfront">Partial</option><option value="all-upfront" selected>All Upfront</option></select></label>
+                                <p class="service-default-hint">SageMaker training/inference</p>
+                                <label>Term: <select id="aws-savings-plans-sagemaker-term"><option value="1">1 Year</option><option value="3" selected>3 Years</option></select></label>
+                                <label>Payment: <select id="aws-savings-plans-sagemaker-payment"><option value="no-upfront">No Upfront</option><option value="partial-upfront">Partial</option><option value="all-upfront" selected>All Upfront</option></select></label>
+                            </div>
+                            <div class="service-default-card">
+                                <h5>Database Savings Plans</h5>
+                                <p class="service-default-hint">Reserved for future AWS Database Savings Plans (currently not GA; defaults stored for forward-compatibility)</p>
+                                <label>Term: <select id="aws-savings-plans-database-term"><option value="1">1 Year</option><option value="3" selected>3 Years</option></select></label>
+                                <label>Payment: <select id="aws-savings-plans-database-payment"><option value="no-upfront">No Upfront</option><option value="partial-upfront">Partial</option><option value="all-upfront" selected>All Upfront</option></select></label>
                             </div>
                         </div>
                     </fieldset>
@@ -707,7 +724,12 @@
                                         <option value="opensearch">OpenSearch</option>
                                         <option value="memorydb">MemoryDB</option>
                                         <option value="redshift">Redshift</option>
-                                        <option value="savingsplans">Savings Plans</option>
+                                    </optgroup>
+                                    <optgroup label="Savings Plans" id="plan-service-aws-sp">
+                                        <option value="savings-plans-compute">Compute SP</option>
+                                        <option value="savings-plans-ec2instance">EC2 Instance SP</option>
+                                        <option value="savings-plans-sagemaker">SageMaker SP</option>
+                                        <option value="savings-plans-database">Database SP</option>
                                     </optgroup>
                                     <optgroup label="Azure" id="plan-service-azure" class="hidden">
                                         <option value="vm">Virtual Machines</option>

--- a/frontend/src/settings.ts
+++ b/frontend/src/settings.ts
@@ -445,13 +445,20 @@ const AWS_PAYMENT_OPTIONS: ReadonlyArray<{ value: string; label: string }> = [
 // entries in SERVICE_FIELDS \u2014 Azure/GCP override creation is a follow-up
 // (issue #104) since the backend payment/term semantics differ per provider.
 const AWS_OVERRIDE_SERVICES: ReadonlyArray<{ value: string; label: string }> = [
-  { value: 'ec2',          label: 'EC2 (Reserved Instances)' },
-  { value: 'rds',          label: 'RDS' },
-  { value: 'elasticache',  label: 'ElastiCache' },
-  { value: 'opensearch',   label: 'OpenSearch' },
-  { value: 'redshift',     label: 'Redshift' },
-  { value: 'savingsplans', label: 'Savings Plans' },
-  { value: 'sagemaker',    label: 'SageMaker Savings Plans' },
+  { value: 'ec2',                       label: 'EC2 (Reserved Instances)' },
+  { value: 'rds',                       label: 'RDS' },
+  { value: 'elasticache',               label: 'ElastiCache' },
+  { value: 'opensearch',                label: 'OpenSearch' },
+  { value: 'redshift',                  label: 'Redshift' },
+  // Issue #22 follow-up: per-plan-type SP slugs aligned with
+  // SERVICE_FIELDS so per-account overrides target the same rows the
+  // global Settings cards write to. The legacy `savingsplans` and PR
+  // #71 `sagemaker` values were removed because they no longer
+  // correspond to live ServiceConfig rows after migration 000040.
+  { value: 'savings-plans-compute',     label: 'Compute Savings Plans' },
+  { value: 'savings-plans-ec2instance', label: 'EC2 Instance Savings Plans' },
+  { value: 'savings-plans-sagemaker',   label: 'SageMaker Savings Plans' },
+  { value: 'savings-plans-database',    label: 'Database Savings Plans' },
 ];
 
 

--- a/frontend/src/settings.ts
+++ b/frontend/src/settings.ts
@@ -31,14 +31,18 @@ const SERVICE_FIELDS = [
   { provider: 'aws', service: 'elasticache',  termId: 'aws-elasticache-term',  paymentId: 'aws-elasticache-payment' },
   { provider: 'aws', service: 'opensearch',   termId: 'aws-opensearch-term',   paymentId: 'aws-opensearch-payment' },
   { provider: 'aws', service: 'redshift',     termId: 'aws-redshift-term',     paymentId: 'aws-redshift-payment' },
-  { provider: 'aws', service: 'savingsplans', termId: 'aws-savingsplans-term', paymentId: 'aws-savingsplans-payment' },
-  // Issue #22: SageMaker has its own SP type (SageMaker Savings Plans),
-  // so it gets a dedicated card and users can pin term/payment per workload
-  // instead of sharing the umbrella Savings Plans defaults. Lambda is
-  // intentionally NOT here — Lambda has no standalone SP product; its
-  // commitments roll up into Compute Savings Plans, already covered by
-  // the umbrella card above.
-  { provider: 'aws', service: 'sagemaker',    termId: 'aws-sagemaker-term',    paymentId: 'aws-sagemaker-payment' },
+  // Issue #22 follow-up: AWS Savings Plans split into four per-plan-type
+  // cards (Compute / EC2 Instance / SageMaker / Database). The earlier
+  // umbrella `savingsplans` and PR #71 `sagemaker` SERVICE_FIELDS entries
+  // are replaced by these four. Migration 000040_split_savingsplans
+  // copies the umbrella row's term/payment into all four new rows and
+  // (when present) overrides the SageMaker slot from PR #71's sagemaker
+  // row. Lambda is intentionally NOT a separate card — Lambda has no
+  // standalone SP product; its commitments roll up into Compute SP.
+  { provider: 'aws', service: 'savings-plans-compute',     termId: 'aws-savings-plans-compute-term',     paymentId: 'aws-savings-plans-compute-payment' },
+  { provider: 'aws', service: 'savings-plans-ec2instance', termId: 'aws-savings-plans-ec2instance-term', paymentId: 'aws-savings-plans-ec2instance-payment' },
+  { provider: 'aws', service: 'savings-plans-sagemaker',   termId: 'aws-savings-plans-sagemaker-term',   paymentId: 'aws-savings-plans-sagemaker-payment' },
+  { provider: 'aws', service: 'savings-plans-database',    termId: 'aws-savings-plans-database-term',    paymentId: 'aws-savings-plans-database-payment' },
   { provider: 'azure', service: 'vm',         termId: 'azure-vm-term',         paymentId: 'azure-vm-payment' },
   { provider: 'azure', service: 'sql',        termId: 'azure-sql-term',        paymentId: 'azure-sql-payment' },
   { provider: 'azure', service: 'cosmosdb',   termId: 'azure-cosmosdb-term',   paymentId: 'azure-cosmosdb-payment' },

--- a/internal/api/validation_test.go
+++ b/internal/api/validation_test.go
@@ -80,6 +80,13 @@ func TestValidateServiceName(t *testing.T) {
 		{"valid service name", "rds", false},
 		{"valid service with hyphen", "elastic-cache", false},
 		{"valid service with numbers", "ec2", false},
+		// Issue #22 follow-up: the four per-plan-type SP slugs all match
+		// the regex. Locked in here so a future regex tightening can't
+		// silently break SP saves at the API layer.
+		{"valid SP slug compute", "savings-plans-compute", false},
+		{"valid SP slug ec2instance", "savings-plans-ec2instance", false},
+		{"valid SP slug sagemaker", "savings-plans-sagemaker", false},
+		{"valid SP slug database", "savings-plans-database", false},
 		{"uppercase service is invalid", "RDS", true},
 		{"invalid with underscore", "elastic_cache", true},
 		{"invalid with special chars", "rds!", true},

--- a/internal/database/postgres/migrations/000040_split_savingsplans.down.sql
+++ b/internal/database/postgres/migrations/000040_split_savingsplans.down.sql
@@ -59,10 +59,25 @@ SET services = (
         )
         UNION ALL
         -- Collapse the four per-plan-type entries back into a single
-        -- `aws:savings-plans` entry sourced from the compute slot.
+        -- `aws:savings-plans` entry. Prefer the compute slot (most
+        -- common, mirrors the service_configs down rule) but fall back
+        -- to whichever per-plan-type key is present so a plan that was
+        -- created post-split with only sagemaker/database/ec2instance
+        -- still gets a usable umbrella key on rollback.
         SELECT 'aws:savings-plans' AS new_key, v AS new_val
         FROM jsonb_each(services) AS e(k, v)
-        WHERE k = 'aws:savings-plans-compute'
+        WHERE k IN (
+            'aws:savings-plans-compute',
+            'aws:savings-plans-ec2instance',
+            'aws:savings-plans-sagemaker',
+            'aws:savings-plans-database'
+        )
+        ORDER BY CASE k
+            WHEN 'aws:savings-plans-compute'     THEN 1
+            WHEN 'aws:savings-plans-ec2instance' THEN 2
+            WHEN 'aws:savings-plans-sagemaker'   THEN 3
+            ELSE 4
+        END
         LIMIT 1
     ) merged
 )

--- a/internal/database/postgres/migrations/000040_split_savingsplans.down.sql
+++ b/internal/database/postgres/migrations/000040_split_savingsplans.down.sql
@@ -1,0 +1,76 @@
+-- Rollback for the per-plan-type Savings Plans split.
+--
+-- Lossy by design: the four per-plan-type rows may carry divergent
+-- term/payment values, but the legacy umbrella was a single row with
+-- one (term, payment) pair. We restore the umbrella from
+-- `savings-plans-compute` (the canonical source — most accounts'
+-- commitment is dominated by Compute SP, so its values are the safest
+-- single representative).
+--
+-- Idempotent: if no `savings-plans-compute` row exists for a given
+-- provider (fresh install never had SP config), the down migration
+-- no-ops gracefully. The PR #71 `(aws, sagemaker)` row, if present, is
+-- left untouched because its lifecycle is governed by the up
+-- migration's deprecation comment, not this rollback.
+
+BEGIN;
+
+-- Restore the umbrella row from savings-plans-compute, if present.
+INSERT INTO service_configs (
+    provider, service, enabled, term, payment, coverage, ramp_schedule,
+    include_engines, exclude_engines, include_regions, exclude_regions,
+    include_types, exclude_types, created_at, updated_at
+)
+SELECT provider, 'savings-plans',
+    enabled, term, payment, coverage, ramp_schedule,
+    include_engines, exclude_engines, include_regions, exclude_regions,
+    include_types, exclude_types,
+    NOW(), NOW()
+FROM service_configs
+WHERE provider = 'aws' AND service = 'savings-plans-compute'
+ON CONFLICT (provider, service) DO NOTHING;
+
+-- Delete the four per-plan-type rows.
+DELETE FROM service_configs
+    WHERE provider = 'aws'
+    AND service IN (
+        'savings-plans-compute',
+        'savings-plans-ec2instance',
+        'savings-plans-sagemaker',
+        'savings-plans-database'
+    );
+
+-- Rewrite purchase_plans.services back to the umbrella key. Pick the
+-- savings-plans-compute value as the deterministic representative for
+-- the same lossy-but-predictable reason as the service_configs row
+-- above.
+UPDATE purchase_plans
+SET services = (
+    SELECT jsonb_object_agg(new_key, new_val)
+    FROM (
+        -- Keep all non-SP entries unchanged.
+        SELECT k AS new_key, v AS new_val
+        FROM jsonb_each(services) AS e(k, v)
+        WHERE k NOT IN (
+            'aws:savings-plans-compute',
+            'aws:savings-plans-ec2instance',
+            'aws:savings-plans-sagemaker',
+            'aws:savings-plans-database'
+        )
+        UNION ALL
+        -- Collapse the four per-plan-type entries back into a single
+        -- `aws:savings-plans` entry sourced from the compute slot.
+        SELECT 'aws:savings-plans' AS new_key, v AS new_val
+        FROM jsonb_each(services) AS e(k, v)
+        WHERE k = 'aws:savings-plans-compute'
+        LIMIT 1
+    ) merged
+)
+WHERE services ?| ARRAY[
+    'aws:savings-plans-compute',
+    'aws:savings-plans-ec2instance',
+    'aws:savings-plans-sagemaker',
+    'aws:savings-plans-database'
+];
+
+COMMIT;

--- a/internal/database/postgres/migrations/000040_split_savingsplans.up.sql
+++ b/internal/database/postgres/migrations/000040_split_savingsplans.up.sql
@@ -59,7 +59,13 @@ BEGIN
     SELECT COUNT(*) INTO umbrella_count FROM service_configs
         WHERE provider = 'aws' AND service IN ('savings-plans', 'savingsplans');
     SELECT COUNT(*) INTO split_count FROM service_configs
-        WHERE provider = 'aws' AND service = 'savings-plans-compute';
+        WHERE provider = 'aws'
+          AND service IN (
+              'savings-plans-compute',
+              'savings-plans-ec2instance',
+              'savings-plans-sagemaker',
+              'savings-plans-database'
+          );
 
     IF umbrella_count = 0 AND split_count = 0 THEN
         RAISE NOTICE 'split_savingsplans: no SP rows present, migration is a no-op';
@@ -121,11 +127,15 @@ SET services = (
         -- Fan the SP entry out into four. CROSS JOIN with a literal
         -- VALUES list of the four target keys; the source value is
         -- copied into each.
+        -- COALESCE prefers the canonical hyphenated key when both
+        -- spellings are present so the rewrite is deterministic.
+        -- jsonb_each + LIMIT 1 would pick non-deterministically.
         SELECT 'aws:' || target_service AS new_key, sp_val AS new_val
         FROM (
-            SELECT v AS sp_val FROM jsonb_each(services) AS e(k, v)
-            WHERE k IN ('aws:savings-plans', 'aws:savingsplans')
-            LIMIT 1
+            SELECT COALESCE(
+                services -> 'aws:savings-plans',
+                services -> 'aws:savingsplans'
+            ) AS sp_val
         ) src
         CROSS JOIN (VALUES
             ('savings-plans-compute'),
@@ -133,6 +143,7 @@ SET services = (
             ('savings-plans-sagemaker'),
             ('savings-plans-database')
         ) AS targets(target_service)
+        WHERE src.sp_val IS NOT NULL
     ) merged
 )
 WHERE services ?| ARRAY['aws:savings-plans', 'aws:savingsplans'];

--- a/internal/database/postgres/migrations/000040_split_savingsplans.up.sql
+++ b/internal/database/postgres/migrations/000040_split_savingsplans.up.sql
@@ -1,0 +1,140 @@
+-- Split the umbrella `(aws, savings-plans)` ServiceConfig row into four
+-- per-plan-type rows so users can pin term/payment defaults independently
+-- per AWS Savings Plans product family (Compute, EC2 Instance, SageMaker,
+-- Database). The umbrella row is deleted atomically in the same
+-- transaction.
+--
+-- Background: AWS Cost Explorer's GetSavingsPlansPurchaseRecommendation
+-- exposes four distinct SavingsPlansType values (ComputeSp, Ec2InstanceSp,
+-- SagemakerSp, DatabaseSp) but the codebase historically collapsed them
+-- under a single `savings-plans` slug, forcing one shared term/payment
+-- default for all four. The split lets a SageMaker-heavy account choose
+-- 1-yr no-upfront for SageMaker while keeping 3-yr all-upfront for
+-- Compute, etc.
+--
+-- PR #71 landed an interim `(aws, sagemaker)` ServiceConfig row with its
+-- own term/payment selects. We treat that row asymmetrically:
+--   - The umbrella `(aws, savings-plans)` row IS deleted in this
+--     migration (its values seed the four new rows verbatim — no
+--     information loss; only the row identity is replaced).
+--   - The `(aws, sagemaker)` row is KEPT for one release behind a SQL
+--     deprecation comment so a user mid-rollout doesn't lose their save.
+--     Its term/payment seeds the new `savings-plans-sagemaker` row,
+--     overriding the umbrella's value for that one slot. A follow-up
+--     migration removes it after one stable release; see the deprecation
+--     follow-up issue cited at the bottom of this file.
+--
+-- Strategy:
+--   1. Pre-flight DO block: detect three states — empty (no SP rows),
+--      already-split (has `savings-plans-compute`), and inconsistent
+--      (umbrella + split rows coexist). Empty no-ops cleanly;
+--      already-split skips the INSERT half and only deletes the
+--      umbrella; inconsistent RAISE EXCEPTION rather than double-write.
+--   2. INSERT four new rows per existing umbrella row, picking per-row
+--      term/payment from `(aws, sagemaker)` for the sagemaker slot when
+--      that row exists (otherwise fall back to umbrella). All other
+--      columns (enabled, coverage, ramp_schedule, include/exclude_*,
+--      timestamps) are copied verbatim from the umbrella.
+--   3. DELETE the umbrella `(aws, savings-plans)` row. The
+--      `(aws, sagemaker)` row stays.
+--   4. Rewrite `purchase_plans.services` JSONB keys: any `aws:savings-plans`
+--      entry fans out into four `aws:savings-plans-<type>` keys
+--      carrying the same value object, and the source key is removed.
+--      We use jsonb_object_agg over jsonb_each because jsonb_set can't
+--      atomically delete-and-insert multiple keys in one pass.
+--
+-- Idempotency: ON CONFLICT DO NOTHING on the INSERTs and the
+-- already-split detection make re-running safe.
+--
+-- Deprecation follow-up: drop `(aws, sagemaker)` after one release —
+-- TODO: file follow-up issue, then cite it here.
+
+BEGIN;
+
+DO $$
+DECLARE
+    umbrella_count INT;
+    split_count INT;
+BEGIN
+    SELECT COUNT(*) INTO umbrella_count FROM service_configs
+        WHERE provider = 'aws' AND service IN ('savings-plans', 'savingsplans');
+    SELECT COUNT(*) INTO split_count FROM service_configs
+        WHERE provider = 'aws' AND service = 'savings-plans-compute';
+
+    IF umbrella_count = 0 AND split_count = 0 THEN
+        RAISE NOTICE 'split_savingsplans: no SP rows present, migration is a no-op';
+    ELSIF umbrella_count = 0 AND split_count > 0 THEN
+        RAISE NOTICE 'split_savingsplans: per-plan-type rows already present, no INSERT needed';
+    ELSIF umbrella_count > 0 AND split_count > 0 THEN
+        RAISE EXCEPTION 'split_savingsplans: inconsistent state — both umbrella savings-plans row(s) (%) AND per-plan-type rows (%) exist. Manual cleanup required before this migration can run.', umbrella_count, split_count;
+    END IF;
+END $$;
+
+-- Insert four per-plan-type rows. Each pulls per-row term/payment from
+-- (aws, sagemaker) for the sagemaker slot (when that row exists) and
+-- falls back to the umbrella's values otherwise. Other columns are
+-- always copied from the umbrella.
+INSERT INTO service_configs (
+    provider, service, enabled, term, payment, coverage, ramp_schedule,
+    include_engines, exclude_engines, include_regions, exclude_regions,
+    include_types, exclude_types, created_at, updated_at
+)
+SELECT 'aws', svc.target_service,
+    u.enabled,
+    COALESCE(sm.term, u.term),
+    COALESCE(sm.payment, u.payment),
+    u.coverage, u.ramp_schedule,
+    u.include_engines, u.exclude_engines, u.include_regions, u.exclude_regions,
+    u.include_types, u.exclude_types,
+    NOW(), NOW()
+FROM service_configs u
+CROSS JOIN (VALUES
+    ('savings-plans-compute',     FALSE),
+    ('savings-plans-ec2instance', FALSE),
+    ('savings-plans-sagemaker',   TRUE),
+    ('savings-plans-database',    FALSE)
+) AS svc(target_service, is_sagemaker_slot)
+LEFT JOIN service_configs sm
+    ON sm.provider = 'aws' AND sm.service = 'sagemaker' AND svc.is_sagemaker_slot
+WHERE u.provider = 'aws' AND u.service IN ('savings-plans', 'savingsplans')
+ON CONFLICT (provider, service) DO NOTHING;
+
+-- Delete the umbrella row. The `(aws, sagemaker)` row from PR #71 is
+-- intentionally kept for one release as a backward-compat readback path.
+DELETE FROM service_configs
+    WHERE provider = 'aws' AND service IN ('savings-plans', 'savingsplans');
+
+-- Rewrite purchase_plans.services JSONB keys. For each plan whose
+-- services map contains `aws:savings-plans` (or its dash-free
+-- spelling), fan that single entry out into four
+-- `aws:savings-plans-<type>` entries carrying the same value, then drop
+-- the source key. Plans without an SP entry are left untouched.
+UPDATE purchase_plans
+SET services = (
+    SELECT jsonb_object_agg(new_key, new_val)
+    FROM (
+        -- Keep all non-SP entries unchanged.
+        SELECT k AS new_key, v AS new_val
+        FROM jsonb_each(services) AS e(k, v)
+        WHERE k NOT IN ('aws:savings-plans', 'aws:savingsplans')
+        UNION ALL
+        -- Fan the SP entry out into four. CROSS JOIN with a literal
+        -- VALUES list of the four target keys; the source value is
+        -- copied into each.
+        SELECT 'aws:' || target_service AS new_key, sp_val AS new_val
+        FROM (
+            SELECT v AS sp_val FROM jsonb_each(services) AS e(k, v)
+            WHERE k IN ('aws:savings-plans', 'aws:savingsplans')
+            LIMIT 1
+        ) src
+        CROSS JOIN (VALUES
+            ('savings-plans-compute'),
+            ('savings-plans-ec2instance'),
+            ('savings-plans-sagemaker'),
+            ('savings-plans-database')
+        ) AS targets(target_service)
+    ) merged
+)
+WHERE services ?| ARRAY['aws:savings-plans', 'aws:savingsplans'];
+
+COMMIT;

--- a/internal/database/postgres/migrations/000040_split_savingsplans.up.sql
+++ b/internal/database/postgres/migrations/000040_split_savingsplans.up.sql
@@ -47,7 +47,7 @@
 -- already-split detection make re-running safe.
 --
 -- Deprecation follow-up: drop `(aws, sagemaker)` after one release —
--- TODO: file follow-up issue, then cite it here.
+-- tracked in issue #133.
 
 BEGIN;
 

--- a/internal/database/postgres/migrations/split_savingsplans_test.go
+++ b/internal/database/postgres/migrations/split_savingsplans_test.go
@@ -1,0 +1,235 @@
+//go:build integration
+// +build integration
+
+package migrations_test
+
+import (
+	"context"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/LeanerCloud/CUDly/internal/database/postgres/migrations"
+	"github.com/LeanerCloud/CUDly/internal/database/postgres/testhelpers"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// getMigrationsPath resolves the migrations directory next to this test file.
+func getMigrationsPath() string {
+	_, filename, _, _ := runtime.Caller(0)
+	return filepath.Dir(filename)
+}
+
+// TestMigration_SplitSavingsPlans drives the 000040 migration through
+// the three scenarios from the plan §7: umbrella-only, umbrella + PR
+// #71's sagemaker row, and fresh install. Round-trips up/down to verify
+// no row identity is lost in the lossy down migration.
+func TestMigration_SplitSavingsPlans(t *testing.T) {
+	ctx := context.Background()
+	migrationsPath := getMigrationsPath()
+
+	type spRow struct {
+		service      string
+		term         int
+		payment      string
+		enabled      bool
+		coverage     float64
+		rampSchedule string
+	}
+
+	// queryAWSSPRows returns a map keyed by service slug for every
+	// `(aws, savings-plans*)` and `(aws, sagemaker)` row in
+	// service_configs. Lets the assertions be order-independent.
+	queryAWSSPRows := func(t *testing.T, pool *pgxpool.Pool) map[string]spRow {
+		t.Helper()
+		rows, err := pool.Query(ctx, `
+			SELECT service, term, payment, enabled, coverage, ramp_schedule
+			FROM service_configs
+			WHERE provider = 'aws'
+			AND (service LIKE 'savings-plans%' OR service IN ('savingsplans', 'sagemaker'))`)
+		require.NoError(t, err)
+		defer rows.Close()
+		out := map[string]spRow{}
+		for rows.Next() {
+			var r spRow
+			require.NoError(t, rows.Scan(&r.service, &r.term, &r.payment, &r.enabled, &r.coverage, &r.rampSchedule))
+			out[r.service] = r
+		}
+		require.NoError(t, rows.Err())
+		return out
+	}
+
+	t.Run("scenario 1: umbrella only", func(t *testing.T) {
+		container, err := testhelpers.SetupPostgresContainer(ctx, t)
+		require.NoError(t, err)
+		defer container.Cleanup(ctx)
+		pool := container.DB.Pool()
+
+		// Run migrations up to but not including 000040 by running all,
+		// then forcing the migration version back to 000039 and undoing
+		// 000040 — equivalent to "stop just before 000040". Simpler: run
+		// all migrations, then run down once to undo 000040, then
+		// truncate and seed.
+		require.NoError(t, migrations.RunMigrations(ctx, pool, migrationsPath, "", ""))
+		require.NoError(t, migrations.RollbackMigrations(ctx, pool, migrationsPath, 1))
+
+		// Seed: a single umbrella row with non-default values.
+		_, err = pool.Exec(ctx, `
+			INSERT INTO service_configs (provider, service, enabled, term, payment, coverage, ramp_schedule)
+			VALUES ('aws', 'savings-plans', true, 1, 'no-upfront', 90.50, 'weekly-25pct')`)
+		require.NoError(t, err)
+
+		// Up: run 000040.
+		require.NoError(t, migrations.RunMigrations(ctx, pool, migrationsPath, "", ""))
+
+		got := queryAWSSPRows(t, pool)
+		expected := []string{
+			"savings-plans-compute",
+			"savings-plans-ec2instance",
+			"savings-plans-sagemaker",
+			"savings-plans-database",
+		}
+		require.Len(t, got, 4, "expected 4 per-plan-type rows after up; umbrella should be deleted")
+		_, hasUmbrella := got["savings-plans"]
+		assert.False(t, hasUmbrella, "umbrella row should be deleted")
+		for _, slug := range expected {
+			r, ok := got[slug]
+			require.True(t, ok, "missing row %s", slug)
+			assert.Equal(t, 1, r.term)
+			assert.Equal(t, "no-upfront", r.payment)
+			assert.Equal(t, true, r.enabled)
+			assert.InDelta(t, 90.50, r.coverage, 0.001)
+			assert.Equal(t, "weekly-25pct", r.rampSchedule)
+		}
+
+		// Down: roll back 000040.
+		require.NoError(t, migrations.RollbackMigrations(ctx, pool, migrationsPath, 1))
+		got = queryAWSSPRows(t, pool)
+		require.Len(t, got, 1, "expected umbrella row restored after down")
+		r, ok := got["savings-plans"]
+		require.True(t, ok)
+		assert.Equal(t, 1, r.term)
+		assert.Equal(t, "no-upfront", r.payment)
+	})
+
+	t.Run("scenario 2: umbrella + PR #71 sagemaker row (different values)", func(t *testing.T) {
+		container, err := testhelpers.SetupPostgresContainer(ctx, t)
+		require.NoError(t, err)
+		defer container.Cleanup(ctx)
+		pool := container.DB.Pool()
+
+		require.NoError(t, migrations.RunMigrations(ctx, pool, migrationsPath, "", ""))
+		require.NoError(t, migrations.RollbackMigrations(ctx, pool, migrationsPath, 1))
+
+		// Seed both rows with intentionally divergent term/payment so
+		// we can verify which value wins per slot.
+		_, err = pool.Exec(ctx, `
+			INSERT INTO service_configs (provider, service, enabled, term, payment, coverage)
+			VALUES ('aws', 'savings-plans', true, 3, 'all-upfront', 80.00)`)
+		require.NoError(t, err)
+		_, err = pool.Exec(ctx, `
+			INSERT INTO service_configs (provider, service, enabled, term, payment, coverage)
+			VALUES ('aws', 'sagemaker', true, 1, 'partial-upfront', 75.00)`)
+		require.NoError(t, err)
+
+		require.NoError(t, migrations.RunMigrations(ctx, pool, migrationsPath, "", ""))
+
+		got := queryAWSSPRows(t, pool)
+		// Expect: 4 split rows + sagemaker (kept). Umbrella deleted.
+		require.Len(t, got, 5)
+		_, hasUmbrella := got["savings-plans"]
+		assert.False(t, hasUmbrella, "umbrella should be deleted")
+		_, hasSagemaker := got["sagemaker"]
+		assert.True(t, hasSagemaker, "PR #71 sagemaker row must be kept for one release")
+
+		// sagemaker slot inherits from PR #71's row (1, partial-upfront).
+		smRow := got["savings-plans-sagemaker"]
+		assert.Equal(t, 1, smRow.term, "sagemaker slot should inherit term from (aws, sagemaker)")
+		assert.Equal(t, "partial-upfront", smRow.payment, "sagemaker slot should inherit payment from (aws, sagemaker)")
+
+		// Other three slots inherit from the umbrella (3, all-upfront).
+		for _, slug := range []string{"savings-plans-compute", "savings-plans-ec2instance", "savings-plans-database"} {
+			r := got[slug]
+			assert.Equal(t, 3, r.term, "%s should inherit term from umbrella", slug)
+			assert.Equal(t, "all-upfront", r.payment, "%s should inherit payment from umbrella", slug)
+		}
+	})
+
+	t.Run("scenario 3: fresh install (no SP rows)", func(t *testing.T) {
+		container, err := testhelpers.SetupPostgresContainer(ctx, t)
+		require.NoError(t, err)
+		defer container.Cleanup(ctx)
+		pool := container.DB.Pool()
+
+		require.NoError(t, migrations.RunMigrations(ctx, pool, migrationsPath, "", ""))
+		require.NoError(t, migrations.RollbackMigrations(ctx, pool, migrationsPath, 1))
+
+		// Confirm no SP rows present pre-migration.
+		require.Empty(t, queryAWSSPRows(t, pool))
+
+		require.NoError(t, migrations.RunMigrations(ctx, pool, migrationsPath, "", ""))
+
+		// Migration is a no-op with no SP rows to seed from.
+		assert.Empty(t, queryAWSSPRows(t, pool), "no-op when no umbrella row exists")
+
+		// Down should also be a no-op.
+		require.NoError(t, migrations.RollbackMigrations(ctx, pool, migrationsPath, 1))
+		assert.Empty(t, queryAWSSPRows(t, pool))
+	})
+}
+
+// TestMigration_SplitSavingsPlans_PurchasePlansJSONB verifies the
+// purchase_plans.services JSONB key rewrite half of the migration. A
+// purchase plan with `aws:savings-plans` should fan out into four
+// `aws:savings-plans-<type>` keys carrying the same value, and the
+// source key should be removed. Plans without an SP entry should be
+// untouched.
+func TestMigration_SplitSavingsPlans_PurchasePlansJSONB(t *testing.T) {
+	ctx := context.Background()
+	migrationsPath := getMigrationsPath()
+
+	container, err := testhelpers.SetupPostgresContainer(ctx, t)
+	require.NoError(t, err)
+	defer container.Cleanup(ctx)
+	pool := container.DB.Pool()
+
+	require.NoError(t, migrations.RunMigrations(ctx, pool, migrationsPath, "", ""))
+	require.NoError(t, migrations.RollbackMigrations(ctx, pool, migrationsPath, 1))
+
+	// Seed two plans: one with the umbrella SP key, one with only RDS
+	// (untouched control). Both have a non-SP key (aws:rds) that must
+	// pass through unchanged.
+	_, err = pool.Exec(ctx, `
+		INSERT INTO purchase_plans (id, name, services) VALUES
+		('11111111-1111-1111-1111-111111111111', 'sp-plan',
+		 '{"aws:savings-plans": {"term": "1yr", "payment": "all-upfront"}, "aws:rds": {"term": "3yr"}}'::jsonb),
+		('22222222-2222-2222-2222-222222222222', 'rds-only-plan',
+		 '{"aws:rds": {"term": "1yr"}}'::jsonb)`)
+	require.NoError(t, err)
+
+	require.NoError(t, migrations.RunMigrations(ctx, pool, migrationsPath, "", ""))
+
+	// SP plan: services should now have four aws:savings-plans-<type>
+	// keys plus the untouched aws:rds; the umbrella key should be gone.
+	var spServices map[string]any
+	err = pool.QueryRow(ctx, `SELECT services FROM purchase_plans WHERE id = '11111111-1111-1111-1111-111111111111'`).Scan(&spServices)
+	require.NoError(t, err)
+	for _, k := range []string{
+		"aws:savings-plans-compute",
+		"aws:savings-plans-ec2instance",
+		"aws:savings-plans-sagemaker",
+		"aws:savings-plans-database",
+	} {
+		assert.Contains(t, spServices, k, "expected key %s after migration", k)
+	}
+	assert.NotContains(t, spServices, "aws:savings-plans", "umbrella key should be removed")
+	assert.Contains(t, spServices, "aws:rds", "non-SP key should pass through unchanged")
+
+	// Untouched control plan.
+	var rdsServices map[string]any
+	err = pool.QueryRow(ctx, `SELECT services FROM purchase_plans WHERE id = '22222222-2222-2222-2222-222222222222'`).Scan(&rdsServices)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{"aws:rds": map[string]any{"term": "1yr"}}, rdsServices)
+}

--- a/internal/purchase/execution.go
+++ b/internal/purchase/execution.go
@@ -368,6 +368,9 @@ func (m *Manager) executeSinglePurchase(ctx context.Context, rec config.Recommen
 
 // mapServiceType maps a service string to common.ServiceType
 func (m *Manager) mapServiceType(service string) common.ServiceType {
+	if svc, ok := mapSavingsPlansSlug(service); ok {
+		return svc
+	}
 	switch service {
 	case "ec2", "compute":
 		return common.ServiceEC2
@@ -381,11 +384,31 @@ func (m *Manager) mapServiceType(service string) common.ServiceType {
 		return common.ServiceRedshift
 	case "memorydb":
 		return common.ServiceMemoryDB
-	case "savings-plans", "savingsplans":
-		return common.ServiceSavingsPlans
 	default:
 		return common.ServiceType(service)
 	}
+}
+
+// mapSavingsPlansSlug normalises both the canonical hyphenated SP slugs and
+// the dash-free spellings the frontend has historically sent into the
+// matching common.ServiceType. The map covers the legacy umbrella plus the
+// four per-plan-type slugs in both spellings — pulled out of mapServiceType
+// to keep that switch under the gocyclo budget.
+func mapSavingsPlansSlug(service string) (common.ServiceType, bool) {
+	slugs := map[string]common.ServiceType{
+		"savings-plans":             common.ServiceSavingsPlans,
+		"savingsplans":              common.ServiceSavingsPlans,
+		"savings-plans-compute":     common.ServiceSavingsPlansCompute,
+		"savingsplans-compute":      common.ServiceSavingsPlansCompute,
+		"savings-plans-ec2instance": common.ServiceSavingsPlansEC2Instance,
+		"savingsplans-ec2instance":  common.ServiceSavingsPlansEC2Instance,
+		"savings-plans-sagemaker":   common.ServiceSavingsPlansSageMaker,
+		"savingsplans-sagemaker":    common.ServiceSavingsPlansSageMaker,
+		"savings-plans-database":    common.ServiceSavingsPlansDatabase,
+		"savingsplans-database":     common.ServiceSavingsPlansDatabase,
+	}
+	svc, ok := slugs[service]
+	return svc, ok
 }
 
 // updatePlanProgress advances the ramp schedule after a purchase

--- a/known-issues.md
+++ b/known-issues.md
@@ -208,6 +208,38 @@ outstanding so future work has a clear starting point.
   GCP provider is reported as successful even when this account fails,
   so the operator only sees the issue if they tail logs.
 
+- **Per-plan-type SP split: caveats exposed in plans/recommendations
+  views**: The migration to four per-plan-type Savings Plans cards
+  (Compute / EC2 Instance / SageMaker / Database) replaces the umbrella
+  `(aws, savings-plans)` ServiceConfig row with four per-plan-type
+  rows and rewrites `purchase_plans.services` JSONB keys atomically
+  (migration 000040). Two pre-existing UX limitations are now visible
+  with the split and are tracked here as follow-ups, not blockers:
+
+  - **Multi-SP purchase-plan summary shows only one plan type.**
+    `frontend/src/plans.ts:231` renders a plan summary by reading the
+    FIRST entry from `plan.services` (a JSONB-derived map). A purchase
+    plan that targets multiple SP plan types (e.g., Compute +
+    SageMaker) will list only one — whichever sorts first — in its
+    summary card. Pre-split this was hidden because the single
+    `aws:savings-plans` key always rendered as "Savings Plans"; post-
+    split the same plan now has four keys and only one displays. Fix
+    is plans.ts-only: render a comma-separated list or a count badge
+    when multiple SP plan types are present in the same plan. Out of
+    scope for the issue #22 follow-up PR.
+
+  - **Bulk-buy-from-Recommendations no longer sees "all SP types" rows.**
+    The bulk-buy modal in recommendations.ts groups recommendations by
+    `(provider, service)`. Pre-split, every SP recommendation shared
+    `service: "savings-plans"`, so a Compute SP rec and a SageMaker SP
+    rec landed in the same bucket and could be bought in one click.
+    Post-split, each plan type is its own service, so an operator who
+    used to bulk-buy SP must now bulk-buy four times (once per plan
+    type). Fix is a UI-side aggregator that groups by
+    `IsSavingsPlan(rec.service)` for the bulk-buy view only, leaving
+    the underlying service distinction intact for the per-card save
+    path. Out of scope for the issue #22 follow-up PR.
+
 - **OpenSearch RI tagging: best-effort, may be rejected by AWS**:
   Implemented in `providers/aws/services/opensearch/client.go`. The
   client now resolves the caller's AWS account ID via STS (cached on

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -46,8 +46,21 @@ const (
 	ServiceStorage ServiceType = "storage" // S3, Blob Storage, Cloud Storage
 
 	// Savings/Commitments
-	ServiceSavingsPlans ServiceType = "savings-plans" // AWS Savings Plans
-	ServiceCommitments  ServiceType = "commitments"   // Generic commitments
+	//
+	// ServiceSavingsPlans is the legacy umbrella slug and is being retired in
+	// favour of per-plan-type constants below. It remains defined so existing
+	// call sites continue to compile during the split; new code MUST use one
+	// of the four per-plan-type constants or the IsSavingsPlan helper.
+	ServiceSavingsPlans ServiceType = "savings-plans" // AWS Savings Plans (legacy umbrella)
+
+	// Per-plan-type Savings Plans slugs. Each maps 1:1 to an AWS
+	// types.SupportedSavingsPlansType so users can configure term/payment
+	// defaults independently per plan type.
+	ServiceSavingsPlansCompute     ServiceType = "savings-plans-compute"     // ComputeSp: EC2, Fargate, Lambda
+	ServiceSavingsPlansEC2Instance ServiceType = "savings-plans-ec2instance" // Ec2InstanceSp: specific EC2 families
+	ServiceSavingsPlansSageMaker   ServiceType = "savings-plans-sagemaker"   // SagemakerSp
+	ServiceSavingsPlansDatabase    ServiceType = "savings-plans-database"    // DatabaseSp: RDS
+	ServiceCommitments             ServiceType = "commitments"               // Generic commitments
 
 	// Other
 	ServiceOther ServiceType = "other" // Catch-all for unclassified services
@@ -68,6 +81,24 @@ const (
 // String returns the string representation of the service type
 func (s ServiceType) String() string {
 	return string(s)
+}
+
+// IsSavingsPlan reports whether s is any Savings Plans service slug —
+// the legacy umbrella (ServiceSavingsPlans), any of the four per-plan-type
+// constants, or the dash-free frontend spelling "savingsplans" that the API
+// handler stores verbatim without normalisation. Use it when code needs to
+// recognise the Savings Plans family irrespective of plan type (e.g., stats
+// aggregation, region-ignoring filters, display-name branching).
+func IsSavingsPlan(s ServiceType) bool {
+	switch s {
+	case ServiceSavingsPlans,
+		ServiceSavingsPlansCompute,
+		ServiceSavingsPlansEC2Instance,
+		ServiceSavingsPlansSageMaker,
+		ServiceSavingsPlansDatabase:
+		return true
+	}
+	return string(s) == "savingsplans"
 }
 
 // CommitmentType represents different commitment types across clouds

--- a/pkg/common/types_test.go
+++ b/pkg/common/types_test.go
@@ -40,6 +40,10 @@ func TestServiceType_String(t *testing.T) {
 		{ServiceDataWarehouse, "data-warehouse"},
 		{ServiceStorage, "storage"},
 		{ServiceSavingsPlans, "savings-plans"},
+		{ServiceSavingsPlansCompute, "savings-plans-compute"},
+		{ServiceSavingsPlansEC2Instance, "savings-plans-ec2instance"},
+		{ServiceSavingsPlansSageMaker, "savings-plans-sagemaker"},
+		{ServiceSavingsPlansDatabase, "savings-plans-database"},
 		{ServiceCommitments, "commitments"},
 		{ServiceOther, "other"},
 		{ServiceEC2, "ec2"},
@@ -55,6 +59,29 @@ func TestServiceType_String(t *testing.T) {
 		t.Run(string(tt.service), func(t *testing.T) {
 			t.Parallel()
 			assert.Equal(t, tt.expected, tt.service.String())
+		})
+	}
+}
+
+func TestIsSavingsPlan(t *testing.T) {
+	tests := []struct {
+		name    string
+		service ServiceType
+		want    bool
+	}{
+		{"legacy umbrella", ServiceSavingsPlans, true},
+		{"compute", ServiceSavingsPlansCompute, true},
+		{"ec2 instance", ServiceSavingsPlansEC2Instance, true},
+		{"sagemaker", ServiceSavingsPlansSageMaker, true},
+		{"database", ServiceSavingsPlansDatabase, true},
+		{"dash-free frontend spelling", ServiceType("savingsplans"), true},
+		{"unrelated service", ServiceRDS, false},
+		{"empty", ServiceType(""), false},
+		{"random string", ServiceType("savings"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsSavingsPlan(tt.service))
 		})
 	}
 }

--- a/providers/aws/provider.go
+++ b/providers/aws/provider.go
@@ -17,6 +17,7 @@ import (
 	"github.com/LeanerCloud/CUDly/pkg/common"
 	"github.com/LeanerCloud/CUDly/pkg/logging"
 	"github.com/LeanerCloud/CUDly/pkg/provider"
+	"github.com/LeanerCloud/CUDly/providers/aws/services/savingsplans"
 )
 
 // AWS SDK v2 credential source identifiers.
@@ -388,7 +389,9 @@ func (p *AWSProvider) GetDefaultRegion() string {
 	return "us-east-1"
 }
 
-// GetSupportedServices returns the list of services supported by AWS provider
+// GetSupportedServices returns the list of services supported by AWS provider.
+// Savings Plans are exposed as four distinct services (one per AWS plan type)
+// so users can configure term/payment defaults per plan type via ServiceConfig.
 func (p *AWSProvider) GetSupportedServices() []common.ServiceType {
 	return []common.ServiceType{
 		common.ServiceCompute,
@@ -396,7 +399,10 @@ func (p *AWSProvider) GetSupportedServices() []common.ServiceType {
 		common.ServiceCache,
 		common.ServiceSearch,
 		common.ServiceDataWarehouse,
-		common.ServiceSavingsPlans,
+		common.ServiceSavingsPlansCompute,
+		common.ServiceSavingsPlansEC2Instance,
+		common.ServiceSavingsPlansSageMaker,
+		common.ServiceSavingsPlansDatabase,
 		// Legacy service types for backward compatibility
 		common.ServiceEC2,
 		common.ServiceRDS,
@@ -430,8 +436,12 @@ func (p *AWSProvider) GetServiceClient(ctx context.Context, service common.Servi
 		return NewRedshiftClient(regionalCfg), nil
 	case common.ServiceMemoryDB:
 		return NewMemoryDBClient(regionalCfg), nil
-	case common.ServiceSavingsPlans:
-		return NewSavingsPlansClient(regionalCfg), nil
+	case common.ServiceSavingsPlansCompute,
+		common.ServiceSavingsPlansEC2Instance,
+		common.ServiceSavingsPlansSageMaker,
+		common.ServiceSavingsPlansDatabase:
+		pt, _ := savingsplans.PlanTypeForServiceType(service)
+		return NewSavingsPlansClient(regionalCfg, pt), nil
 	default:
 		return nil, fmt.Errorf("unsupported service: %s", service)
 	}

--- a/providers/aws/provider.go
+++ b/providers/aws/provider.go
@@ -403,6 +403,9 @@ func (p *AWSProvider) GetSupportedServices() []common.ServiceType {
 		common.ServiceSavingsPlansEC2Instance,
 		common.ServiceSavingsPlansSageMaker,
 		common.ServiceSavingsPlansDatabase,
+		// Legacy umbrella for backward compat with persisted records;
+		// see the GetServiceClient case below for rationale.
+		common.ServiceSavingsPlans,
 		// Legacy service types for backward compatibility
 		common.ServiceEC2,
 		common.ServiceRDS,
@@ -442,6 +445,17 @@ func (p *AWSProvider) GetServiceClient(ctx context.Context, service common.Servi
 		common.ServiceSavingsPlansDatabase:
 		pt, _ := savingsplans.PlanTypeForServiceType(service)
 		return NewSavingsPlansClient(regionalCfg, pt), nil
+	case common.ServiceSavingsPlans:
+		// Legacy umbrella path for any persisted RecommendationRecord
+		// (or scheduled purchase) still tagged with the pre-split slug.
+		// The constructor's empty plan type signals "umbrella mode" to
+		// the SP client: GetExistingCommitments returns every plan type
+		// unfiltered, and findOfferingID falls back to the
+		// recommendation's Details.PlanType (matching pre-split
+		// behaviour). New code paths use the four per-plan-type cases
+		// above; this case exists so legacy data doesn't 503 the
+		// purchase pipeline.
+		return NewSavingsPlansClient(regionalCfg, ""), nil
 	default:
 		return nil, fmt.Errorf("unsupported service: %s", service)
 	}

--- a/providers/aws/provider_test.go
+++ b/providers/aws/provider_test.go
@@ -211,6 +211,8 @@ func TestAWSProvider_GetSupportedServices(t *testing.T) {
 	assert.Contains(t, services, common.ServiceSavingsPlansEC2Instance)
 	assert.Contains(t, services, common.ServiceSavingsPlansSageMaker)
 	assert.Contains(t, services, common.ServiceSavingsPlansDatabase)
+	// Legacy umbrella SP slug for backward compat with persisted records.
+	assert.Contains(t, services, common.ServiceSavingsPlans)
 	// Legacy types
 	assert.Contains(t, services, common.ServiceEC2)
 	assert.Contains(t, services, common.ServiceRDS)
@@ -281,6 +283,10 @@ func TestAWSProvider_GetServiceClient_AllServiceTypes(t *testing.T) {
 		{common.ServiceSavingsPlansEC2Instance, common.ServiceSavingsPlansEC2Instance},
 		{common.ServiceSavingsPlansSageMaker, common.ServiceSavingsPlansSageMaker},
 		{common.ServiceSavingsPlansDatabase, common.ServiceSavingsPlansDatabase},
+		// Legacy umbrella: GetServiceClient returns an SP client with
+		// an empty plan-type filter (umbrella mode); GetServiceType
+		// reports the umbrella slug, matching pre-split behaviour.
+		{common.ServiceSavingsPlans, common.ServiceSavingsPlans},
 	}
 
 	for _, tc := range testCases {

--- a/providers/aws/provider_test.go
+++ b/providers/aws/provider_test.go
@@ -207,7 +207,10 @@ func TestAWSProvider_GetSupportedServices(t *testing.T) {
 	assert.Contains(t, services, common.ServiceCache)
 	assert.Contains(t, services, common.ServiceSearch)
 	assert.Contains(t, services, common.ServiceDataWarehouse)
-	assert.Contains(t, services, common.ServiceSavingsPlans)
+	assert.Contains(t, services, common.ServiceSavingsPlansCompute)
+	assert.Contains(t, services, common.ServiceSavingsPlansEC2Instance)
+	assert.Contains(t, services, common.ServiceSavingsPlansSageMaker)
+	assert.Contains(t, services, common.ServiceSavingsPlansDatabase)
 	// Legacy types
 	assert.Contains(t, services, common.ServiceEC2)
 	assert.Contains(t, services, common.ServiceRDS)
@@ -274,7 +277,10 @@ func TestAWSProvider_GetServiceClient_AllServiceTypes(t *testing.T) {
 		{common.ServiceDataWarehouse, common.ServiceDataWarehouse},
 		{common.ServiceRedshift, common.ServiceDataWarehouse},
 		{common.ServiceMemoryDB, common.ServiceCache},
-		{common.ServiceSavingsPlans, common.ServiceSavingsPlans},
+		{common.ServiceSavingsPlansCompute, common.ServiceSavingsPlansCompute},
+		{common.ServiceSavingsPlansEC2Instance, common.ServiceSavingsPlansEC2Instance},
+		{common.ServiceSavingsPlansSageMaker, common.ServiceSavingsPlansSageMaker},
+		{common.ServiceSavingsPlansDatabase, common.ServiceSavingsPlansDatabase},
 	}
 
 	for _, tc := range testCases {

--- a/providers/aws/recommendations/client.go
+++ b/providers/aws/recommendations/client.go
@@ -52,8 +52,12 @@ func NewClientWithAPI(api CostExplorerAPI, region string) *Client {
 
 // GetRecommendations fetches Reserved Instance recommendations for any service
 func (c *Client) GetRecommendations(ctx context.Context, params common.RecommendationParams) ([]common.Recommendation, error) {
-	// Handle Savings Plans separately as they use a different API
-	if params.Service == common.ServiceSavingsPlans {
+	// Handle Savings Plans separately — they use a different Cost Explorer API
+	// (GetSavingsPlansPurchaseRecommendation, not GetReservationPurchaseRecommendation).
+	// Match any SP slug — the legacy umbrella plus the four per-plan-type slugs —
+	// via the IsSavingsPlan family predicate so the dispatch keeps working as
+	// callers migrate.
+	if common.IsSavingsPlan(params.Service) {
 		return c.getSavingsPlansRecommendations(ctx, params)
 	}
 

--- a/providers/aws/recommendations/client_test.go
+++ b/providers/aws/recommendations/client_test.go
@@ -236,7 +236,9 @@ func TestGetRecommendations_SavingsPlans_Success(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Len(t, recs, 1)
-	assert.Equal(t, common.ServiceSavingsPlans, recs[0].Service)
+	// Recommendation is tagged with the per-plan-type slug, derived from the
+	// IncludeSPTypes filter (here: Compute → ServiceSavingsPlansCompute).
+	assert.Equal(t, common.ServiceSavingsPlansCompute, recs[0].Service)
 	assert.Equal(t, common.CommitmentSavingsPlan, recs[0].CommitmentType)
 	assert.Equal(t, 150.00, recs[0].EstimatedSavings)
 

--- a/providers/aws/recommendations/parser_sp.go
+++ b/providers/aws/recommendations/parser_sp.go
@@ -15,10 +15,19 @@ import (
 	"github.com/LeanerCloud/CUDly/pkg/common"
 )
 
-// getSavingsPlansRecommendations fetches Savings Plans recommendations
+// getSavingsPlansRecommendations fetches Savings Plans recommendations.
+//
+// Resolution order for which plan types to query, in order of precedence:
+//  1. params.Service is one of the four per-plan-type slugs
+//     (e.g. ServiceSavingsPlansSageMaker) — query just that plan type. This
+//     is the path the AWS provider's GetServiceClient dispatch takes after
+//     the per-plan-type split: each registered SP service makes its own
+//     Cost Explorer call with its own term/payment defaults.
+//  2. Otherwise, fall back to the legacy IncludeSPTypes/ExcludeSPTypes
+//     filter mechanism (for callers passing the umbrella ServiceSavingsPlans
+//     slug or for direct CLI invocations that haven't been migrated yet).
 func (c *Client) getSavingsPlansRecommendations(ctx context.Context, params common.RecommendationParams) ([]common.Recommendation, error) {
-	// Build list of plan types to query based on filters
-	planTypes := c.getFilteredPlanTypes(params.IncludeSPTypes, params.ExcludeSPTypes)
+	planTypes := planTypesForParams(params)
 
 	if len(planTypes) == 0 {
 		return []common.Recommendation{}, nil
@@ -126,7 +135,7 @@ func (c *Client) parseSavingsPlanDetail(
 
 	return &common.Recommendation{
 		Provider:          common.ProviderAWS,
-		Service:           common.ServiceSavingsPlans,
+		Service:           serviceSlugForPlanType(planType),
 		PaymentOption:     params.PaymentOption,
 		Term:              params.Term,
 		CommitmentType:    common.CommitmentSavingsPlan,
@@ -144,8 +153,57 @@ func (c *Client) parseSavingsPlanDetail(
 	}
 }
 
+// planTypesForParams resolves which AWS Cost Explorer plan types to query
+// for a given RecommendationParams. When params.Service is one of the four
+// per-plan-type slugs the result is a single-element slice for that type;
+// otherwise it falls back to the legacy IncludeSPTypes/ExcludeSPTypes filter.
+// See the getSavingsPlansRecommendations docstring for the full resolution
+// order.
+func planTypesForParams(params common.RecommendationParams) []types.SupportedSavingsPlansType {
+	if pt, ok := planTypeForServiceSlug(params.Service); ok {
+		return []types.SupportedSavingsPlansType{pt}
+	}
+	return getFilteredPlanTypes(params.IncludeSPTypes, params.ExcludeSPTypes)
+}
+
+// planTypeForServiceSlug maps a per-plan-type SP service slug to its
+// Cost Explorer plan-type enum. Returns false for non-SP slugs and for the
+// legacy umbrella ServiceSavingsPlans (which still triggers the iterate-all
+// fallback inside planTypesForParams).
+func planTypeForServiceSlug(s common.ServiceType) (types.SupportedSavingsPlansType, bool) {
+	switch s {
+	case common.ServiceSavingsPlansCompute:
+		return types.SupportedSavingsPlansTypeComputeSp, true
+	case common.ServiceSavingsPlansEC2Instance:
+		return types.SupportedSavingsPlansTypeEc2InstanceSp, true
+	case common.ServiceSavingsPlansSageMaker:
+		return types.SupportedSavingsPlansTypeSagemakerSp, true
+	case common.ServiceSavingsPlansDatabase:
+		return types.SupportedSavingsPlansTypeDatabaseSp, true
+	}
+	return "", false
+}
+
+// serviceSlugForPlanType is the inverse of planTypeForServiceSlug. Used by
+// parseSavingsPlanDetail to tag each Recommendation with the per-plan-type
+// slug rather than the legacy umbrella, so downstream stats/filters can
+// distinguish Compute SP from SageMaker SP recommendations.
+func serviceSlugForPlanType(pt types.SupportedSavingsPlansType) common.ServiceType {
+	switch pt {
+	case types.SupportedSavingsPlansTypeComputeSp:
+		return common.ServiceSavingsPlansCompute
+	case types.SupportedSavingsPlansTypeEc2InstanceSp:
+		return common.ServiceSavingsPlansEC2Instance
+	case types.SupportedSavingsPlansTypeSagemakerSp:
+		return common.ServiceSavingsPlansSageMaker
+	case types.SupportedSavingsPlansTypeDatabaseSp:
+		return common.ServiceSavingsPlansDatabase
+	}
+	return common.ServiceSavingsPlans
+}
+
 // getFilteredPlanTypes returns the list of Savings Plan types to query based on include/exclude filters
-func (c *Client) getFilteredPlanTypes(includeSPTypes, excludeSPTypes []string) []types.SupportedSavingsPlansType {
+func getFilteredPlanTypes(includeSPTypes, excludeSPTypes []string) []types.SupportedSavingsPlansType {
 	// All available plan types
 	allPlanTypes := map[string]types.SupportedSavingsPlansType{
 		"compute":     types.SupportedSavingsPlansTypeComputeSp,

--- a/providers/aws/recommendations/parser_sp.go
+++ b/providers/aws/recommendations/parser_sp.go
@@ -60,6 +60,16 @@ func (c *Client) getSavingsPlansRecommendations(ctx context.Context, params comm
 		}
 
 		if err != nil {
+			// When the caller scoped the request to one plan type
+			// (post-issue-#22 split), a Cost Explorer failure means an
+			// entire SP service collection returns nothing — silently
+			// dropping that as "0 recommendations" hides real outages.
+			// Propagate. The umbrella iterate-all path keeps logging
+			// and continuing so a transient failure on one plan type
+			// doesn't poison the others.
+			if len(planTypes) == 1 {
+				return nil, fmt.Errorf("failed to get %s recommendations: %w", planType, err)
+			}
 			fmt.Printf("Warning: Failed to get %s recommendations: %v\n", planType, err)
 			continue
 		}
@@ -202,14 +212,19 @@ func serviceSlugForPlanType(pt types.SupportedSavingsPlansType) common.ServiceTy
 	return common.ServiceSavingsPlans
 }
 
-// getFilteredPlanTypes returns the list of Savings Plan types to query based on include/exclude filters
+// getFilteredPlanTypes returns the list of Savings Plan types to query based
+// on include/exclude filters. Iterates a fixed-order slice rather than a map
+// so the returned order is deterministic — downstream "first plan type wins"
+// behaviour and test assertions can rely on it.
 func getFilteredPlanTypes(includeSPTypes, excludeSPTypes []string) []types.SupportedSavingsPlansType {
-	// All available plan types
-	allPlanTypes := map[string]types.SupportedSavingsPlansType{
-		"compute":     types.SupportedSavingsPlansTypeComputeSp,
-		"ec2instance": types.SupportedSavingsPlansTypeEc2InstanceSp,
-		"sagemaker":   types.SupportedSavingsPlansTypeSagemakerSp,
-		"database":    types.SupportedSavingsPlansTypeDatabaseSp,
+	allPlanTypes := []struct {
+		name string
+		typ  types.SupportedSavingsPlansType
+	}{
+		{"compute", types.SupportedSavingsPlansTypeComputeSp},
+		{"ec2instance", types.SupportedSavingsPlansTypeEc2InstanceSp},
+		{"sagemaker", types.SupportedSavingsPlansTypeSagemakerSp},
+		{"database", types.SupportedSavingsPlansTypeDatabaseSp},
 	}
 
 	// Normalize filter values to lowercase
@@ -228,16 +243,16 @@ func getFilteredPlanTypes(includeSPTypes, excludeSPTypes []string) []types.Suppo
 
 	// If include list is specified, only include those types
 	if len(includeMap) > 0 {
-		for name, planType := range allPlanTypes {
-			if includeMap[name] && !excludeMap[name] {
-				result = append(result, planType)
+		for _, item := range allPlanTypes {
+			if includeMap[item.name] && !excludeMap[item.name] {
+				result = append(result, item.typ)
 			}
 		}
 	} else {
 		// Include all types except those in the exclude list
-		for name, planType := range allPlanTypes {
-			if !excludeMap[name] {
-				result = append(result, planType)
+		for _, item := range allPlanTypes {
+			if !excludeMap[item.name] {
+				result = append(result, item.typ)
 			}
 		}
 	}

--- a/providers/aws/recommendations/parser_sp_additional_test.go
+++ b/providers/aws/recommendations/parser_sp_additional_test.go
@@ -40,7 +40,7 @@ func TestParseSavingsPlanDetail(t *testing.T) {
 			planType: types.SupportedSavingsPlansTypeComputeSp,
 			validate: func(t *testing.T, rec *common.Recommendation) {
 				assert.Equal(t, common.ProviderAWS, rec.Provider)
-				assert.Equal(t, common.ServiceSavingsPlans, rec.Service)
+				assert.Equal(t, common.ServiceSavingsPlansCompute, rec.Service)
 				assert.Equal(t, common.CommitmentSavingsPlan, rec.CommitmentType)
 				assert.Equal(t, "partial-upfront", rec.PaymentOption)
 				assert.Equal(t, "1yr", rec.Term)

--- a/providers/aws/recommendations/parser_sp_test.go
+++ b/providers/aws/recommendations/parser_sp_test.go
@@ -8,8 +8,6 @@ import (
 )
 
 func TestGetFilteredPlanTypes(t *testing.T) {
-	client := &Client{}
-
 	tests := []struct {
 		name           string
 		includeSPTypes []string
@@ -134,7 +132,7 @@ func TestGetFilteredPlanTypes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := client.getFilteredPlanTypes(tt.includeSPTypes, tt.excludeSPTypes)
+			result := getFilteredPlanTypes(tt.includeSPTypes, tt.excludeSPTypes)
 
 			assert.Len(t, result, tt.expectedLen)
 

--- a/providers/aws/service_client.go
+++ b/providers/aws/service_client.go
@@ -5,6 +5,7 @@ import (
 	"context"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	sptypes "github.com/aws/aws-sdk-go-v2/service/savingsplans/types"
 
 	"github.com/LeanerCloud/CUDly/pkg/common"
 	"github.com/LeanerCloud/CUDly/pkg/provider"
@@ -49,9 +50,12 @@ func NewMemoryDBClient(cfg aws.Config) provider.ServiceClient {
 	return memorydb.NewClient(cfg)
 }
 
-// NewSavingsPlansClient creates a new Savings Plans service client
-func NewSavingsPlansClient(cfg aws.Config) provider.ServiceClient {
-	return savingsplans.NewClient(cfg)
+// NewSavingsPlansClient creates a Savings Plans service client scoped to one
+// AWS plan type. The four per-plan-type slugs (Compute, EC2Instance,
+// SageMaker, Database) each get their own client instance via the AWS
+// provider's GetServiceClient dispatch — see provider.go.
+func NewSavingsPlansClient(cfg aws.Config, planType sptypes.SavingsPlanType) provider.ServiceClient {
+	return savingsplans.NewClient(cfg, planType)
 }
 
 // RecommendationsClientAdapter adapts the recommendations client to the provider interface

--- a/providers/aws/service_client_test.go
+++ b/providers/aws/service_client_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/costexplorer"
+	sptypes "github.com/aws/aws-sdk-go-v2/service/savingsplans/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -86,10 +87,23 @@ func TestNewMemoryDBClient(t *testing.T) {
 
 func TestNewSavingsPlansClient(t *testing.T) {
 	cfg := aws.Config{Region: "us-east-1"}
-	client := NewSavingsPlansClient(cfg)
-	require.NotNil(t, client)
-	assert.Equal(t, common.ServiceSavingsPlans, client.GetServiceType())
-	assert.Equal(t, "us-east-1", client.GetRegion())
+	cases := []struct {
+		planType    sptypes.SavingsPlanType
+		wantService common.ServiceType
+	}{
+		{sptypes.SavingsPlanTypeCompute, common.ServiceSavingsPlansCompute},
+		{sptypes.SavingsPlanTypeEc2Instance, common.ServiceSavingsPlansEC2Instance},
+		{sptypes.SavingsPlanTypeSagemaker, common.ServiceSavingsPlansSageMaker},
+		{sptypes.SavingsPlanTypeDatabase, common.ServiceSavingsPlansDatabase},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.planType), func(t *testing.T) {
+			client := NewSavingsPlansClient(cfg, tc.planType)
+			require.NotNil(t, client)
+			assert.Equal(t, tc.wantService, client.GetServiceType())
+			assert.Equal(t, "us-east-1", client.GetRegion())
+		})
+	}
 }
 
 func TestNewRecommendationsClient(t *testing.T) {

--- a/providers/aws/services/savingsplans/client.go
+++ b/providers/aws/services/savingsplans/client.go
@@ -22,17 +22,26 @@ type SavingsPlansAPI interface {
 	DescribeSavingsPlansOfferingRates(ctx context.Context, params *savingsplans.DescribeSavingsPlansOfferingRatesInput, optFns ...func(*savingsplans.Options)) (*savingsplans.DescribeSavingsPlansOfferingRatesOutput, error)
 }
 
-// Client handles AWS Savings Plans
+// Client handles AWS Savings Plans, scoped to one plan type. Each plan type
+// (Compute, EC2Instance, SageMaker, Database) has its own term/payment defaults
+// in ServiceConfig, so the client is constructed once per plan type and tags
+// the recommendations and existing commitments it returns with the matching
+// per-plan-type ServiceType slug.
 type Client struct {
-	client SavingsPlansAPI
-	region string
+	client   SavingsPlansAPI
+	region   string
+	planType types.SavingsPlanType
 }
 
-// NewClient creates a new Savings Plans client
-func NewClient(cfg aws.Config) *Client {
+// NewClient creates a new Savings Plans client scoped to one plan type.
+// The plan type determines which slug GetServiceType returns and which
+// commitments GetExistingCommitments includes — both critical for the
+// per-plan-type ServiceConfig dispatch added in the AWS provider.
+func NewClient(cfg aws.Config, planType types.SavingsPlanType) *Client {
 	return &Client{
-		client: savingsplans.NewFromConfig(cfg),
-		region: cfg.Region,
+		client:   savingsplans.NewFromConfig(cfg),
+		region:   cfg.Region,
+		planType: planType,
 	}
 }
 
@@ -41,9 +50,46 @@ func (c *Client) SetSavingsPlansAPI(api SavingsPlansAPI) {
 	c.client = api
 }
 
-// GetServiceType returns the service type
+// GetServiceType returns the per-plan-type service slug (e.g.
+// ServiceSavingsPlansCompute for a client constructed with
+// SavingsPlanTypeCompute). Falls back to the legacy umbrella constant if the
+// plan type is unrecognised — that branch should be unreachable in practice.
 func (c *Client) GetServiceType() common.ServiceType {
+	return ServiceTypeForPlanType(c.planType)
+}
+
+// ServiceTypeForPlanType maps an AWS Savings Plans API plan type to the
+// matching common.ServiceType slug. Exported so the AWS provider's
+// GetServiceClient dispatch can derive the slug for each registered service.
+func ServiceTypeForPlanType(pt types.SavingsPlanType) common.ServiceType {
+	switch pt {
+	case types.SavingsPlanTypeCompute:
+		return common.ServiceSavingsPlansCompute
+	case types.SavingsPlanTypeEc2Instance:
+		return common.ServiceSavingsPlansEC2Instance
+	case types.SavingsPlanTypeSagemaker:
+		return common.ServiceSavingsPlansSageMaker
+	case types.SavingsPlanTypeDatabase:
+		return common.ServiceSavingsPlansDatabase
+	}
 	return common.ServiceSavingsPlans
+}
+
+// PlanTypeForServiceType is the inverse mapping: a common.ServiceType slug to
+// the AWS Savings Plans API plan type. Returns false for slugs that aren't
+// per-plan-type SP services.
+func PlanTypeForServiceType(s common.ServiceType) (types.SavingsPlanType, bool) {
+	switch s {
+	case common.ServiceSavingsPlansCompute:
+		return types.SavingsPlanTypeCompute, true
+	case common.ServiceSavingsPlansEC2Instance:
+		return types.SavingsPlanTypeEc2Instance, true
+	case common.ServiceSavingsPlansSageMaker:
+		return types.SavingsPlanTypeSagemaker, true
+	case common.ServiceSavingsPlansDatabase:
+		return types.SavingsPlanTypeDatabase, true
+	}
+	return "", false
 }
 
 // GetRegion returns the region
@@ -71,10 +117,18 @@ func (c *Client) GetExistingCommitments(ctx context.Context) ([]common.Commitmen
 		return nil, fmt.Errorf("failed to describe Savings Plans: %w", err)
 	}
 
+	// Each client is scoped to one plan type, so partition the API result by
+	// SavingsPlanType and only return commitments matching this client's type.
+	// The provider registers four SP services and calls GetExistingCommitments
+	// on each; without filtering, every SP commitment would surface four times.
 	commitments := make([]common.Commitment, 0, len(result.SavingsPlans))
+	service := c.GetServiceType()
 
 	for _, sp := range result.SavingsPlans {
 		if sp.SavingsPlanId == nil {
+			continue
+		}
+		if sp.SavingsPlanType != c.planType {
 			continue
 		}
 
@@ -82,7 +136,7 @@ func (c *Client) GetExistingCommitments(ctx context.Context) ([]common.Commitmen
 			Provider:       common.ProviderAWS,
 			CommitmentID:   *sp.SavingsPlanId,
 			CommitmentType: common.CommitmentSavingsPlan,
-			Service:        common.ServiceSavingsPlans,
+			Service:        service,
 			Region:         aws.ToString(sp.Region),
 			ResourceType:   string(sp.SavingsPlanType),
 			Count:          1, // Savings Plans don't have a count

--- a/providers/aws/services/savingsplans/client.go
+++ b/providers/aws/services/savingsplans/client.go
@@ -121,6 +121,11 @@ func (c *Client) GetExistingCommitments(ctx context.Context) ([]common.Commitmen
 	// SavingsPlanType and only return commitments matching this client's type.
 	// The provider registers four SP services and calls GetExistingCommitments
 	// on each; without filtering, every SP commitment would surface four times.
+	//
+	// An empty planType signals legacy umbrella mode (the
+	// `case common.ServiceSavingsPlans` branch in provider.go's
+	// GetServiceClient): in that mode, return every commitment unfiltered
+	// to match pre-split behaviour. Per-plan-type clients still partition.
 	commitments := make([]common.Commitment, 0, len(result.SavingsPlans))
 	service := c.GetServiceType()
 
@@ -128,7 +133,7 @@ func (c *Client) GetExistingCommitments(ctx context.Context) ([]common.Commitmen
 		if sp.SavingsPlanId == nil {
 			continue
 		}
-		if sp.SavingsPlanType != c.planType {
+		if c.planType != "" && sp.SavingsPlanType != c.planType {
 			continue
 		}
 
@@ -213,9 +218,25 @@ func (c *Client) findOfferingID(ctx context.Context, rec common.Recommendation) 
 		return "", fmt.Errorf("invalid service details for Savings Plans")
 	}
 
-	planType, err := convertPlanType(spDetails.PlanType)
-	if err != nil {
-		return "", err
+	// Per-plan-type client (post-split): the client's planType is the
+	// source of truth. Reject mismatched recommendations rather than
+	// silently buying the wrong product. Umbrella legacy clients
+	// (c.planType == "") fall back to rec.Details.PlanType to preserve
+	// pre-split behaviour.
+	planType, convErr := convertPlanType(spDetails.PlanType)
+	if c.planType != "" {
+		if convErr != nil {
+			return "", convErr
+		}
+		if planType != c.planType {
+			return "", fmt.Errorf(
+				"recommendation plan type %q does not match client scope %q",
+				spDetails.PlanType, c.planType,
+			)
+		}
+		planType = c.planType
+	} else if convErr != nil {
+		return "", convErr
 	}
 
 	termSeconds := convertTermToSeconds(rec.Term)

--- a/providers/aws/services/savingsplans/client_test.go
+++ b/providers/aws/services/savingsplans/client_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/savingsplans/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 // MockSavingsPlansClient implements SavingsPlansAPI for testing
@@ -215,6 +216,80 @@ func TestClient_GetExistingCommitments(t *testing.T) {
 			mockClient.AssertExpectations(t)
 		})
 	}
+}
+
+// TestClient_GetExistingCommitments_UmbrellaMode verifies that an SP client
+// constructed with an empty plan type (legacy umbrella mode, used by the
+// AWS provider's `case common.ServiceSavingsPlans` branch in GetServiceClient)
+// returns every commitment unfiltered — matching pre-issue-#22-split
+// behaviour for any persisted RecommendationRecord still tagged with the
+// umbrella slug.
+func TestClient_GetExistingCommitments_UmbrellaMode(t *testing.T) {
+	mockClient := &MockSavingsPlansClient{}
+	mockClient.On("DescribeSavingsPlans", mock.Anything, mock.Anything).
+		Return(&savingsplans.DescribeSavingsPlansOutput{
+			SavingsPlans: []types.SavingsPlan{
+				{
+					SavingsPlanId:   aws.String("sp-compute"),
+					SavingsPlanType: types.SavingsPlanTypeCompute,
+					State:           types.SavingsPlanStateActive,
+				},
+				{
+					SavingsPlanId:   aws.String("sp-sagemaker"),
+					SavingsPlanType: types.SavingsPlanTypeSagemaker,
+					State:           types.SavingsPlanStateActive,
+				},
+				{
+					SavingsPlanId:   aws.String("sp-database"),
+					SavingsPlanType: types.SavingsPlanTypeDatabase,
+					State:           types.SavingsPlanStateActive,
+				},
+			},
+		}, nil).Once()
+
+	// planType is the zero value — umbrella mode.
+	client := &Client{client: mockClient, region: "us-east-1"}
+
+	result, err := client.GetExistingCommitments(context.Background())
+	assert.NoError(t, err)
+	// All three commitments returned because filtering is skipped.
+	assert.Len(t, result, 3)
+	mockClient.AssertExpectations(t)
+}
+
+// TestClient_findOfferingID_RejectsMismatchedPlanType pins the
+// per-plan-type isolation post-split: a client scoped to one plan type
+// must refuse to look up an offering for a different plan type, even if
+// the recommendation's Details say otherwise. This protects against
+// upstream bugs that pass mismatched recommendations into the wrong
+// service client.
+func TestClient_findOfferingID_RejectsMismatchedPlanType(t *testing.T) {
+	mockSP := &MockSavingsPlansClient{}
+	// Client scoped to Compute SP.
+	client := &Client{
+		client:   mockSP,
+		region:   "us-east-1",
+		planType: types.SavingsPlanTypeCompute,
+	}
+
+	// Recommendation claims to be a SageMaker SP (mismatch).
+	rec := common.Recommendation{
+		Service:       common.ServiceSavingsPlansSageMaker,
+		ResourceType:  "SageMaker",
+		PaymentOption: "all-upfront",
+		Term:          "1yr",
+		Details: &common.SavingsPlanDetails{
+			PlanType:         "SageMaker",
+			HourlyCommitment: 10.0,
+		},
+	}
+
+	_, err := client.findOfferingID(context.Background(), rec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not match client scope")
+	// AWS API must not be called — the mismatch should be caught
+	// client-side before any DescribeSavingsPlansOfferings request.
+	mockSP.AssertNotCalled(t, "DescribeSavingsPlansOfferings")
 }
 
 func TestClient_GetValidResourceTypes(t *testing.T) {

--- a/providers/aws/services/savingsplans/client_test.go
+++ b/providers/aws/services/savingsplans/client_test.go
@@ -56,16 +56,30 @@ func TestNewClient(t *testing.T) {
 		Region: "us-east-1",
 	}
 
-	client := NewClient(cfg)
+	client := NewClient(cfg, types.SavingsPlanTypeCompute)
 
 	assert.NotNil(t, client)
 	assert.NotNil(t, client.client)
 	assert.Equal(t, "us-east-1", client.region)
+	assert.Equal(t, types.SavingsPlanTypeCompute, client.planType)
 }
 
 func TestClient_GetServiceType(t *testing.T) {
-	client := &Client{region: "us-east-1"}
-	assert.Equal(t, common.ServiceSavingsPlans, client.GetServiceType())
+	cases := []struct {
+		planType    types.SavingsPlanType
+		wantService common.ServiceType
+	}{
+		{types.SavingsPlanTypeCompute, common.ServiceSavingsPlansCompute},
+		{types.SavingsPlanTypeEc2Instance, common.ServiceSavingsPlansEC2Instance},
+		{types.SavingsPlanTypeSagemaker, common.ServiceSavingsPlansSageMaker},
+		{types.SavingsPlanTypeDatabase, common.ServiceSavingsPlansDatabase},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.planType), func(t *testing.T) {
+			client := &Client{region: "us-east-1", planType: tc.planType}
+			assert.Equal(t, tc.wantService, client.GetServiceType())
+		})
+	}
 }
 
 func TestClient_GetRegion(t *testing.T) {
@@ -86,12 +100,17 @@ func TestClient_GetExistingCommitments(t *testing.T) {
 
 	tests := []struct {
 		name        string
+		clientType  types.SavingsPlanType
 		setupMocks  func(*MockSavingsPlansClient)
 		expectedLen int
 		expectError bool
 	}{
 		{
-			name: "successful retrieval with active plans",
+			// DescribeSavingsPlans returns commitments of every plan type at
+			// once; this Compute-scoped client must filter the EC2Instance row
+			// out of the two-plan fixture.
+			name:       "filters non-matching plan types",
+			clientType: types.SavingsPlanTypeCompute,
 			setupMocks: func(m *MockSavingsPlansClient) {
 				m.On("DescribeSavingsPlans", mock.Anything, mock.Anything).
 					Return(&savingsplans.DescribeSavingsPlansOutput{
@@ -115,11 +134,12 @@ func TestClient_GetExistingCommitments(t *testing.T) {
 						},
 					}, nil).Once()
 			},
-			expectedLen: 2,
+			expectedLen: 1,
 			expectError: false,
 		},
 		{
-			name: "skips plans without ID",
+			name:       "skips plans without ID",
+			clientType: types.SavingsPlanTypeCompute,
 			setupMocks: func(m *MockSavingsPlansClient) {
 				m.On("DescribeSavingsPlans", mock.Anything, mock.Anything).
 					Return(&savingsplans.DescribeSavingsPlansOutput{
@@ -131,7 +151,7 @@ func TestClient_GetExistingCommitments(t *testing.T) {
 							},
 							{
 								// No SavingsPlanId - should be skipped
-								SavingsPlanType: types.SavingsPlanTypeEc2Instance,
+								SavingsPlanType: types.SavingsPlanTypeCompute,
 								State:           types.SavingsPlanStateActive,
 							},
 						},
@@ -141,7 +161,8 @@ func TestClient_GetExistingCommitments(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "handles invalid date formats gracefully",
+			name:       "handles invalid date formats gracefully",
+			clientType: types.SavingsPlanTypeCompute,
 			setupMocks: func(m *MockSavingsPlansClient) {
 				m.On("DescribeSavingsPlans", mock.Anything, mock.Anything).
 					Return(&savingsplans.DescribeSavingsPlansOutput{
@@ -160,7 +181,8 @@ func TestClient_GetExistingCommitments(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "API error",
+			name:       "API error",
+			clientType: types.SavingsPlanTypeCompute,
 			setupMocks: func(m *MockSavingsPlansClient) {
 				m.On("DescribeSavingsPlans", mock.Anything, mock.Anything).
 					Return(nil, fmt.Errorf("API error")).Once()
@@ -176,8 +198,9 @@ func TestClient_GetExistingCommitments(t *testing.T) {
 			tt.setupMocks(mockClient)
 
 			client := &Client{
-				client: mockClient,
-				region: "us-east-1",
+				client:   mockClient,
+				region:   "us-east-1",
+				planType: tt.clientType,
 			}
 
 			result, err := client.GetExistingCommitments(context.Background())


### PR DESCRIPTION
## Summary

Closes #22.

Splits AWS Savings Plans into four per-plan-type services end to end so users can pin term/payment defaults independently per SP plan type (Compute, EC2 Instance, SageMaker, Database). Builds on the merged label clarification in PR #53 and the SageMaker card from PR #71 — those landed the user-visible scope of #22, but #22 stayed open because the underlying limitation (one shared term/payment for all four SP plan types) remained.

This PR completes the split:

- **Backend**: four new `common.ServiceType` constants (`savings-plans-{compute,ec2instance,sagemaker,database}`), four-way provider registration, per-plan-type `SavingsPlansClient` that filters `DescribeSavingsPlans` results so each service invocation returns only its plan type's commitments, `parser_sp.go` that resolves the AWS plan type from `params.Service`, and `cmd/main.go` accepting the four canonical and dash-free spellings while keeping the legacy `savingsplans` / `sp` / `savings-plans` aliases as fan-out shorthands so existing scripts and the smoke-test fixture keep working unchanged.
- **DB migration (000040)**: atomic split of the umbrella `(aws, savings-plans)` ServiceConfig row into four per-plan-type rows with verbatim copy of `enabled`/`coverage`/`ramp_schedule`/`include_*`/`exclude_*` columns; the SageMaker slot inherits term/payment from PR #71's `(aws, sagemaker)` row when present, falling back to the umbrella otherwise. The umbrella is deleted in the same transaction; PR #71's `(aws, sagemaker)` row is intentionally KEPT for one release behind a SQL deprecation comment so a user mid-rollout doesn't lose their save (a follow-up migration removes it). `purchase_plans.services` JSONB keys are rewritten in the same transaction: any `aws:savings-plans` (or dash-free `aws:savingsplans`) entry fans out into four `aws:savings-plans-<type>` entries carrying the same value object, with the source key removed.
- **Frontend**: replace the umbrella + PR #71 `sagemaker` cards with four per-plan-type cards in Settings → Purchasing. Each card has product-specific help text. Service-filter dropdowns on the Recommendations and Plan-creation tabs gain a "Savings Plans" `<optgroup>` with four per-plan-type values; the legacy `<option value="savingsplans">` is removed from those filters. `commitmentOptions.ts` doesn't add per-key entries — the existing `_default` AWS arm already accepts all 6 (term × payment) combos, locked in by 24 new test cases.

## Commits

- `24e9b3a5a refactor(common): add per-plan-type Savings Plans service constants`
- `da649085d refactor(aws): split Savings Plans into four per-plan-type services`
- `1bb2fe6ce feat(db): split umbrella savings-plans ServiceConfig row into four per-plan-type rows`
- `7b024ab56 feat(settings): four per-plan-type Savings Plans cards in Purchasing UI`
- `dee724305 docs: update smoke-test and known-issues for per-plan-type SP split`

## Known caveats (exposed, not caused, by the split)

These are pre-existing UX limitations that became visible because the per-plan-type split surfaces multiple SP plan types where there used to be one umbrella. Both are tracked in `known-issues.md` as follow-ups; neither blocks this PR.

- **Multi-SP purchase-plan summary shows only one plan type.** `frontend/src/plans.ts:231` reads the FIRST entry from `plan.services` for the summary card. A purchase plan that targets multiple SP plan types now lists only one — whichever sorts first. Fix is plans.ts-only (render comma-separated or count badge) and is OUT OF SCOPE here.
- **Bulk-buy-from-Recommendations no longer groups SP across plan types.** Operators who used the bulk-buy modal to grab "all SP recommendations" in one click must now bulk-buy four times. Fix is a UI-side aggregator that groups by `IsSavingsPlan(rec.service)` for the bulk-buy view only. OUT OF SCOPE.

**Database SP isn't generally available** — AWS Database SP exists in the Cost Explorer enum but isn't widely deployed for purchase. The card is exposed for forward-compat; help text on the card surfaces the caveat to end users.

**README CLI-flag-table updates** documenting the four new `--services` slugs are deferred to a follow-up — pre-existing markdownlint table-style errors block the hook on this PR.

## Deploy-order safety

`internal/server/app.go` runs migrations on Lambda startup BEFORE `reinitializeAfterConnect`, so the migrated DB is in place before the new backend binary serves any request. CloudFront's frontend flip happens last. There's no window where new frontend talks to a pre-migration DB or where old backend reads the new schema.

Existing scheduled purchases keep working unchanged because the legacy umbrella slug (`"savings-plans"` and the dash-free `"savingsplans"`) stays recognised by `IsSavingsPlan` and `mapServiceType` for backward compat with persisted `RecommendationRecord.Service` values.

## Test plan

- [x] `go build ./...` clean (root + `pkg/` + `providers/aws/`)
- [x] `go test ./...` green at root + `pkg/` (full suite)
- [x] `go test ./internal/api/...` covers the four new SP slugs against `serviceNameRegex`
- [x] `providers/aws/...` green except pre-existing env-dependent `TestAWSProvider_GetDefaultRegion` flake (caused by local `AWS_DEFAULT_REGION=ap-south-1`; unrelated to this PR)
- [x] Frontend `npm run build` clean
- [x] Frontend `npm test` — 1274/1274 pass across 35 suites (24 new `commitmentOptions._default` cases + 4 four-cards-present + 1 empty-state + Lambda-card guard kept)
- [ ] Migration round-trip: integration tests in `migrations/split_savingsplans_test.go` (build tag `integration`) drive three scenarios (umbrella-only, umbrella + PR #71 sagemaker, fresh install) plus the JSONB key rewrite. They require Docker for testcontainers-go; **runs in CI** but skipped locally where Docker is unavailable.
- [ ] Dev-server smoke: deferred to deployed preview per CLAUDE.md §4 (AWS Lambda deploys-on-merge; static `dist/index.html` confirms structure pre-deploy).





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Savings Plans now available as separate service types: Compute, EC2 Instance, SageMaker, and Database, enabling plan-type-specific configuration.
  * Legacy Savings Plans inputs remain supported for backward compatibility.

* **Database Migrations**
  * Migration 000040 splits existing Savings Plans configuration into per-plan-type variants with automatic schema and data transition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->