### PR TITLE
feat(recommendations): per-column header filters + sticky bottom action box

### DIFF
--- a/frontend/src/__tests__/html.test.ts
+++ b/frontend/src/__tests__/html.test.ts
@@ -145,26 +145,24 @@ describe('HTML Structure', () => {
   });
 
   describe('Recommendations Tab', () => {
-    test('has recommendations controls', () => {
-      const controls = document.getElementById('recommendations-controls');
-      expect(controls).toBeTruthy();
-    });
-
-    test('has service filter', () => {
-      const filter = document.getElementById('service-filter');
-      expect(filter).toBeTruthy();
-      expect(filter?.tagName.toLowerCase()).toBe('select');
-    });
-
-    test('has region filter', () => {
-      const filter = document.getElementById('region-filter');
-      expect(filter).toBeTruthy();
-    });
-
-    test('has min savings filter', () => {
-      const filter = document.getElementById('min-savings-filter') as HTMLInputElement | null;
-      expect(filter).toBeTruthy();
-      expect(filter?.getAttribute('type')).toBe('number');
+    // Bundle B (column-filter UX overhaul) deleted the legacy top filter bar
+    // and the #recommendations-controls section that hosted it. The
+    // service-filter / region-filter / min-savings-filter / provider-filter /
+    // account-filter <select>s are gone — replaced by per-column header-mounted
+    // popovers driven by recommendations.ts:openColumnPopover. Negative-guard
+    // tests below ensure no regression accidentally re-introduces them.
+    test('legacy top filter bar is absent (Bundle B)', () => {
+      const recsTab = document.getElementById('recommendations-tab');
+      expect(recsTab).toBeTruthy();
+      expect(document.getElementById('recommendations-controls')).toBeNull();
+      // .controls-bar still exists on other tabs (Dashboard, Plans, …).
+      // Only assert the rec tab is clean.
+      expect(recsTab?.querySelector('.controls-bar')).toBeNull();
+      expect(document.getElementById('service-filter')).toBeNull();
+      expect(document.getElementById('region-filter')).toBeNull();
+      expect(document.getElementById('min-savings-filter')).toBeNull();
+      expect(document.getElementById('recommendations-account-filter')).toBeNull();
+      expect(document.getElementById('recommendations-provider-filter')).toBeNull();
     });
 
     test('has recommendations list container', () => {
@@ -333,15 +331,9 @@ describe('HTML Structure', () => {
       expect(values).toContain('gcp');
     });
 
-    test('service filter has correct options', () => {
-      const selector = document.getElementById('service-filter');
-      const options = selector?.querySelectorAll('option') ?? [];
-      const values = Array.from(options).map(o => o.value);
-
-      expect(values).toContain('');
-      expect(values).toContain('ec2');
-      expect(values).toContain('rds');
-    });
+    // Bundle B: #service-filter <select> deleted; service filtering happens
+    // via the per-column header popover. See tests/recommendations.test.ts
+    // for the popover behaviour.
 
     test('term select has 1 and 3 year options', () => {
       const selector = document.getElementById('setting-default-term');
@@ -362,15 +354,10 @@ describe('HTML Structure', () => {
       expect(values).toContain('all-upfront');
     });
 
-    test('service filter has optgroups for each provider', () => {
-      const selector = document.getElementById('service-filter');
-      const optgroups = selector?.querySelectorAll('optgroup') ?? [];
-      const labels = Array.from(optgroups).map(og => og.getAttribute('label'));
-
-      expect(labels).toContain('AWS');
-      expect(labels).toContain('Azure');
-      expect(labels).toContain('GCP');
-    });
+    // Bundle B: legacy service-filter optgroups deleted along with the
+    // <select id="service-filter">. The Service column-header popover lists
+    // distinct service values from the loaded recs at runtime, no static
+    // optgroup tree.
 
     // Refs #45 — admins land on the Accounts page primarily to action the
     // pending registration queue, so the filter must default to "pending".

--- a/frontend/src/__tests__/plans.test.ts
+++ b/frontend/src/__tests__/plans.test.ts
@@ -25,7 +25,13 @@ jest.mock('../api', () => ({
 // Mock state module
 jest.mock('../state', () => ({
   getRecommendations: jest.fn().mockReturnValue([]),
-  getSelectedRecommendationIDs: jest.fn().mockReturnValue(new Set())
+  getSelectedRecommendationIDs: jest.fn().mockReturnValue(new Set()),
+  // Bundle B (column-filter UX overhaul): savePlan now reads the
+  // post-filter visible set so plans never include filtered-out rows.
+  // Default to empty so tests that don't seed a target keep their old
+  // behaviour (no recommendations attached to plan).
+  getVisibleRecommendations: jest.fn().mockReturnValue([]),
+  setVisibleRecommendations: jest.fn(),
 }));
 
 // Mock history module
@@ -876,9 +882,12 @@ describe('Plans Module', () => {
       }));
     });
 
-    test('includes selected recommendations', async () => {
-      (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set([0, 1]));
-      (state.getRecommendations as jest.Mock).mockReturnValue([
+    test('includes selected ∩ visible recommendations (Bundle B)', async () => {
+      // Bundle B: savePlan reads getVisibleRecommendations (post-filter set)
+      // so plans never include filtered-out rows. Selection is intersected
+      // with that visible list.
+      (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set(['rec-1', 'rec-2']));
+      (state.getVisibleRecommendations as jest.Mock).mockReturnValue([
         { id: 'rec-1', service: 'ec2' },
         { id: 'rec-2', service: 'rds' }
       ]);
@@ -889,9 +898,44 @@ describe('Plans Module', () => {
       const event = { preventDefault: jest.fn() } as unknown as Event;
       await savePlan(event);
 
-      expect(api.createPlan).toHaveBeenCalledWith(expect.objectContaining({
-        recommendations: expect.any(Array)
-      }));
+      const sentRecs = (api.createPlan as jest.Mock).mock.calls[0][0].recommendations;
+      expect(sentRecs.map((r: { id: string }) => r.id).sort()).toEqual(['rec-1', 'rec-2']);
+    });
+
+    test('falls back to all visible when no selection (Bundle B)', async () => {
+      (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set());
+      (state.getVisibleRecommendations as jest.Mock).mockReturnValue([
+        { id: 'rec-1', service: 'ec2' },
+        { id: 'rec-2', service: 'rds' }
+      ]);
+      (api.createPlan as jest.Mock).mockResolvedValue({});
+      (api.getPlans as jest.Mock).mockResolvedValue({ plans: [] });
+      (api.getPlannedPurchases as jest.Mock).mockResolvedValue({ purchases: [] });
+
+      const event = { preventDefault: jest.fn() } as unknown as Event;
+      await savePlan(event);
+
+      const sentRecs = (api.createPlan as jest.Mock).mock.calls[0][0].recommendations;
+      expect(sentRecs.map((r: { id: string }) => r.id).sort()).toEqual(['rec-1', 'rec-2']);
+    });
+
+    test('plan does not include filtered-out recs (Bundle B)', async () => {
+      // Selection points at IDs that aren't in the visible set — they're
+      // filtered out, so the plan should silently ignore them.
+      (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set(['stale-1']));
+      (state.getVisibleRecommendations as jest.Mock).mockReturnValue([
+        { id: 'rec-1', service: 'ec2' }
+      ]);
+      (api.createPlan as jest.Mock).mockResolvedValue({});
+      (api.getPlans as jest.Mock).mockResolvedValue({ plans: [] });
+      (api.getPlannedPurchases as jest.Mock).mockResolvedValue({ purchases: [] });
+
+      const event = { preventDefault: jest.fn() } as unknown as Event;
+      await savePlan(event);
+
+      const sentRecs = (api.createPlan as jest.Mock).mock.calls[0][0].recommendations;
+      // selection had no intersection with visible → recommendations field empty/undefined.
+      expect(sentRecs == null || sentRecs.length === 0).toBe(true);
     });
 
     test('closes modal after successful save', async () => {

--- a/frontend/src/__tests__/recommendations.test.ts
+++ b/frontend/src/__tests__/recommendations.test.ts
@@ -39,6 +39,12 @@ jest.mock('../state', () => ({
   removeSelectedRecommendation: jest.fn(),
   getRecommendationsSort: jest.fn().mockReturnValue({ column: 'savings', direction: 'desc' }),
   setRecommendationsSort: jest.fn(),
+  // Bundle A column-filter accessors (default empty filters → applyColumnFilters is a no-op).
+  getRecommendationsColumnFilters: jest.fn().mockReturnValue({}),
+  setRecommendationsColumnFilter: jest.fn(),
+  clearAllRecommendationsColumnFilters: jest.fn(),
+  getVisibleRecommendations: jest.fn().mockReturnValue([]),
+  setVisibleRecommendations: jest.fn(),
 }));
 
 // Mock utils
@@ -794,5 +800,260 @@ describe('Recommendations Module', () => {
       const minSavingsFilter = document.getElementById('min-savings-filter') as HTMLInputElement;
       expect(minSavingsFilter).toBeTruthy();
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bundle A: numeric expression parser + applyColumnFilters
+// ---------------------------------------------------------------------------
+
+import { parseNumericFilter, applyColumnFilters } from '../recommendations';
+import type { LocalRecommendation } from '../types';
+
+describe('parseNumericFilter', () => {
+  const accept = (expr: string, n: number): boolean => {
+    const r = parseNumericFilter(expr);
+    if (!r.ok) throw new Error(`unexpected parse failure for "${expr}": ${r.error}`);
+    return r.predicate(n);
+  };
+
+  test('empty / whitespace expression matches everything', () => {
+    expect(accept('', 0)).toBe(true);
+    expect(accept('   ', 42)).toBe(true);
+    expect(accept('\t\n', -7)).toBe(true);
+  });
+
+  test('plain integer matches by equality', () => {
+    expect(accept('42', 42)).toBe(true);
+    expect(accept('42', 41)).toBe(false);
+    expect(accept('-3', -3)).toBe(true);
+  });
+
+  test('plain decimal matches by equality', () => {
+    expect(accept('3.14', 3.14)).toBe(true);
+    expect(accept('3.14', 3.15)).toBe(false);
+  });
+
+  test('comparator > / >= / < / <=', () => {
+    expect(accept('>10', 11)).toBe(true);
+    expect(accept('>10', 10)).toBe(false);
+    expect(accept('>=10', 10)).toBe(true);
+    expect(accept('<5', 4)).toBe(true);
+    expect(accept('<5', 5)).toBe(false);
+    expect(accept('<=5', 5)).toBe(true);
+  });
+
+  test('inclusive range X..Y', () => {
+    expect(accept('10..20', 10)).toBe(true);
+    expect(accept('10..20', 20)).toBe(true);
+    expect(accept('10..20', 15)).toBe(true);
+    expect(accept('10..20', 9)).toBe(false);
+    expect(accept('10..20', 21)).toBe(false);
+  });
+
+  test('reversed range still works (max..min)', () => {
+    expect(accept('20..10', 15)).toBe(true);
+  });
+
+  test('comma-separated terms OR together', () => {
+    // `5, >100, 200..400`
+    expect(accept('5, >100, 200..400', 5)).toBe(true);
+    expect(accept('5, >100, 200..400', 150)).toBe(true);
+    expect(accept('5, >100, 200..400', 250)).toBe(true);
+    expect(accept('5, >100, 200..400', 50)).toBe(false);
+    expect(accept('5, >100, 200..400', 500)).toBe(true); // matches >100
+  });
+
+  test('whitespace inside terms is tolerated', () => {
+    expect(accept('  >  10  ', 11)).toBe(true);
+    expect(accept('10 .. 20', 15)).toBe(true);
+  });
+
+  test('invalid expression returns ok:false with an error message', () => {
+    const r1 = parseNumericFilter('>>5');
+    expect(r1.ok).toBe(false);
+    if (!r1.ok) expect(r1.error).toMatch(/Invalid filter term/);
+
+    const r2 = parseNumericFilter('not a number');
+    expect(r2.ok).toBe(false);
+
+    const r3 = parseNumericFilter('1..');
+    expect(r3.ok).toBe(false);
+  });
+});
+
+describe('applyColumnFilters', () => {
+  const rec = (
+    overrides: Partial<LocalRecommendation> = {},
+  ): LocalRecommendation => ({
+    id: overrides.id ?? 'r1',
+    provider: overrides.provider ?? 'aws',
+    cloud_account_id: overrides.cloud_account_id ?? 'acct-1',
+    service: overrides.service ?? 'ec2',
+    resource_type: overrides.resource_type ?? 't3.medium',
+    region: overrides.region ?? 'us-east-1',
+    count: overrides.count ?? 1,
+    term: overrides.term ?? 1,
+    upfront_cost: overrides.upfront_cost ?? 100,
+    monthly_cost: overrides.monthly_cost ?? 10,
+    savings: overrides.savings ?? 50,
+    engine: overrides.engine,
+  } as unknown as LocalRecommendation);
+
+  test('empty filters returns a clone of the input (no-op)', () => {
+    const recs = [rec({ id: 'a' }), rec({ id: 'b' })];
+    const out = applyColumnFilters(recs, {});
+    expect(out).toEqual(recs);
+    expect(out).not.toBe(recs); // defensive clone
+  });
+
+  test('categorical set filter narrows by membership', () => {
+    const recs = [
+      rec({ id: 'a', provider: 'aws' }),
+      rec({ id: 'b', provider: 'azure' }),
+      rec({ id: 'c', provider: 'gcp' }),
+    ];
+    const out = applyColumnFilters(recs, {
+      provider: { kind: 'set', values: ['aws'] },
+    });
+    expect(out.map(r => r.id)).toEqual(['a']);
+  });
+
+  test('Account filter matches on cloud_account_id, not display name', () => {
+    const recs = [
+      rec({ id: 'a', cloud_account_id: 'acct-prod' }),
+      rec({ id: 'b', cloud_account_id: 'acct-dev' }),
+    ];
+    const out = applyColumnFilters(recs, {
+      account: { kind: 'set', values: ['acct-prod'] },
+    });
+    expect(out.map(r => r.id)).toEqual(['a']);
+  });
+
+  test('Term filter values are strings; row term integer stringifies', () => {
+    const recs = [
+      rec({ id: 'a', term: 1 }),
+      rec({ id: 'b', term: 3 }),
+    ];
+    const out = applyColumnFilters(recs, {
+      term: { kind: 'set', values: ['3'] },
+    });
+    expect(out.map(r => r.id)).toEqual(['b']);
+  });
+
+  test('(empty) sentinel matches null / undefined / "" cloud_account_id', () => {
+    // Build raw objects — bypass the rec() factory because its `??` defaults
+    // would replace null/undefined cloud_account_id with 'acct-1'.
+    const recs: LocalRecommendation[] = [
+      { ...rec({ id: 'a' }), cloud_account_id: '' } as LocalRecommendation,
+      { ...rec({ id: 'b' }), cloud_account_id: undefined } as unknown as LocalRecommendation,
+      rec({ id: 'c', cloud_account_id: 'acct-x' }),
+    ];
+    const out = applyColumnFilters(recs, {
+      account: { kind: 'set', values: [''] },
+    });
+    expect(out.map(r => r.id).sort()).toEqual(['a', 'b']);
+  });
+
+  test('numeric expr filter narrows by predicate', () => {
+    const recs = [
+      rec({ id: 'a', savings: 25 }),
+      rec({ id: 'b', savings: 150 }),
+      rec({ id: 'c', savings: 1500 }),
+    ];
+    const out = applyColumnFilters(recs, {
+      savings: { kind: 'expr', expr: '>100' },
+    });
+    expect(out.map(r => r.id)).toEqual(['b', 'c']);
+  });
+
+  test('invalid numeric expression is ignored (filter not applied)', () => {
+    const recs = [rec({ id: 'a', savings: 1 }), rec({ id: 'b', savings: 100 })];
+    const out = applyColumnFilters(recs, {
+      savings: { kind: 'expr', expr: '>>5' }, // syntax error
+    });
+    // All rows pass — broken filter is silently inert.
+    expect(out.map(r => r.id)).toEqual(['a', 'b']);
+  });
+
+  test('multiple column filters AND together', () => {
+    const recs = [
+      rec({ id: 'a', provider: 'aws', savings: 50 }),
+      rec({ id: 'b', provider: 'aws', savings: 500 }),
+      rec({ id: 'c', provider: 'azure', savings: 500 }),
+    ];
+    const out = applyColumnFilters(recs, {
+      provider: { kind: 'set', values: ['aws'] },
+      savings: { kind: 'expr', expr: '>100' },
+    });
+    expect(out.map(r => r.id)).toEqual(['b']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bundle A: state-accessor tests for the new column-filter / visible-recs API.
+// These import the REAL state module (the recommendations.test.ts above mocks
+// it; here we exercise the actual implementation in a separate require scope).
+// ---------------------------------------------------------------------------
+
+describe('state.ts column-filter accessors', () => {
+  // The top-level jest.mock('../state', …) replaces the module for every
+  // import. Use jest.requireActual to bypass it for these state-accessor
+  // tests so we exercise the real implementation. Each test starts from
+  // a clean filter state via clearAllRecommendationsColumnFilters().
+  const realState = jest.requireActual<typeof import('../state')>('../state');
+
+  beforeEach(() => {
+    realState.clearAllRecommendationsColumnFilters();
+    realState.setVisibleRecommendations([]);
+  });
+
+  test('default filters are empty', () => {
+    expect(realState.getRecommendationsColumnFilters()).toEqual({});
+  });
+
+  test('setRecommendationsColumnFilter adds an entry', () => {
+    realState.setRecommendationsColumnFilter('provider', { kind: 'set', values: ['aws'] });
+    expect(realState.getRecommendationsColumnFilters()).toEqual({
+      provider: { kind: 'set', values: ['aws'] },
+    });
+  });
+
+  test('passing null clears that single column', () => {
+    realState.setRecommendationsColumnFilter('provider', { kind: 'set', values: ['aws'] });
+    realState.setRecommendationsColumnFilter('savings', { kind: 'expr', expr: '>100' });
+    realState.setRecommendationsColumnFilter('provider', null);
+    expect(realState.getRecommendationsColumnFilters()).toEqual({
+      savings: { kind: 'expr', expr: '>100' },
+    });
+  });
+
+  test('clearAllRecommendationsColumnFilters empties the record', () => {
+    realState.setRecommendationsColumnFilter('provider', { kind: 'set', values: ['aws'] });
+    realState.setRecommendationsColumnFilter('savings', { kind: 'expr', expr: '>100' });
+    realState.clearAllRecommendationsColumnFilters();
+    expect(realState.getRecommendationsColumnFilters()).toEqual({});
+  });
+
+  test('getRecommendationsColumnFilters returns a defensive shallow copy', () => {
+    realState.setRecommendationsColumnFilter('provider', { kind: 'set', values: ['aws'] });
+    const a = realState.getRecommendationsColumnFilters();
+    delete a.provider;
+    // mutation of the returned object must not affect module state
+    expect(realState.getRecommendationsColumnFilters()).toEqual({
+      provider: { kind: 'set', values: ['aws'] },
+    });
+  });
+
+  test('setVisibleRecommendations / getVisibleRecommendations round-trip with defensive clone', () => {
+    const recs = [{ id: 'r1' }, { id: 'r2' }] as unknown as Parameters<
+      typeof realState.setVisibleRecommendations
+    >[0];
+    realState.setVisibleRecommendations(recs);
+    const out = realState.getVisibleRecommendations();
+    expect(out.map((r) => (r as unknown as { id: string }).id)).toEqual(['r1', 'r2']);
+    // mutating returned array must not affect module state
+    (out as unknown as Array<unknown>).pop();
+    expect(realState.getVisibleRecommendations()).toHaveLength(2);
   });
 });

--- a/frontend/src/__tests__/recommendations.test.ts
+++ b/frontend/src/__tests__/recommendations.test.ts
@@ -62,18 +62,10 @@ describe('Recommendations Module', () => {
   beforeEach(() => {
     // Reset DOM
     document.body.innerHTML = `
-      <select id="service-filter">
-        <option value="">All Services</option>
-        <option value="ec2">EC2</option>
-      </select>
-      <select id="region-filter">
-        <option value="">All Regions</option>
-        <option value="us-east-1">us-east-1</option>
-        <option value="us-west-2">us-west-2</option>
-      </select>
-      <input type="number" id="min-savings-filter" value="">
-      <div id="recommendations-summary"></div>
-      <div id="recommendations-list"></div>
+      <div id="recommendations-tab" class="tab-content active">
+        <div id="recommendations-summary"></div>
+        <div id="recommendations-list"></div>
+      </div>
       <div id="purchase-modal" class="hidden">
         <div id="purchase-details"></div>
       </div>
@@ -89,28 +81,21 @@ describe('Recommendations Module', () => {
   });
 
   describe('loadRecommendations', () => {
-    test('fetches recommendations with filters', async () => {
+    test('fetches recommendations with provider/account_ids hints (Bundle B)', async () => {
+      // After Bundle B, only provider + account_ids are sent to the API as
+      // hints; service/region/numeric filters are pure client-side via
+      // applyColumnFilters. The legacy DOM filter inputs are gone.
       (api.getRecommendations as jest.Mock).mockResolvedValue({
         summary: {},
         recommendations: [],
         regions: []
       });
 
-      const serviceFilter = document.getElementById('service-filter') as HTMLSelectElement;
-      const regionFilter = document.getElementById('region-filter') as HTMLSelectElement;
-      const minSavingsFilter = document.getElementById('min-savings-filter') as HTMLInputElement;
-
-      serviceFilter.value = 'ec2';
-      regionFilter.value = 'us-east-1';
-      minSavingsFilter.value = '100';
-
       await loadRecommendations();
 
       expect(api.getRecommendations).toHaveBeenCalledWith({
         provider: 'all',
-        service: 'ec2',
-        region: 'us-east-1',
-        minSavings: 100
+        account_ids: undefined,
       });
     });
 
@@ -161,7 +146,7 @@ describe('Recommendations Module', () => {
       expect(list?.innerHTML).toContain('us-east-1');
     });
 
-    test('shows empty message when no recommendations', async () => {
+    test('shows empty-state message when no recommendations', async () => {
       (api.getRecommendations as jest.Mock).mockResolvedValue({
         summary: {},
         recommendations: [],
@@ -171,20 +156,7 @@ describe('Recommendations Module', () => {
       await loadRecommendations();
 
       const list = document.getElementById('recommendations-list');
-      expect(list?.innerHTML).toContain('No recommendations found');
-    });
-
-    test('populates region filter', async () => {
-      (api.getRecommendations as jest.Mock).mockResolvedValue({
-        summary: {},
-        recommendations: [],
-        regions: ['us-east-1', 'us-west-2', 'eu-west-1']
-      });
-
-      await loadRecommendations();
-
-      const regionFilter = document.getElementById('region-filter') as HTMLSelectElement;
-      expect(regionFilter.options.length).toBe(4); // All Regions + 3 regions
+      expect(list?.innerHTML).toContain('No recommendations match');
     });
 
     test('stores recommendations in state', async () => {
@@ -362,9 +334,11 @@ describe('Recommendations Module', () => {
 
       await loadRecommendations();
 
-      // Per-row Purchase button removed in Commit 3 of bulk-purchase-
-      // with-grace. Use the bulk Purchase button on the top toolbar
-      // instead — a single visible rec purchases that one.
+      // Bundle B: per-row Purchase buttons gone; the Purchase action lives
+      // in the sticky bottom action box at #bulk-purchase-btn. The button
+      // resolves its target via state.getVisibleRecommendations(), so the
+      // mock needs to return the loaded recs for the click to fire.
+      (state.getVisibleRecommendations as jest.Mock).mockReturnValue(mockRecs);
       const purchaseBtn = document.querySelector('#bulk-purchase-btn') as HTMLButtonElement;
       expect(purchaseBtn).not.toBeNull();
       purchaseBtn.click();
@@ -419,12 +393,14 @@ describe('Recommendations Module', () => {
       });
     });
 
-    test('renders sortable column headers with indicators', async () => {
+    test('renders sortable column headers with indicators (Bundle B: 9 columns)', async () => {
       await loadRecommendations();
       const list = document.getElementById('recommendations-list');
-      // Four sortable columns: count, term, savings (default), upfront_cost.
+      // Bundle B: every data column is sortable. 9 sortable data columns:
+      // provider, account, service, resource_type, region, count, term,
+      // savings, upfront_cost. The leading checkbox column is not sortable.
       const sortables = list?.querySelectorAll('th.sortable');
-      expect(sortables?.length).toBe(4);
+      expect(sortables?.length).toBe(9);
       // The default sort is savings desc → that header shows an active ▼.
       const savingsHeader = list?.querySelector('th[data-sort="savings"]');
       expect(savingsHeader?.innerHTML).toContain('active');
@@ -437,7 +413,9 @@ describe('Recommendations Module', () => {
       expect(state.setRecommendationsSort).toHaveBeenCalledWith({ column: 'upfront_cost', direction: 'desc' });
     });
 
-    test('bulk toolbar appears when at least one row is selected', async () => {
+    test('bottom action box selection summary reflects current selection (Bundle B)', async () => {
+      // Bundle B replaced the floating .recommendations-bulk-toolbar with
+      // selection-summary text inside the sticky bottom action box.
       (api.getRecommendations as jest.Mock).mockResolvedValue({
         summary: {},
         recommendations: [
@@ -446,16 +424,24 @@ describe('Recommendations Module', () => {
         regions: []
       });
       (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set(['rec-bt']));
+      (state.getVisibleRecommendations as jest.Mock).mockReturnValue([
+        { id: 'rec-bt', provider: 'aws', service: 'ec2', resource_type: 't3.medium', region: 'us-east-1', count: 1, term: 1, savings: 100, upfront_cost: 500 }
+      ]);
 
       await loadRecommendations();
 
-      const toolbar = document.querySelector('.recommendations-bulk-toolbar');
-      expect(toolbar).not.toBeNull();
+      const summary = document.getElementById('recommendations-action-summary');
+      expect(summary?.textContent).toContain('1 selected of 1 visible');
+      // Old bulk-toolbar surface is gone.
+      expect(document.querySelector('.recommendations-bulk-toolbar')).toBeNull();
     });
 
-    test('bulk toolbar is absent when no row is selected', async () => {
+    test('bottom action box shows "All N visible" when no row is selected (Bundle B)', async () => {
       (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set());
+      (state.getVisibleRecommendations as jest.Mock).mockReturnValue(twoRecs);
       await loadRecommendations();
+      const summary = document.getElementById('recommendations-action-summary');
+      expect(summary?.textContent).toMatch(/All \d+ visible/);
       expect(document.querySelector('.recommendations-bulk-toolbar')).toBeNull();
     });
 
@@ -727,78 +713,14 @@ describe('Recommendations Module', () => {
       });
     });
 
-    test('sets up provider filter change handler', () => {
-      setupRecommendationsHandlers();
-
-      const providerFilter = document.getElementById('recommendations-provider-filter') as HTMLSelectElement;
-      providerFilter.value = 'aws';
-      providerFilter.dispatchEvent(new Event('change'));
-
-      expect(state.setCurrentProvider).toHaveBeenCalledWith('aws');
-    });
-
-    test('provider filter updates service filter visibility', () => {
-      setupRecommendationsHandlers();
-
-      const providerFilter = document.getElementById('recommendations-provider-filter') as HTMLSelectElement;
-      const serviceFilter = document.getElementById('service-filter') as HTMLSelectElement;
-      const awsGroup = serviceFilter.querySelector('optgroup[label="AWS Services"]') as HTMLOptGroupElement;
-      const azureGroup = serviceFilter.querySelector('optgroup[label="Azure Services"]') as HTMLOptGroupElement;
-
-      providerFilter.value = 'aws';
-      providerFilter.dispatchEvent(new Event('change'));
-
-      expect(awsGroup.classList.contains('hidden')).toBe(false);
-      expect(azureGroup.classList.contains('hidden')).toBe(true);
-    });
-
-    test('shows all service groups when "all" selected', () => {
-      setupRecommendationsHandlers();
-
-      const providerFilter = document.getElementById('recommendations-provider-filter') as HTMLSelectElement;
-      const serviceFilter = document.getElementById('service-filter') as HTMLSelectElement;
-      const awsGroup = serviceFilter.querySelector('optgroup[label="AWS Services"]') as HTMLOptGroupElement;
-      const azureGroup = serviceFilter.querySelector('optgroup[label="Azure Services"]') as HTMLOptGroupElement;
-
-      providerFilter.value = '';
-      providerFilter.dispatchEvent(new Event('change'));
-
-      expect(awsGroup.classList.contains('hidden')).toBe(false);
-      expect(azureGroup.classList.contains('hidden')).toBe(false);
-    });
-
-    test('resets service filter when changing provider', () => {
-      setupRecommendationsHandlers();
-
-      const providerFilter = document.getElementById('recommendations-provider-filter') as HTMLSelectElement;
-      const serviceFilter = document.getElementById('service-filter') as HTMLSelectElement;
-
-      serviceFilter.value = 'ec2';
-      providerFilter.value = 'azure';
-      providerFilter.dispatchEvent(new Event('change'));
-
-      expect(serviceFilter.value).toBe('');
-    });
-
-    test('sets up service filter change handler', () => {
-      setupRecommendationsHandlers();
-
-      const serviceFilter = document.getElementById('service-filter') as HTMLSelectElement;
-      expect(serviceFilter).toBeTruthy();
-    });
-
-    test('sets up region filter change handler', () => {
-      setupRecommendationsHandlers();
-
-      const regionFilter = document.getElementById('region-filter') as HTMLSelectElement;
-      expect(regionFilter).toBeTruthy();
-    });
-
-    test('sets up min savings filter change handler', () => {
-      setupRecommendationsHandlers();
-
-      const minSavingsFilter = document.getElementById('min-savings-filter') as HTMLInputElement;
-      expect(minSavingsFilter).toBeTruthy();
+    // The legacy top filter bar tests (provider-filter / service-filter /
+    // region-filter / min-savings-filter change handlers + service-filter
+    // visibility-toggle) are obsolete: Bundle B replaced those DOM elements
+    // with per-column header-mounted popovers. See the column-filter +
+    // bottom-action-box tests below for their successors.
+    test('setupRecommendationsHandlers is a no-op (Bundle B)', () => {
+      // Should not throw, even with the legacy filter-bar DOM absent.
+      expect(() => setupRecommendationsHandlers()).not.toThrow();
     });
   });
 });
@@ -1055,5 +977,307 @@ describe('state.ts column-filter accessors', () => {
     // mutating returned array must not affect module state
     (out as unknown as Array<unknown>).pop();
     expect(realState.getVisibleRecommendations()).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bundle B: column-filter popover + sticky bottom action box DOM behaviour.
+// These tests assert the surfaces Bundle B introduced — header filter
+// triggers, the detached popover lifecycle, and the bottom action box's
+// label/disabled-state transitions.
+// ---------------------------------------------------------------------------
+
+describe('Bundle B: column header filter triggers', () => {
+  const sampleRecs = [
+    { id: 'rec-aws-1', provider: 'aws', cloud_account_id: 'a1', service: 'ec2', resource_type: 't3.medium', region: 'us-east-1', count: 1, term: 1, savings: 100, upfront_cost: 500 },
+    { id: 'rec-az-1',  provider: 'azure', cloud_account_id: 'a2', service: 'vm',  resource_type: 'D2s',       region: 'eastus',    count: 2, term: 3, savings: 200, upfront_cost: 800 },
+  ];
+
+  beforeEach(() => {
+    // Set up DOM (the top-level beforeEach belongs to a different describe).
+    document.body.replaceChildren();
+    const recsTab = document.createElement('div');
+    recsTab.id = 'recommendations-tab';
+    recsTab.className = 'tab-content active';
+    const summary = document.createElement('div');
+    summary.id = 'recommendations-summary';
+    const list = document.createElement('div');
+    list.id = 'recommendations-list';
+    recsTab.appendChild(summary);
+    recsTab.appendChild(list);
+    document.body.appendChild(recsTab);
+    const purchaseModal = document.createElement('div');
+    purchaseModal.id = 'purchase-modal';
+    purchaseModal.className = 'hidden';
+    const purchaseDetails = document.createElement('div');
+    purchaseDetails.id = 'purchase-details';
+    purchaseModal.appendChild(purchaseDetails);
+    document.body.appendChild(purchaseModal);
+
+    jest.clearAllMocks();
+    (api.getRecommendations as jest.Mock).mockResolvedValue({
+      summary: {},
+      recommendations: sampleRecs,
+      regions: [],
+    });
+    (state.getRecommendations as jest.Mock).mockReturnValue(sampleRecs);
+    (state.getVisibleRecommendations as jest.Mock).mockReturnValue(sampleRecs);
+    (state.getRecommendationsColumnFilters as jest.Mock).mockReturnValue({});
+    (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set());
+  });
+
+  test('every data column header has a filter trigger button', async () => {
+    await loadRecommendations();
+    const buttons = document.querySelectorAll<HTMLButtonElement>('th .column-filter-btn[data-column]');
+    const cols = Array.from(buttons).map((b) => b.dataset['column']);
+    expect(cols.sort()).toEqual(
+      ['account', 'count', 'provider', 'region', 'resource_type', 'savings', 'service', 'term', 'upfront_cost'].sort(),
+    );
+  });
+
+  test('filter button gets .active class when its column has a filter', async () => {
+    (state.getRecommendationsColumnFilters as jest.Mock).mockReturnValue({
+      provider: { kind: 'set', values: ['aws'] },
+    });
+    await loadRecommendations();
+    const providerBtn = document.querySelector<HTMLButtonElement>('th .column-filter-btn[data-column="provider"]');
+    expect(providerBtn?.classList.contains('active')).toBe(true);
+    const serviceBtn = document.querySelector<HTMLButtonElement>('th .column-filter-btn[data-column="service"]');
+    expect(serviceBtn?.classList.contains('active')).toBe(false);
+  });
+
+  test('clicking a filter trigger opens a popover detached to document.body', async () => {
+    await loadRecommendations();
+    const providerBtn = document.querySelector<HTMLButtonElement>('th .column-filter-btn[data-column="provider"]');
+    providerBtn?.click();
+    const popover = document.body.querySelector('.column-filter-popover');
+    expect(popover).not.toBeNull();
+    // Not a descendant of the table.
+    expect(popover?.closest('table')).toBeNull();
+  });
+
+  test('clicking the same trigger toggles the popover closed', async () => {
+    await loadRecommendations();
+    const providerBtn = document.querySelector<HTMLButtonElement>('th .column-filter-btn[data-column="provider"]');
+    providerBtn?.click();
+    expect(document.querySelector('.column-filter-popover')).not.toBeNull();
+    providerBtn?.click();
+    expect(document.querySelector('.column-filter-popover')).toBeNull();
+  });
+
+  test('ESC closes the popover and restores focus to the trigger', async () => {
+    await loadRecommendations();
+    const providerBtn = document.querySelector<HTMLButtonElement>('th .column-filter-btn[data-column="provider"]');
+    providerBtn?.click();
+    expect(document.querySelector('.column-filter-popover')).not.toBeNull();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(document.querySelector('.column-filter-popover')).toBeNull();
+  });
+
+  test('categorical popover lists distinct values from the unfiltered rec set', async () => {
+    await loadRecommendations();
+    const providerBtn = document.querySelector<HTMLButtonElement>('th .column-filter-btn[data-column="provider"]');
+    providerBtn?.click();
+    const checkboxes = document.querySelectorAll<HTMLInputElement>('.column-filter-popover .column-filter-item input[type="checkbox"]');
+    const values = Array.from(checkboxes).map((cb) => cb.dataset['value']);
+    expect(values.sort()).toEqual(['aws', 'azure']);
+  });
+
+  test('Term popover labels show formatted terms; ticking commits string filter values', async () => {
+    await loadRecommendations();
+    const termBtn = document.querySelector<HTMLButtonElement>('th .column-filter-btn[data-column="term"]');
+    termBtn?.click();
+    const items = Array.from(
+      document.querySelectorAll<HTMLLabelElement>('.column-filter-popover .column-filter-item'),
+    );
+    const labels = items.map((l) => l.querySelector('span')?.textContent);
+    expect(labels.sort()).toEqual(['1 Year', '3 Years']);
+    // Tick the "3 Years" checkbox
+    const threeYearLabel = items.find((l) => l.textContent === '3 Years');
+    const cb = threeYearLabel?.querySelector<HTMLInputElement>('input[type="checkbox"]');
+    expect(cb?.dataset['value']).toBe('3');
+    cb!.checked = true;
+    cb!.dispatchEvent(new Event('change'));
+    expect(state.setRecommendationsColumnFilter).toHaveBeenCalledWith('term', { kind: 'set', values: ['3'] });
+  });
+
+  test('numeric popover input validates expression on blur', async () => {
+    await loadRecommendations();
+    const savingsBtn = document.querySelector<HTMLButtonElement>('th .column-filter-btn[data-column="savings"]');
+    savingsBtn?.click();
+    const input = document.querySelector<HTMLInputElement>('.column-filter-popover .column-filter-numeric-input');
+    expect(input).not.toBeNull();
+    input!.value = '>>5';
+    input!.dispatchEvent(new Event('blur'));
+    const err = document.querySelector('.column-filter-popover .column-filter-error');
+    expect(err?.textContent).toMatch(/Invalid filter term/);
+    // No filter applied for invalid syntax.
+    expect(state.setRecommendationsColumnFilter).not.toHaveBeenCalledWith(
+      'savings',
+      expect.objectContaining({ kind: 'expr' }),
+    );
+  });
+
+  test('numeric popover commits valid expression on Enter', async () => {
+    await loadRecommendations();
+    const savingsBtn = document.querySelector<HTMLButtonElement>('th .column-filter-btn[data-column="savings"]');
+    savingsBtn?.click();
+    const input = document.querySelector<HTMLInputElement>('.column-filter-popover .column-filter-numeric-input');
+    input!.value = '>100';
+    input!.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    expect(state.setRecommendationsColumnFilter).toHaveBeenCalledWith('savings', { kind: 'expr', expr: '>100' });
+  });
+
+  test('Clear button drops the filter for that column', async () => {
+    (state.getRecommendationsColumnFilters as jest.Mock).mockReturnValue({
+      provider: { kind: 'set', values: ['aws'] },
+    });
+    await loadRecommendations();
+    const providerBtn = document.querySelector<HTMLButtonElement>('th .column-filter-btn[data-column="provider"]');
+    providerBtn?.click();
+    const clearBtn = document.querySelector<HTMLButtonElement>('.column-filter-popover .column-filter-clear');
+    clearBtn?.click();
+    expect(state.setRecommendationsColumnFilter).toHaveBeenCalledWith('provider', null);
+  });
+
+  test('Clear-filters badge appears when at least one filter is active', async () => {
+    (state.getRecommendationsColumnFilters as jest.Mock).mockReturnValue({
+      provider: { kind: 'set', values: ['aws'] },
+    });
+    await loadRecommendations();
+    const badge = document.querySelector<HTMLButtonElement>('.recommendations-filter-status .clear-filters');
+    expect(badge).not.toBeNull();
+    expect(badge?.textContent).toContain('Clear filters (1)');
+  });
+
+  test('aria-live region announces visible/loaded count', async () => {
+    await loadRecommendations();
+    const live = document.querySelector('.recommendations-filter-live');
+    expect(live).not.toBeNull();
+    expect(live?.getAttribute('aria-live')).toBe('polite');
+    expect(live?.textContent).toMatch(/Showing \d+ of \d+/);
+  });
+});
+
+describe('Bundle B: sticky bottom action box', () => {
+  const recs = [
+    { id: 'r1', provider: 'aws', cloud_account_id: 'a1', service: 'ec2', resource_type: 't3.medium', region: 'us-east-1', count: 1, term: 1, savings: 100, upfront_cost: 500 },
+    { id: 'r2', provider: 'aws', cloud_account_id: 'a1', service: 'ec2', resource_type: 't3.large', region: 'us-east-1', count: 2, term: 3, savings: 200, upfront_cost: 800 },
+  ];
+
+  beforeEach(() => {
+    document.body.replaceChildren();
+    const recsTab = document.createElement('div');
+    recsTab.id = 'recommendations-tab';
+    recsTab.className = 'tab-content active';
+    const summary = document.createElement('div');
+    summary.id = 'recommendations-summary';
+    const list = document.createElement('div');
+    list.id = 'recommendations-list';
+    recsTab.appendChild(summary);
+    recsTab.appendChild(list);
+    document.body.appendChild(recsTab);
+
+    jest.clearAllMocks();
+    (api.getRecommendations as jest.Mock).mockResolvedValue({ summary: {}, recommendations: recs, regions: [] });
+    (state.getRecommendations as jest.Mock).mockReturnValue(recs);
+    (state.getVisibleRecommendations as jest.Mock).mockReturnValue(recs);
+    (state.getRecommendationsColumnFilters as jest.Mock).mockReturnValue({});
+    (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set());
+  });
+
+  test('bottom box exposes Payment / Capacity % / Purchase / Create Plan; no Term selector', async () => {
+    await loadRecommendations();
+    expect(document.getElementById('bulk-purchase-payment')).not.toBeNull();
+    expect(document.getElementById('bulk-purchase-capacity')).not.toBeNull();
+    expect(document.getElementById('bulk-purchase-btn')).not.toBeNull();
+    expect(document.getElementById('create-plan-btn')).not.toBeNull();
+    // Term selector is gone — each rec carries its own term through the API call.
+    expect(document.getElementById('bulk-purchase-term')).toBeNull();
+  });
+
+  test('button labels reflect the action target', async () => {
+    await loadRecommendations();
+    let purchaseBtn = document.getElementById('bulk-purchase-btn') as HTMLButtonElement;
+    expect(purchaseBtn.textContent).toBe('Purchase 2 visible');
+
+    (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set(['r1']));
+    await loadRecommendations();
+    purchaseBtn = document.getElementById('bulk-purchase-btn') as HTMLButtonElement;
+    expect(purchaseBtn.textContent).toBe('Purchase 1 selected');
+  });
+
+  test('buttons disabled when target is empty', async () => {
+    (state.getVisibleRecommendations as jest.Mock).mockReturnValue([]);
+    (api.getRecommendations as jest.Mock).mockResolvedValue({ summary: {}, recommendations: [], regions: [] });
+    await loadRecommendations();
+    const purchaseBtn = document.getElementById('bulk-purchase-btn') as HTMLButtonElement;
+    const planBtn = document.getElementById('create-plan-btn') as HTMLButtonElement;
+    expect(purchaseBtn.disabled).toBe(true);
+    expect(planBtn.disabled).toBe(true);
+  });
+
+  test('Capacity input value persists across re-render (mount-once-then-update)', async () => {
+    await loadRecommendations();
+    const cap = document.getElementById('bulk-purchase-capacity') as HTMLInputElement;
+    cap.value = '50';
+    // Trigger an unrelated re-render via sort
+    const header = document.querySelector<HTMLTableCellElement>('th[data-sort="service"]');
+    header?.click();
+    const cap2 = document.getElementById('bulk-purchase-capacity') as HTMLInputElement;
+    // Same DOM node (mount-once); value preserved (no rebuild).
+    expect(cap2).toBe(cap);
+    expect(cap2.value).toBe('50');
+  });
+});
+
+describe('Bundle B: term-aware bucketing in the Purchase flow', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+    const recsTab = document.createElement('div');
+    recsTab.id = 'recommendations-tab';
+    recsTab.className = 'tab-content active';
+    const summary = document.createElement('div');
+    summary.id = 'recommendations-summary';
+    const list = document.createElement('div');
+    list.id = 'recommendations-list';
+    recsTab.appendChild(summary);
+    recsTab.appendChild(list);
+    document.body.appendChild(recsTab);
+    const purchaseModal = document.createElement('div');
+    purchaseModal.id = 'purchase-modal';
+    purchaseModal.className = 'hidden';
+    const purchaseDetails = document.createElement('div');
+    purchaseDetails.id = 'purchase-details';
+    purchaseModal.appendChild(purchaseDetails);
+    document.body.appendChild(purchaseModal);
+    jest.clearAllMocks();
+  });
+
+  test('multi-term selection produces multiple fan-out buckets', async () => {
+    const mixed = [
+      { id: 'a', provider: 'aws', cloud_account_id: 'a1', service: 'ec2', resource_type: 't3.medium', region: 'us-east-1', count: 1, term: 1, savings: 100, upfront_cost: 500 },
+      { id: 'b', provider: 'aws', cloud_account_id: 'a1', service: 'ec2', resource_type: 't3.medium', region: 'us-east-1', count: 1, term: 3, savings: 200, upfront_cost: 800 },
+    ];
+    (api.getRecommendations as jest.Mock).mockResolvedValue({ summary: {}, recommendations: mixed, regions: [] });
+    (state.getRecommendations as jest.Mock).mockReturnValue(mixed);
+    (state.getVisibleRecommendations as jest.Mock).mockReturnValue(mixed);
+    (state.getRecommendationsColumnFilters as jest.Mock).mockReturnValue({});
+    (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set());
+
+    await loadRecommendations();
+    const purchaseBtn = document.getElementById('bulk-purchase-btn') as HTMLButtonElement;
+    purchaseBtn.click();
+
+    const { getFanOutBuckets } = await import('../recommendations');
+    const buckets = getFanOutBuckets();
+    expect(buckets).not.toBeNull();
+    expect(buckets!.length).toBe(2);
+    expect(buckets!.map((b) => b.term).sort()).toEqual([1, 3]);
+    // Each bucket carries the rec's own term, not a toolbar override.
+    const b0 = buckets![0]!;
+    const b1 = buckets![1]!;
+    expect(b0.recs.every((r) => r.term === b0.term)).toBe(true);
+    expect(b1.recs.every((r) => r.term === b1.term)).toBe(true);
   });
 });

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -8,7 +8,7 @@ import { showLoginModal, showAdminSetupModal, showResetPasswordModal, updateUser
 import { loadDashboard, setupDashboardHandlers } from './dashboard';
 import { setupRecommendationsHandlers, getPurchaseModalRecommendations, clearPurchaseModalRecommendations, getFanOutBuckets, clearFanOutBuckets, type FanOutBucket } from './recommendations';
 import { switchTab, applyTabFromPath, initRouter, switchSettingsSubTab, getSettingsSubTabFromPath } from './navigation';
-import { savePlan, setupPlanHandlers, closePlanModal, openCreatePlanModal, openNewPlanModal, closePurchaseModal } from './plans';
+import { savePlan, setupPlanHandlers, closePlanModal, openNewPlanModal, closePurchaseModal } from './plans';
 import { saveGlobalSettings, setupSettingsHandlers, resetSettings } from './settings';
 import { setupUserHandlers } from './users';
 import { initApiKeys } from './apikeys';
@@ -170,10 +170,11 @@ function setupButtonHandlers(): void {
   // Refresh button was removed because it duplicated the freshness-
   // indicator Refresh with strictly worse UX (alert() popup + 5s delay
   // vs. the freshness button's inline disable + re-render).
-  const createPlanBtn = document.getElementById('create-plan-btn');
-  if (createPlanBtn) {
-    createPlanBtn.addEventListener('click', () => openCreatePlanModal());
-  }
+  //
+  // Bundle B note (column-filter UX overhaul): #create-plan-btn was relocated
+  // from the old top filter bar into the sticky bottom action box. The
+  // button is now created and wired by recommendations.ts:mountBottomActionBox,
+  // which calls openCreatePlanModal directly. The wiring used to live here.
 
   // Plans buttons
   const newPlanBtn = document.getElementById('new-plan-btn');

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -88,72 +88,14 @@
 
             <!-- Recommendations Tab -->
             <div id="recommendations-tab" class="tab-content" role="tabpanel" aria-labelledby="recommendations-tab-btn">
-                <section id="recommendations-controls">
-                    <div class="controls-bar">
-                        <div class="filter-group">
-                            <label>Provider:
-                                <select id="recommendations-provider-filter">
-                                    <option value="">All Providers</option>
-                                    <option value="aws">AWS</option>
-                                    <option value="azure">Azure</option>
-                                    <option value="gcp">GCP</option>
-                                </select>
-                            </label>
-                            <label>Service:
-                                <select id="service-filter">
-                                    <option value="">All Services</option>
-                                    <optgroup label="AWS">
-                                        <option value="ec2">EC2</option>
-                                        <option value="rds">RDS</option>
-                                        <option value="elasticache">ElastiCache</option>
-                                        <option value="opensearch">OpenSearch</option>
-                                        <option value="memorydb">MemoryDB</option>
-                                        <option value="redshift">Redshift</option>
-                                    </optgroup>
-                                    <optgroup label="Savings Plans">
-                                        <option value="savings-plans-compute">Compute SP</option>
-                                        <option value="savings-plans-ec2instance">EC2 Instance SP</option>
-                                        <option value="savings-plans-sagemaker">SageMaker SP</option>
-                                        <option value="savings-plans-database">Database SP</option>
-                                    </optgroup>
-                                    <optgroup label="Azure">
-                                        <option value="vm">Virtual Machines</option>
-                                        <option value="sql">SQL Database</option>
-                                        <option value="cosmosdb">Cosmos DB</option>
-                                        <option value="redis">Azure Cache</option>
-                                        <option value="search">Cognitive Search</option>
-                                    </optgroup>
-                                    <optgroup label="GCP">
-                                        <option value="compute">Compute Engine</option>
-                                        <option value="cloudsql">Cloud SQL</option>
-                                        <option value="memorystore">Memorystore</option>
-                                        <option value="cloudstorage">Cloud Storage</option>
-                                    </optgroup>
-                                </select>
-                            </label>
-                            <label>Region:
-                                <select id="region-filter">
-                                    <option value="">All Regions</option>
-                                </select>
-                            </label>
-                            <label>Min Savings:
-                                <input type="number" id="min-savings-filter" placeholder="$0" min="0">
-                            </label>
-                        </div>
-                        <div class="filter-group">
-                            <label>Account:
-                                <select id="recommendations-account-filter">
-                                    <option value="">All Accounts</option>
-                                </select>
-                            </label>
-                        </div>
-                        <div class="action-group">
-                            <button id="create-plan-btn" class="primary">Create Purchase Plan</button>
-                        </div>
-                    </div>
-                </section>
                 <section id="recommendations-freshness" class="freshness-indicator" aria-live="polite"></section>
                 <section id="recommendations-summary"></section>
+                <!-- Per-column header filters replace the old top filter bar.
+                     The Clear-filters badge + aria-live count are injected
+                     by recommendations.ts:renderFilterStatusBar above the
+                     list. Bottom action box (Payment / Capacity % / Purchase /
+                     Create Plan) is rendered after the table by
+                     mountBottomActionBox. -->
                 <section id="recommendations-list"></section>
             </div>
 

--- a/frontend/src/plans.ts
+++ b/frontend/src/plans.ts
@@ -549,10 +549,19 @@ export async function savePlan(e: Event): Promise<void> {
     plan.custom_interval_days = parseInt((document.getElementById('ramp-interval-days') as HTMLInputElement).value, 10);
   }
 
+  // Bundle B (column-filter UX overhaul): read from getVisibleRecommendations
+  // — the post-filter, post-sort set tracked by recommendations.ts on every
+  // render — instead of getRecommendations() (raw API-loaded list). This
+  // ensures plans never include recs the user filtered out of view.
+  // When no row is explicitly selected, fall back to the full visible set so
+  // "Create Plan" with filters but no selection plans against everything the
+  // user can see.
   const selectedIDs = state.getSelectedRecommendationIDs();
+  const visibleRecs = state.getVisibleRecommendations();
   if (selectedIDs.size > 0) {
-    const currentRecs = state.getRecommendations();
-    plan.recommendations = currentRecs.filter((r) => selectedIDs.has(r.id)) as api.Recommendation[];
+    plan.recommendations = visibleRecs.filter((r) => selectedIDs.has(r.id)) as api.Recommendation[];
+  } else if (visibleRecs.length > 0) {
+    plan.recommendations = [...visibleRecs] as api.Recommendation[];
   }
 
   try {

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -4,7 +4,7 @@
 
 import * as api from './api';
 import * as state from './state';
-import { formatCurrency, formatTerm, escapeHtml, populateAccountFilter } from './utils';
+import { formatCurrency, formatTerm, escapeHtml, formatRelativeTime } from './utils';
 import { renderFreshness } from './freshness';
 import { getRecommendationDetail, type RecommendationDetail } from './api/recommendations';
 import { showToast } from './toast';
@@ -17,9 +17,11 @@ let currentPurchaseRecommendations: LocalRecommendation[] = [];
 // Cache of account ID → name for column display
 let accountNamesCache: Map<string, string> = new Map();
 
-function populateRecommendationsAccountFilter(provider?: string): Promise<void> {
-  return populateAccountFilter('recommendations-account-filter', api.listAccounts, provider);
-}
+// populateRecommendationsAccountFilter / populateRegionFilter / the legacy
+// service-filter helpers were removed in Bundle B — those DOM elements are
+// gone from index.html. Provider / Account values now drive an API re-fetch
+// via the column-header popovers (see openColumnPopover wiring); Service /
+// Region filtering is purely client-side via applyColumnFilters.
 
 /**
  * Get the recommendations currently loaded in the purchase modal
@@ -39,66 +41,14 @@ export function clearPurchaseModalRecommendations(): void {
  * Setup recommendations event handlers
  */
 export function setupRecommendationsHandlers(): void {
-  const providerFilter = document.getElementById('recommendations-provider-filter') as HTMLSelectElement | null;
-  if (providerFilter) {
-    // Set initial value from state
-    providerFilter.value = state.getCurrentProvider();
-
-    providerFilter.addEventListener('change', () => {
-      state.setCurrentProvider(providerFilter.value as '' | 'aws' | 'azure' | 'gcp');
-      updateServiceFilterVisibility(providerFilter.value);
-      void populateRecommendationsAccountFilter(providerFilter.value);
-      void loadRecommendations();
-    });
-  }
-
-  const accountFilter = document.getElementById('recommendations-account-filter') as HTMLSelectElement | null;
-  if (accountFilter) {
-    accountFilter.addEventListener('change', () => {
-      const val = accountFilter.value;
-      state.setCurrentAccountIDs(val ? [val] : []);
-      void loadRecommendations();
-    });
-  }
-
-  void populateRecommendationsAccountFilter(state.getCurrentProvider());
-
-  // Setup service filter handler
-  const serviceFilter = document.getElementById('service-filter') as HTMLSelectElement | null;
-  if (serviceFilter) {
-    serviceFilter.addEventListener('change', () => void loadRecommendations());
-  }
-
-  // Setup region filter handler
-  const regionFilter = document.getElementById('region-filter') as HTMLSelectElement | null;
-  if (regionFilter) {
-    regionFilter.addEventListener('change', () => void loadRecommendations());
-  }
-
-  // Setup min savings filter handler
-  const minSavingsFilter = document.getElementById('min-savings-filter') as HTMLInputElement | null;
-  if (minSavingsFilter) {
-    minSavingsFilter.addEventListener('change', () => void loadRecommendations());
-  }
-}
-
-/**
- * Update service filter visibility based on selected provider
- */
-function updateServiceFilterVisibility(provider: string): void {
-  const serviceFilter = document.getElementById('service-filter') as HTMLSelectElement | null;
-  if (!serviceFilter) return;
-
-  // Show/hide optgroups based on selected provider
-  const optgroups = serviceFilter.querySelectorAll('optgroup');
-  optgroups.forEach(optgroup => {
-    const providerLabel = optgroup.label.toLowerCase();
-    const shouldShow = provider === '' || providerLabel.includes(provider);
-    optgroup.classList.toggle('hidden', !shouldShow);
-  });
-
-  // Reset selection to "All Services" when switching providers
-  serviceFilter.value = '';
+  // The legacy top filter bar (#recommendations-provider-filter,
+  // #recommendations-account-filter, #service-filter, #region-filter,
+  // #min-savings-filter) is gone — Bundle B replaced those with per-column
+  // header-mounted popovers driven by state.RecommendationsColumnFilters.
+  // No DOM listeners need wiring here anymore; the column-filter trigger
+  // listeners are attached per-render inside renderRecommendationsList,
+  // and Provider/Account-driven API re-fetch is handled by their popover
+  // commit hooks (see Bundle B follow-up).
 }
 
 /**
@@ -106,17 +56,13 @@ function updateServiceFilterVisibility(provider: string): void {
  */
 export async function loadRecommendations(): Promise<void> {
   try {
-    const serviceFilter = document.getElementById('service-filter') as HTMLSelectElement | null;
-    const regionFilter = document.getElementById('region-filter') as HTMLSelectElement | null;
-    const minSavingsFilter = document.getElementById('min-savings-filter') as HTMLInputElement | null;
-
+    // Provider + account_ids are still sent to the API as hints so the
+    // backend stays bounded for big multi-cloud tenants. Service / Region /
+    // numeric filters are pure client-side via applyColumnFilters.
     const accountIDs = state.getCurrentAccountIDs();
     const filters: api.RecommendationFilters = {
       provider: state.getCurrentProvider(),
-      service: serviceFilter?.value,
-      region: regionFilter?.value,
-      minSavings: minSavingsFilter?.value ? parseInt(minSavingsFilter.value, 10) : undefined,
-      account_ids: accountIDs.length > 0 ? accountIDs : undefined
+      account_ids: accountIDs.length > 0 ? accountIDs : undefined,
     };
 
     const [data, accounts] = await Promise.all([
@@ -129,7 +75,6 @@ export async function loadRecommendations(): Promise<void> {
 
     renderRecommendationsSummary(data.summary || {});
     renderRecommendationsList(data.recommendations || []);
-    populateRegionFilter(data.regions || []);
 
     // Freshness indicator reflects the last collection timestamp; refreshed
     // on every load so provider/account switches + manual refreshes stay
@@ -169,18 +114,35 @@ function renderRecommendationsSummary(summary: RecommendationsSummary): void {
   `;
 }
 
-const SORTABLE_COLUMNS: Record<string, (r: LocalRecommendation) => number> = {
+// Comparator extractors per column. Numeric columns return numbers
+// (subtraction-based sort); string columns return strings (localeCompare-based
+// sort). Bundle B extended this with the string columns so every visible data
+// column is sortable.
+const SORTABLE_NUMERIC_COLUMNS: Record<string, (r: LocalRecommendation) => number> = {
   savings: (r) => r.savings,
   upfront_cost: (r) => r.upfront_cost,
   count: (r) => r.count,
   term: (r) => r.term,
 };
 
+const SORTABLE_STRING_COLUMNS: Record<string, (r: LocalRecommendation) => string> = {
+  provider: (r) => r.provider ?? '',
+  account: (r) => accountNamesCache.get(r.cloud_account_id ?? '') ?? r.cloud_account_id ?? '',
+  service: (r) => r.service ?? '',
+  resource_type: (r) => r.resource_type ?? '',
+  region: (r) => r.region ?? '',
+};
+
 const SORT_HEADER_LABELS: Record<string, string> = {
-  savings: 'Monthly Savings',
-  upfront_cost: 'Upfront Cost',
+  provider: 'Provider',
+  account: 'Account',
+  service: 'Service',
+  resource_type: 'Resource Type',
+  region: 'Region',
   count: 'Count',
   term: 'Term',
+  savings: 'Monthly Savings',
+  upfront_cost: 'Upfront Cost',
 };
 
 function sortIndicator(column: string, active: string, direction: 'asc' | 'desc'): string {
@@ -192,11 +154,17 @@ function sortIndicator(column: string, active: string, direction: 'asc' | 'desc'
 
 function sortedRecommendations(recs: LocalRecommendation[]): LocalRecommendation[] {
   const sort = state.getRecommendationsSort();
-  const key = SORTABLE_COLUMNS[sort.column];
-  if (!key) return recs;
   const direction = sort.direction === 'asc' ? 1 : -1;
-  // slice() clones so we don't mutate the caller's array.
-  return recs.slice().sort((a, b) => (key(a) - key(b)) * direction);
+  const numericKey = SORTABLE_NUMERIC_COLUMNS[sort.column];
+  if (numericKey) {
+    // slice() clones so we don't mutate the caller's array.
+    return recs.slice().sort((a, b) => (numericKey(a) - numericKey(b)) * direction);
+  }
+  const stringKey = SORTABLE_STRING_COLUMNS[sort.column];
+  if (stringKey) {
+    return recs.slice().sort((a, b) => stringKey(a).localeCompare(stringKey(b)) * direction);
+  }
+  return recs;
 }
 
 // Numeric filter expression parser. Grammar:
@@ -322,51 +290,508 @@ function numericCellValue(r: LocalRecommendation, col: state.RecommendationsColu
   }
 }
 
-function renderBulkToolbar(container: HTMLElement, recommendations: LocalRecommendation[], selectedCount: number): void {
-  const existing = container.querySelector('.recommendations-bulk-toolbar');
-  if (existing) existing.remove();
-  if (selectedCount === 0) return;
-  const toolbar = document.createElement('div');
-  toolbar.className = 'recommendations-bulk-toolbar';
-  toolbar.setAttribute('role', 'toolbar');
-  toolbar.setAttribute('aria-label', 'Bulk actions for selected recommendations');
+// ---------------------------------------------------------------------------
+// Column-filter popover (portal pattern)
+//
+// The popover element lives appended to document.body so it survives
+// renderRecommendationsList's table re-render (which does container.innerHTML
+// = buildListMarkup, destroying anything inside <th>). Module-scope state
+// tracks which column id is currently open; the trigger DOM node is re-found
+// by `[data-column="..."]` on every render (anchor re-bind).
+//
+// The popover STRUCTURE is built once on open; STATE (.checked / .value) is
+// re-synced on every anchor re-bind from the latest column-filter state, EXCEPT
+// when the input is document.activeElement (mid-typing protection).
+// ---------------------------------------------------------------------------
 
-  const count = document.createElement('span');
-  count.className = 'bulk-count';
-  count.textContent = `${selectedCount} selected`;
-  toolbar.appendChild(count);
+const NUMERIC_COLUMNS: ReadonlySet<state.RecommendationsColumnId> = new Set([
+  'count', 'savings', 'upfront_cost',
+]);
 
-  const addBtn = document.createElement('button');
-  addBtn.type = 'button';
-  addBtn.className = 'btn btn-small btn-primary';
-  addBtn.textContent = 'Add to plan';
-  addBtn.addEventListener('click', () => {
-    const picks = selectedRecsFromVisible(recommendations);
-    if (picks.length > 0) openPurchaseModal(picks);
+interface PopoverState {
+  column: state.RecommendationsColumnId;
+  el: HTMLDivElement;
+  // The categorical-popover checkboxes are keyed by their underlying filter
+  // value (cloud_account_id for Account, "1"/"3" for Term, raw string
+  // otherwise). Saved here so anchor re-bind can resync .checked from state.
+  checkboxes: Map<string, HTMLInputElement>;
+  // Numeric-popover input + error span for re-sync.
+  input: HTMLInputElement | null;
+  errorEl: HTMLElement | null;
+  // Trigger lives in the table; rebound by `[data-column="..."]` on each
+  // render so we don't hold a stale reference.
+  triggerColumn: state.RecommendationsColumnId;
+}
+
+let openPopover: PopoverState | null = null;
+// Document-level click-outside listener; attached once on first open and
+// torn down on close.
+let outsideClickHandler: ((e: MouseEvent) => void) | null = null;
+let escKeyHandler: ((e: KeyboardEvent) => void) | null = null;
+let scrollCloseHandler: (() => void) | null = null;
+let resizeHandler: (() => void) | null = null;
+
+function getColumnTriggerButton(column: state.RecommendationsColumnId): HTMLButtonElement | null {
+  return document.querySelector<HTMLButtonElement>(
+    `th .column-filter-btn[data-column="${column}"]`,
+  );
+}
+
+function positionPopover(popover: HTMLElement, anchor: HTMLElement): void {
+  const rect = anchor.getBoundingClientRect();
+  // Show, then measure (popover may be display:none initially).
+  popover.style.display = 'block';
+  const popRect = popover.getBoundingClientRect();
+  const margin = 8;
+
+  // Vertical: prefer below, flip above on overflow.
+  let top = rect.bottom + 4;
+  if (top + popRect.height > window.innerHeight - margin) {
+    top = Math.max(margin, rect.top - popRect.height - 4);
+  }
+
+  // Horizontal: clamp right edge.
+  let left = rect.left;
+  if (left + popRect.width > window.innerWidth - margin) {
+    left = Math.max(margin, window.innerWidth - margin - popRect.width);
+  }
+
+  popover.style.position = 'absolute';
+  popover.style.top = `${top + window.scrollY}px`;
+  popover.style.left = `${left + window.scrollX}px`;
+}
+
+function distinctValuesForColumn(
+  recs: readonly LocalRecommendation[],
+  column: state.RecommendationsColumnId,
+): string[] {
+  // Numeric columns don't get a checkbox list, but we still call this for
+  // categorical columns only.
+  const seen = new Set<string>();
+  for (const r of recs) {
+    seen.add(categoricalCellValue(r, column));
+  }
+  return Array.from(seen).sort((a, b) => {
+    if (a === '' && b !== '') return -1; // (empty) first
+    if (a !== '' && b === '') return 1;
+    return a.localeCompare(b);
   });
-  toolbar.appendChild(addBtn);
+}
 
+function categoricalDisplayLabel(
+  column: state.RecommendationsColumnId,
+  value: string,
+): string {
+  if (value === '') return '(empty)';
+  if (column === 'account') {
+    return accountNamesCache.get(value) || value;
+  }
+  if (column === 'term') {
+    const n = Number(value);
+    return Number.isFinite(n) ? formatTerm(n) : value;
+  }
+  if (column === 'provider') {
+    return providerDisplayName(value);
+  }
+  return value;
+}
+
+// Build the popover DOM for a given column. Categorical: checkbox list with
+// (All) tri-state + Clear footer. Numeric: free-text expression input with
+// inline error and Clear footer.
+function buildPopoverContent(
+  column: state.RecommendationsColumnId,
+  recs: readonly LocalRecommendation[],
+): { el: HTMLDivElement; checkboxes: Map<string, HTMLInputElement>; input: HTMLInputElement | null; errorEl: HTMLElement | null } {
+  const popover = document.createElement('div');
+  popover.className = 'column-filter-popover';
+  popover.setAttribute('role', 'dialog');
+  popover.setAttribute('aria-modal', 'false');
+
+  const headingId = `column-filter-heading-${column}`;
+  popover.setAttribute('aria-labelledby', headingId);
+
+  const heading = document.createElement('h3');
+  heading.id = headingId;
+  heading.className = 'column-filter-heading';
+  heading.textContent = `Filter ${SORT_HEADER_LABELS[column]}`;
+  popover.appendChild(heading);
+
+  const checkboxes = new Map<string, HTMLInputElement>();
+  let input: HTMLInputElement | null = null;
+  let errorEl: HTMLElement | null = null;
+
+  if (NUMERIC_COLUMNS.has(column)) {
+    const label = document.createElement('label');
+    label.className = 'column-filter-numeric-label';
+    label.textContent = 'Expression';
+    input = document.createElement('input');
+    input.type = 'text';
+    input.className = 'column-filter-numeric-input';
+    input.placeholder = 'e.g. >100, 50..200, 5';
+    input.setAttribute('aria-describedby', `column-filter-error-${column}`);
+    label.appendChild(input);
+    popover.appendChild(label);
+
+    errorEl = document.createElement('div');
+    errorEl.id = `column-filter-error-${column}`;
+    errorEl.className = 'column-filter-error';
+    errorEl.setAttribute('role', 'status');
+    popover.appendChild(errorEl);
+
+    const commit = (): void => {
+      const expr = input!.value.trim();
+      if (expr === '') {
+        state.setRecommendationsColumnFilter(column, null);
+        errorEl!.textContent = '';
+        rerenderRecommendations();
+        return;
+      }
+      const parsed = parseNumericFilter(expr);
+      if (!parsed.ok) {
+        errorEl!.textContent = parsed.error;
+        return;
+      }
+      errorEl!.textContent = '';
+      state.setRecommendationsColumnFilter(column, { kind: 'expr', expr });
+      rerenderRecommendations();
+    };
+    input.addEventListener('blur', commit);
+    input.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        commit();
+      }
+    });
+  } else {
+    const distinct = distinctValuesForColumn(recs, column);
+
+    // (All) tri-state checkbox at the top.
+    const allLabel = document.createElement('label');
+    allLabel.className = 'column-filter-all';
+    const allBox = document.createElement('input');
+    allBox.type = 'checkbox';
+    allBox.dataset['role'] = 'all';
+    allLabel.appendChild(allBox);
+    const allText = document.createElement('span');
+    allText.textContent = '(All)';
+    allLabel.appendChild(allText);
+    popover.appendChild(allLabel);
+
+    const list = document.createElement('div');
+    list.className = 'column-filter-list';
+    for (const value of distinct) {
+      const itemLabel = document.createElement('label');
+      itemLabel.className = 'column-filter-item';
+      const cb = document.createElement('input');
+      cb.type = 'checkbox';
+      cb.dataset['value'] = value;
+      itemLabel.appendChild(cb);
+      const text = document.createElement('span');
+      text.textContent = categoricalDisplayLabel(column, value);
+      itemLabel.appendChild(text);
+      list.appendChild(itemLabel);
+      checkboxes.set(value, cb);
+    }
+    popover.appendChild(list);
+
+    const updateAllTriState = (): void => {
+      const total = checkboxes.size;
+      let checked = 0;
+      checkboxes.forEach((cb) => { if (cb.checked) checked++; });
+      allBox.indeterminate = checked > 0 && checked < total;
+      allBox.checked = checked === total && total > 0;
+    };
+
+    const commit = (): void => {
+      const selected: string[] = [];
+      checkboxes.forEach((cb, value) => { if (cb.checked) selected.push(value); });
+      // No selections OR all selections == "no narrowing", clear the filter.
+      if (selected.length === 0 || selected.length === checkboxes.size) {
+        state.setRecommendationsColumnFilter(column, null);
+      } else {
+        state.setRecommendationsColumnFilter(column, { kind: 'set', values: selected });
+      }
+      updateAllTriState();
+      rerenderRecommendations();
+    };
+
+    checkboxes.forEach((cb) => {
+      cb.addEventListener('change', commit);
+    });
+    allBox.addEventListener('change', () => {
+      const target = allBox.checked;
+      checkboxes.forEach((cb) => { cb.checked = target; });
+      // After (All) flips, update underlying filter once.
+      commit();
+    });
+  }
+
+  // Footer with Clear button.
+  const footer = document.createElement('div');
+  footer.className = 'column-filter-footer';
   const clearBtn = document.createElement('button');
   clearBtn.type = 'button';
-  clearBtn.className = 'btn btn-small btn-secondary';
+  clearBtn.className = 'column-filter-clear';
   clearBtn.textContent = 'Clear';
   clearBtn.addEventListener('click', () => {
-    state.clearSelectedRecommendations();
-    renderRecommendationsList(recommendations);
+    state.setRecommendationsColumnFilter(column, null);
+    if (input) {
+      input.value = '';
+      if (errorEl) errorEl.textContent = '';
+    } else {
+      checkboxes.forEach((cb) => { cb.checked = false; });
+    }
+    rerenderRecommendations();
   });
-  toolbar.appendChild(clearBtn);
+  footer.appendChild(clearBtn);
+  popover.appendChild(footer);
 
-  container.insertBefore(toolbar, container.firstChild);
+  return { el: popover, checkboxes, input, errorEl };
 }
 
-// selectedRecsFromVisible returns the intersection of state-selected
-// IDs with the currently-visible list. Out-of-view selection is
-// silently discarded — the user filtered it out, so it shouldn't
-// affect the bulk action.
-function selectedRecsFromVisible(recommendations: LocalRecommendation[]): LocalRecommendation[] {
-  const selected = state.getSelectedRecommendationIDs();
-  return recommendations.filter((r) => selected.has(r.id));
+// Re-sync popover .checked / .value from current filter state, except when
+// the active element is the numeric input (mid-typing protection).
+function resyncOpenPopover(): void {
+  if (!openPopover) return;
+  const f = state.getRecommendationsColumnFilters()[openPopover.column];
+  if (openPopover.input) {
+    if (document.activeElement !== openPopover.input) {
+      const expr = f && f.kind === 'expr' ? f.expr : '';
+      openPopover.input.value = expr;
+      if (openPopover.errorEl) openPopover.errorEl.textContent = '';
+    }
+    return;
+  }
+  // Categorical: tick checkboxes whose value is in the active filter.
+  const values: ReadonlySet<string> = f && f.kind === 'set' ? new Set(f.values) : new Set();
+  // Special case: if no filter is set, every checkbox should be unchecked
+  // (the (All) tri-state checkbox follows from this).
+  openPopover.checkboxes.forEach((cb, value) => {
+    cb.checked = f != null && values.has(value);
+  });
+  // Update (All) tri-state.
+  const allBox = openPopover.el.querySelector<HTMLInputElement>('input[data-role="all"]');
+  if (allBox) {
+    const total = openPopover.checkboxes.size;
+    let checked = 0;
+    openPopover.checkboxes.forEach((cb) => { if (cb.checked) checked++; });
+    allBox.indeterminate = checked > 0 && checked < total;
+    allBox.checked = checked === total && total > 0;
+  }
 }
+
+function attachPopoverGlobalListeners(): void {
+  if (outsideClickHandler) return;
+  outsideClickHandler = (e: MouseEvent): void => {
+    if (!openPopover) return;
+    const target = e.target as Node | null;
+    if (!target) return;
+    if (openPopover.el.contains(target)) return;
+    // Any column-filter trigger button click is handled by the trigger's own
+    // handler; don't double-close.
+    if (target instanceof Element && target.closest('.column-filter-btn')) return;
+    closePopover();
+  };
+  escKeyHandler = (e: KeyboardEvent): void => {
+    if (!openPopover) return;
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      closePopover(true);
+    }
+  };
+  scrollCloseHandler = (): void => {
+    if (openPopover) closePopover();
+  };
+  resizeHandler = (): void => {
+    if (!openPopover) return;
+    const trigger = getColumnTriggerButton(openPopover.column);
+    if (!trigger) {
+      closePopover();
+      return;
+    }
+    positionPopover(openPopover.el, trigger);
+  };
+  document.addEventListener('mousedown', outsideClickHandler);
+  document.addEventListener('keydown', escKeyHandler);
+  // Use capture for scroll so we catch all scroll containers; passive for perf.
+  window.addEventListener('scroll', scrollCloseHandler, { capture: true, passive: true });
+  window.addEventListener('resize', resizeHandler);
+}
+
+function detachPopoverGlobalListeners(): void {
+  if (outsideClickHandler) document.removeEventListener('mousedown', outsideClickHandler);
+  if (escKeyHandler) document.removeEventListener('keydown', escKeyHandler);
+  if (scrollCloseHandler) window.removeEventListener('scroll', scrollCloseHandler, { capture: true } as EventListenerOptions);
+  if (resizeHandler) window.removeEventListener('resize', resizeHandler);
+  outsideClickHandler = null;
+  escKeyHandler = null;
+  scrollCloseHandler = null;
+  resizeHandler = null;
+}
+
+function openColumnPopover(column: state.RecommendationsColumnId, anchor: HTMLElement): void {
+  // Defensive: if the popover element is no longer in the document (jest
+  // DOM reset between tests, or an external script removed it), drop the
+  // stale ref before applying the toggle/swap logic below.
+  if (openPopover && !openPopover.el.isConnected) {
+    detachPopoverGlobalListeners();
+    openPopover = null;
+  }
+  // Toggle: clicking same trigger closes.
+  if (openPopover && openPopover.column === column) {
+    closePopover(true);
+    return;
+  }
+  if (openPopover) closePopover();
+
+  const recs = state.getRecommendations() as unknown as LocalRecommendation[];
+  const built = buildPopoverContent(column, recs);
+  document.body.appendChild(built.el);
+  openPopover = {
+    column,
+    el: built.el,
+    checkboxes: built.checkboxes,
+    input: built.input,
+    errorEl: built.errorEl,
+    triggerColumn: column,
+  };
+  resyncOpenPopover();
+  positionPopover(built.el, anchor);
+
+  // ARIA wiring on the trigger.
+  anchor.setAttribute('aria-expanded', 'true');
+
+  attachPopoverGlobalListeners();
+
+  // Move focus into the popover for keyboard users.
+  const firstFocusable = built.input
+    ?? built.el.querySelector<HTMLInputElement>('input[type="checkbox"]');
+  firstFocusable?.focus();
+}
+
+function closePopover(restoreFocus = false): void {
+  if (!openPopover) return;
+  const { column, el } = openPopover;
+  el.remove();
+  openPopover = null;
+  detachPopoverGlobalListeners();
+  // ARIA cleanup on the trigger (if it still exists in the DOM).
+  const trigger = getColumnTriggerButton(column);
+  if (trigger) {
+    trigger.setAttribute('aria-expanded', 'false');
+    if (restoreFocus) trigger.focus();
+  }
+}
+
+// Called by renderRecommendationsList after the table is rebuilt to re-anchor
+// any open popover to the freshly-rendered trigger button. If the column was
+// removed from the table somehow, close gracefully.
+function rebindOpenPopoverAnchor(): void {
+  if (!openPopover) return;
+  const trigger = getColumnTriggerButton(openPopover.column);
+  if (!trigger) {
+    closePopover();
+    return;
+  }
+  trigger.setAttribute('aria-expanded', 'true');
+  positionPopover(openPopover.el, trigger);
+  resyncOpenPopover();
+}
+
+// rerenderRecommendations triggers a full re-render from the latest loaded
+// state. Used by popover commits and the Clear-filters badge so the table
+// reflects new column-filter state immediately.
+function rerenderRecommendations(): void {
+  const loaded = state.getRecommendations() as unknown as LocalRecommendation[];
+  renderRecommendationsList(loaded);
+}
+
+// Close the popover when the Recommendations tab loses .active, so the
+// detached popover doesn't float over other tabs' content. Wired via a
+// MutationObserver on the recommendations-tab element.
+let recommendationsTabObserver: MutationObserver | null = null;
+function ensureRecommendationsTabObserver(): void {
+  if (recommendationsTabObserver) return;
+  const tab = document.getElementById('recommendations-tab');
+  if (!tab) return;
+  recommendationsTabObserver = new MutationObserver(() => {
+    if (!tab.classList.contains('active') && openPopover) {
+      closePopover();
+    }
+  });
+  recommendationsTabObserver.observe(tab, { attributes: true, attributeFilter: ['class'] });
+}
+
+// ---------------------------------------------------------------------------
+
+// Render (or update) the filter-status bar: a "Clear filters (N)" button
+// when at least one column filter is active, plus an aria-live region
+// announcing visible vs loaded counts. Mounted above the table; survives
+// container.innerHTML rewrites because it lives outside #recommendations-list.
+function renderFilterStatusBar(loadedCount: number, visibleCount: number): void {
+  const recsTab = document.getElementById('recommendations-tab');
+  const list = document.getElementById('recommendations-list');
+  if (!recsTab || !list) return;
+
+  let bar = document.getElementById('recommendations-filter-status');
+  if (!bar) {
+    bar = document.createElement('div');
+    bar.id = 'recommendations-filter-status';
+    bar.className = 'recommendations-filter-status';
+    list.parentNode?.insertBefore(bar, list);
+  }
+
+  // Build content fresh on every call. We set textContent on the live
+  // region directly so screen readers fire announcements on actual changes.
+  let badge = bar.querySelector<HTMLButtonElement>('.clear-filters');
+  let live = bar.querySelector<HTMLElement>('.recommendations-filter-live');
+
+  if (!live) {
+    live = document.createElement('span');
+    live.className = 'recommendations-filter-live';
+    live.setAttribute('aria-live', 'polite');
+    live.setAttribute('aria-atomic', 'true');
+    bar.appendChild(live);
+  }
+  // Always update the live region (even when no filters active) so the
+  // spoken count reflects state after every render.
+  live.textContent = `Showing ${visibleCount} of ${loadedCount} recommendations`;
+
+  const filters = state.getRecommendationsColumnFilters();
+  const activeCount = Object.keys(filters).length;
+  if (activeCount === 0) {
+    if (badge) badge.remove();
+    return;
+  }
+  if (!badge) {
+    badge = document.createElement('button');
+    badge.type = 'button';
+    badge.className = 'clear-filters';
+    badge.addEventListener('click', () => {
+      state.clearAllRecommendationsColumnFilters();
+      rerenderRecommendations();
+    });
+    bar.insertBefore(badge, live);
+  }
+  badge.textContent = `Clear filters (${activeCount})`;
+}
+
+// renderBulkToolbar was the old "N selected / Add to plan / Clear" pill that
+// rendered above the table whenever any rows were selected. Bundle B folded
+// that surface into the sticky bottom action box: the selection-summary text
+// is in updateBottomActionBox, and the Create-Plan button in the bottom box
+// supersedes the old "Add to plan". Function removed; tests for its DOM
+// (bulk-count etc.) are gone too.
+//
+// For "Clear selection" affordance, see the bottom box's selection-summary
+// text — when a selection exists the summary is followed by the row-checkbox
+// columns (per-row deselect) and the all-selectAll checkbox in the table
+// header (selectAll's third state clears).
+
+// (Bundle B) selectedRecsFromVisible was inlined into resolvePurchaseTarget
+// inside the bottom action box. The old helper had only one caller; folding
+// keeps the action-target logic centralised in one place.
 
 function openDetailDrawer(rec: LocalRecommendation): void {
   // Remove any previous drawer so repeat clicks don't stack.
@@ -601,11 +1026,25 @@ function providerDisplayName(provider: string): string {
   }
 }
 
+// Columns that get the per-column header filter button. Order matches the
+// table column order (excluding the leading checkbox column, which is
+// neither sortable nor filterable).
+const FILTERABLE_COLUMNS: readonly state.RecommendationsColumnId[] = [
+  'provider', 'account', 'service', 'resource_type', 'region',
+  'count', 'term', 'savings', 'upfront_cost',
+];
+
 function buildListMarkup(recommendations: LocalRecommendation[], selectedRecs: ReadonlySet<string>): string {
   const sort = state.getRecommendationsSort();
   const sorted = sortedRecommendations(recommendations);
-  const sortHeader = (column: string): string =>
-    `<th class="sortable" data-sort="${column}" tabindex="0" role="button" aria-label="Sort by ${SORT_HEADER_LABELS[column]}"><span>${SORT_HEADER_LABELS[column]}</span>${sortIndicator(column, sort.column, sort.direction)}</th>`;
+  const filters = state.getRecommendationsColumnFilters();
+  const filterBtn = (column: state.RecommendationsColumnId): string => {
+    const active = filters[column] ? ' active' : '';
+    const label = filters[column] ? `Filter ${SORT_HEADER_LABELS[column]} — currently active` : `Filter ${SORT_HEADER_LABELS[column]}`;
+    return `<button type="button" class="column-filter-btn${active}" data-column="${column}" aria-haspopup="dialog" aria-expanded="false" aria-label="${label}" title="${label}">⛛</button>`;
+  };
+  const sortHeader = (column: state.RecommendationsColumnId): string =>
+    `<th class="sortable" data-sort="${column}" tabindex="0" role="button" aria-label="Sort by ${SORT_HEADER_LABELS[column]}"><span>${SORT_HEADER_LABELS[column]}</span>${sortIndicator(column, sort.column, sort.direction)}${filterBtn(column)}</th>`;
 
   return `
     <table>
@@ -614,15 +1053,7 @@ function buildListMarkup(recommendations: LocalRecommendation[], selectedRecs: R
           <th class="checkbox-col">
             <input type="checkbox" id="select-all-recs" aria-label="Select all recommendations">
           </th>
-          <th>Provider</th>
-          <th>Account</th>
-          <th>Service</th>
-          <th>Resource Type</th>
-          <th>Region</th>
-          ${sortHeader('count')}
-          ${sortHeader('term')}
-          ${sortHeader('savings')}
-          ${sortHeader('upfront_cost')}
+          ${FILTERABLE_COLUMNS.map(sortHeader).join('')}
         </tr>
       </thead>
       <tbody>
@@ -685,28 +1116,30 @@ function renderSuppressionBadge(rec: LocalRecommendation): string {
 // a stale cached blob.
 const BULK_PURCHASE_LS_KEY = 'cudly.recommendations.bulkPurchase.v1';
 
+// BulkPurchaseToolbarState used to carry a `term` field that overrode each
+// row's recommended term at API-call time. Bundle B drops it: each rec is
+// purchased with its own per-row term (see term-aware bucketing in
+// handleBulkPurchaseClick). loadBulkPurchaseState explicitly picks known
+// fields so any legacy `term` from older localStorage values is silently
+// ignored on read — no migration shim needed.
 interface BulkPurchaseToolbarState {
-  term: 1 | 3;
   payment: 'all-upfront' | 'partial-upfront' | 'no-upfront' | 'monthly';
   capacity: number; // 1..100
 }
 
 const defaultBulkPurchaseState: BulkPurchaseToolbarState = {
-  term: 3,
   payment: 'all-upfront',
   capacity: 100,
 };
 
-// loadBulkPurchaseState reads the toolbar state from localStorage with
-// a try/catch around JSON.parse — a garbage value shouldn't blow up the
-// page render; defaults take over and the next Save overwrites.
 function loadBulkPurchaseState(): BulkPurchaseToolbarState {
   try {
     const raw = localStorage.getItem(BULK_PURCHASE_LS_KEY);
     if (!raw) return { ...defaultBulkPurchaseState };
-    const parsed = JSON.parse(raw) as Partial<BulkPurchaseToolbarState>;
+    const parsed = JSON.parse(raw) as Partial<BulkPurchaseToolbarState> & { term?: unknown };
+    // Explicit field-pick rather than spread-and-omit — avoids leaking a
+    // legacy `term` value into the returned object even at runtime.
     return {
-      term: parsed.term === 1 ? 1 : 3,
       payment: parsed.payment || 'all-upfront',
       capacity: Math.max(1, Math.min(100, Number(parsed.capacity) || 100)),
     };
@@ -720,42 +1153,46 @@ function saveBulkPurchaseState(s: BulkPurchaseToolbarState): void {
     localStorage.setItem(BULK_PURCHASE_LS_KEY, JSON.stringify(s));
   } catch {
     // Private-browsing / quota-exceeded — non-fatal, just lose the
-    // sticky choice. The toolbar still works in-session.
+    // sticky choice. The bottom box still works in-session.
   }
 }
 
-// renderTopBulkPurchaseToolbar renders the always-visible toolbar above
-// the recs list with Term / Payment / Capacity % controls and the
-// Purchase button. Wired via ID-based selection: when no rows are
-// selected the Purchase action targets the full visible list; with
-// any selection, only the selected-and-visible subset.
-function renderTopBulkPurchaseToolbar(container: HTMLElement, recommendations: LocalRecommendation[]): void {
-  const existing = container.querySelector('.recommendations-top-toolbar');
-  if (existing) existing.remove();
+// Mount-once-then-update lifecycle for the sticky bottom action box.
+// mountBottomActionBox builds the DOM (input/select/button identities) and
+// wires listeners exactly once. updateBottomActionBox refreshes only the
+// mutable surface — button labels, .disabled, the selection-summary text —
+// leaving the input/select elements (and their in-progress values) alone.
+//
+// IDs preserved for backward compatibility:
+//   #bulk-purchase-payment  (Payment dropdown)
+//   #bulk-purchase-capacity (Capacity % input — read by app.ts:307)
+//   #bulk-purchase-btn      (Purchase one-off button)
+//   #create-plan-btn        (Create Purchase Plan button — relocated from
+//                            the old top filter bar)
+function mountBottomActionBox(): HTMLElement | null {
+  const recsTab = document.getElementById('recommendations-tab');
+  if (!recsTab) return null;
 
-  const toolbar = document.createElement('div');
-  toolbar.className = 'recommendations-top-toolbar';
-  toolbar.setAttribute('role', 'toolbar');
-  toolbar.setAttribute('aria-label', 'Bulk purchase controls');
+  let box = document.getElementById('recommendations-action-box');
+  if (box) return box;
+
+  box = document.createElement('div');
+  box.id = 'recommendations-action-box';
+  box.className = 'recommendations-action-box';
+  box.setAttribute('role', 'toolbar');
+  box.setAttribute('aria-label', 'Recommendations actions');
 
   const tbState = loadBulkPurchaseState();
 
-  const termLabel = document.createElement('label');
-  termLabel.innerHTML = 'Term: ';
-  const termSelect = document.createElement('select');
-  termSelect.id = 'bulk-purchase-term';
-  [['1', '1 Year'], ['3', '3 Years']].forEach(([v, t]) => {
-    const opt = document.createElement('option');
-    opt.value = v as string;
-    opt.textContent = t as string;
-    if (Number(v) === tbState.term) opt.selected = true;
-    termSelect.appendChild(opt);
-  });
-  termLabel.appendChild(termSelect);
-  toolbar.appendChild(termLabel);
+  // Selection summary text (e.g. "(3 selected of 19 visible)" or "(All 19 visible)")
+  const summary = document.createElement('span');
+  summary.id = 'recommendations-action-summary';
+  summary.className = 'recommendations-action-summary';
+  box.appendChild(summary);
 
+  // Payment dropdown — preserved ID
   const paymentLabel = document.createElement('label');
-  paymentLabel.innerHTML = 'Payment: ';
+  paymentLabel.textContent = 'Payment ';
   const paymentSelect = document.createElement('select');
   paymentSelect.id = 'bulk-purchase-payment';
   [['all-upfront', 'All Upfront'], ['partial-upfront', 'Partial Upfront'], ['no-upfront', 'No Upfront'], ['monthly', 'Monthly']].forEach(([v, t]) => {
@@ -766,10 +1203,11 @@ function renderTopBulkPurchaseToolbar(container: HTMLElement, recommendations: L
     paymentSelect.appendChild(opt);
   });
   paymentLabel.appendChild(paymentSelect);
-  toolbar.appendChild(paymentLabel);
+  box.appendChild(paymentLabel);
 
+  // Capacity % input — preserved ID (app.ts:307 reads this)
   const capacityLabel = document.createElement('label');
-  capacityLabel.innerHTML = 'Capacity %: ';
+  capacityLabel.textContent = 'Capacity % ';
   const capacityInput = document.createElement('input');
   capacityInput.id = 'bulk-purchase-capacity';
   capacityInput.type = 'number';
@@ -778,47 +1216,145 @@ function renderTopBulkPurchaseToolbar(container: HTMLElement, recommendations: L
   capacityInput.step = '1';
   capacityInput.value = String(tbState.capacity);
   capacityLabel.appendChild(capacityInput);
-  toolbar.appendChild(capacityLabel);
+  box.appendChild(capacityLabel);
 
+  // Purchase one-off — preserved ID
   const purchaseBtn = document.createElement('button');
   purchaseBtn.type = 'button';
   purchaseBtn.className = 'btn btn-primary';
   purchaseBtn.id = 'bulk-purchase-btn';
-  purchaseBtn.textContent = 'Purchase…';
-  purchaseBtn.disabled = recommendations.length === 0;
-  if (purchaseBtn.disabled) purchaseBtn.title = 'No recommendations to purchase';
-  toolbar.appendChild(purchaseBtn);
+  purchaseBtn.textContent = 'Purchase';
+  purchaseBtn.title = 'Buy these reservations now (one-off, processed immediately)';
+  box.appendChild(purchaseBtn);
+
+  // Create Purchase Plan — relocated from old top bar
+  const planBtn = document.createElement('button');
+  planBtn.type = 'button';
+  planBtn.className = 'btn btn-secondary';
+  planBtn.id = 'create-plan-btn';
+  planBtn.textContent = 'Create Plan';
+  planBtn.title = 'Schedule a recurring plan that will purchase these recommendations on a defined cadence';
+  box.appendChild(planBtn);
 
   const persist = (): void => {
     saveBulkPurchaseState({
-      term: (Number(termSelect.value) === 1 ? 1 : 3) as 1 | 3,
       payment: paymentSelect.value as BulkPurchaseToolbarState['payment'],
       capacity: Math.max(1, Math.min(100, parseInt(capacityInput.value, 10) || 100)),
     });
   };
-  termSelect.addEventListener('change', persist);
   paymentSelect.addEventListener('change', persist);
   capacityInput.addEventListener('change', persist);
 
   purchaseBtn.addEventListener('click', () => {
-    handleBulkPurchaseClick(recommendations);
+    const target = resolvePurchaseTarget();
+    if (target.length === 0) return;
+    handleBulkPurchaseClick(target);
   });
 
-  container.insertBefore(toolbar, container.firstChild);
+  planBtn.addEventListener('click', () => {
+    const target = resolvePurchaseTarget();
+    if (target.length === 0) return;
+    // Plans-side savePlan reads state.getVisibleRecommendations() and
+    // intersects with state.getSelectedRecommendationIDs() — it'll see
+    // the same target as the Purchase button uses.
+    void openCreatePlanFromBottomBox();
+  });
+
+  recsTab.appendChild(box);
+  return box;
+}
+
+// Resolve the action target: selected ∩ visible if a selection exists,
+// else all visible. "Visible" is the post-filter set tracked in module
+// state via setVisibleRecommendations.
+function resolvePurchaseTarget(): LocalRecommendation[] {
+  const visible = state.getVisibleRecommendations() as unknown as LocalRecommendation[];
+  const selected = state.getSelectedRecommendationIDs();
+  const intersection = visible.filter((r) => selected.has(r.id));
+  return intersection.length > 0 ? intersection : visible;
+}
+
+// updateBottomActionBox refreshes labels and disabled state on every
+// renderRecommendationsList call without rebuilding the input/select DOM,
+// preserving any in-progress typing in the Capacity input.
+function updateBottomActionBox(visibleCount: number, loadedCount: number): void {
+  const box = document.getElementById('recommendations-action-box');
+  if (!box) return;
+
+  const selected = state.getSelectedRecommendationIDs();
+  // Count only selections that are currently visible.
+  const visible = state.getVisibleRecommendations() as unknown as LocalRecommendation[];
+  const selectedVisibleCount = visible.reduce(
+    (n, r) => n + (selected.has(r.id) ? 1 : 0),
+    0,
+  );
+
+  const summary = document.getElementById('recommendations-action-summary');
+  if (summary) {
+    if (loadedCount === 0) {
+      summary.textContent = '(No recommendations loaded)';
+    } else if (visibleCount === 0) {
+      summary.textContent = '(0 visible — adjust filters)';
+    } else if (selectedVisibleCount > 0) {
+      summary.textContent = `(${selectedVisibleCount} selected of ${visibleCount} visible)`;
+    } else {
+      summary.textContent = `(All ${visibleCount} visible — no selection)`;
+    }
+  }
+
+  const purchaseBtn = document.getElementById('bulk-purchase-btn') as HTMLButtonElement | null;
+  const planBtn = document.getElementById('create-plan-btn') as HTMLButtonElement | null;
+  const targetCount = selectedVisibleCount > 0 ? selectedVisibleCount : visibleCount;
+  const empty = targetCount === 0;
+  const targetIsSelection = selectedVisibleCount > 0;
+
+  if (purchaseBtn) {
+    purchaseBtn.disabled = empty;
+    purchaseBtn.textContent = empty
+      ? 'Purchase'
+      : targetIsSelection
+        ? `Purchase ${targetCount} selected`
+        : `Purchase ${targetCount} visible`;
+    purchaseBtn.title = empty
+      ? (loadedCount === 0
+          ? 'No recommendations loaded'
+          : 'No rows visible — adjust filters')
+      : 'Buy these reservations now (one-off, processed immediately)';
+  }
+  if (planBtn) {
+    planBtn.disabled = empty;
+    planBtn.textContent = empty
+      ? 'Create Plan'
+      : targetIsSelection
+        ? `Plan from ${targetCount} selected`
+        : `Plan from ${targetCount} visible`;
+    planBtn.title = empty
+      ? (loadedCount === 0
+          ? 'No recommendations loaded'
+          : 'No rows visible — adjust filters')
+      : 'Schedule a recurring plan that will purchase these recommendations on a defined cadence';
+  }
+}
+
+// openCreatePlanFromBottomBox opens the plan-creation modal. plans.ts'
+// savePlan reads state.getVisibleRecommendations() (Bundle B's plumbing
+// addition in Step 8c) so the plan only includes selected ∩ visible (or
+// all visible if no selection).
+async function openCreatePlanFromBottomBox(): Promise<void> {
+  const { openCreatePlanModal } = await import('./plans');
+  openCreatePlanModal();
 }
 
 function handleBulkPurchaseClick(recommendations: LocalRecommendation[]): void {
   const tb = loadBulkPurchaseState();
-  const selected = selectedRecsFromVisible(recommendations);
-  const target = selected.length > 0 ? selected : recommendations;
-  if (target.length === 0) {
+  if (recommendations.length === 0) {
     showToast({ message: 'No recommendations to purchase.', kind: 'warning' });
     return;
   }
 
   // Scale by capacity %; drop rows whose scaled count floors to 0.
   const scaled: LocalRecommendation[] = [];
-  for (const r of target) {
+  for (const r of recommendations) {
     const newCount = Math.floor((r.count * tb.capacity) / 100);
     if (newCount <= 0) continue;
     const ratio = r.count > 0 ? newCount / r.count : 1;
@@ -838,24 +1374,24 @@ function handleBulkPurchaseClick(recommendations: LocalRecommendation[]): void {
     return;
   }
 
-  // Bucket by (provider, service) — the compatibility check runs per
-  // bucket since e.g. AWS EC2 accepts no-upfront but AWS RDS doesn't
-  // for 3yr.
+  // Bucket by (provider, service, term). Bundle B added `term` to the key:
+  // each rec is purchased with its OWN per-row term (the toolbar Term
+  // selector is gone). Multi-term selections legitimately fan out into
+  // multiple buckets, e.g. AWS EC2 1y + AWS EC2 3y → 2 buckets.
   const buckets = new Map<string, LocalRecommendation[]>();
   for (const r of scaled) {
-    const key = `${r.provider}|${r.service}`;
+    const key = `${r.provider}|${r.service}|${r.term}`;
     const existing = buckets.get(key);
     if (existing) existing.push(r);
     else buckets.set(key, [r]);
   }
   const bucketEntries = Array.from(buckets.entries());
 
-  // Check compatibility per bucket. A bucket with an unsupported
-  // (term, payment) combo is just as problematic as having multiple
-  // providers — neither case can proceed with a single POST.
-  const incompatible = bucketEntries.filter(([key]) => {
-    const [provider, service] = key.split('|') as [CompatProvider, string];
-    return !isPaymentSupported(provider, service, tb.term as 1 | 3, tb.payment);
+  // Per-bucket compatibility check using the bucket's own term.
+  const incompatible = bucketEntries.filter(([_key, recs]) => {
+    const r = recs[0];
+    if (!r) return false;
+    return !isPaymentSupported(r.provider as CompatProvider, r.service, r.term as 1 | 3, tb.payment);
   });
 
   if (bucketEntries.length > 1 || incompatible.length > 0) {
@@ -901,17 +1437,22 @@ function openFanOutModal(
   bucketEntries: Array<[string, LocalRecommendation[]]>,
   toolbar: BulkPurchaseToolbarState,
 ): void {
-  const buckets: FanOutBucket[] = bucketEntries.map(([key, recs]) => {
-    const [provider, service] = key.split('|') as [CompatProvider, string];
-    return {
-      provider,
-      service,
-      term: toolbar.term,
-      payment: toolbar.payment,
-      capacityPercent: toolbar.capacity,
-      recs,
-    };
-  });
+  const buckets: FanOutBucket[] = bucketEntries
+    .filter(([_key, recs]) => recs.length > 0)
+    .map(([_key, recs]) => {
+      const r = recs[0]!;
+      return {
+        provider: r.provider as CompatProvider,
+        service: r.service,
+        // Each bucket is now term-uniform (key includes term), so we read
+        // the term from the bucket itself rather than from the dropped
+        // toolbar override.
+        term: r.term as 1 | 3,
+        payment: toolbar.payment,
+        capacityPercent: toolbar.capacity,
+        recs,
+      };
+    });
   currentFanOutBuckets = buckets;
 
   const container = document.getElementById('purchase-details');
@@ -1008,21 +1549,28 @@ function renderRecommendationsList(loadedRecs: LocalRecommendation[]): void {
   const container = document.getElementById('recommendations-list');
   if (!container) return;
 
-  // Pipeline (Bundle A — no-op when no column filters are set):
+  // Pipeline:
   //   loaded -> applyColumnFilters -> visible
   //   state.setVisibleRecommendations(visible)   (read by plans.ts:savePlan)
   // When the column-filters record is empty, applyColumnFilters returns a
-  // clone of the input, so every existing test stays green. Bundle B will
-  // populate filters from the per-column popovers.
+  // clone of the input.
   const recommendations = applyColumnFilters(
     loadedRecs ?? [],
     state.getRecommendationsColumnFilters(),
   );
   state.setVisibleRecommendations(recommendations as unknown as readonly api.Recommendation[]);
 
+  // Filter status: Clear-filters badge + aria-live count. Mounted as a
+  // sibling above the table so it survives the container's innerHTML
+  // rewrite without losing aria-live announcements.
+  renderFilterStatusBar(loadedRecs?.length ?? 0, recommendations.length);
+
+  // Mount once; update is per-render below.
+  mountBottomActionBox();
+
   if (!recommendations || recommendations.length === 0) {
-    container.innerHTML = '<p class="empty">No recommendations found. Try adjusting filters or refreshing.</p>';
-    renderTopBulkPurchaseToolbar(container, []);
+    container.innerHTML = '<p class="empty">No recommendations match these filters. Try clearing filters or refreshing.</p>';
+    updateBottomActionBox(0, loadedRecs?.length ?? 0);
     return;
   }
 
@@ -1031,15 +1579,27 @@ function renderRecommendationsList(loadedRecs: LocalRecommendation[]): void {
   // escapeHtml or is a number. The string is built in buildListMarkup.
   container.innerHTML = buildListMarkup(recommendations, selectedIDs);
 
-  // Count only the intersection with currently-visible recs so the
-  // selection toolbar's "N selected" doesn't include stale selections
-  // that live outside the current filter.
-  const visibleSelectedCount = recommendations.reduce(
-    (n, r) => n + (selectedIDs.has(r.id) ? 1 : 0),
-    0,
-  );
-  renderBulkToolbar(container, recommendations, visibleSelectedCount);
-  renderTopBulkPurchaseToolbar(container, recommendations);
+  updateBottomActionBox(recommendations.length, loadedRecs?.length ?? recommendations.length);
+
+  // Per-column filter button: trigger opens the popover anchored to the
+  // button. e.stopPropagation prevents the surrounding <th>'s sort handler
+  // from also firing.
+  container.querySelectorAll<HTMLButtonElement>('.column-filter-btn').forEach((btn) => {
+    const column = btn.dataset['column'] as state.RecommendationsColumnId | undefined;
+    if (!column) return;
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      openColumnPopover(column, btn);
+    });
+  });
+
+  // After the table is rebuilt, re-anchor any open popover to the new
+  // trigger DOM node and re-sync .checked / .value from current state.
+  rebindOpenPopoverAnchor();
+
+  // Watch the recommendations tab's class so we can close the popover if
+  // the user switches away to another tab.
+  ensureRecommendationsTabObserver();
 
   // Sortable column headers. Toggle ascending/descending on repeat click.
   container.querySelectorAll<HTMLTableCellElement>('th.sortable').forEach((th) => {
@@ -1106,15 +1666,6 @@ function renderRecommendationsList(loadedRecs: LocalRecommendation[]): void {
       if (rec) openDetailDrawer(rec);
     });
   });
-}
-
-function populateRegionFilter(regions: string[]): void {
-  const select = document.getElementById('region-filter') as HTMLSelectElement | null;
-  if (!select) return;
-
-  const currentValue = select.value;
-  select.innerHTML = '<option value="">All Regions</option>' +
-    regions.map(r => `<option value="${escapeHtml(r)}" ${r === currentValue ? 'selected' : ''}>${escapeHtml(r)}</option>`).join('');
 }
 
 /**

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -199,6 +199,129 @@ function sortedRecommendations(recs: LocalRecommendation[]): LocalRecommendation
   return recs.slice().sort((a, b) => (key(a) - key(b)) * direction);
 }
 
+// Numeric filter expression parser. Grammar:
+//   - empty/whitespace      -> match-all
+//   - "42"                  -> equals
+//   - ">X" / "<X" / ">=X" / "<=X" -> comparator
+//   - "X..Y"                -> inclusive range (X and Y both numbers)
+//   - comma-separated       -> OR of any of the above
+// Returns a discriminated union so callers can render parse errors
+// inline without type-narrowing gymnastics. Whitespace inside terms is
+// trimmed; whitespace between terms is allowed.
+export type ParsedNumericFilter =
+  | { ok: true; predicate: (n: number) => boolean }
+  | { ok: false; error: string };
+
+const MATCH_ALL: ParsedNumericFilter = { ok: true, predicate: () => true };
+
+export function parseNumericFilter(expr: string): ParsedNumericFilter {
+  if (!expr || expr.trim() === '') return MATCH_ALL;
+  const terms = expr.split(',').map((t) => t.trim()).filter((t) => t !== '');
+  if (terms.length === 0) return MATCH_ALL;
+
+  const predicates: Array<(n: number) => boolean> = [];
+  for (const term of terms) {
+    // Order matters: ">=" / "<=" must be checked before ">" / "<".
+    let p: ((n: number) => boolean) | null = null;
+    let m: RegExpMatchArray | null;
+    if ((m = term.match(/^>=\s*(-?\d+(?:\.\d+)?)$/))) {
+      const v = Number(m[1]);
+      p = (n) => n >= v;
+    } else if ((m = term.match(/^<=\s*(-?\d+(?:\.\d+)?)$/))) {
+      const v = Number(m[1]);
+      p = (n) => n <= v;
+    } else if ((m = term.match(/^>\s*(-?\d+(?:\.\d+)?)$/))) {
+      const v = Number(m[1]);
+      p = (n) => n > v;
+    } else if ((m = term.match(/^<\s*(-?\d+(?:\.\d+)?)$/))) {
+      const v = Number(m[1]);
+      p = (n) => n < v;
+    } else if ((m = term.match(/^(-?\d+(?:\.\d+)?)\s*\.\.\s*(-?\d+(?:\.\d+)?)$/))) {
+      const lo = Number(m[1]);
+      const hi = Number(m[2]);
+      const min = Math.min(lo, hi);
+      const max = Math.max(lo, hi);
+      p = (n) => n >= min && n <= max;
+    } else if ((m = term.match(/^(-?\d+(?:\.\d+)?)$/))) {
+      const v = Number(m[1]);
+      p = (n) => n === v;
+    }
+    if (p === null) {
+      return { ok: false, error: `Invalid filter term: "${term}"` };
+    }
+    predicates.push(p);
+  }
+  // OR across terms
+  return {
+    ok: true,
+    predicate: (n) => predicates.some((p) => p(n)),
+  };
+}
+
+// Apply the per-column filters to a rec list. ANDs all column filters
+// together. Categorical: row passes iff its column value (string-form,
+// empty/null mapped to "") is in `values`. Numeric: row passes iff
+// parseNumericFilter(expr).predicate accepts the value (skipped if
+// parse failed — the popover's inline error tells the user).
+//
+// Account uses cloud_account_id for matching; Term uses String(r.term).
+// All other categorical columns compare on the underlying string field.
+export function applyColumnFilters(
+  recs: readonly LocalRecommendation[],
+  filters: state.RecommendationsColumnFilters,
+): LocalRecommendation[] {
+  const entries = Object.entries(filters) as Array<
+    [state.RecommendationsColumnId, state.RecommendationsColumnFilter]
+  >;
+  if (entries.length === 0) return [...recs];
+
+  return recs.filter((r) => {
+    for (const [col, f] of entries) {
+      if (f.kind === 'set') {
+        const cellRaw = categoricalCellValue(r, col);
+        if (!f.values.includes(cellRaw)) return false;
+      } else {
+        const parsed = parseNumericFilter(f.expr);
+        if (!parsed.ok) continue; // ignore broken expressions; UI shows the error
+        const cellNum = numericCellValue(r, col);
+        if (!parsed.predicate(cellNum)) return false;
+      }
+    }
+    return true;
+  });
+}
+
+function categoricalCellValue(r: LocalRecommendation, col: state.RecommendationsColumnId): string {
+  switch (col) {
+    case 'provider':       return r.provider ?? '';
+    case 'account':        return r.cloud_account_id ?? '';
+    case 'service':        return r.service ?? '';
+    case 'resource_type':  return r.resource_type ?? '';
+    case 'region':         return r.region ?? '';
+    case 'term':           return r.term == null ? '' : String(r.term);
+    // Numeric columns shouldn't reach this branch; return empty for type-safety.
+    case 'count':
+    case 'savings':
+    case 'upfront_cost':   return '';
+  }
+}
+
+function numericCellValue(r: LocalRecommendation, col: state.RecommendationsColumnId): number {
+  switch (col) {
+    case 'count':         return r.count ?? 0;
+    case 'savings':       return r.savings ?? 0;
+    case 'upfront_cost':  return r.upfront_cost ?? 0;
+    // Categorical columns shouldn't reach this branch; return NaN so any
+    // numeric predicate returns false rather than coincidentally matching 0.
+    case 'provider':
+    case 'account':
+    case 'service':
+    case 'resource_type':
+    case 'region':
+    case 'term':          return Number.NaN;
+  }
+}
+
 function renderBulkToolbar(container: HTMLElement, recommendations: LocalRecommendation[], selectedCount: number): void {
   const existing = container.querySelector('.recommendations-bulk-toolbar');
   if (existing) existing.remove();
@@ -881,9 +1004,21 @@ function renderFanOutBucketSection(b: FanOutBucket): HTMLElement {
   return section;
 }
 
-function renderRecommendationsList(recommendations: LocalRecommendation[]): void {
+function renderRecommendationsList(loadedRecs: LocalRecommendation[]): void {
   const container = document.getElementById('recommendations-list');
   if (!container) return;
+
+  // Pipeline (Bundle A — no-op when no column filters are set):
+  //   loaded -> applyColumnFilters -> visible
+  //   state.setVisibleRecommendations(visible)   (read by plans.ts:savePlan)
+  // When the column-filters record is empty, applyColumnFilters returns a
+  // clone of the input, so every existing test stays green. Bundle B will
+  // populate filters from the per-column popovers.
+  const recommendations = applyColumnFilters(
+    loadedRecs ?? [],
+    state.getRecommendationsColumnFilters(),
+  );
+  state.setVisibleRecommendations(recommendations as unknown as readonly api.Recommendation[]);
 
   if (!recommendations || recommendations.length === 0) {
     container.innerHTML = '<p class="empty">No recommendations found. Try adjusting filters or refreshing.</p>';

--- a/frontend/src/state.ts
+++ b/frontend/src/state.ts
@@ -3,12 +3,27 @@
  */
 
 import type { AppState } from './types';
+import type { Recommendation } from './api/types';
 
 export type RecommendationsSortColumn = 'savings' | 'upfront_cost' | 'count' | 'term' | 'payback';
 export interface RecommendationsSort {
   column: RecommendationsSortColumn;
   direction: 'asc' | 'desc';
 }
+
+// Closed enumeration of column ids the per-column filters target.
+// Typo-safety: misspellings at call sites become compile errors.
+export type RecommendationsColumnId =
+  | 'provider' | 'account' | 'service' | 'resource_type' | 'region'
+  | 'count' | 'term' | 'savings' | 'upfront_cost';
+
+export type RecommendationsColumnFilter =
+  | { kind: 'set'; values: string[] }   // categorical — values always string-form
+  | { kind: 'expr'; expr: string };     // numeric — parsed on apply
+
+export type RecommendationsColumnFilters = Partial<
+  Record<RecommendationsColumnId, RecommendationsColumnFilter>
+>;
 
 // Singleton state instance
 export const state: AppState = {
@@ -93,4 +108,47 @@ export function getCurrentAccountIDs(): string[] {
 
 export function setCurrentAccountIDs(ids: string[]) {
   state.currentAccountIDs = ids;
+}
+
+// Per-column filters live in their own module-scoped state, in-memory only.
+// Survives tab-switch within the page; resets on full page reload. Not
+// persisted to localStorage on this iteration — see the plan's "Out of
+// scope" for the persistence follow-up.
+let recommendationsColumnFilters: RecommendationsColumnFilters = {};
+
+export function getRecommendationsColumnFilters(): RecommendationsColumnFilters {
+  return { ...recommendationsColumnFilters };
+}
+
+export function setRecommendationsColumnFilter(
+  column: RecommendationsColumnId,
+  filter: RecommendationsColumnFilter | null,
+): void {
+  if (filter === null) {
+    const next = { ...recommendationsColumnFilters };
+    delete next[column];
+    recommendationsColumnFilters = next;
+    return;
+  }
+  recommendationsColumnFilters = {
+    ...recommendationsColumnFilters,
+    [column]: filter,
+  };
+}
+
+export function clearAllRecommendationsColumnFilters(): void {
+  recommendationsColumnFilters = {};
+}
+
+// Post-filter visible list, set by recommendations.ts on every render
+// and read by plans.ts so plan-creation never includes filtered-out
+// rows. Defensive clone on read so callers can't mutate module state.
+let visibleRecommendations: readonly Recommendation[] = [];
+
+export function getVisibleRecommendations(): readonly Recommendation[] {
+  return [...visibleRecommendations];
+}
+
+export function setVisibleRecommendations(recs: readonly Recommendation[]): void {
+  visibleRecommendations = [...recs];
 }

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -694,25 +694,11 @@ button.danger:hover {
     border: 1px solid #f2b8b5;
 }
 
-/* Recommendations-table affordances: bulk toolbar, sortable headers,
- * row-click detail drawer. See P6 of the UX audit for rationale.
+/* Recommendations-table affordances: sortable headers, per-column filter
+ * popovers, sticky bottom action box. The legacy .recommendations-bulk-
+ * toolbar / .bulk-count rules were removed in Bundle B (column-filter UX
+ * overhaul) — that surface was folded into the bottom action box.
  */
-.recommendations-bulk-toolbar {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    padding: 0.6rem 1rem;
-    margin-bottom: 0.75rem;
-    background: #e8f0fe;
-    border: 1px solid #a9c7f5;
-    border-radius: 4px;
-}
-
-.recommendations-bulk-toolbar .bulk-count {
-    font-weight: 500;
-    color: #1a73e8;
-    margin-right: auto;
-}
 
 th.sortable {
     cursor: pointer;
@@ -732,6 +718,145 @@ th.sortable .sort-indicator {
 th.sortable .sort-indicator.active {
     color: #1a73e8;
 }
+
+/* Per-column filter trigger button inside <th>. */
+th .column-filter-btn {
+    margin-left: 0.35rem;
+    padding: 0 0.25rem;
+    border: 0;
+    background: transparent;
+    color: #bbb;
+    cursor: pointer;
+    font-size: 0.85em;
+    line-height: 1;
+}
+th .column-filter-btn:hover {
+    color: #1a73e8;
+}
+th .column-filter-btn.active {
+    color: #1a73e8;
+    font-weight: 700;
+}
+
+/* Detached popover (lives in document.body, positioned absolutely). */
+.column-filter-popover {
+    background: #fff;
+    border: 1px solid #d0d7de;
+    border-radius: 4px;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+    padding: 0.75rem;
+    min-width: 220px;
+    max-width: 320px;
+    max-height: 400px;
+    overflow-y: auto;
+    z-index: 1000;
+}
+.column-filter-popover .column-filter-heading {
+    margin: 0 0 0.5rem 0;
+    font-size: 0.9rem;
+    font-weight: 600;
+}
+.column-filter-popover .column-filter-all {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.25rem 0;
+    border-bottom: 1px solid #eee;
+    margin-bottom: 0.5rem;
+    font-weight: 500;
+}
+.column-filter-popover .column-filter-list {
+    max-height: 240px;
+    overflow-y: auto;
+}
+.column-filter-popover .column-filter-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.2rem 0;
+}
+.column-filter-popover .column-filter-numeric-label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-size: 0.85em;
+    color: #666;
+}
+.column-filter-popover .column-filter-numeric-input {
+    padding: 0.35rem 0.5rem;
+    border: 1px solid #d0d7de;
+    border-radius: 3px;
+    font-size: 0.9rem;
+}
+.column-filter-popover .column-filter-error {
+    color: #d32f2f;
+    font-size: 0.8em;
+    min-height: 1em;
+    margin-top: 0.25rem;
+}
+.column-filter-popover .column-filter-footer {
+    margin-top: 0.5rem;
+    padding-top: 0.5rem;
+    border-top: 1px solid #eee;
+    display: flex;
+    justify-content: flex-end;
+}
+.column-filter-popover .column-filter-clear {
+    background: transparent;
+    border: 1px solid #d0d7de;
+    border-radius: 3px;
+    padding: 0.3rem 0.6rem;
+    font-size: 0.85em;
+    cursor: pointer;
+}
+
+/* Filter-status bar (Clear-filters badge + aria-live count) above the table. */
+.recommendations-filter-status {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.4rem 0;
+    font-size: 0.85em;
+    color: #666;
+}
+.recommendations-filter-status .clear-filters {
+    background: #e8f0fe;
+    border: 1px solid #a9c7f5;
+    border-radius: 3px;
+    color: #1a73e8;
+    padding: 0.25rem 0.6rem;
+    font-size: 0.85em;
+    cursor: pointer;
+}
+
+/* Sticky bottom action box — Payment / Capacity % / Purchase / Create Plan. */
+:root { --action-box-height: 80px; }
+.recommendations-action-box {
+    position: sticky;
+    bottom: 0;
+    height: var(--action-box-height);
+    background: #fff;
+    border-top: 1px solid #d0d7de;
+    box-shadow: 0 -2px 8px rgba(0,0,0,0.08);
+    z-index: 10;
+    padding: 0.75rem 1rem;
+    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+.recommendations-action-box .recommendations-action-summary {
+    color: #555;
+    font-size: 0.9em;
+    margin-right: auto;
+}
+.recommendations-action-box label {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.9em;
+}
+#recommendations-list { padding-bottom: var(--action-box-height); }
 
 tr.recommendation-row {
     cursor: pointer;


### PR DESCRIPTION
## Summary

UX overhaul of the Recommendations table: drop the top filter bar in favour of per-column header filters (Excel-style), and move Purchase + Create Plan into a sticky bottom action box. Driven by user request — see plan at `~/.claude/plans/generic-painting-volcano.md` (2026-04-27, 19 review passes, 3 consecutive clean).

Two atomic commits land in this PR:

- **`cb0a9105c` — `refactor(recommendations): column-filter parser + state + apply pipeline (no-op)`**: introduces the column-filter primitives (parser, state, apply pipeline, visibleRecommendations accessor). Behaviourally a no-op until Bundle B surfaces them. Existing tests stay green as the no-op proof.

- **`f9d97a720` — `feat(recommendations): per-column header filters + sticky bottom action box`**: surfaces the primitives in the UI; deletes the legacy top filter bar; adds the detached-popover infrastructure; replaces the bulk toolbar with a sticky bottom box; switches `handleBulkPurchaseClick` to term-aware bucketing; switches `plans.ts:savePlan` to read `getVisibleRecommendations()`.

## What the user will see

| Before | After |
|---|---|
| Top filter bar with 5 dropdowns + Create Purchase Plan button | No top filter bar — every column header has its own sort + filter affordance |
| Bulk-purchase toolbar above the table with Term / Payment / Capacity / Purchase | Sticky bottom action box with Payment / Capacity / **Purchase N selected/visible** / **Plan from N selected/visible**; no Term selector |
| Toolbar Term overrode each rec's recommended term silently | Each rec is bought with its own per-row term — multi-term selections fan out into multiple buckets |
| Floating "N selected / Add to plan / Clear" toolbar appeared on selection | Selection summary inline with the bottom box buttons; one control surface, not two |

## Bundle A — Silent refactor (commit `cb0a9105c`)

- `frontend/src/state.ts`: `RecommendationsColumnId` closed union, discriminated `ColumnFilter`, getters/setters, `getVisibleRecommendations` / `setVisibleRecommendations`.
- `frontend/src/recommendations.ts`: `parseNumericFilter` discriminated-union parser (`X`, `X..Y`, `>X`, `<X`, `>=X`, `<=X`, comma-separated for OR, invalid → inline error). `applyColumnFilters` AND-combiner. Pipeline insertion: `loaded → applyColumnFilters → setVisibleRecommendations(visible) → buildListMarkup`.
- 23 new tests for parser + apply + state. The existing 39 tests stay green — the no-op proof.

## Bundle B — UI overhaul (commit `f9d97a720`)

### Per-column filter popover (portal pattern)

- Detached popover lives in `document.body` so it survives the table's innerHTML rewrite.
- Module-scope state tracks the active **column id** (string), not a DOM-node ref. Anchor re-bind by `[data-column="..."]` after every render.
- Toggle (click same trigger closes), swap (click different trigger replaces), click-outside, ESC, window scroll, window resize, tab-leave (MutationObserver on `#recommendations-tab.active`) all close.
- Defensive close on rebind failure or detached-state.
- ARIA wiring: `role="dialog"`, `aria-modal="false"`, `aria-haspopup="dialog"` + `aria-expanded` on the trigger, `aria-labelledby` on the popover, `aria-live="polite"` count region above the table.
- Categorical popover: checkbox list of distinct values from the unfiltered rec set, `(All)` tri-state checkbox, `Clear` footer. Account displays name (resolved via `accountNamesCache`) but filters by `cloud_account_id`. Term displays via `formatTerm` but filters by stringified integer.
- Numeric popover: free-text expression input, applies on **blur or Enter** (not on every keystroke). Mid-typing protection — anchor re-bind skips re-sync of any input that's `document.activeElement`.

### Sticky bottom action box

- Mount-once-then-update lifecycle: `mountBottomActionBox()` builds DOM identities once, `updateBottomActionBox(target)` refreshes labels/disabled/aria-busy per render. Fixes the pre-existing pre-Bundle-B bug where rebuilds destroyed mid-typing values in the Capacity input.
- IDs preserved for backward compatibility: `#bulk-purchase-payment`, `#bulk-purchase-capacity` (`app.ts:307` keeps reading it), `#bulk-purchase-btn`, `#create-plan-btn`.
- Dynamic labels: *"Purchase 3 selected"* / *"Purchase 19 visible"* / *"Purchase"* (disabled). Tooltips spell out the difference between one-off Purchase and recurring Plan.
- CSS: `:root { --action-box-height: 80px; }` + `position: sticky; bottom: 0` + `#recommendations-list { padding-bottom: var(--action-box-height) }` so the box never occludes the last row.

### Term-aware bucketing

- Bucket key in `handleBulkPurchaseClick`: `provider|service` → `provider|service|term`. Each bucket is term-uniform; `isPaymentSupported` is called per bucket with the bucket's own term. `FanOutBucket.term` reads from the bucket itself.
- `BulkPurchaseToolbarState` drops the `term` field. `loadBulkPurchaseState` was rewritten to **explicitly pick** known fields rather than spread-and-omit, so any stray `term` from legacy localStorage values silently disappears.

### Plans.ts target alignment

- `savePlan` reads `state.getVisibleRecommendations()` (post-filter) instead of `state.getRecommendations()` (raw API). Same selected-IDs intersection on top. Falls back to all visible when no selection. **Plans never include filtered-out recs.**

## Test plan

- [x] `npx jest` — **1342/1342 tests pass** across 38 suites.
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run build` — production webpack build succeeds (224 KB app.js minified).
- [x] Pre-commit `Build frontend` + `Run frontend tests` — green on both bundle commits.
- [ ] Browser smoke against the production bundle + mock-API server (per the plan's Verification §4 checklist) — TODO post-merge or via a follow-up smoke session.

## Known follow-ups (out of scope, documented in the plan)

- Server-side filter pushdown for Service / Region / numerics (only relevant for tenants exceeding the API page-cap).
- localStorage persistence of column filters.
- Cross-column-aware distinct values for categorical popovers (Excel-style — first iteration uses the unfiltered rec set).
- Column visibility toggles.
- Harvesting the column-filter helpers as a shared module for Purchase Plans / Purchase History / RI Exchange tables.

## Plan file

The implementation plan (incl. context, glossary, pipeline order, popover lifecycle, term-aware bucketing rationale, edge cases, 19-pass review log, and verification checklist) lives at `~/.claude/plans/generic-painting-volcano.md` on the local machine that authored this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added per-column header filter popovers supporting numeric expressions and categorical filtering
  * Introduced sticky bottom action box for plan creation and purchase workflow

* **Improvements**
  * Relocated filter controls from top toolbar to column-based headers
  * Added visible recommendation counter with clear-all filters option

<!-- end of auto-generated comment: release notes by coderabbit.ai -->