### PR TITLE
fix(security/azure): switch Logic App scheduled tasks to user-assigned identities (unbreak Azure deploy)

### DIFF
--- a/terraform/modules/compute/azure/container-apps/scheduled-tasks.tf
+++ b/terraform/modules/compute/azure/container-apps/scheduled-tasks.tf
@@ -2,11 +2,12 @@
 # This is the Azure equivalent of AWS EventBridge + Lambda or GCP Cloud Scheduler + Cloud Run
 #
 # SECURITY: The shared scheduled-task secret is NEVER interpolated into the
-# workflow definition or Terraform state. Each Logic App workflow has a
-# system-assigned managed identity that holds "Key Vault Secrets User" on the
-# vault that stores `scheduled-task-secret`. At workflow runtime the first
-# action (`get-secret`) calls the Key Vault data-plane REST API authenticated
-# by the workflow's managed identity, and the call-endpoint action references
+# workflow definition or Terraform state. Each Logic App workflow is attached
+# to a per-workflow user-assigned managed identity (see the UA-identity
+# resources defined just below) that holds "Key Vault Secrets User" on the
+# vault storing `scheduled-task-secret`. At workflow runtime the first action
+# (`get-secret`) calls the Key Vault data-plane REST API authenticated by that
+# user-assigned identity, and the call-endpoint action references
 # `@body('get-secret')['value']` in the outgoing Authorization header.
 #
 # Effect: `terraform show` / `az logicapp show` only ever reveal the Key Vault
@@ -138,7 +139,7 @@ resource "azurerm_logic_app_trigger_recurrence" "daily" {
 }
 
 # Step 1: Fetch the shared secret from Key Vault using the workflow's
-# system-assigned managed identity. The secret value lives in the workflow
+# user-assigned managed identity. The secret value lives in the workflow
 # run's transient state only — never in the workflow definition or TF state.
 resource "azurerm_logic_app_action_custom" "recommendations_get_secret" {
   count = var.enable_scheduled_tasks ? 1 : 0

--- a/terraform/modules/compute/azure/container-apps/scheduled-tasks.tf
+++ b/terraform/modules/compute/azure/container-apps/scheduled-tasks.tf
@@ -58,6 +58,53 @@ resource "terraform_data" "scheduled_task_secret_preconditions" {
 }
 
 # ==============================================
+# User-assigned managed identities for the Logic App workflows
+# ==============================================
+#
+# We use user-assigned identities (one per workflow) instead of the
+# system-assigned identity originally introduced in #74 because azurerm's
+# `azurerm_logic_app_workflow` exposes the system-assigned `identity[0].
+# principal_id` attribute as null at plan time when the resource is being
+# created from scratch — Terraform's role-assignment validator then fails
+# with "principal_id is required, but no definition was found", blocking
+# every Azure deploy. UA identities are first-class resources whose
+# `principal_id` is populated at plan time, so the role assignment can
+# resolve cleanly. The same module already uses an UA identity for the
+# Container App itself (`azurerm_user_assigned_identity.container_app`),
+# so the pattern is consistent.
+#
+# Each workflow gets its own UA identity rather than sharing one so the
+# count gating on enable_scheduled_tasks vs enable_ri_exchange_schedule
+# stays per-workflow.
+
+resource "azurerm_user_assigned_identity" "recommendations" {
+  count = var.enable_scheduled_tasks ? 1 : 0
+
+  name                = "${var.app_name}-recommendations-uami"
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  tags                = var.tags
+}
+
+resource "azurerm_user_assigned_identity" "ri_exchange" {
+  count = var.enable_ri_exchange_schedule ? 1 : 0
+
+  name                = "${var.app_name}-ri-exchange-uami"
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  tags                = var.tags
+}
+
+resource "azurerm_user_assigned_identity" "cleanup" {
+  count = var.enable_scheduled_tasks ? 1 : 0
+
+  name                = "${var.app_name}-cleanup-uami"
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  tags                = var.tags
+}
+
+# ==============================================
 # Logic App workflow for recommendations refresh
 # ==============================================
 
@@ -68,10 +115,11 @@ resource "azurerm_logic_app_workflow" "recommendations" {
   location            = var.location
   resource_group_name = var.resource_group_name
 
-  # System-assigned managed identity used to read the shared secret from
-  # Key Vault at workflow runtime. See header comment.
+  # User-assigned managed identity used to read the shared secret from
+  # Key Vault at workflow runtime. See the UA-identity rationale block above.
   identity {
-    type = "SystemAssigned"
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.recommendations[0].id]
   }
 
   tags = var.tags
@@ -106,6 +154,12 @@ resource "azurerm_logic_app_action_custom" "recommendations_get_secret" {
       authentication = {
         type     = "ManagedServiceIdentity"
         audience = "https://vault.azure.net"
+        # Pin to the UA identity attached above. With multiple UA identities
+        # (we attach exactly one per workflow today, but the Logic Apps
+        # runtime can in principle accept multiple), the action MUST specify
+        # which to use; with system-assigned the runtime would default to
+        # the SA identity, but we don't have one anymore.
+        identity = azurerm_user_assigned_identity.recommendations[0].id
       }
     }
     runAfter = {}
@@ -185,7 +239,8 @@ resource "azurerm_logic_app_workflow" "ri_exchange" {
   resource_group_name = var.resource_group_name
 
   identity {
-    type = "SystemAssigned"
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.ri_exchange[0].id]
   }
 
   tags = var.tags
@@ -216,6 +271,7 @@ resource "azurerm_logic_app_action_custom" "ri_exchange_get_secret" {
       authentication = {
         type     = "ManagedServiceIdentity"
         audience = "https://vault.azure.net"
+        identity = azurerm_user_assigned_identity.ri_exchange[0].id
       }
     }
     runAfter = {}
@@ -277,7 +333,8 @@ resource "azurerm_logic_app_workflow" "cleanup" {
   resource_group_name = var.resource_group_name
 
   identity {
-    type = "SystemAssigned"
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.cleanup[0].id]
   }
 
   tags = var.tags
@@ -309,6 +366,7 @@ resource "azurerm_logic_app_action_custom" "cleanup_get_secret" {
       authentication = {
         type     = "ManagedServiceIdentity"
         audience = "https://vault.azure.net"
+        identity = azurerm_user_assigned_identity.cleanup[0].id
       }
     }
     runAfter = {}
@@ -376,7 +434,7 @@ resource "azurerm_role_assignment" "recommendations_kv_secrets_user" {
 
   scope                = var.key_vault_id
   role_definition_name = "Key Vault Secrets User"
-  principal_id         = azurerm_logic_app_workflow.recommendations[0].identity[0].principal_id
+  principal_id         = azurerm_user_assigned_identity.recommendations[0].principal_id
 }
 
 resource "azurerm_role_assignment" "ri_exchange_kv_secrets_user" {
@@ -384,7 +442,7 @@ resource "azurerm_role_assignment" "ri_exchange_kv_secrets_user" {
 
   scope                = var.key_vault_id
   role_definition_name = "Key Vault Secrets User"
-  principal_id         = azurerm_logic_app_workflow.ri_exchange[0].identity[0].principal_id
+  principal_id         = azurerm_user_assigned_identity.ri_exchange[0].principal_id
 }
 
 resource "azurerm_role_assignment" "cleanup_kv_secrets_user" {
@@ -392,5 +450,5 @@ resource "azurerm_role_assignment" "cleanup_kv_secrets_user" {
 
   scope                = var.key_vault_id
   role_definition_name = "Key Vault Secrets User"
-  principal_id         = azurerm_logic_app_workflow.cleanup[0].identity[0].principal_id
+  principal_id         = azurerm_user_assigned_identity.cleanup[0].principal_id
 }


### PR DESCRIPTION
## Summary

Every Azure deploy since #74 fails terraform plan with:

```
Error: Missing required argument
  with module.compute_container_apps[0].azurerm_role_assignment.recommendations_kv_secrets_user[0],
  on ../../modules/compute/azure/container-apps/scheduled-tasks.tf line 379, in resource "azurerm_role_assignment" "recommendations_kv_secrets_user":
 379:   principal_id = azurerm_logic_app_workflow.recommendations[0].identity[0].principal_id
The argument "principal_id" is required, but no definition was found.
```

…and the same for `cleanup_kv_secrets_user`. (`ri_exchange` doesn't fail because `enable_ri_exchange_schedule` is currently `false`, so its role assignment has count=0 and isn't planned.)

## Root cause

In azurerm 3.117.1, `azurerm_logic_app_workflow.<x>.identity[0].principal_id` evaluates to null at plan time when the resource is being created from scratch (no prior state). `azurerm_role_assignment.principal_id` is a required string the validator can't accept null for, so the plan fails before apply ever runs. There's no apply state for Terraform to learn the identity's principal_id from, so it never recovers.

## Fix

Switch the three Logic App workflows from system-assigned to **user-assigned** managed identities. UA identities are first-class `azurerm_user_assigned_identity` resources whose `.principal_id` attribute is populated at plan time, so the role assignment resolves cleanly. The same module already uses this pattern for the Container App's own RBAC (`azurerm_user_assigned_identity.container_app` at `main.tf:242`), so the codebase is now consistent.

Changes in `scheduled-tasks.tf`:

- **+3 `azurerm_user_assigned_identity` resources**: one per workflow (`recommendations`, `ri_exchange`, `cleanup`), gated on the same `enable_scheduled_tasks` / `enable_ri_exchange_schedule` flags as their workflows.
- **Each Logic App's identity block**: `type = "SystemAssigned"` → `type = "UserAssigned"` with `identity_ids = [azurerm_user_assigned_identity.<x>[0].id]`.
- **Each role assignment's `principal_id`**: reads `azurerm_user_assigned_identity.<x>[0].principal_id` directly — no more `identity[0]` chain.
- **Each `get-secret` action body JSON**: the `authentication` block gains `identity = <UA-resource-id>`. With UA identities the Logic Apps runtime needs to know which identity to use for the KV call (with SA there was exactly one, picked by default).

Variables, secret-name plumbing, and the precondition/validation block are unchanged. The change is contained to `scheduled-tasks.tf`.

## Test plan

- [x] `terraform validate` clean against `terraform/environments/azure`.
- [ ] Deploy run on merge — the actual repro that broke. Expect plan to succeed where it previously errored on `principal_id`.
- [ ] Post-deploy: trigger one Logic App workflow manually (via Azure portal "Run trigger") to confirm the get-secret action successfully fetches the KV secret using the UA identity. May 403 in the first 5–10 minutes if RBAC propagation lags — the existing `depends_on = [azurerm_role_assignment.<x>_kv_secrets_user]` on each get-secret action is preserved.

## Out of scope

- Re-doing #74's CodeRabbit nitpick about adding `depends_on` from the workflows themselves to the role assignments — already implemented at the `*_get_secret` level, which is the actual gate for runtime KV access.
- Sharing one UA identity across all three workflows. Per-workflow identities preserve the count-gating discipline (recommendations + cleanup share `enable_scheduled_tasks`; ri_exchange has its own flag) without complicating the role-assignment count expression.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security configuration for identity and authentication management across backend workflows to improve access control and credential handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->