### PR TITLE
fix(terraform): rewrite dynamic-around-scalar in two orphan azurerm modules (closes #147)

### DIFF
--- a/terraform/modules/compute/azure/cleanup-function/main.tf
+++ b/terraform/modules/compute/azure/cleanup-function/main.tf
@@ -1,61 +1,3 @@
-variable "resource_group_name" {
-  description = "Name of the resource group"
-  type        = string
-}
-
-variable "location" {
-  description = "Azure region"
-  type        = string
-}
-
-variable "function_app_name" {
-  description = "Name of the Function App"
-  type        = string
-}
-
-variable "storage_account_name" {
-  description = "Name of the storage account for Function App"
-  type        = string
-}
-
-variable "image_uri" {
-  description = "Container image URI for the cleanup function"
-  type        = string
-}
-
-variable "db_host" {
-  description = "Database host (Azure Database for PostgreSQL FQDN)"
-  type        = string
-}
-
-variable "db_password_secret_uri" {
-  description = "Azure Key Vault secret URI containing the database password"
-  type        = string
-}
-
-variable "key_vault_id" {
-  description = "ID of the Key Vault containing secrets"
-  type        = string
-}
-
-variable "subnet_id" {
-  description = "Subnet ID for VNet integration"
-  type        = string
-  default     = ""
-}
-
-variable "schedule" {
-  description = "CRON schedule (NCRONTAB format)"
-  type        = string
-  default     = "0 2 * * *"
-}
-
-variable "tags" {
-  description = "Tags to apply to all resources"
-  type        = map(string)
-  default     = {}
-}
-
 # Storage account for Function App
 resource "azurerm_storage_account" "cleanup" {
   name                     = var.storage_account_name
@@ -119,13 +61,10 @@ resource "azurerm_linux_function_app" "cleanup" {
       }
     }
 
-    # VNet integration
-    dynamic "vnet_route_all_enabled" {
-      for_each = var.subnet_id != "" ? [1] : []
-      content {
-        vnet_route_all_enabled = true
-      }
-    }
+    # VNet integration: vnet_route_all_enabled is a scalar bool on
+    # site_config, so set it conditionally rather than wrapping in a
+    # dynamic block (which expects nested-block content).
+    vnet_route_all_enabled = var.subnet_id != ""
   }
 
   # App settings (environment variables)
@@ -150,13 +89,11 @@ resource "azurerm_linux_function_app" "cleanup" {
     identity_ids = [azurerm_user_assigned_identity.cleanup.id]
   }
 
-  # VNet integration
-  dynamic "virtual_network_subnet_id" {
-    for_each = var.subnet_id != "" ? [1] : []
-    content {
-      virtual_network_subnet_id = var.subnet_id
-    }
-  }
+  # VNet integration: virtual_network_subnet_id is a scalar string
+  # attribute on the function-app resource — null when no VNet is
+  # supplied, otherwise the configured subnet ID. The previous
+  # dynamic-around-scalar wrapper was rejected by Terraform.
+  virtual_network_subnet_id = var.subnet_id != "" ? var.subnet_id : null
 
   tags = var.tags
 }
@@ -200,25 +137,4 @@ resource "azurerm_logic_app_action_http" "cleanup" {
   body = jsonencode({
     dryRun = false
   })
-}
-
-# Outputs
-output "function_app_name" {
-  description = "Name of the Function App"
-  value       = azurerm_linux_function_app.cleanup.name
-}
-
-output "function_app_url" {
-  description = "Default hostname of the Function App"
-  value       = "https://${azurerm_linux_function_app.cleanup.default_hostname}"
-}
-
-output "identity_principal_id" {
-  description = "Principal ID of the managed identity"
-  value       = azurerm_user_assigned_identity.cleanup.principal_id
-}
-
-output "schedule" {
-  description = "Cleanup schedule"
-  value       = var.schedule
 }

--- a/terraform/modules/compute/azure/cleanup-function/outputs.tf
+++ b/terraform/modules/compute/azure/cleanup-function/outputs.tf
@@ -1,0 +1,19 @@
+output "function_app_name" {
+  description = "Name of the Function App"
+  value       = azurerm_linux_function_app.cleanup.name
+}
+
+output "function_app_url" {
+  description = "Default hostname of the Function App"
+  value       = "https://${azurerm_linux_function_app.cleanup.default_hostname}"
+}
+
+output "identity_principal_id" {
+  description = "Principal ID of the managed identity"
+  value       = azurerm_user_assigned_identity.cleanup.principal_id
+}
+
+output "schedule" {
+  description = "Cleanup schedule"
+  value       = var.schedule
+}

--- a/terraform/modules/compute/azure/cleanup-function/variables.tf
+++ b/terraform/modules/compute/azure/cleanup-function/variables.tf
@@ -1,0 +1,57 @@
+variable "resource_group_name" {
+  description = "Name of the resource group"
+  type        = string
+}
+
+variable "location" {
+  description = "Azure region"
+  type        = string
+}
+
+variable "function_app_name" {
+  description = "Name of the Function App"
+  type        = string
+}
+
+variable "storage_account_name" {
+  description = "Name of the storage account for Function App"
+  type        = string
+}
+
+variable "image_uri" {
+  description = "Container image URI for the cleanup function"
+  type        = string
+}
+
+variable "db_host" {
+  description = "Database host (Azure Database for PostgreSQL FQDN)"
+  type        = string
+}
+
+variable "db_password_secret_uri" {
+  description = "Azure Key Vault secret URI containing the database password"
+  type        = string
+}
+
+variable "key_vault_id" {
+  description = "ID of the Key Vault containing secrets"
+  type        = string
+}
+
+variable "subnet_id" {
+  description = "Subnet ID for VNet integration"
+  type        = string
+  default     = ""
+}
+
+variable "schedule" {
+  description = "CRON schedule (NCRONTAB format)"
+  type        = string
+  default     = "0 2 * * *"
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/compute/azure/cleanup-function/versions.tf
+++ b/terraform/modules/compute/azure/cleanup-function/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.10.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+  }
+}

--- a/terraform/modules/registry/azure/main.tf
+++ b/terraform/modules/registry/azure/main.tf
@@ -1,48 +1,3 @@
-variable "resource_group_name" {
-  description = "Name of the resource group"
-  type        = string
-}
-
-variable "location" {
-  description = "Azure region"
-  type        = string
-}
-
-variable "acr_name" {
-  description = "Name of the Azure Container Registry (must be globally unique)"
-  type        = string
-}
-
-variable "sku" {
-  description = "SKU for ACR (Basic, Standard, Premium)"
-  type        = string
-  default     = "Standard"
-}
-
-variable "keep_image_count" {
-  description = "Number of images to keep"
-  type        = number
-  default     = 10
-}
-
-variable "image_retention_days" {
-  description = "Days to retain images"
-  type        = number
-  default     = 30
-}
-
-variable "enable_admin_user" {
-  description = "Enable admin user (not recommended for production)"
-  type        = bool
-  default     = false
-}
-
-variable "tags" {
-  description = "Tags to apply to all resources"
-  type        = map(string)
-  default     = {}
-}
-
 # Azure Container Registry
 resource "azurerm_container_registry" "main" {
   name                = var.acr_name
@@ -51,30 +6,13 @@ resource "azurerm_container_registry" "main" {
   sku                 = var.sku
   admin_enabled       = var.enable_admin_user
 
-  # Enable vulnerability scanning (Premium SKU only)
-  dynamic "quarantine_policy_enabled" {
-    for_each = var.sku == "Premium" ? [1] : []
-    content {
-      enabled = true
-    }
-  }
-
-  # Retention policy (Premium SKU only)
-  dynamic "retention_policy" {
-    for_each = var.sku == "Premium" ? [1] : []
-    content {
-      days    = var.image_retention_days
-      enabled = true
-    }
-  }
-
-  # Trust policy (Premium SKU only)
-  dynamic "trust_policy" {
-    for_each = var.sku == "Premium" ? [1] : []
-    content {
-      enabled = true
-    }
-  }
+  # Premium-SKU policy attributes. In azurerm 4.x these are scalar
+  # attributes on the resource (the v3.x nested `retention_policy` /
+  # `trust_policy` blocks were removed). Set them conditionally on SKU
+  # — null leaves the provider default in place for non-Premium SKUs.
+  quarantine_policy_enabled = var.sku == "Premium"
+  trust_policy_enabled      = var.sku == "Premium"
+  retention_policy_in_days  = var.sku == "Premium" ? var.image_retention_days : null
 
   tags = var.tags
 }
@@ -119,38 +57,4 @@ resource "azurerm_role_assignment" "acr_pull" {
 
   # This will be provided by the container apps module
   count = var.container_app_identity_principal_id != "" ? 1 : 0
-}
-
-variable "container_app_identity_principal_id" {
-  description = "Principal ID of the container app managed identity"
-  type        = string
-  default     = ""
-}
-
-# Outputs
-output "registry_url" {
-  description = "Login server URL for the ACR"
-  value       = azurerm_container_registry.main.login_server
-}
-
-output "registry_id" {
-  description = "ID of the container registry"
-  value       = azurerm_container_registry.main.id
-}
-
-output "registry_name" {
-  description = "Name of the container registry"
-  value       = azurerm_container_registry.main.name
-}
-
-output "admin_username" {
-  description = "Admin username (only if admin_enabled is true)"
-  value       = var.enable_admin_user ? azurerm_container_registry.main.admin_username : null
-  sensitive   = true
-}
-
-output "admin_password" {
-  description = "Admin password (only if admin_enabled is true)"
-  value       = var.enable_admin_user ? azurerm_container_registry.main.admin_password : null
-  sensitive   = true
 }

--- a/terraform/modules/registry/azure/outputs.tf
+++ b/terraform/modules/registry/azure/outputs.tf
@@ -1,0 +1,26 @@
+output "registry_url" {
+  description = "Login server URL for the ACR"
+  value       = azurerm_container_registry.main.login_server
+}
+
+output "registry_id" {
+  description = "ID of the container registry"
+  value       = azurerm_container_registry.main.id
+}
+
+output "registry_name" {
+  description = "Name of the container registry"
+  value       = azurerm_container_registry.main.name
+}
+
+output "admin_username" {
+  description = "Admin username (only if admin_enabled is true)"
+  value       = var.enable_admin_user ? azurerm_container_registry.main.admin_username : null
+  sensitive   = true
+}
+
+output "admin_password" {
+  description = "Admin password (only if admin_enabled is true)"
+  value       = var.enable_admin_user ? azurerm_container_registry.main.admin_password : null
+  sensitive   = true
+}

--- a/terraform/modules/registry/azure/variables.tf
+++ b/terraform/modules/registry/azure/variables.tf
@@ -1,0 +1,50 @@
+variable "resource_group_name" {
+  description = "Name of the resource group"
+  type        = string
+}
+
+variable "location" {
+  description = "Azure region"
+  type        = string
+}
+
+variable "acr_name" {
+  description = "Name of the Azure Container Registry (must be globally unique)"
+  type        = string
+}
+
+variable "sku" {
+  description = "SKU for ACR (Basic, Standard, Premium)"
+  type        = string
+  default     = "Standard"
+}
+
+variable "keep_image_count" {
+  description = "Number of images to keep"
+  type        = number
+  default     = 10
+}
+
+variable "image_retention_days" {
+  description = "Days to retain images"
+  type        = number
+  default     = 30
+}
+
+variable "enable_admin_user" {
+  description = "Enable admin user (not recommended for production)"
+  type        = bool
+  default     = false
+}
+
+variable "container_app_identity_principal_id" {
+  description = "Principal ID of the container app managed identity"
+  type        = string
+  default     = ""
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/registry/azure/versions.tf
+++ b/terraform/modules/registry/azure/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.10.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes #147.

Two terraform modules were silently broken by `dynamic` blocks wrapped around scalar attributes — invalid HCL in any azurerm version. Both modules are unreferenced (no environment instantiates them) so the breakage went undetected until the new pre-commit CI gate in #105 ran `terraform_validate` against every module.

### `compute/azure/cleanup-function/`

- `vnet_route_all_enabled` is a scalar bool attribute on `site_config`, not a nested block. Replaced the `dynamic` wrapper with a plain conditional: `vnet_route_all_enabled = var.subnet_id != ""`.
- `virtual_network_subnet_id` is a scalar string attribute on the function-app resource. Replaced the `dynamic` wrapper with `var.subnet_id != "" ? var.subnet_id : null`.

### `registry/azure/`

- In azurerm 4.x (pinned at 4.61.0 via `.terraform.lock.hcl`) the nested `retention_policy` and `trust_policy` blocks were removed in favour of scalar attributes. Replaced all three `dynamic` blocks with the modern shape:
  ```
  quarantine_policy_enabled = var.sku == "Premium"
  trust_policy_enabled      = var.sku == "Premium"
  retention_policy_in_days  = var.sku == "Premium" ? var.image_retention_days : null
  ```

### Standard module structure

Both modules also got the `terraform_standard_module_structure` treatment that #105 applied to 5 other modules (commit `ff0a630fa`):
- `versions.tf` — pin `azurerm ~> 4.0` + `terraform >= 1.10.0`
- `variables.tf` — variables moved out of `main.tf`
- `outputs.tf` — outputs moved out of `main.tf`
- `main.tf` — resources only

Without this split, `terraform_tflint` flagged ~16 `terraform_standard_module_structure` warnings per module, blocking the pre-commit gate.

## Verification

- `terraform validate` passes cleanly for both modules under azurerm 4.61.0.
- Full pre-commit suite green (gofmt, gosec, trivy, tflint, terraform_fmt, terraform_validate).

## Follow-up

#105 (`fix/supply-chain`) added a `.pre-commit-config.yaml` exclusion pointing at this issue. Once both PRs land, the exclusion should be dropped — the `terraform_validate` hook will cover these modules under the standard sweep.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized infrastructure modules for improved maintainability and clarity
  * Updated Terraform version requirements and provider constraints
  * Simplified infrastructure configuration across Azure compute and registry modules

<!-- end of auto-generated comment: release notes by coderabbit.ai -->