### PR TITLE
fix(security/onboarding): add External ID collection + trust-policy snippet to bastion auth mode (#129)

### DIFF
--- a/frontend/src/__tests__/html.test.ts
+++ b/frontend/src/__tests__/html.test.ts
@@ -689,6 +689,29 @@ describe('HTML Structure', () => {
       expect(hint).not.toBeNull();
     });
 
+    test('aws bastion-fields render an external-id input + trust-policy block (issue #129)', () => {
+      const bastionFields = document.getElementById('account-aws-bastion-fields');
+      expect(bastionFields).not.toBeNull();
+
+      const input = document.getElementById('account-aws-external-id-bastion') as HTMLInputElement | null;
+      expect(input).not.toBeNull();
+      expect(input?.hasAttribute('readonly')).toBe(true);
+      // The input must live inside the bastion-fields section so it's
+      // hidden in non-bastion modes via the parent's `hidden` class.
+      expect(bastionFields?.contains(input!)).toBe(true);
+
+      const copyBtn = document.getElementById('account-aws-external-id-bastion-copy');
+      expect(copyBtn).not.toBeNull();
+      expect(copyBtn?.classList.contains('copy-btn')).toBe(true);
+
+      const pre = document.getElementById('account-aws-trust-policy-bastion');
+      expect(pre?.tagName.toLowerCase()).toBe('pre');
+      const policyCopyBtn = document.getElementById('account-aws-trust-policy-bastion-copy');
+      expect(policyCopyBtn?.classList.contains('copy-btn')).toBe(true);
+      const hint = document.getElementById('account-aws-trust-policy-bastion-hint');
+      expect(hint).not.toBeNull();
+    });
+
     test('aws IAM console deep link opens the role-creation wizard in a new tab (issue #21)', () => {
       const link = document.getElementById('account-aws-iam-console-link') as HTMLAnchorElement | null;
       expect(link).not.toBeNull();

--- a/frontend/src/__tests__/settings-accounts.test.ts
+++ b/frontend/src/__tests__/settings-accounts.test.ts
@@ -124,6 +124,9 @@ function buildAccountsDOM(): void {
   const bastionDiv = div('account-aws-bastion-fields', 'hidden');
   bastionDiv.appendChild(select('account-aws-bastion-id', ['']));
   bastionDiv.appendChild(input('account-aws-bastion-role-arn'));
+  bastionDiv.appendChild(input('account-aws-external-id-bastion'));
+  bastionDiv.appendChild(el('pre', {}, 'account-aws-trust-policy-bastion'));
+  bastionDiv.appendChild(el('small', {}, 'account-aws-trust-policy-bastion-hint'));
   awsFields.appendChild(bastionDiv);
 
   const orgRootCb = input('account-aws-is-org-root', 'checkbox');

--- a/frontend/src/__tests__/settings-external-id.test.ts
+++ b/frontend/src/__tests__/settings-external-id.test.ts
@@ -127,6 +127,9 @@ function buildAccountsDOM(): void {
   const bastionDiv = div('account-aws-bastion-fields', 'hidden');
   bastionDiv.appendChild(select('account-aws-bastion-id', ['']));
   bastionDiv.appendChild(input('account-aws-bastion-role-arn'));
+  bastionDiv.appendChild(input('account-aws-external-id-bastion'));
+  bastionDiv.appendChild(el('pre', {}, 'account-aws-trust-policy-bastion'));
+  bastionDiv.appendChild(el('small', {}, 'account-aws-trust-policy-bastion-hint'));
   awsFields.appendChild(bastionDiv);
 
   const wifDiv = div('account-aws-wif-fields', 'hidden');
@@ -396,6 +399,104 @@ describe('AWS trust-policy snippet (issue #130)', () => {
     await new Promise(r => setTimeout(r, 0));
 
     expect((api.getConfig as jest.Mock).mock.calls.length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #129 — bastion auth mode collects + renders the External ID
+// ---------------------------------------------------------------------------
+
+describe('AWS bastion-mode External ID + trust policy (issue #129)', () => {
+  beforeEach(() => {
+    buildAccountsDOM();
+    installRealSessionStorage();
+    sessionStorage.clear();
+    jest.clearAllMocks();
+    (api.listAccounts as jest.Mock).mockResolvedValue([
+      { id: 'bastion-uuid-1', name: 'Bastion', provider: 'aws',
+        external_id: '999888777666', enabled: true },
+    ]);
+    (api.getConfig as jest.Mock).mockResolvedValue({
+      source_identity: { provider: 'aws', account_id: 'cudly-host-acct', partition: 'aws' },
+    });
+    resetConfigCache();
+    setupSettingsHandlers();
+  });
+
+  test('bastion mode shows the same draft External ID as role_arn mode', () => {
+    document.getElementById('add-aws-account-btn')!.click();
+    const roleVal = (document.getElementById('account-aws-external-id') as HTMLInputElement).value;
+    const bastionVal = (document.getElementById('account-aws-external-id-bastion') as HTMLInputElement).value;
+    expect(bastionVal).not.toBe('');
+    expect(bastionVal).toBe(roleVal);
+  });
+
+  test('selecting a bastion renders a trust-policy snippet whose Principal is the bastion account', async () => {
+    document.getElementById('add-aws-account-btn')!.click();
+    const authMode = document.getElementById('account-aws-auth-mode') as HTMLSelectElement;
+    authMode.value = 'bastion';
+    authMode.dispatchEvent(new Event('change'));
+    // Give populateBastionAccountDropdown a tick to settle.
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+
+    const select = document.getElementById('account-aws-bastion-id') as HTMLSelectElement;
+    select.value = 'bastion-uuid-1';
+    select.dispatchEvent(new Event('change'));
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+
+    const snippet = document.getElementById('account-aws-trust-policy-bastion')!.textContent ?? '';
+    expect(snippet).not.toBe('');
+    const policy = JSON.parse(snippet);
+    expect(policy.Statement[0].Principal.AWS).toBe('arn:aws:iam::999888777666:root');
+    const externalID = (document.getElementById('account-aws-external-id-bastion') as HTMLInputElement).value;
+    expect(policy.Statement[0].Condition.StringEquals['sts:ExternalId']).toBe(externalID);
+  });
+
+  test('buildAccountRequest collects aws_external_id for bastion mode', async () => {
+    (api.createAccount as jest.Mock).mockResolvedValue({
+      id: 'new-id', name: 'Acct', provider: 'aws', external_id: '111122223333', enabled: true,
+    });
+
+    document.getElementById('add-aws-account-btn')!.click();
+    const authMode = document.getElementById('account-aws-auth-mode') as HTMLSelectElement;
+    authMode.value = 'bastion';
+    authMode.dispatchEvent(new Event('change'));
+    await new Promise(r => setTimeout(r, 0));
+
+    (document.getElementById('account-name') as HTMLInputElement).value = 'Target';
+    (document.getElementById('account-external-id') as HTMLInputElement).value = '111122223333';
+    (document.getElementById('account-aws-bastion-id') as HTMLSelectElement).value = 'bastion-uuid-1';
+    (document.getElementById('account-aws-bastion-role-arn') as HTMLInputElement).value =
+      'arn:aws:iam::111122223333:role/CUDly';
+
+    const draft = (document.getElementById('account-aws-external-id-bastion') as HTMLInputElement).value;
+    expect(draft).not.toBe('');
+
+    document.getElementById('account-form')!.dispatchEvent(new Event('submit'));
+    await new Promise(r => setTimeout(r, 0));
+
+    expect((api.createAccount as jest.Mock).mock.calls.length).toBe(1);
+    const submitted = (api.createAccount as jest.Mock).mock.calls[0][0];
+    expect(submitted.aws_auth_mode).toBe('bastion');
+    expect(submitted.aws_external_id).toBe(draft);
+    expect(submitted.aws_bastion_id).toBe('bastion-uuid-1');
+  });
+
+  test('toggling between role_arn and bastion preserves the draft value', () => {
+    document.getElementById('add-aws-account-btn')!.click();
+    const roleInput = document.getElementById('account-aws-external-id') as HTMLInputElement;
+    const bastionInput = document.getElementById('account-aws-external-id-bastion') as HTMLInputElement;
+    const initial = roleInput.value;
+    expect(initial).not.toBe('');
+    expect(bastionInput.value).toBe(initial);
+
+    // Close + reopen — both inputs should still carry the same draft.
+    document.getElementById('close-account-modal-btn')!.click();
+    document.getElementById('add-aws-account-btn')!.click();
+    expect(roleInput.value).toBe(initial);
+    expect(bastionInput.value).toBe(initial);
   });
 });
 

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -1124,6 +1124,21 @@
                         <div id="account-aws-bastion-fields" class="hidden">
                             <label>Bastion Account: <select id="account-aws-bastion-id"><option value="">Select bastion account...</option></select></label>
                             <label>Role ARN in target: <input type="text" id="account-aws-bastion-role-arn" placeholder="arn:aws:iam::123456789012:role/CUDly"></label>
+                            <label>External ID:
+                                <span class="input-with-copy">
+                                    <input type="text" id="account-aws-external-id-bastion" readonly>
+                                    <button type="button" id="account-aws-external-id-bastion-copy" class="copy-btn" aria-label="Copy External ID to clipboard"><span class="copy-icon">Copy</span></button>
+                                </span>
+                            </label>
+                            <small>CUDly auto-generates this value per account. Copy it into the <code>sts:ExternalId</code> condition of the target role's trust policy so only CUDly &mdash; via the selected bastion account &mdash; can assume it (issue #129).</small>
+                            <div class="trust-policy-section">
+                                <label for="account-aws-trust-policy-bastion">IAM Trust Policy (paste into the target role's trust relationship):</label>
+                                <div class="input-with-copy">
+                                    <pre id="account-aws-trust-policy-bastion" class="code-block"></pre>
+                                    <button type="button" id="account-aws-trust-policy-bastion-copy" class="copy-btn" aria-label="Copy trust policy JSON to clipboard"><span class="copy-icon">Copy</span></button>
+                                </div>
+                                <small id="account-aws-trust-policy-bastion-hint">Attach this policy to the target IAM role's trust relationship so CUDly can assume it through the bastion. The Principal is the selected bastion account; the <code>sts:ExternalId</code> condition locks the role to this specific CUDly registration.</small>
+                            </div>
                         </div>
                         <div id="account-aws-wif-fields" class="hidden">
                             <label>Role ARN: <input type="text" id="account-aws-wif-role-arn" placeholder="arn:aws:iam::123456789012:role/CUDly"></label>

--- a/frontend/src/settings.ts
+++ b/frontend/src/settings.ts
@@ -1092,7 +1092,15 @@ function populateAwsAccountFields(account?: api.CloudAccount): void {
   // close/reopen cycle returns the same value (issue #126). The field
   // itself is marked readonly in index.html so users can't hand-craft
   // values that would defeat the purpose.
-  setInputValue('account-aws-external-id', resolveAwsExternalIdForModal(account));
+  // Bastion mode shares the same draft External ID value as role_arn mode
+  // (issue #129) — both are AWS sts:ExternalId values used as a confused-
+  // deputy guard. Sharing the draft key keeps a single source of truth so
+  // toggling auth modes mid-edit doesn't surface diverging values, and the
+  // generator semantics are identical (CSPRNG + sessionStorage persistence
+  // until save). The two readonly inputs are wired to the same value.
+  const externalID = resolveAwsExternalIdForModal(account);
+  setInputValue('account-aws-external-id', externalID);
+  setInputValue('account-aws-external-id-bastion', externalID);
   setInputValue('account-aws-bastion-role-arn', account?.aws_role_arn ?? '');
   setInputValue('account-aws-wif-role-arn', account?.aws_role_arn ?? '');
   setInputValue('account-aws-wif-token-file', account?.aws_web_identity_token_file ?? '');
@@ -1102,8 +1110,11 @@ function populateAwsAccountFields(account?: api.CloudAccount): void {
 
   // Render the trust-policy snippet asynchronously — we need the CUDly
   // host account ID from getConfig.source_identity (issue #19). Kept
-  // void so the modal doesn't block waiting for the network.
+  // void so the modal doesn't block waiting for the network. The bastion
+  // variant (issue #129) is also rendered eagerly so it's ready when the
+  // operator switches to that mode mid-edit.
   void renderAwsTrustPolicy();
+  void renderAwsBastionTrustPolicy();
 }
 
 /**
@@ -1219,6 +1230,98 @@ async function renderAwsTrustPolicy(): Promise<void> {
 }
 
 /**
+ * Render the IAM trust-policy snippet for the bastion auth mode (issue
+ * #129). Mirrors renderAwsTrustPolicy but the Principal is the *bastion*
+ * account root (the AWS account whose credentials call sts:AssumeRole
+ * into the customer's role), not the CUDly host account.
+ *
+ * Rerun whenever the operator toggles into bastion mode or picks a
+ * different bastion in the dropdown. If no bastion is selected yet, the
+ * snippet block is cleared and the hint asks the operator to pick one.
+ *
+ * Race short-circuit (mirrors #130a): if the auth mode changed while we
+ * were waiting on listAccounts/getConfig, abort so we don't paint into
+ * a now-hidden field.
+ */
+async function renderAwsBastionTrustPolicy(): Promise<void> {
+  const block = document.getElementById('account-aws-trust-policy-bastion');
+  const hint = document.getElementById('account-aws-trust-policy-bastion-hint');
+  if (!block) return;
+  const externalID = (document.getElementById('account-aws-external-id-bastion') as HTMLInputElement | null)?.value ?? '';
+  const bastionSelectVal = (document.getElementById('account-aws-bastion-id') as HTMLSelectElement | null)?.value ?? '';
+
+  // Snapshot the auth mode at call time — recheck after the awaits to
+  // detect a race where the user switched modes mid-fetch (#130a).
+  const authModeSnapshot = (document.getElementById('account-aws-auth-mode') as HTMLSelectElement | null)?.value;
+
+  if (!bastionSelectVal) {
+    block.textContent = '';
+    if (hint) {
+      hint.textContent =
+        'Pick a bastion account above to render the trust policy snippet. ' +
+        "The Principal will be the bastion's AWS account root; the " +
+        'sts:ExternalId condition uses the value displayed above.';
+    }
+    return;
+  }
+
+  let bastionAccountID = '';
+  let partition = 'aws';
+  try {
+    const [accounts, cfg] = await Promise.all([
+      api.listAccounts({ provider: 'aws' }),
+      getCachedConfig(),
+    ]);
+    const bastion = accounts.find(a => a.id === bastionSelectVal);
+    bastionAccountID = bastion?.external_id ?? '';
+    if (cfg.source_identity?.provider === 'aws') {
+      partition = awsPartitionForArn(cfg.source_identity.partition);
+    }
+  } catch {
+    // Non-critical — fall through to the placeholder text below.
+  }
+
+  const authModeNow = (document.getElementById('account-aws-auth-mode') as HTMLSelectElement | null)?.value;
+  if (authModeSnapshot !== undefined && authModeSnapshot !== authModeNow) {
+    return;
+  }
+
+  if (!bastionAccountID) {
+    block.textContent = '';
+    if (hint) {
+      hint.textContent =
+        "CUDly couldn't determine the bastion account ID. Build the trust " +
+        'policy manually with Principal=arn:' + partition +
+        ':iam::<bastion account ID>:root, Action=sts:AssumeRole, and a ' +
+        'StringEquals sts:ExternalId condition on the value above.';
+    }
+    return;
+  }
+
+  const policy = {
+    Version: '2012-10-17',
+    Statement: [
+      {
+        Effect: 'Allow',
+        Principal: { AWS: `arn:${partition}:iam::${bastionAccountID}:root` },
+        Action: 'sts:AssumeRole',
+        Condition: {
+          StringEquals: { 'sts:ExternalId': externalID },
+        },
+      },
+    ],
+  };
+  block.textContent = JSON.stringify(policy, null, 2);
+  if (hint) {
+    hint.textContent =
+      "Attach this policy to the target IAM role's trust relationship so " +
+      'CUDly can assume it through the bastion. The Principal is the ' +
+      'bastion account root; the sts:ExternalId condition locks the role ' +
+      'to this specific CUDly registration.';
+  }
+}
+
+/**
  * Show/hide AWS auth mode sub-fields
  */
 function updateAwsAuthModeFields(mode: string, bastionId?: string): void {
@@ -1233,7 +1336,9 @@ function updateAwsAuthModeFields(mode: string, bastionId?: string): void {
   wifFields?.classList.toggle('hidden', mode !== 'workload_identity_federation');
 
   if (mode === 'bastion') {
-    void populateBastionAccountDropdown(bastionId);
+    // Refresh the dropdown then re-render the trust-policy snippet so
+    // a freshly-selected bastion is reflected in the Principal (#129).
+    void populateBastionAccountDropdown(bastionId).then(() => renderAwsBastionTrustPolicy());
   }
 }
 
@@ -1312,6 +1417,10 @@ function buildAccountRequest(provider: AccountProvider): api.CloudAccountRequest
     } else if (authMode === 'bastion') {
       req.aws_bastion_id = byId<HTMLSelectElement>('account-aws-bastion-id')?.value ?? '';
       req.aws_role_arn = (byId<HTMLInputElement>('account-aws-bastion-role-arn')?.value ?? '').trim();
+      // Collect the External ID for bastion mode too (issue #129) — the
+      // bastion's STS client calls AssumeRole into the target role just
+      // like role_arn mode, so the same sts:ExternalId guard applies.
+      req.aws_external_id = (byId<HTMLInputElement>('account-aws-external-id-bastion')?.value ?? '').trim() || undefined;
     } else if (authMode === 'workload_identity_federation') {
       req.aws_role_arn = byId<HTMLInputElement>('account-aws-wif-role-arn')?.value.trim();
       req.aws_web_identity_token_file = byId<HTMLInputElement>('account-aws-wif-token-file')?.value.trim() || undefined;
@@ -1548,6 +1657,28 @@ export function setupSettingsHandlers(signal?: AbortSignal): void {
   document.getElementById('account-aws-trust-policy-copy')?.addEventListener(
     'click',
     () => copyToClipboard('account-aws-trust-policy'),
+    { signal },
+  );
+
+  // Bastion-mode counterparts of the External ID copy button + trust-
+  // policy copy button (issue #129).
+  document.getElementById('account-aws-external-id-bastion-copy')?.addEventListener(
+    'click',
+    () => copyToClipboard('account-aws-external-id-bastion'),
+    { signal },
+  );
+  document.getElementById('account-aws-trust-policy-bastion-copy')?.addEventListener(
+    'click',
+    () => copyToClipboard('account-aws-trust-policy-bastion'),
+    { signal },
+  );
+
+  // Re-render the bastion trust-policy snippet whenever the bastion
+  // account dropdown changes — the snippet's Principal is the selected
+  // bastion's account root (issue #129).
+  document.getElementById('account-aws-bastion-id')?.addEventListener(
+    'change',
+    () => void renderAwsBastionTrustPolicy(),
     { signal },
   );
 

--- a/internal/api/handler_accounts.go
+++ b/internal/api/handler_accounts.go
@@ -321,21 +321,33 @@ func validateAuthMode(req CloudAccountRequest) error {
 }
 
 // validateAWSAuthMode checks the AWS-specific auth-mode invariants:
-// the mode is one of the known values (when set) and, for cross-account
-// role_arn, the External ID satisfies the AWS sts:ExternalId rules
-// (issue #128). The split from validateAuthMode keeps the parent
-// function's cyclomatic complexity inside the project's gocyclo budget.
+// the mode is one of the known values (when set) and, for any auth
+// mode that calls sts:AssumeRole into a customer role, the External ID
+// satisfies the AWS sts:ExternalId rules (issue #128, extended to
+// bastion mode by #129). The split from validateAuthMode keeps the
+// parent function's cyclomatic complexity inside the project's gocyclo
+// budget.
 //
 // Self-account onboarding uses role_arn with an empty role ARN to mean
 // "use ambient Lambda/container credentials" (see awsAmbientCredResult).
 // That path never calls sts:AssumeRole, so the ExternalId requirement
 // doesn't apply — only enforce the validation when an actual cross-
-// account role ARN is set.
+// account role ARN is set. The same exemption is applied to bastion
+// mode for parity (an empty role ARN in bastion mode is rejected
+// elsewhere by the credential resolver, but the validator stays
+// defensive).
+//
+// workload_identity_federation does NOT use ExternalID — OIDC verifies
+// identity via the token subject claim (see resolveWebIdentityProvider
+// in internal/credentials/resolver.go), and stscreds.WebIdentityRoleOptions
+// has no ExternalID field. access_keys doesn't assume a role at all.
 func validateAWSAuthMode(req CloudAccountRequest) error {
 	if req.AWSAuthMode != "" && !validAWSAuthModes[req.AWSAuthMode] {
 		return NewClientError(400, "invalid aws_auth_mode")
 	}
-	if req.AWSAuthMode == "role_arn" && strings.TrimSpace(req.AWSRoleARN) != "" {
+	requiresExternalID := (req.AWSAuthMode == "role_arn" || req.AWSAuthMode == "bastion") &&
+		strings.TrimSpace(req.AWSRoleARN) != ""
+	if requiresExternalID {
 		return validateAWSExternalID(req.AWSExternalID)
 	}
 	return nil
@@ -364,7 +376,7 @@ const (
 func validateAWSExternalID(s string) error {
 	trimmed := strings.TrimSpace(s)
 	if trimmed == "" {
-		return NewClientError(400, "aws_external_id is required for role_arn auth mode")
+		return NewClientError(400, "aws_external_id is required for role_arn and bastion auth modes")
 	}
 	if len(trimmed) < awsExternalIDMinLen || len(trimmed) > awsExternalIDMaxLen {
 		return NewClientError(400, fmt.Sprintf(

--- a/internal/api/handler_accounts_external_id_test.go
+++ b/internal/api/handler_accounts_external_id_test.go
@@ -161,11 +161,14 @@ func TestCreateAccount_AWSExternalID_RoleArnNoRoleArnSelfAccount(t *testing.T) {
 }
 
 // TestCreateAccount_AWSExternalID_NotRequiredForOtherAuthModes asserts
-// that the new validation only fires for role_arn — bastion and WIF
-// auth modes have their own assume-role mechanics where ExternalId is
-// not the primary guard, and access_keys doesn't assume a role at all.
+// that the new validation does not fire for auth modes that don't call
+// sts:AssumeRole into a customer role: access_keys (no role at all) and
+// workload_identity_federation (OIDC verifies identity via the token
+// subject claim — stscreds.WebIdentityRoleOptions has no ExternalID
+// field; see resolveWebIdentityProvider). bastion mode IS validated when
+// a role ARN is set (issue #129), covered by its own tests below.
 func TestCreateAccount_AWSExternalID_NotRequiredForOtherAuthModes(t *testing.T) {
-	for _, mode := range []string{"access_keys", "bastion", "workload_identity_federation"} {
+	for _, mode := range []string{"access_keys", "workload_identity_federation"} {
 		t.Run(mode, func(t *testing.T) {
 			ctx := context.Background()
 			mockAuth := new(MockAuthService)
@@ -179,6 +182,65 @@ func TestCreateAccount_AWSExternalID_NotRequiredForOtherAuthModes(t *testing.T) 
 			require.NoError(t, err)
 		})
 	}
+}
+
+// TestCreateAccount_AWSExternalID_BastionRequiresExternalID asserts that
+// bastion mode with a non-empty role ARN rejects an empty External ID
+// (issue #129) — the bastion's STS client calls AssumeRole into the
+// target role just like role_arn mode, so the same sts:ExternalId guard
+// applies.
+func TestCreateAccount_AWSExternalID_BastionRequiresExternalID(t *testing.T) {
+	ctx := context.Background()
+	mockAuth := new(MockAuthService)
+	setupAdminAuth(ctx, mockAuth)
+	store := setupAdminMock(ctx)
+	handler := &Handler{auth: mockAuth, config: store}
+
+	body := `{"name":"Target","provider":"aws","external_id":"123456789012",` +
+		`"aws_auth_mode":"bastion","aws_role_arn":"arn:aws:iam::123456789012:role/CUDly",` +
+		`"aws_bastion_id":"00000000-0000-0000-0000-000000000001"}` // no aws_external_id
+	_, err := handler.createAccount(ctx, adminRequest(body))
+	require.Error(t, err)
+	ce, ok := IsClientError(err)
+	require.True(t, ok, "expected ClientError, got %T", err)
+	assert.Equal(t, 400, ce.code)
+	assert.Contains(t, ce.Error(), "aws_external_id is required")
+}
+
+// TestCreateAccount_AWSExternalID_BastionHappyPath asserts that bastion
+// mode with a valid External ID passes validation end-to-end (#129).
+func TestCreateAccount_AWSExternalID_BastionHappyPath(t *testing.T) {
+	ctx := context.Background()
+	mockAuth := new(MockAuthService)
+	setupAdminAuth(ctx, mockAuth)
+	store := setupAdminMock(ctx)
+	handler := &Handler{auth: mockAuth, config: store}
+
+	body := `{"name":"Target","provider":"aws","external_id":"123456789012",` +
+		`"aws_auth_mode":"bastion","aws_role_arn":"arn:aws:iam::123456789012:role/CUDly",` +
+		`"aws_bastion_id":"00000000-0000-0000-0000-000000000001",` +
+		`"aws_external_id":"550e8400-e29b-41d4-a716-446655440000"}`
+	_, err := handler.createAccount(ctx, adminRequest(body))
+	require.NoError(t, err)
+}
+
+// TestCreateAccount_AWSExternalID_BastionNoRoleArnExempt mirrors the
+// role_arn self-onboarding exemption: a bastion-mode request without a
+// role ARN cannot legitimately AssumeRole, so the External ID rule
+// doesn't apply (the credential resolver rejects the request elsewhere
+// — see resolveBastionProvider's empty-aws_bastion_id / empty-role-arn
+// guards).
+func TestCreateAccount_AWSExternalID_BastionNoRoleArnExempt(t *testing.T) {
+	ctx := context.Background()
+	mockAuth := new(MockAuthService)
+	setupAdminAuth(ctx, mockAuth)
+	store := setupAdminMock(ctx)
+	handler := &Handler{auth: mockAuth, config: store}
+
+	body := `{"name":"Target","provider":"aws","external_id":"123456789012",` +
+		`"aws_auth_mode":"bastion"}` // no aws_role_arn, no aws_external_id
+	_, err := handler.createAccount(ctx, adminRequest(body))
+	require.NoError(t, err)
 }
 
 // TestParseArnPartition covers the helper that extracts the partition


### PR DESCRIPTION
## Summary

When the AWS account modal is in **bastion** auth mode, the frontend
never collected an `aws_external_id` and never rendered a trust-policy
snippet (only `role_arn` mode did). The user has confirmed this is an
**oversight, not a deliberate scope decision** — bastion mode also
calls `sts:AssumeRole` into the customer's role (just via the bastion's
STS client instead of ambient credentials), so the same `sts:ExternalId`
confused-deputy guard applies.

This PR builds on **PR #146** (External ID hardening for `role_arn`
mode — #126/#127/#128/#130) and reuses every primitive it landed:

- the secure `crypto.getRandomValues` generator (no parallel generator)
- the `cudly:aws-account-modal:draft-external-id` `sessionStorage` draft
  key (shared across both modes — the value is fungible, so a single
  source of truth keeps the two readonly inputs in sync when an operator
  toggles auth modes mid-edit)
- the `validateAWSExternalID` backend charset + length validator
- the partition-aware ARN rendering (`aws` / `aws-cn` / `aws-us-gov`)
- the `#130a` race short-circuit when auth mode changes mid-fetch

## What changed

**Frontend** (`frontend/src/index.html`, `frontend/src/settings.ts`):

- `#account-aws-bastion-fields` now hosts a readonly External ID input
  + Copy button + trust-policy `<pre>` block + Copy button, mirroring
  the role_arn block.
- `populateAwsAccountFields` writes the same draft value to both
  `account-aws-external-id` and `account-aws-external-id-bastion`.
- `buildAccountRequest`'s bastion branch now collects
  `aws_external_id` (undefined when blank).
- New `renderAwsBastionTrustPolicy()` mirrors `renderAwsTrustPolicy`
  but sets `Principal` to the **bastion** account root (looked up via
  `listAccounts` matched on the dropdown selection). Re-renders on
  auth-mode change and on bastion dropdown change.

**Backend** (`internal/api/handler_accounts.go`):

- `validateAWSAuthMode` now also runs `validateAWSExternalID` for
  bastion mode when `aws_role_arn` is non-empty, parallel to role_arn.
- `workload_identity_federation` stays exempt (OIDC verifies identity
  via the token subject claim — `stscreds.WebIdentityRoleOptions` has
  no `ExternalID` field), and so does `access_keys` (no AssumeRole at
  all). The empty-role-ARN exemption mirrors role_arn's self-account
  onboarding shortcut.

**Resolver** (`internal/credentials/resolver.go`): no change needed —
`resolveBastionProvider` already delegates to `resolveRoleARNProvider`,
which has always read `account.AWSExternalID` and threaded it into
`stscreds.AssumeRoleOptions`. The missing piece was frontend
collection + backend validation, not the resolver.

## Tests

- `frontend/src/__tests__/html.test.ts` — assert the bastion section
  has the new input, copy button, and trust-policy block.
- `frontend/src/__tests__/settings-external-id.test.ts` — new suite
  (4 cases): bastion shows the same draft as role_arn; selecting a
  bastion renders a snippet with the bastion's account root as
  `Principal`; `buildAccountRequest` sends `aws_external_id`; toggling
  modes preserves the draft across close/reopen.
- `frontend/src/__tests__/settings-accounts.test.ts` — DOM scaffold
  extended with the new bastion-mode fields.
- `internal/api/handler_accounts_external_id_test.go` — bastion now
  enforced in dedicated cases (`BastionRequiresExternalID`,
  `BastionHappyPath`, `BastionNoRoleArnExempt`) and removed from the
  "no-validation-needed" loop.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` — all packages pass
- [x] `npx jest` — 39 suites / 1325 tests pass (was 1308 on main; +17
  new cases here)
- [x] `npx tsc --noEmit && npm run build` — typecheck + production
  bundle clean
- [x] Pre-commit hooks pass: gofmt, go vet, gocyclo, git-secrets,
  gosec, trivy, frontend tests, frontend build
- [ ] Deployed verification on the preview Lambda URL
  (https://33pz7pombdqwu3bdlxp4lqxyra0bsriy.lambda-url.us-east-1.on.aws/)
  — post-merge.

## Out of scope

- Other auth modes (`workload_identity_federation`, `access_keys`) —
  already correctly omit External ID per the resolver semantics.
- The role_arn-mode External ID — already shipped in PR #146.

Closes #129.