### PR TITLE
chore(repo): gitignore the bin/ build output directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ cudly
 cmd/cmd
 cmd.test
 
+# Local build output directory (e.g. `bin/cudly-server` from `go build -o bin/...`)
+bin/
+
 # Go build artifacts
 *.exe
 *.exe~

--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,10 @@ cudly
 cmd/cmd
 cmd.test
 
-# Local build output directory (e.g. `bin/cudly-server` from `go build -o bin/...`)
-bin/
+# Local build output directory at repo root (e.g. `bin/cudly-server` from
+# `go build -o bin/...` in Makefile:45). Anchored with a leading slash so
+# nested bin/ directories elsewhere in the tree are not affected.
+/bin/
 
 # Go build artifacts
 *.exe


### PR DESCRIPTION
## Summary

Gitignore the `bin/` build output directory.

`Makefile:45` runs `go build -o bin/cudly-server ./cmd/server`, producing a 119MB executable in `bin/`. The existing `.gitignore` only covers individual binary names (`rds-ri-tool`, `ri-helper`, `cudly`, `cmd/cmd`, `cmd.test`) — the `bin/` directory itself was never covered, so a fresh `make` run shows the binary as untracked in `git status`.

One-line addition to `.gitignore`. No code or behaviour change.

## Test plan

- [x] `Makefile:45` confirmed to write into `bin/cudly-server` (no other source code lives under `bin/`).
- [x] `git status` after `make` no longer surfaces the binary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated gitignore to exclude locally built artifacts from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->