### PR TITLE
chore(settings): drop stale .account-overrides-panel cleanup selector

### DIFF
--- a/frontend/src/settings.ts
+++ b/frontend/src/settings.ts
@@ -275,10 +275,13 @@ function renderAccountsList(
   provider: AccountProvider,
   filter: AccountStatusFilter = 'all'
 ): void {
-  // Remove prior rendered rows (Overrides panels are sibling elements,
-  // banner lives in a separate className managed by renderSelfAccountBanner).
+  // Remove prior rendered rows (banner lives in a separate className
+  // managed by renderSelfAccountBanner). `.account-overrides-panel` used
+  // to be cleaned up here too — it was the inline expandable panel each
+  // account carried before #122/#124 moved overrides into a per-account
+  // modal. No such elements exist anymore.
   container.querySelectorAll(
-    '.accounts-table, .account-overrides-panel, .accounts-empty, .status-chip-row'
+    '.accounts-table, .accounts-empty, .status-chip-row'
   ).forEach(el => el.remove());
 
   if (!accounts || accounts.length === 0) {


### PR DESCRIPTION
Follow-up to #124. The renderAccountsList cleanup selector still listed the `.account-overrides-panel` class even though that element no longer exists post-rework. One-line dead-code removal.

Tests: full suite (1273) green; typecheck + build clean.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)