### PR TITLE
ux(history): swap default windows — Savings 90d, Purchase events 7d

### DIFF
--- a/frontend/src/__tests__/history.test.ts
+++ b/frontend/src/__tests__/history.test.ts
@@ -136,6 +136,51 @@ describe('History Module', () => {
 
       expect(console.error).toHaveBeenCalledWith('Failed to load plan history:', expect.any(Error));
     });
+
+    test('snaps From/To inputs to min/max purchase timestamps after fetch', async () => {
+      // Reproduces the scenario from PR #139's CodeRabbit nitpick: the
+      // plan-history endpoint returns the full history regardless of
+      // date range, so the inputs should reflect the rendered data, not
+      // the tab's generic 7-day default.
+      (api.getHistory as jest.Mock).mockResolvedValue({
+        summary: {},
+        purchases: [
+          { timestamp: '2025-12-15T10:00:00Z' },
+          { timestamp: '2026-02-04T10:00:00Z' },
+          { timestamp: '2026-01-20T10:00:00Z' },
+        ],
+      });
+
+      const startInput = document.getElementById('history-start') as HTMLInputElement;
+      const endInput = document.getElementById('history-end') as HTMLInputElement;
+      // Pre-seed with the tab default so we can prove the snap overwrites.
+      startInput.value = '2026-04-20';
+      endInput.value = '2026-04-27';
+
+      await viewPlanHistory('plan-123');
+
+      expect(startInput.value).toBe('2025-12-15');
+      expect(endInput.value).toBe('2026-02-04');
+    });
+
+    test('leaves From/To inputs untouched when the plan has no purchases', async () => {
+      // No data → no honest range to display. Clobbering the inputs with
+      // `today` would lie to the user; preserve whatever was there.
+      (api.getHistory as jest.Mock).mockResolvedValue({
+        summary: {},
+        purchases: [],
+      });
+
+      const startInput = document.getElementById('history-start') as HTMLInputElement;
+      const endInput = document.getElementById('history-end') as HTMLInputElement;
+      startInput.value = '2026-04-20';
+      endInput.value = '2026-04-27';
+
+      await viewPlanHistory('plan-123');
+
+      expect(startInput.value).toBe('2026-04-20');
+      expect(endInput.value).toBe('2026-04-27');
+    });
   });
 
   describe('loadHistory', () => {

--- a/frontend/src/__tests__/history.test.ts
+++ b/frontend/src/__tests__/history.test.ts
@@ -43,7 +43,7 @@ describe('History Module', () => {
   });
 
   describe('initHistoryDateRange', () => {
-    test('sets default date range to 3 months', () => {
+    test('sets default date range to 7 days', () => {
       initHistoryDateRange();
 
       const startInput = document.getElementById('history-start') as HTMLInputElement;
@@ -57,9 +57,12 @@ describe('History Module', () => {
       const todayUTC = today.toISOString().split('T')[0] || '';
       expect(endInput.value).toBe(todayUTC);
 
-      // Start date should be about 3 months ago (UTC)
+      // Start date should be 7 days ago (UTC). Purchase events are a log
+      // view — recent activity is what matters. Savings History (the trend
+      // view) defaults to 90 days separately via #savings-period in
+      // index.html.
       const expectedStart = new Date();
-      expectedStart.setMonth(expectedStart.getMonth() - 3);
+      expectedStart.setDate(expectedStart.getDate() - 7);
       const expectedStartUTC = expectedStart.toISOString().split('T')[0] || '';
       expect(startInput.value).toBe(expectedStartUTC);
     });

--- a/frontend/src/__tests__/savings-history.test.ts
+++ b/frontend/src/__tests__/savings-history.test.ts
@@ -35,9 +35,9 @@ describe('Savings History Module', () => {
     document.body.innerHTML = `
       <select id="savings-period">
         <option value="24h">Last 24 Hours</option>
-        <option value="7d" selected>Last 7 Days</option>
+        <option value="7d">Last 7 Days</option>
         <option value="30d">Last 30 Days</option>
-        <option value="90d">Last 90 Days</option>
+        <option value="90d" selected>Last 90 Days</option>
       </select>
       <button id="refresh-savings-btn">Refresh</button>
       <div id="savings-history-container">
@@ -56,11 +56,11 @@ describe('Savings History Module', () => {
   });
 
   describe('loadSavingsHistory', () => {
-    test('loads and renders savings data for default 7d period', async () => {
+    test('loads and renders savings data for default 90d period', async () => {
       const mockData = {
         start: '2024-01-01T00:00:00Z',
-        end: '2024-01-08T00:00:00Z',
-        interval: 'hourly',
+        end: '2024-04-01T00:00:00Z',
+        interval: 'daily',
         summary: {
           total_period_savings: 500,
           total_upfront_spent: 1000,
@@ -77,8 +77,10 @@ describe('Savings History Module', () => {
 
       await loadSavingsHistory();
 
+      // 90d is the new default (multi-month trend signal); switch case in
+      // savings-history.ts maps it to the 'daily' interval.
       expect(getSavingsAnalytics).toHaveBeenCalledWith(expect.objectContaining({
-        interval: 'hourly'
+        interval: 'daily'
       }));
       expect(Chart).toHaveBeenCalled();
     });

--- a/frontend/src/history.ts
+++ b/frontend/src/history.ts
@@ -74,12 +74,19 @@ export function setupHistoryHandlers(): void {
 }
 
 /**
- * Initialize history date range
+ * Initialize history date range.
+ *
+ * Defaults to a 7-day window because the Purchase events table is a *log*
+ * view — recent activity is what matters; older days are mostly empty and
+ * mostly noise. The Savings History card on the same page covers the
+ * complementary multi-month *trend* view (default 90 days, see
+ * `#savings-period` in index.html), so the two controls open to their
+ * own natural windows rather than fighting over one default.
  */
 export function initHistoryDateRange(): void {
   const end = new Date();
   const start = new Date();
-  start.setMonth(start.getMonth() - 3);
+  start.setDate(start.getDate() - 7);
 
   const startInput = document.getElementById('history-start') as HTMLInputElement | null;
   const endInput = document.getElementById('history-end') as HTMLInputElement | null;

--- a/frontend/src/history.ts
+++ b/frontend/src/history.ts
@@ -100,16 +100,30 @@ export function initHistoryDateRange(): void {
 }
 
 /**
- * View plan history
+ * View plan history.
+ *
+ * The plan-history endpoint returns the plan's *full* history regardless
+ * of date range — `api.getHistory({ planId })` ignores `start`/`end`.
+ * Don't seed the From/To inputs with the generic 7-day default here:
+ * they would visibly disagree with the table contents (the tab-level
+ * default would suggest the table only covers the last week, while in
+ * fact every purchase the plan ever recorded is shown). Instead, after
+ * the fetch lands, snap the inputs to the actual min/max purchase
+ * timestamps so the date pickers reflect what the user is looking at.
+ *
+ * If the plan has no purchases yet, leave the inputs untouched — there's
+ * no meaningful range to display, and clobbering them with `today`
+ * would be misleading.
  */
 export async function viewPlanHistory(planId: string): Promise<void> {
   switchTab('history');
-  initHistoryDateRange();
 
   try {
     const data = await api.getHistory({ planId }) as unknown as HistoryResponse;
     renderHistorySummary(data.summary || {});
-    renderHistoryList(data.purchases || []);
+    const purchases = data.purchases || [];
+    renderHistoryList(purchases);
+    snapDateInputsToPurchases(purchases);
   } catch (error) {
     console.error('Failed to load plan history:', error);
     const list = document.getElementById('history-list');
@@ -118,6 +132,26 @@ export async function viewPlanHistory(planId: string): Promise<void> {
       list.innerHTML = `<p class="error">Failed to load plan history: ${escapeHtml(err.message)}</p>`;
     }
   }
+}
+
+/**
+ * Set the From/To inputs to bracket the purchases that just rendered.
+ * No-op when the list is empty — keeping the previous values is more
+ * honest than seeding a fake "today" range. Timestamps are normalised
+ * to UTC YYYY-MM-DD so they slot directly into `<input type="date">`.
+ */
+function snapDateInputsToPurchases(purchases: HistoryPurchase[]): void {
+  if (purchases.length === 0) return;
+  const epochs = purchases
+    .map(p => Date.parse(p.timestamp))
+    .filter(n => !Number.isNaN(n));
+  if (epochs.length === 0) return;
+  const startInput = document.getElementById('history-start') as HTMLInputElement | null;
+  const endInput = document.getElementById('history-end') as HTMLInputElement | null;
+  const minDate = new Date(Math.min(...epochs)).toISOString().split('T')[0] || '';
+  const maxDate = new Date(Math.max(...epochs)).toISOString().split('T')[0] || '';
+  if (startInput) startInput.value = minDate;
+  if (endInput) endInput.value = maxDate;
 }
 
 /**

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -201,9 +201,9 @@
                             <label>Period:
                                 <select id="savings-period">
                                     <option value="24h">Last 24 Hours</option>
-                                    <option value="7d" selected>Last 7 Days</option>
+                                    <option value="7d">Last 7 Days</option>
                                     <option value="30d">Last 30 Days</option>
-                                    <option value="90d">Last 90 Days</option>
+                                    <option value="90d" selected>Last 90 Days</option>
                                 </select>
                             </label>
                             <button id="refresh-savings-btn" class="btn-small">Refresh</button>


### PR DESCRIPTION
## Summary

Refs #55. Replaces #75 (closed).

The History tab carries two date controls because they actually scope two semantically different views — keeping them separate is the right call; the original framing of #55 (which #75 implemented) collapsed both under one window that fit neither.

- **Savings History** — *trend* view over hourly/daily aggregates. Multi-month signal needed to see whether a plan is paying off.
- **Purchase events** — *log* view of individual events. Recent activity is what matters; older days are mostly empty.

The previous defaults had each opening to the *wrong* window — Savings to 7d (too short to see a trend, KPI cards looked flat) and Purchase events to 3 months (mostly empty rows). This PR swaps them so each opens to its own natural window:

- `#savings-period` `selected` flipped from `7d` → `90d` (`frontend/src/index.html`)
- `initHistoryDateRange` seeds 7 days instead of 3 months (`frontend/src/history.ts`)
- `getPeriodDates` fallback (unknown dropdown value) left at 7d/hourly — that's a safety net, not a user-facing default

## Test plan

- [x] `jest` — 1278/1278 pass (35 suites)
- [x] `tsc --noEmit` clean
- [x] `frontend/src/__tests__/history.test.ts` — `initHistoryDateRange` test now asserts a 7-day window
- [x] `frontend/src/__tests__/savings-history.test.ts` — DOM `selected` moved to `90d`, `default 90d period` test asserts `interval: 'daily'`
- [ ] Browser smoke after deploy: open `/history`, confirm Savings KPIs/chart open at 90d/daily, Purchase events table opens at 7d

## Notes

- `viewPlanHistory` (plan-specific deep-link) calls `initHistoryDateRange` but the API call there only sends `planId` (`api.getHistory({ planId })`), not the date range — so the input default is purely cosmetic for that path; no functional change.
- The doc comment in `history.ts` cross-references `#savings-period` in `index.html` so a reader landing on either side knows where the complementary default lives.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated fixtures and assertions to match new default date ranges and plan-history behaviors.

* **Chores**
  * Purchase history now defaults to a 7-day range.
  * Savings history now defaults to a 90-day period.
  * Plan-specific history view syncs the date inputs to the actual purchases shown (and preserves inputs when no purchases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->