### PR TITLE
fix(aws): GetDefaultRegion no longer leaks ambient AWS_REGION via IsConfigured (closes #96)

### DIFF
--- a/providers/aws/provider.go
+++ b/providers/aws/provider.go
@@ -378,10 +378,31 @@ func (p *AWSProvider) GetRegions(ctx context.Context) ([]common.Region, error) {
 	return regions, nil
 }
 
-// GetDefaultRegion returns the default AWS region
+// GetDefaultRegion returns the default AWS region.
+//
+// Priority order:
+//
+//  1. p.region if explicitly set on the provider.
+//  2. p.cfg.Region if the caller pre-populated cfg (e.g. tests with a
+//     synthetic config) — checked BEFORE IsConfigured to avoid the SDK's
+//     credentials/config chain overwriting a caller-supplied region with
+//     the ambient AWS_REGION / ~/.aws/config default.
+//  3. The SDK-loaded region (via IsConfigured → loadConfig).
+//  4. "us-east-1" as a last-resort default.
+//
+// Step 2 is what fixes #96: previously this function called
+// IsConfigured() unconditionally, which triggers cfgOnce.Do(loadConfig)
+// and lets the SDK's credentials/config chain populate p.cfg.Region from
+// the developer's ambient environment, masking a region the test had set
+// explicitly. Reading the already-set p.cfg.Region first keeps test
+// fixtures honest while still falling through to the SDK chain when no
+// caller has touched cfg.
 func (p *AWSProvider) GetDefaultRegion() string {
 	if p.region != "" {
 		return p.region
+	}
+	if p.cfg.Region != "" {
+		return p.cfg.Region
 	}
 	if p.IsConfigured() && p.cfg.Region != "" {
 		return p.cfg.Region

--- a/providers/aws/provider_test.go
+++ b/providers/aws/provider_test.go
@@ -158,6 +158,13 @@ func TestAWSProvider_DisplayName(t *testing.T) {
 }
 
 func TestAWSProvider_GetDefaultRegion(t *testing.T) {
+	// Isolate from ambient AWS env on the developer machine — without this,
+	// the SDK's credentials/config chain (loadConfig via IsConfigured) would
+	// overwrite p.cfg.Region with whatever the developer's ~/.aws/config or
+	// AWS_REGION env var says, masking the values these test cases set
+	// explicitly. See #96.
+	clearAWSAmbientEnv(t)
+
 	tests := []struct {
 		name           string
 		provider       *AWSProvider
@@ -195,6 +202,39 @@ func TestAWSProvider_GetDefaultRegion(t *testing.T) {
 			assert.Equal(t, tt.expectedRegion, tt.provider.GetDefaultRegion())
 		})
 	}
+}
+
+// TestAWSProvider_GetDefaultRegion_NoLeakViaIsConfigured is the regression
+// guard for #96: GetDefaultRegion must NOT trigger the SDK's
+// credentials/config chain when the caller has already populated
+// p.cfg.Region. This prevents ambient AWS_REGION / ~/.aws/config from
+// leaking in and silently overwriting test-supplied regions.
+//
+// We force a non-default ambient region and confirm GetDefaultRegion
+// returns the test-supplied region, not the ambient one.
+func TestAWSProvider_GetDefaultRegion_NoLeakViaIsConfigured(t *testing.T) {
+	t.Setenv("AWS_REGION", "ap-south-1")
+	t.Setenv("AWS_DEFAULT_REGION", "ap-south-1")
+	// Don't clear AWS_CONFIG_FILE here — the test still works if one exists,
+	// because our fix consults p.cfg.Region BEFORE IsConfigured.
+
+	p := &AWSProvider{
+		cfg: aws.Config{Region: "ap-southeast-1"},
+	}
+	got := p.GetDefaultRegion()
+	assert.Equal(t, "ap-southeast-1", got, "test-supplied cfg.Region must not be overwritten by ambient AWS_REGION")
+}
+
+// clearAWSAmbientEnv zeroes the ambient AWS env vars + redirects the
+// SDK's config/credentials file lookups to /dev/null, isolating tests
+// that exercise loadConfig from developer machine state.
+func clearAWSAmbientEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("AWS_REGION", "")
+	t.Setenv("AWS_DEFAULT_REGION", "")
+	t.Setenv("AWS_PROFILE", "")
+	t.Setenv("AWS_CONFIG_FILE", "/dev/null")
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", "/dev/null")
 }
 
 func TestAWSProvider_GetSupportedServices(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #96.

`GetDefaultRegion` previously called `IsConfigured()` unconditionally, which triggers `cfgOnce.Do(loadConfig)` and lets the SDK's credentials/config chain populate `p.cfg.Region` from the developer's ambient environment (`~/.aws/config [default]`, `AWS_REGION`, `AWS_DEFAULT_REGION`). On a developer machine with `AWS_REGION=ap-south-1`, this overwrote a test-supplied `p.cfg.Region` of `"ap-southeast-1"` with `"ap-south-1"` — a silent flake that didn't reproduce in CI (no `[default]` profile / no `AWS_REGION` env).

## Fix

Read the already-set `p.cfg.Region` **before** calling `IsConfigured`. If a caller (test or production code) populated `cfg.Region` explicitly, that value wins. Only fall back to the SDK chain when neither `p.region` nor `p.cfg.Region` was set.

Production behaviour unchanged: callers that don't pre-populate `cfg` still get the SDK-loaded region via the `IsConfigured()` fallback.

## Tests

- Existing `TestAWSProvider_GetDefaultRegion` now starts with `clearAWSAmbientEnv(t)` for cross-machine determinism (belt-and-braces; the production fix already makes the test pass without isolation).
- New `TestAWSProvider_GetDefaultRegion_NoLeakViaIsConfigured` is the explicit regression guard: sets ambient `AWS_REGION=ap-south-1` and asserts the test-supplied `cfg.Region="ap-southeast-1"` wins.

## Verification

- `AWS_REGION=ap-south-1 go test -count=1 -run TestAWSProvider_GetDefaultRegion ./providers/aws/` — green with fix.
- `go test -short -race -count=1 ./providers/aws/...` — full provider suite green.
- All pre-commit hooks pass.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)