### PR TITLE
ux(settings): default Registrations filter to Pending

### DIFF
--- a/frontend/src/__tests__/html.test.ts
+++ b/frontend/src/__tests__/html.test.ts
@@ -371,6 +371,40 @@ describe('HTML Structure', () => {
       expect(labels).toContain('Azure');
       expect(labels).toContain('GCP');
     });
+
+    // Refs #45 — admins land on the Accounts page primarily to action the
+    // pending registration queue, so the filter must default to "pending".
+    test('registrations status filter defaults to "pending"', () => {
+      const selector = document.getElementById('registrations-status-filter') as HTMLSelectElement | null;
+      expect(selector).toBeTruthy();
+      // value reflects the initial `selected` option in static HTML.
+      expect(selector?.value).toBe('pending');
+      const selected = selector?.querySelector('option[selected]') as HTMLOptionElement | null;
+      expect(selected?.value).toBe('pending');
+    });
+  });
+
+  describe('Accounts Section Layout', () => {
+    // Refs #45 — Account Registrations must render above all per-provider
+    // account tables so pending registrations across providers stay visible
+    // at the top of the Accounts page.
+    test('registrations fieldset precedes per-provider account fieldsets in DOM order', () => {
+      const registrations = document.getElementById('accounts-registrations');
+      const awsBlock = document.getElementById('accounts-aws-block');
+      const azureBlock = document.getElementById('accounts-azure-block');
+      const gcpBlock = document.getElementById('accounts-gcp-block');
+
+      expect(registrations).toBeTruthy();
+      expect(awsBlock).toBeTruthy();
+      expect(azureBlock).toBeTruthy();
+      expect(gcpBlock).toBeTruthy();
+
+      // DOCUMENT_POSITION_FOLLOWING (0x04) means the argument follows `node`.
+      const FOLLOWING = Node.DOCUMENT_POSITION_FOLLOWING;
+      expect(registrations!.compareDocumentPosition(awsBlock!) & FOLLOWING).toBeTruthy();
+      expect(registrations!.compareDocumentPosition(azureBlock!) & FOLLOWING).toBeTruthy();
+      expect(registrations!.compareDocumentPosition(gcpBlock!) & FOLLOWING).toBeTruthy();
+    });
   });
 
   describe('Security Headers', () => {

--- a/frontend/src/__tests__/registrations.test.ts
+++ b/frontend/src/__tests__/registrations.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Registrations module — default-filter behaviour (refs #45).
+ *
+ * The Account Registrations status dropdown defaults to "Pending" in
+ * index.html. `loadRegistrations` reads that select and forwards the value
+ * to the API, so on first paint the panel must request only pending rows.
+ */
+import { loadRegistrations } from '../modules/registrations';
+
+jest.mock('../api', () => ({
+  listRegistrations: jest.fn(),
+}));
+
+import * as api from '../api';
+
+describe('loadRegistrations default filter', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+    jest.clearAllMocks();
+  });
+
+  function buildDOM(initialFilterValue: string): void {
+    const container = document.createElement('div');
+    container.id = 'registrations-list';
+    document.body.appendChild(container);
+
+    const select = document.createElement('select');
+    select.id = 'registrations-status-filter';
+    for (const v of ['', 'pending', 'approved', 'rejected']) {
+      const opt = document.createElement('option');
+      opt.value = v;
+      // Mirror index.html: "pending" carries the `selected` attribute.
+      if (v === 'pending') opt.defaultSelected = true;
+      select.appendChild(opt);
+    }
+    select.value = initialFilterValue;
+    document.body.appendChild(select);
+  }
+
+  test('passes "pending" to listRegistrations on first load', async () => {
+    buildDOM('pending');
+    (api.listRegistrations as jest.Mock).mockResolvedValue([]);
+
+    await loadRegistrations();
+
+    expect(api.listRegistrations).toHaveBeenCalledTimes(1);
+    expect(api.listRegistrations).toHaveBeenCalledWith('pending');
+  });
+
+  test('passes undefined when the user picks "All" (empty value)', async () => {
+    buildDOM('');
+    (api.listRegistrations as jest.Mock).mockResolvedValue([]);
+
+    await loadRegistrations();
+
+    expect(api.listRegistrations).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -610,8 +610,8 @@
                         <div class="controls-bar">
                             <label>Status:
                                 <select id="registrations-status-filter">
-                                    <option value="" selected>All</option>
-                                    <option value="pending">Pending</option>
+                                    <option value="">All</option>
+                                    <option value="pending" selected>Pending</option>
                                     <option value="approved">Approved</option>
                                     <option value="rejected">Rejected</option>
                                 </select>

--- a/frontend/src/modules/registrations.ts
+++ b/frontend/src/modules/registrations.ts
@@ -186,8 +186,13 @@ export async function loadRegistrations(): Promise<void> {
   if (!container) return;
 
   const filterEl = document.getElementById('registrations-status-filter') as HTMLSelectElement | null;
-  // Empty value = "All" (default). Don't coerce to "pending" — that would hide
-  // approved/rejected registrations after the user approves them.
+  // The select's default `selected` option is "pending" (see index.html), so on
+  // first load `filterEl.value === 'pending'` and only pending registrations
+  // are fetched. This is intentional (refs #45): admins almost always come to
+  // this panel to action the pending queue, and surfacing approved/rejected
+  // rows by default added noise. Operators who need other states can pick
+  // them from the dropdown — picking "All" yields an empty string, which the
+  // `status || undefined` coercion below turns into "no status filter".
   const status = filterEl?.value ?? '';
 
   try {


### PR DESCRIPTION
## Summary

Default the Account Registrations status filter to **Pending** instead of **All**.

Admins land on the Accounts → Registrations panel almost exclusively to action the pending queue; surfacing approved/rejected rows by default added noise. The dropdown still exposes every other state (and "All") in one click, so this is a small UX nudge, not a removal of capability.

### What changed

- `frontend/src/index.html` — `<option value="pending" selected>` replaces `<option value="" selected>` on the registrations status filter.
- `frontend/src/modules/registrations.ts` — the filter-coercion comment is rewritten to explain the new design intent (see "Deliberate reversal" below). No JS logic change: `filterEl?.value ?? ''` already picks up whatever the select is set to, and `status || undefined` still maps "All" (empty string) to "no filter".
- Tests:
  - `frontend/src/__tests__/html.test.ts` — asserts the dropdown's initial selected value is `"pending"`, **and** asserts the Registrations fieldset precedes the AWS / Azure / GCP per-provider fieldsets in DOM order (regression guard so the section stays at the top of the Accounts page above all per-provider tables).
  - `frontend/src/__tests__/registrations.test.ts` (new) — asserts `loadRegistrations()` calls `api.listRegistrations('pending')` on first load, and `api.listRegistrations(undefined)` when the user picks "All".

### Placement verification

The Accounts page section order is preserved and verified in the new DOM-order test:

1. `accounts-overview` (status chips)
2. `accounts-federation` (Federation Setup — onboard a new account)
3. **`accounts-registrations`** ← the filter we're changing
4. `accounts-aws-block` / `accounts-azure-block` / `accounts-gcp-block`

Registrations stays above all per-provider tables, which is the invariant operators care about (pending registrations across providers visible at the top, not buried under any single provider's table).

### Deliberate reversal of prior reasoning

The previous comment in `modules/registrations.ts` argued **against** defaulting to "pending":

> Empty value = "All" (default). Don't coerce to "pending" — that would hide approved/rejected registrations after the user approves them.

That trade-off is being intentionally reversed by request: pending IS what operators care about by default, and the dropdown is a one-click escape hatch back to the wider view. The new comment documents this rationale inline so the next reader doesn't re-litigate it.

### Scope

This is a deliberately narrow first slice of #45. The full Registrations + per-provider unification (multi-PR plan referenced in #45's history) remains open as future work — this PR is `Refs #45`, **not** `Closes #45`.

## Test plan

- [x] `npx jest` — 1300 tests passing (37 suites)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — webpack production build succeeds
- [ ] Manual smoke after deploy: load Accounts tab as admin, confirm the Registrations status filter shows "Pending" selected on first paint and only pending rows render
- [ ] Manual smoke: change the filter to "All" and confirm approved/rejected rows reappear

Refs #45


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * The registrations status filter now defaults to "Pending" on initial page load instead of displaying all registrations.

* **Tests**
  * Added regression tests to validate filter initialization behavior and Accounts page layout structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->