### PR TITLE
feat(history): inline Retry button + retry-{any,own} RBAC + linkage + threshold + ops-hint (closes #47)

### DIFF
--- a/frontend/src/__tests__/history-retry-button.test.ts
+++ b/frontend/src/__tests__/history-retry-button.test.ts
@@ -1,0 +1,314 @@
+/**
+ * History inline Retry button tests (issue #47).
+ *
+ * Mirror of the backend RBAC matrix in
+ * internal/api/handler_purchases.go::authorizeSessionRetry — keep both
+ * sides in sync. The backend remains authoritative; these tests only
+ * verify the UX gate (don't render buttons users can't use, render
+ * the right control for the row's state).
+ *
+ * Tested matrix:
+ *   1. admin sees Retry on every failed row (modulo ops_hint / lineage).
+ *   2. regular user sees Retry only on rows they themselves created.
+ *   3. Anonymous (no current user cached) sees no Retry buttons.
+ *   4. ops_hint row → ops-hint badge replaces the Retry button.
+ *   5. retry_attempt_n >= 5 → "Retried 5×" override button.
+ *   6. retry_execution_id set → no Retry button (act on the descendant).
+ *   7. lineage links: "↻ Retried as #abc" for predecessors, "↻ Retry #n" for retries.
+ *   8. Click + decline confirmDialog → no API call.
+ *   9. Click + accept → retryPurchase + reload + toast.
+ *  10. retryPurchase rejects → toast.error + button re-enabled.
+ *  11. Over-threshold click sends force=true.
+ */
+
+import { loadHistory } from '../history';
+
+jest.mock('../api', () => ({
+  getHistory: jest.fn(),
+  retryPurchase: jest.fn(),
+  cancelPurchase: jest.fn(),
+}));
+
+jest.mock('../navigation', () => ({
+  switchTab: jest.fn(),
+}));
+
+jest.mock('../utils', () => ({
+  formatCurrency: jest.fn((val) => `$${val || 0}`),
+  formatDate: jest.fn((val) => (val ? new Date(val).toLocaleDateString() : '')),
+  formatTerm: jest.fn((years) => (years == null ? '' : `${years} Year${years === 1 ? '' : 's'}`)),
+  escapeHtml: jest.fn((str) => str || ''),
+  populateAccountFilter: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('../confirmDialog', () => ({
+  confirmDialog: jest.fn(),
+}));
+
+jest.mock('../toast', () => ({
+  showToast: jest.fn(),
+}));
+
+jest.mock('../state', () => ({
+  getCurrentUser: jest.fn(),
+}));
+
+import * as api from '../api';
+import { confirmDialog } from '../confirmDialog';
+import { showToast } from '../toast';
+import { getCurrentUser } from '../state';
+
+const ADMIN_USER = { id: 'admin-uuid', email: 'admin@example.com', role: 'admin' };
+const REG_USER = { id: 'user-uuid', email: 'user@example.com', role: 'user' };
+const OTHER_UUID = 'other-uuid';
+
+function setupDOM(): void {
+  while (document.body.firstChild) document.body.removeChild(document.body.firstChild);
+
+  const mkInput = (id: string): HTMLInputElement => {
+    const el = document.createElement('input');
+    el.type = 'date';
+    el.id = id;
+    return el;
+  };
+  const mkSelect = (id: string): HTMLSelectElement => {
+    const el = document.createElement('select');
+    el.id = id;
+    const opt = document.createElement('option');
+    opt.value = '';
+    opt.textContent = 'All';
+    el.appendChild(opt);
+    return el;
+  };
+  const mkDiv = (id: string): HTMLDivElement => {
+    const el = document.createElement('div');
+    el.id = id;
+    return el;
+  };
+
+  document.body.appendChild(mkInput('history-start'));
+  document.body.appendChild(mkInput('history-end'));
+  document.body.appendChild(mkSelect('history-provider-filter'));
+  document.body.appendChild(mkSelect('history-account-filter'));
+  document.body.appendChild(mkDiv('history-summary'));
+  document.body.appendChild(mkDiv('history-list'));
+}
+
+function makeRow(overrides: Record<string, unknown>) {
+  return {
+    purchase_id: 'exec-1',
+    timestamp: '2024-01-15T00:00:00Z',
+    provider: 'aws',
+    service: 'ec2',
+    resource_type: 't3.medium',
+    region: 'us-east-1',
+    count: 1,
+    term: 1,
+    upfront_cost: 100,
+    estimated_savings: 50,
+    plan_name: '',
+    status: 'failed',
+    ...overrides,
+  };
+}
+
+describe('History inline Retry button (issue #47)', () => {
+  beforeEach(() => {
+    setupDOM();
+    jest.clearAllMocks();
+  });
+
+  test('admin sees Retry on every failed row regardless of creator', async () => {
+    (getCurrentUser as jest.Mock).mockReturnValue(ADMIN_USER);
+    (api.getHistory as jest.Mock).mockResolvedValue({
+      summary: {},
+      purchases: [
+        makeRow({ purchase_id: 'fail-mine', created_by_user_id: ADMIN_USER.id }),
+        makeRow({ purchase_id: 'fail-other', created_by_user_id: OTHER_UUID }),
+        makeRow({ purchase_id: 'fail-legacy', created_by_user_id: undefined }),
+      ],
+    });
+
+    await loadHistory();
+
+    const buttons = document.querySelectorAll<HTMLButtonElement>('.history-retry-btn');
+    const ids = Array.from(buttons).map((b) => b.dataset['retryId']);
+    expect(ids).toEqual(expect.arrayContaining(['fail-mine', 'fail-other', 'fail-legacy']));
+    expect(ids).toHaveLength(3);
+  });
+
+  test('regular user sees Retry only on rows they created', async () => {
+    (getCurrentUser as jest.Mock).mockReturnValue(REG_USER);
+    (api.getHistory as jest.Mock).mockResolvedValue({
+      summary: {},
+      purchases: [
+        makeRow({ purchase_id: 'fail-mine', created_by_user_id: REG_USER.id }),
+        makeRow({ purchase_id: 'fail-other', created_by_user_id: OTHER_UUID }),
+        makeRow({ purchase_id: 'fail-legacy', created_by_user_id: undefined }),
+      ],
+    });
+
+    await loadHistory();
+
+    const buttons = document.querySelectorAll<HTMLButtonElement>('.history-retry-btn');
+    const ids = Array.from(buttons).map((b) => b.dataset['retryId']);
+    expect(ids).toEqual(['fail-mine']);
+  });
+
+  test('renders no Retry buttons when no current user is cached', async () => {
+    (getCurrentUser as jest.Mock).mockReturnValue(null);
+    (api.getHistory as jest.Mock).mockResolvedValue({
+      summary: {},
+      purchases: [makeRow({ created_by_user_id: 'anything' })],
+    });
+
+    await loadHistory();
+    expect(document.querySelectorAll('.history-retry-btn')).toHaveLength(0);
+  });
+
+  test('Retry button absent on non-failed rows even for admin', async () => {
+    (getCurrentUser as jest.Mock).mockReturnValue(ADMIN_USER);
+    (api.getHistory as jest.Mock).mockResolvedValue({
+      summary: {},
+      purchases: [
+        makeRow({ purchase_id: 'r-pending', status: 'pending', created_by_user_id: ADMIN_USER.id }),
+        makeRow({ purchase_id: 'r-completed', status: 'completed', created_by_user_id: ADMIN_USER.id }),
+        makeRow({ purchase_id: 'r-cancelled', status: 'cancelled', created_by_user_id: ADMIN_USER.id }),
+        makeRow({ purchase_id: 'r-expired', status: 'expired', created_by_user_id: ADMIN_USER.id }),
+      ],
+    });
+
+    await loadHistory();
+    expect(document.querySelectorAll('.history-retry-btn')).toHaveLength(0);
+  });
+
+  test('ops_hint replaces the Retry button on failed rows', async () => {
+    (getCurrentUser as jest.Mock).mockReturnValue(ADMIN_USER);
+    (api.getHistory as jest.Mock).mockResolvedValue({
+      summary: {},
+      purchases: [
+        makeRow({ purchase_id: 'r-1', created_by_user_id: ADMIN_USER.id, ops_hint: 'Set FROM_EMAIL tfvar then retry' }),
+      ],
+    });
+
+    await loadHistory();
+    expect(document.querySelectorAll('.history-retry-btn')).toHaveLength(0);
+    const hint = document.querySelector('.history-ops-hint');
+    expect(hint).not.toBeNull();
+    expect(hint?.textContent).toContain('FROM_EMAIL');
+  });
+
+  test('threshold-reached row renders override button + sends force=true on accept', async () => {
+    (getCurrentUser as jest.Mock).mockReturnValue(ADMIN_USER);
+    (confirmDialog as jest.Mock).mockResolvedValue(true);
+    (api.retryPurchase as jest.Mock).mockResolvedValue({ execution_id: 'new', original_execution: 'r-1' });
+    (api.getHistory as jest.Mock).mockResolvedValue({
+      summary: {},
+      purchases: [
+        makeRow({ purchase_id: 'r-1', created_by_user_id: ADMIN_USER.id, retry_attempt_n: 5 }),
+      ],
+    });
+
+    await loadHistory();
+    const btn = document.querySelector<HTMLButtonElement>('.history-retry-btn');
+    expect(btn?.classList.contains('history-retry-over-threshold')).toBe(true);
+    expect(btn?.textContent).toContain('Retried 5×');
+
+    btn?.click();
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(api.retryPurchase).toHaveBeenCalledWith('r-1', { force: true });
+  });
+
+  test('retry_execution_id set → no Retry button, lineage link rendered', async () => {
+    (getCurrentUser as jest.Mock).mockReturnValue(ADMIN_USER);
+    (api.getHistory as jest.Mock).mockResolvedValue({
+      summary: {},
+      purchases: [
+        makeRow({ purchase_id: 'old-1', created_by_user_id: ADMIN_USER.id, retry_execution_id: 'abcdef0123456789' }),
+      ],
+    });
+
+    await loadHistory();
+    expect(document.querySelectorAll('.history-retry-btn')).toHaveLength(0);
+    const link = document.querySelector('.history-retry-link');
+    expect(link).not.toBeNull();
+    expect(link?.textContent).toContain('Retried as');
+    expect(link?.getAttribute('href')).toContain('execution=abcdef0123456789');
+  });
+
+  test('retry_attempt_n > 0 row gets a "Retry #n" provenance badge', async () => {
+    (getCurrentUser as jest.Mock).mockReturnValue(ADMIN_USER);
+    (api.getHistory as jest.Mock).mockResolvedValue({
+      summary: {},
+      purchases: [
+        // n=2 retry that hasn't been retried again — eligible to retry,
+        // so we ALSO see the Retry button. This exercises the case where
+        // a middle-of-chain row has BOTH ↻ Retry button AND lineage
+        // metadata visible to the user.
+        makeRow({ purchase_id: 'mid-2', status: 'completed', created_by_user_id: ADMIN_USER.id, retry_attempt_n: 2 }),
+      ],
+    });
+
+    await loadHistory();
+    const badge = document.querySelector('.history-retry-of');
+    expect(badge).not.toBeNull();
+    expect(badge?.textContent).toContain('Retry #2');
+  });
+
+  test('declined confirm dialog skips API call', async () => {
+    (getCurrentUser as jest.Mock).mockReturnValue(ADMIN_USER);
+    (confirmDialog as jest.Mock).mockResolvedValue(false);
+    (api.getHistory as jest.Mock).mockResolvedValue({
+      summary: {},
+      purchases: [makeRow({ purchase_id: 'r-1', created_by_user_id: ADMIN_USER.id })],
+    });
+
+    await loadHistory();
+    const btn = document.querySelector<HTMLButtonElement>('.history-retry-btn');
+    btn?.click();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(confirmDialog).toHaveBeenCalled();
+    expect(api.retryPurchase).not.toHaveBeenCalled();
+  });
+
+  test('accepted confirm posts retry + reloads + toasts', async () => {
+    (getCurrentUser as jest.Mock).mockReturnValue(ADMIN_USER);
+    (confirmDialog as jest.Mock).mockResolvedValue(true);
+    (api.retryPurchase as jest.Mock).mockResolvedValue({ execution_id: 'new', original_execution: 'r-1' });
+    (api.getHistory as jest.Mock).mockResolvedValue({
+      summary: {},
+      purchases: [makeRow({ purchase_id: 'r-1', created_by_user_id: ADMIN_USER.id })],
+    });
+
+    await loadHistory();
+    expect(api.getHistory).toHaveBeenCalledTimes(1);
+    const btn = document.querySelector<HTMLButtonElement>('.history-retry-btn');
+    btn?.click();
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(api.retryPurchase).toHaveBeenCalledWith('r-1', undefined);
+    expect(api.getHistory).toHaveBeenCalledTimes(2);
+    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ kind: 'success' }));
+  });
+
+  test('retry API failure surfaces toast and re-enables the button', async () => {
+    (getCurrentUser as jest.Mock).mockReturnValue(ADMIN_USER);
+    (confirmDialog as jest.Mock).mockResolvedValue(true);
+    (api.retryPurchase as jest.Mock).mockRejectedValue(new Error('boom'));
+    (api.getHistory as jest.Mock).mockResolvedValue({
+      summary: {},
+      purchases: [makeRow({ purchase_id: 'r-1', created_by_user_id: ADMIN_USER.id })],
+    });
+    console.error = jest.fn();
+
+    await loadHistory();
+    const btn = document.querySelector<HTMLButtonElement>('.history-retry-btn');
+    btn?.click();
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ kind: 'error' }));
+    expect(btn?.disabled).toBe(false);
+  });
+});

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -209,8 +209,21 @@ export async function apiRequest<T>(endpoint: string, options: RequestOptions = 
     const error: ApiError = new Error(`HTTP ${response.status}`);
     error.status = response.status;
     try {
-      const data = await response.json() as { error?: string };
-      error.message = data.error || error.message;
+      const data = await response.json() as Record<string, unknown>;
+      const message = typeof data['error'] === 'string' ? data['error'] : '';
+      if (message) error.message = message;
+      // Strip the `error` key and surface the rest as structured
+      // details so callers can branch on ops_hint / retry_attempt_n /
+      // threshold / retry_execution_id without substring-matching the
+      // human message (see PurchaseHistory Retry button — issue #47).
+      const details: Record<string, unknown> = {};
+      for (const k of Object.keys(data)) {
+        if (k === 'error') continue;
+        details[k] = data[k];
+      }
+      if (Object.keys(details).length > 0) {
+        error.details = details;
+      }
     } catch {
       // Ignore JSON parse errors
     }

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -115,6 +115,7 @@ export {
   executePurchase,
   getPurchaseDetails,
   cancelPurchase,
+  retryPurchase,
   getPlannedPurchases,
   pausePlannedPurchase,
   resumePlannedPurchase,
@@ -122,6 +123,7 @@ export {
   deletePlannedPurchase,
   createPlannedPurchases
 } from './purchases';
+export type { RetryPurchaseResult } from './purchases';
 
 // Re-export users functions
 export {

--- a/frontend/src/api/purchases.ts
+++ b/frontend/src/api/purchases.ts
@@ -42,6 +42,38 @@ export async function cancelPurchase(executionId: string): Promise<void> {
 }
 
 /**
+ * Retry a failed purchase execution (issue #47).
+ *
+ * The session-authed endpoint creates a new execution from the failed
+ * row's stored Recommendations slice, stamps the predecessor with a
+ * pointer to the successor, and increments retry_attempt_n on the
+ * chain. Pass `force: true` to bypass the soft-block threshold (the
+ * frontend gates this behind a confirm-with-warning dialog so a user
+ * can't trip it accidentally).
+ *
+ * Returns the API response shape — execution_id of the new row and
+ * retry_attempt_n on it — so the caller can toast a meaningful link.
+ */
+export interface RetryPurchaseResult {
+  execution_id: string;
+  original_execution: string;
+  status: string;
+  retry_attempt_n: number;
+  email_sent?: boolean;
+  email_reason?: string;
+}
+
+export async function retryPurchase(
+  executionId: string,
+  opts?: { force?: boolean },
+): Promise<RetryPurchaseResult> {
+  const qs = opts?.force ? '?force=true' : '';
+  return apiRequest<RetryPurchaseResult>(`/purchases/retry/${executionId}${qs}`, {
+    method: 'POST',
+  });
+}
+
+/**
  * Get planned purchases (scheduled from plans)
  */
 export async function getPlannedPurchases(): Promise<PlannedPurchasesResponse> {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -515,6 +515,13 @@ export interface RIExchangeHistoryRecord {
 // Internal types
 export interface ApiError extends Error {
   status?: number;
+  // Structured detail fields the backend attaches to a 4xx response
+  // alongside the human `error` message (e.g. `ops_hint`,
+  // `retry_attempt_n`, `threshold`, `retry_execution_id`). Callers
+  // can branch on these without substring-matching the message.
+  // See internal/api/handler.go for the flattening — keys are
+  // promoted to the top level of the JSON body.
+  details?: Record<string, unknown>;
 }
 
 export interface RequestOptions extends RequestInit {

--- a/frontend/src/history.ts
+++ b/frontend/src/history.ts
@@ -597,8 +597,22 @@ function renderHistoryList(purchases: HistoryPurchase[]): void {
         await api.retryPurchase(id, overThreshold ? { force: true } : undefined);
       } catch (retryError) {
         console.error('Failed to retry purchase:', retryError);
-        const err = retryError as Error;
-        showToast({ message: `Failed to retry: ${err.message || 'unknown error'}`, kind: 'error' });
+        // Surface structured retry hints from the backend (issue #47):
+        //   * ops_hint — operator-actionable reason; takes priority
+        //   * retry_attempt_n + threshold — soft-block message
+        //   * else — fall back to the raw error message
+        const err = retryError as Error & { details?: Record<string, unknown> };
+        const opsHint = typeof err.details?.['ops_hint'] === 'string' ? err.details['ops_hint'] : '';
+        const retryAttemptN = typeof err.details?.['retry_attempt_n'] === 'number' ? err.details['retry_attempt_n'] : undefined;
+        const threshold = typeof err.details?.['threshold'] === 'number' ? err.details['threshold'] : undefined;
+        let detailMessage = '';
+        if (opsHint) {
+          detailMessage = opsHint;
+        } else if (retryAttemptN != null && threshold != null) {
+          detailMessage = `already retried ${retryAttemptN} times (threshold ${threshold}) — confirm the override prompt to force`;
+        }
+        const finalMessage = detailMessage || err.message || 'unknown error';
+        showToast({ message: `Failed to retry: ${finalMessage}`, kind: 'error' });
         btn.disabled = false;
         return;
       }

--- a/frontend/src/history.ts
+++ b/frontend/src/history.ts
@@ -321,6 +321,113 @@ function canCancelPendingRow(p: HistoryPurchase): boolean {
   return p.created_by_user_id === user.id;
 }
 
+// canRetryFailedRow returns true when the current session is permitted
+// to retry the given failed history row via the inline Retry button
+// (issue #47). UX gate only — the backend authorizeSessionRetry in
+// internal/api/handler_purchases.go remains the security boundary.
+//
+// Heuristic mirrors canCancelPendingRow:
+//   * status must be "failed";
+//   * row must NOT carry an ops_hint (persistent failure → no retry,
+//     show the hint instead);
+//   * row must NOT already have a retry_execution_id (we don't allow
+//     retrying the same failure twice — the user should retry the
+//     latest descendant in the chain);
+//   * admin → always yes;
+//   * non-admin matching the row's created_by_user_id → yes (retry-own).
+function canRetryFailedRow(p: HistoryPurchase): boolean {
+  const status = (p.status || '').toLowerCase();
+  if (status !== 'failed') return false;
+  if (p.ops_hint) return false;
+  if (p.retry_execution_id) return false; // already retried — user should act on the descendant
+  const user = getCurrentUser();
+  if (!user) return false;
+  if (user.role === 'admin') return true;
+  if (!p.created_by_user_id) return false;
+  return p.created_by_user_id === user.id;
+}
+
+// retryThresholdReached returns true when the row has hit the soft-
+// block threshold (5 attempts). The frontend shows a confirm-with-
+// warning dialog and forwards force=true on confirmation.
+//
+// Kept in sync with retryThreshold in internal/api/handler_purchases.go;
+// the backend remains authoritative — if this client predicate disagrees
+// with the server, the API surfaces a structured 409 with retry_attempt_n
+// + threshold and the toast falls back to the server message.
+const RETRY_THRESHOLD = 5;
+function retryThresholdReached(p: HistoryPurchase): boolean {
+  return (p.retry_attempt_n ?? 0) >= RETRY_THRESHOLD;
+}
+
+// shortExecID renders the first 8 chars of a UUID so inline lineage
+// links ("Retried as #abc12345") stay readable in the table cell. The
+// full ID is preserved in the data-history-status attribute so the
+// click handler can deep-link without truncation surprises.
+function shortExecID(id: string): string {
+  return (id || '').replace(/^urn:.*?:/, '').slice(0, 8);
+}
+
+// renderActionCell returns the HTML for the Plan / action column on a
+// single history row. The column doubles as the per-row action surface
+// because pending / failed rows rarely have a meaningful plan_name (the
+// pending plan info already shows in StatusDescription) and reusing the
+// existing column keeps table width unchanged.
+//
+// Decision tree (status-driven, mutually exclusive):
+//   * pending|notified + canCancel  → Cancel button (issue #46)
+//   * failed + ops_hint set         → ⚠ ops-hint badge (issue #47, Q3 — no retry)
+//   * failed + threshold reached    → "Retried 5× — confirm to override" Retry button (Q2)
+//   * failed + canRetry             → standard ↻ Retry button
+//   * any row with retry lineage    → inline ↻ Retried as / ↻ Retry of link
+//   * else                          → plan_name or "-"
+function renderActionCell(p: HistoryPurchase): string {
+  // Pending → Cancel takes precedence; we never show Retry on a non-
+  // failed row.
+  if (canCancelPendingRow(p) && p.purchase_id) {
+    return `<button type="button" class="btn-link history-cancel-btn" data-cancel-id="${escapeHtml(p.purchase_id)}">Cancel</button>`;
+  }
+
+  // Failed → either ops-hint (no retry possible), Retry (with optional
+  // threshold-confirm flag), plus lineage link to the successor if it
+  // exists. We never show ops-hint AND Retry on the same row — the
+  // hint replaces the action entirely because retrying a persistent
+  // misconfig is guaranteed to fail again.
+  if ((p.status || '').toLowerCase() === 'failed') {
+    if (p.ops_hint) {
+      return `<span class="history-ops-hint" title="Operator action required — Retry will not help until this is fixed">⚠ ${escapeHtml(p.ops_hint)}</span>`;
+    }
+    if (canRetryFailedRow(p) && p.purchase_id) {
+      const overThreshold = retryThresholdReached(p);
+      const label = overThreshold ? `⚠ Retried ${p.retry_attempt_n ?? 0}× — click to override` : '↻ Retry';
+      const cls = overThreshold ? 'btn-link history-retry-btn history-retry-over-threshold' : 'btn-link history-retry-btn';
+      return `<button type="button" class="${cls}" data-retry-id="${escapeHtml(p.purchase_id)}">${label}</button>`;
+    }
+  }
+
+  // Lineage links: a row that was retried (retry_execution_id set) or
+  // is itself a retry (retry_attempt_n > 0) gets an inline cross-link
+  // to the other end of the chain so the user can navigate without
+  // scrolling. Both can be true simultaneously on a middle-of-chain
+  // row (failed_v2 was retried into v3 AND is itself a retry of v1).
+  const lineage: string[] = [];
+  if (p.retry_execution_id) {
+    lineage.push(`<a href="#history?execution=${encodeURIComponent(p.retry_execution_id)}" class="history-retry-link" title="Jump to the retry execution">↻ Retried as #${escapeHtml(shortExecID(p.retry_execution_id))}</a>`);
+  }
+  if ((p.retry_attempt_n ?? 0) > 0) {
+    // We don't carry a back-pointer field — a future enhancement
+    // could surface the predecessor's exec ID via the API. For now
+    // we render a static badge (no link target) so users at least
+    // see "this is a retry" provenance.
+    lineage.push(`<span class="history-retry-link history-retry-of" title="This row is retry #${p.retry_attempt_n} in its chain">↻ Retry #${p.retry_attempt_n}</span>`);
+  }
+  if (lineage.length > 0) {
+    return lineage.join(' ');
+  }
+
+  return escapeHtml(p.plan_name || '-');
+}
+
 function renderHistoryList(purchases: HistoryPurchase[]): void {
   const container = document.getElementById('history-list');
   if (!container) return;
@@ -364,13 +471,7 @@ function renderHistoryList(purchases: HistoryPurchase[]): void {
       return badge;
     })();
     const execIdAttr = p.purchase_id ? ` data-execution-id="${escapeHtml(p.purchase_id)}"` : '';
-    // Inline Cancel button on pending/notified rows the current user is
-    // permitted to cancel. Renders in the Plan column so the table
-    // width stays the same; pending rows show their plan in
-    // StatusDescription, not the Plan column, so this is non-conflicting.
-    const planCellContent = canCancelPendingRow(p) && p.purchase_id
-      ? `<button type="button" class="btn-link history-cancel-btn" data-cancel-id="${escapeHtml(p.purchase_id)}">Cancel</button>`
-      : escapeHtml(p.plan_name || '-');
+    const planCellContent = renderActionCell(p);
     return `
       <tr${execIdAttr}>
         <td>${statusCell}</td>
@@ -466,6 +567,49 @@ function renderHistoryList(purchases: HistoryPurchase[]): void {
         console.error('Failed to reload history after cancel:', reloadError);
         // Don't downgrade the success toast; loadHistory's own catch
         // already paints an error message into the list area.
+      }
+    });
+  });
+
+  // Wire the inline Retry button on failed rows the current session
+  // may retry (issue #47). Two flows:
+  //   * normal:    confirmDialog → POST /retry → reload + toast.
+  //   * over-threshold: confirmDialog with stronger warning → POST
+  //     with ?force=true → reload + toast.
+  // The backend may still 409 with an ops_hint or threshold response;
+  // the catch block surfaces the structured detail when present.
+  container.querySelectorAll<HTMLButtonElement>('.history-retry-btn[data-retry-id]').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const id = btn.dataset['retryId'];
+      if (!id) return;
+      const overThreshold = btn.classList.contains('history-retry-over-threshold');
+      const ok = await confirmDialog({
+        title: overThreshold ? 'Retry past threshold?' : 'Retry this failed purchase?',
+        body: overThreshold
+          ? 'The same recommendations have already failed multiple times. Are you sure you want to retry again? This may not succeed.'
+          : 'This will create a new purchase execution from the same recommendations. The original failed row will be linked to the new attempt.',
+        confirmLabel: overThreshold ? 'Retry anyway' : 'Retry purchase',
+        destructive: false,
+      });
+      if (!ok) return;
+      btn.disabled = true;
+      try {
+        await api.retryPurchase(id, overThreshold ? { force: true } : undefined);
+      } catch (retryError) {
+        console.error('Failed to retry purchase:', retryError);
+        const err = retryError as Error;
+        showToast({ message: `Failed to retry: ${err.message || 'unknown error'}`, kind: 'error' });
+        btn.disabled = false;
+        return;
+      }
+      // Retry POST succeeded — surface success regardless of whether
+      // the refresh works. The reload error path mirrors the cancel
+      // flow above.
+      showToast({ message: 'Retry execution created', kind: 'success', timeout: 5_000 });
+      try {
+        await loadHistory();
+      } catch (reloadError) {
+        console.error('Failed to reload history after retry:', reloadError);
       }
     });
   });

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -183,6 +183,27 @@ export interface HistoryPurchase {
   // (issue #46) is visible — non-admins only see it on rows they
   // themselves created.
   created_by_user_id?: string;
+  // RetryExecutionID: pointer from a *failed* row to the successor
+  // execution created when the user clicked Retry (issue #47). Set
+  // only on the original failed row; absent on every other row
+  // (including the retry row itself — its own retry_attempt_n > 0 is
+  // the "this is a retry" marker). The History UI renders an inline
+  // "↻ Retried as #abc" link to the successor when this is non-empty.
+  retry_execution_id?: string;
+  // RetryAttemptN: position of this execution in a retry chain. 0 on
+  // every fresh execution; 1 on the first retry; n+1 on the n+1-th.
+  // The History UI renders "↻ Retry of #xyz" on retry rows (n > 0)
+  // pointing back to the predecessor, and gates the Retry button
+  // against the soft-block threshold (n >= 5 → confirm-with-warning).
+  retry_attempt_n?: number;
+  // OpsHint: short operator-actionable message rendered inline in
+  // place of the Retry button when the failure reason on the row
+  // matches a known-persistent-misconfiguration pattern (e.g.
+  // "FROM_EMAIL not configured" → "Set FROM_EMAIL tfvar then retry").
+  // Set only on `failed` rows whose Error matches the persistent map;
+  // absent otherwise. Replaces the Retry button entirely — there is
+  // no actionable retry from a persistent misconfig.
+  ops_hint?: string;
 }
 
 // Savings Analytics types

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -329,6 +329,22 @@ func (h *Handler) handleRequestError(err error) (int, any) {
 		return 404, map[string]string{"error": "Not found"}
 	}
 	if ce, ok := IsClientError(err); ok {
+		// If the error carries structured details (e.g. retry soft-block
+		// surfaces ops_hint / retry_attempt_n / threshold), flatten them
+		// into the JSON body next to "error" so the frontend can branch
+		// on machine-readable hints without substring-matching the
+		// human message.
+		if details := ce.Details(); len(details) > 0 {
+			body := make(map[string]any, len(details)+1)
+			body["error"] = ce.message
+			for k, v := range details {
+				if k == "error" {
+					continue // never let a detail key shadow the message
+				}
+				body[k] = v
+			}
+			return ce.code, body
+		}
 		return ce.code, map[string]string{"error": ce.message}
 	}
 

--- a/internal/api/handler_history.go
+++ b/internal/api/handler_history.go
@@ -160,6 +160,10 @@ func executionToHistoryRow(exec config.PurchaseExecution, approver string) confi
 	if exec.CreatedByUserID != nil {
 		createdBy = *exec.CreatedByUserID
 	}
+	var retryExecID string
+	if exec.RetryExecutionID != nil {
+		retryExecID = *exec.RetryExecutionID
+	}
 	row := config.PurchaseHistoryRecord{
 		AccountID:        accountID,
 		PurchaseID:       exec.ExecutionID,
@@ -173,6 +177,15 @@ func executionToHistoryRow(exec config.PurchaseExecution, approver string) confi
 		PlanID:           exec.PlanID,
 		Status:           exec.Status,
 		CreatedByUserID:  createdBy,
+		RetryExecutionID: retryExecID,
+		RetryAttemptN:    exec.RetryAttemptN,
+	}
+	// Compute ops_hint at read time (issue #47, Q3) so updates to the
+	// persistent-failure map land instantly without a re-collect. Only
+	// failed rows can carry a hint — the resolver returns "" for empty
+	// inputs, so this is safe to call unconditionally.
+	if exec.Status == "failed" {
+		row.OpsHint = resolveOpsHint(exec.Error)
 	}
 	annotateHistoryRowByStatus(&row, exec, approver)
 	return row

--- a/internal/api/handler_purchases.go
+++ b/internal/api/handler_purchases.go
@@ -578,18 +578,24 @@ func (h *Handler) loadAndValidateRetryRequest(ctx context.Context, req *events.L
 		return nil, nil, NewClientError(409, fmt.Sprintf("execution %s cannot be retried (status=%s)", failedExec.ExecutionID, failedExec.Status))
 	}
 
+	// Authorize BEFORE the already-retried guard so an unauthorized
+	// caller can't enumerate descendant execution IDs by probing
+	// failed-row UUIDs (CR #168 review). The status check above is
+	// allowed pre-RBAC because non-admins can already see the row's
+	// status via the History endpoint they're entitled to read.
+	if err := h.authorizeSessionRetry(ctx, session, failedExec); err != nil {
+		return nil, nil, err
+	}
+
 	// Already-retried guard: a row with retry_execution_id set was
 	// already retried into a successor. Retrying it AGAIN would
 	// silently overwrite the linkage pointer and orphan the previous
-	// chain, breaking History attribution.
+	// chain, breaking History attribution. Surfaced only after RBAC
+	// so the descendant ID isn't a cross-user info leak.
 	if failedExec.RetryExecutionID != nil && *failedExec.RetryExecutionID != "" {
 		return nil, nil, NewClientErrorWithDetails(409,
 			fmt.Sprintf("execution %s was already retried; act on its descendant instead", failedExec.ExecutionID),
 			map[string]any{"retry_execution_id": *failedExec.RetryExecutionID})
-	}
-
-	if err := h.authorizeSessionRetry(ctx, session, failedExec); err != nil {
-		return nil, nil, err
 	}
 
 	if err := checkRetryRateGates(failedExec, req); err != nil {
@@ -648,8 +654,14 @@ func (h *Handler) persistRetryExecution(ctx context.Context, failedExec *config.
 	copiedRecs := append([]config.RecommendationRecord(nil), failedExec.Recommendations...)
 
 	newExecutionID := uuid.New().String()
+	// PlanID + StepNumber propagate from the predecessor so a retried
+	// planned execution stays attributed to its plan + ramp step (CR
+	// #168 review). For ad-hoc executions PlanID is "" and StepNumber
+	// is 0, so propagation is a no-op for the non-plan case.
 	newExecution := &config.PurchaseExecution{
 		ExecutionID:      newExecutionID,
+		PlanID:           failedExec.PlanID,
+		StepNumber:       failedExec.StepNumber,
 		Status:           "pending",
 		ScheduledDate:    time.Now(),
 		Recommendations:  copiedRecs,

--- a/internal/api/handler_purchases.go
+++ b/internal/api/handler_purchases.go
@@ -436,6 +436,309 @@ func (h *Handler) requireSession(ctx context.Context, req *events.LambdaFunction
 	return session, nil
 }
 
+// retryThreshold is the number of attempts after which a retry is
+// soft-blocked and requires `?force=true` to override (issue #47, Q2).
+// Five was picked to be generous enough to absorb transient SES /
+// recipient-mailbox blips (which usually clear within a couple of
+// attempts) while still surfacing genuinely-stuck deployments before
+// they accumulate dozens of dead retry rows.
+const retryThreshold = 5
+
+// persistentFailureHints maps known-persistent failure substrings to
+// the operator-actionable hint surfaced on the History row in place of
+// the Retry button (issue #47, Q3). The match is a case-INsensitive
+// substring contains check (see resolveOpsHint) — wording variations
+// like "ses sandbox" / "SES Sandbox" all hit. Keep needles short and
+// distinctive so legitimate transient failures don't accidentally
+// substring-match a persistent hint and lock the user out.
+//
+// Membership criteria: only failures that NO retry can possibly fix —
+// they require an operator to change configuration or unblock an
+// upstream resource. SES sandbox / unverified domain / missing
+// FROM_EMAIL all fit; a transient SES throttle does NOT (the next
+// retry might succeed). When in doubt, leave it out — false-negatives
+// cost a wasted retry; false-positives lock the user out of an
+// actionable button entirely.
+var persistentFailureHints = map[string]string{
+	"FROM_EMAIL not configured": "Set FROM_EMAIL tfvar then retry",
+	"SES sandbox":               "Move SES out of sandbox or verify recipient, then retry",
+	"SES domain not verified":   "Verify SES domain in AWS console, then retry",
+	"IAM denied":                "Grant the deploy role missing IAM permission, then retry",
+}
+
+// resolveOpsHint returns a non-empty hint when the failure reason
+// matches a known-persistent pattern, else empty. Match is case-
+// insensitive substring contains so backend wording variations don't
+// silently slip through ("ses sandbox" / "SES sandbox" / "SES Sandbox"
+// all hit).
+func resolveOpsHint(failureReason string) string {
+	if failureReason == "" {
+		return ""
+	}
+	lower := strings.ToLower(failureReason)
+	for needle, hint := range persistentFailureHints {
+		if strings.Contains(lower, strings.ToLower(needle)) {
+			return hint
+		}
+	}
+	return ""
+}
+
+// retryPurchase creates a new execution from a *failed* execution's
+// stored Recommendations slice (issue #47). The original failed row
+// keeps its `failed` status as a historical record and gains a
+// retry_execution_id pointer to the successor; the new row inherits
+// retry_attempt_n = predecessor.retry_attempt_n + 1.
+//
+// Permission gate (mirrors authorizeSessionCancel from #46):
+//   - retry-any → may retry any failed row.
+//   - retry-own AND failedExec.created_by_user_id == session.user_id
+//     → may retry their own failed row.
+//   - else → 403.
+//
+// State gate:
+//   - failedExec.Status must be "failed" → 409 otherwise.
+//   - failedExec.Error must NOT match the persistent-failure map →
+//     409 with ops_hint when it does (Q3).
+//   - failedExec.RetryAttemptN < retryThreshold OR ?force=true → soft
+//     block at threshold (Q2).
+//
+// Atomicity:
+//
+//	A single tx writes (a) the new execution row and (b) the linkage
+//	on the original failed row. Suppressions for the new execution are
+//	created in the same tx. A crash between any two writes leaves
+//	either everything or nothing — no orphaned successor without a
+//	predecessor pointer, no dangling pointer to a non-existent row.
+func (h *Handler) retryPurchase(ctx context.Context, req *events.LambdaFunctionURLRequest, execID string) (any, error) {
+	failedExec, session, err := h.loadAndValidateRetryRequest(ctx, req, execID)
+	if err != nil {
+		return nil, err
+	}
+
+	totalUpfront, totalSavings, err := validateAndTotalRecommendations(failedExec.Recommendations)
+	if err != nil {
+		return nil, err
+	}
+
+	newExecution, err := h.persistRetryExecution(ctx, failedExec, session, totalUpfront, totalSavings)
+	if err != nil {
+		return nil, err
+	}
+
+	// Send the approval email outside the tx — same pattern as
+	// executePurchase. Email failures flip the new execution to
+	// `failed` so the user sees the reason in History; the linkage on
+	// the original row is unaffected (it points at the failed-again
+	// successor, which is exactly the audit trail we want).
+	emailSent, emailReason := h.sendPurchaseApprovalEmail(ctx, req, newExecution, failedExec.Recommendations, totalUpfront, totalSavings)
+	status := h.finalizePurchaseStatus(ctx, newExecution, emailSent, emailReason)
+
+	resp := map[string]any{
+		"execution_id":         newExecution.ExecutionID,
+		"original_execution":   failedExec.ExecutionID,
+		"status":               status,
+		"recommendation_count": len(failedExec.Recommendations),
+		"total_upfront_cost":   totalUpfront,
+		"estimated_savings":    totalSavings,
+		"email_sent":           emailSent,
+		"retry_attempt_n":      newExecution.RetryAttemptN,
+	}
+	if emailReason != "" {
+		resp["email_reason"] = emailReason
+	}
+	return resp, nil
+}
+
+// loadAndValidateRetryRequest fetches the failed execution, the
+// session, and runs every gate (status, already-retried, RBAC,
+// persistent-failure, threshold) before returning a green-light pair.
+// Extracted from retryPurchase to keep that function under the
+// cyclomatic-complexity ceiling; the gates remain in the order
+// documented on retryPurchase so the security boundary is the same.
+func (h *Handler) loadAndValidateRetryRequest(ctx context.Context, req *events.LambdaFunctionURLRequest, execID string) (*config.PurchaseExecution, *Session, error) {
+	if err := validateUUID(execID); err != nil {
+		return nil, nil, err
+	}
+
+	failedExec, err := h.config.GetExecutionByID(ctx, execID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get execution: %w", err)
+	}
+	if failedExec == nil {
+		return nil, nil, NewClientError(404, "execution not found")
+	}
+
+	session, err := h.requireSession(ctx, req)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if failedExec.Status != "failed" {
+		return nil, nil, NewClientError(409, fmt.Sprintf("execution %s cannot be retried (status=%s)", failedExec.ExecutionID, failedExec.Status))
+	}
+
+	// Already-retried guard: a row with retry_execution_id set was
+	// already retried into a successor. Retrying it AGAIN would
+	// silently overwrite the linkage pointer and orphan the previous
+	// chain, breaking History attribution.
+	if failedExec.RetryExecutionID != nil && *failedExec.RetryExecutionID != "" {
+		return nil, nil, NewClientErrorWithDetails(409,
+			fmt.Sprintf("execution %s was already retried; act on its descendant instead", failedExec.ExecutionID),
+			map[string]any{"retry_execution_id": *failedExec.RetryExecutionID})
+	}
+
+	if err := h.authorizeSessionRetry(ctx, session, failedExec); err != nil {
+		return nil, nil, err
+	}
+
+	if err := checkRetryRateGates(failedExec, req); err != nil {
+		return nil, nil, err
+	}
+
+	return failedExec, session, nil
+}
+
+// checkRetryRateGates runs the persistent-failure (Q3) and
+// retry-attempt-threshold (Q2) gates and returns the appropriate
+// 409 ClientError when either fires. Extracted from
+// loadAndValidateRetryRequest to keep that function under the
+// cyclomatic-complexity ceiling without flattening the gate sequence.
+func checkRetryRateGates(failedExec *config.PurchaseExecution, req *events.LambdaFunctionURLRequest) error {
+	// Persistent-failure block (Q3). Surfaces the ops_hint via the
+	// API for stale-cache callers; the History UI already shows it
+	// inline in place of the Retry button.
+	if hint := resolveOpsHint(failedExec.Error); hint != "" {
+		return NewClientErrorWithDetails(409,
+			"this failure is operator-fixable; retrying without changing configuration will fail again",
+			map[string]any{"ops_hint": hint, "failure_reason": failedExec.Error})
+	}
+
+	// Threshold soft-block (Q2). force=true (set by the frontend
+	// confirm-with-warning) skips the block but still increments the
+	// chain so the next retry is gated by the same threshold against
+	// the new attempt count.
+	force := strings.EqualFold(req.QueryStringParameters["force"], "true")
+	if !force && failedExec.RetryAttemptN >= retryThreshold {
+		return NewClientErrorWithDetails(409,
+			fmt.Sprintf("execution %s has been retried %d times already; pass ?force=true to override", failedExec.ExecutionID, failedExec.RetryAttemptN),
+			map[string]any{"retry_attempt_n": failedExec.RetryAttemptN, "threshold": retryThreshold})
+	}
+
+	return nil
+}
+
+// persistRetryExecution builds the successor PurchaseExecution and
+// writes it + the predecessor linkage + suppressions in a single tx.
+// Returns the populated newExecution so the caller can send the
+// approval email and synthesize the response. Extracted from
+// retryPurchase to keep that function under the cyclomatic-complexity
+// ceiling; tx ordering and the slice-aliasing fix live here.
+func (h *Handler) persistRetryExecution(ctx context.Context, failedExec *config.PurchaseExecution, session *Session, totalUpfront, totalSavings float64) (*config.PurchaseExecution, error) {
+	// Defensive deep copy of the recommendations slice. Sharing the
+	// backing array with failedExec.Recommendations would let the
+	// downstream purchase pipeline (purchase.Manager.purchaseRecommendations
+	// at internal/purchase/execution.go) mutate per-element fields
+	// (.Error / .Purchased / .PurchaseID) on the *original failed row's*
+	// in-memory representation as well — corrupting the historical
+	// record any caller still holding the failedExec pointer would see.
+	// The DB rows are isolated (each row JSON-marshals its own copy),
+	// but in-process aliasing across a "historical" row and its
+	// "successor" is a footgun we want to remove at the source.
+	copiedRecs := append([]config.RecommendationRecord(nil), failedExec.Recommendations...)
+
+	newExecutionID := uuid.New().String()
+	newExecution := &config.PurchaseExecution{
+		ExecutionID:      newExecutionID,
+		Status:           "pending",
+		ScheduledDate:    time.Now(),
+		Recommendations:  copiedRecs,
+		TotalUpfrontCost: totalUpfront,
+		EstimatedSavings: totalSavings,
+		ApprovalToken:    uuid.New().String(),
+		Source:           common.PurchaseSourceWeb,
+		CapacityPercent:  failedExec.CapacityPercent,
+		CreatedByUserID:  resolveCreatorUserID(session),
+		RetryAttemptN:    failedExec.RetryAttemptN + 1,
+	}
+
+	// Stamp the original failed row with the linkage. This is a
+	// separate value copy so the caller's pointer to failedExec doesn't
+	// accidentally pick up other status-mutating concerns: only
+	// retry_execution_id changes here, the status stays `failed`.
+	originalUpdated := *failedExec
+	originalUpdated.RetryExecutionID = &newExecutionID
+
+	var gracePeriodCfg *config.GlobalConfig
+	if g, err := h.config.GetGlobalConfig(ctx); err == nil {
+		gracePeriodCfg = g
+	}
+	suppressions := buildSuppressions(failedExec.Recommendations, newExecutionID, gracePeriodCfg, time.Now())
+
+	// Three writes in one tx:
+	//  1. INSERT the new execution row (the successor).
+	//  2. UPSERT the original failed row to set retry_execution_id.
+	//  3. INSERT suppression rows for the new execution.
+	// Order matters: the FK on retry_execution_id requires the
+	// successor to exist before the original can point at it.
+	if err := h.config.WithTx(ctx, func(tx pgx.Tx) error {
+		if err := h.config.SavePurchaseExecutionTx(ctx, tx, newExecution); err != nil {
+			return err
+		}
+		if err := h.config.SavePurchaseExecutionTx(ctx, tx, &originalUpdated); err != nil {
+			return err
+		}
+		for i := range suppressions {
+			if err := h.config.CreateSuppressionTx(ctx, tx, &suppressions[i]); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("failed to save retry execution: %w", err)
+	}
+
+	return newExecution, nil
+}
+
+// authorizeSessionRetry is the retry-side mirror of
+// authorizeSessionCancel. Returns nil when the session is permitted to
+// retry the given failed execution under the retry-any / retry-own
+// rules (issue #47); 403 ClientError otherwise. Admins short-circuit;
+// non-admins must hold retry-any (allowed for any execution) or
+// retry-own (allowed only when the execution's CreatedByUserID matches
+// the session UserID — legacy NULL-creator rows are out of reach for
+// non-admins, same as the cancel path).
+func (h *Handler) authorizeSessionRetry(ctx context.Context, session *Session, execution *config.PurchaseExecution) error {
+	if session.Role == "admin" {
+		return nil
+	}
+	if h.auth == nil {
+		return NewClientError(500, "authentication service not configured")
+	}
+
+	hasAny, err := h.auth.HasPermissionAPI(ctx, session.UserID, auth.ActionRetryAny, auth.ResourcePurchases)
+	if err != nil {
+		return fmt.Errorf("permission check failed: %w", err)
+	}
+	if hasAny {
+		return nil
+	}
+
+	hasOwn, err := h.auth.HasPermissionAPI(ctx, session.UserID, auth.ActionRetryOwn, auth.ResourcePurchases)
+	if err != nil {
+		return fmt.Errorf("permission check failed: %w", err)
+	}
+	if !hasOwn {
+		return NewClientError(403, "permission denied: requires retry-any or retry-own on purchases")
+	}
+
+	if execution.CreatedByUserID == nil || *execution.CreatedByUserID != session.UserID {
+		return NewClientError(403, "permission denied: cannot retry another user's failed purchase")
+	}
+	return nil
+}
+
 // tryResolveActorEmail returns the email of the session-authenticated user
 // who made the request, or "" when the request carries no valid session.
 // Best-effort: the approve/cancel routes are AuthPublic (token-only), so

--- a/internal/api/handler_purchases_test.go
+++ b/internal/api/handler_purchases_test.go
@@ -1658,6 +1658,60 @@ func TestHandler_retryPurchase_RejectsMissingSession(t *testing.T) {
 	assert.Contains(t, err.Error(), "no authorization token provided")
 }
 
+// TestHandler_retryPurchase_PreservesPlanMetadata verifies that retry
+// successors inherit PlanID + StepNumber from the predecessor (CR #168
+// review — without this, a retried planned execution would drop out of
+// plan-scoped history and lose its ramp-step attribution).
+func TestHandler_retryPurchase_PreservesPlanMetadata(t *testing.T) {
+	creator := retryCallerID
+	failed := &config.PurchaseExecution{
+		ExecutionID:     retryExecID,
+		PlanID:          "plan-abc",
+		StepNumber:      3,
+		Status:          "failed",
+		Error:           "send failed: transient SES throttle",
+		CreatedByUserID: &creator,
+		Recommendations: []config.RecommendationRecord{{Provider: "aws", Service: "ec2", Term: 1}},
+	}
+	session := &Session{UserID: retryCallerID, Role: "admin"}
+	newExec, _ := runSessionRetryAllowed(t, failed, session, false, false, sessionRetryReq())
+	assert.Equal(t, "plan-abc", newExec.PlanID, "successor must inherit predecessor PlanID")
+	assert.Equal(t, 3, newExec.StepNumber, "successor must inherit predecessor StepNumber")
+}
+
+// TestHandler_retryPurchase_AlreadyRetried_RBACBeforeLeak verifies the
+// fix to a CR #168 finding: the already-retried 409 must NOT fire for
+// an unauthorized session, because doing so would leak the descendant
+// execution UUID to anyone who can guess a failed-row ID. The
+// authorization gate must run first and surface a 403 instead.
+func TestHandler_retryPurchase_AlreadyRetried_RBACBeforeLeak(t *testing.T) {
+	creator := retryOtherID // someone else owns the failed row
+	successor := "11111111-2222-3333-4444-555555555555"
+	failed := &config.PurchaseExecution{
+		ExecutionID:      retryExecID,
+		Status:           "failed",
+		CreatedByUserID:  &creator,
+		RetryExecutionID: &successor, // already retried
+		Recommendations:  []config.RecommendationRecord{{Provider: "aws", Service: "ec2", Term: 1}},
+	}
+	// Caller is a non-admin holding NEITHER retry-any nor retry-own —
+	// must hit the 403 from authorizeSessionRetry, NOT the 409 with
+	// successor exposure.
+	session := &Session{UserID: retryCallerID, Role: "user"}
+	handler, _, _ := buildSessionRetryHandler(failed, session, false, false)
+	_, err := handler.retryPurchase(context.Background(), sessionRetryReq(), retryExecID)
+	require.Error(t, err)
+	ce, ok := IsClientError(err)
+	require.True(t, ok)
+	assert.Equal(t, 403, ce.code, "must fail with 403 (RBAC) not 409 (already-retried)")
+	assert.NotContains(t, err.Error(), "already retried")
+	// Most importantly: details must NOT leak the descendant UUID.
+	if d := ce.Details(); d != nil {
+		_, leaked := d["retry_execution_id"]
+		assert.False(t, leaked, "403 must not surface retry_execution_id")
+	}
+}
+
 func TestResolveOpsHint(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/api/handler_purchases_test.go
+++ b/internal/api/handler_purchases_test.go
@@ -1327,3 +1327,353 @@ func TestHandler_cancelPurchase_Session_RejectsMissingSession(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no authorization token provided")
 }
+
+// ─── Session-authed Retry (issue #47) ──────────────────────────────────────
+//
+// Mirror image of the cancel matrix above. retryPurchase creates a NEW
+// execution from the failed row's stored Recommendations slice and stamps
+// retry_execution_id on the original.
+//
+// Covered cells:
+//   1. admin                                     → allowed (any failed row)
+//   2. user with retry-any (operator role)       → allowed (any failed row)
+//   3. user with retry-own + matching creator    → allowed
+//   4. user with retry-own + different creator   → 403
+//   5. user with neither verb                    → 403
+//   6. failed-state guard                        → 409 on non-failed status
+//   7. legacy NULL creator + non-admin retry-own → 403
+//   8. persistent-failure block                  → 409 + ops_hint
+//   9. threshold soft-block                      → 409 (n=5, no force)
+//  10. threshold soft-block + force=true         → allowed (n=5, force=true)
+//  11. just-under threshold                      → allowed (n=4)
+//  12. happy path: linkage + retry_attempt_n+1
+
+const retryExecID = "88888888-8888-8888-8888-888888888888"
+const retryCallerID = "99999999-9999-9999-9999-999999999999"
+const retryOtherID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+
+func buildSessionRetryHandler(failed *config.PurchaseExecution, session *Session, hasAny, hasOwn bool) (*Handler, *MockConfigStore, *MockAuthService) {
+	mockConfig := new(MockConfigStore)
+	mockConfig.On("GetExecutionByID", mock.Anything, failed.ExecutionID).Return(failed, nil)
+	// GetGlobalConfig is consulted for grace-period suppressions; an
+	// empty config is fine (no suppressions written).
+	mockConfig.On("GetGlobalConfig", mock.Anything).Return(&config.GlobalConfig{}, nil).Maybe()
+
+	mockAuth := new(MockAuthService)
+	mockAuth.On("ValidateSession", mock.Anything, "sess-tok").Return(session, nil)
+	if session != nil && session.Role != "admin" {
+		mockAuth.On("HasPermissionAPI", mock.Anything, session.UserID, "retry-any", "purchases").Return(hasAny, nil).Maybe()
+		mockAuth.On("HasPermissionAPI", mock.Anything, session.UserID, "retry-own", "purchases").Return(hasOwn, nil).Maybe()
+	}
+
+	return &Handler{config: mockConfig, auth: mockAuth}, mockConfig, mockAuth
+}
+
+func sessionRetryReq() *events.LambdaFunctionURLRequest {
+	return &events.LambdaFunctionURLRequest{
+		Headers: map[string]string{"authorization": "Bearer sess-tok"},
+	}
+}
+
+func sessionRetryReqWithForce() *events.LambdaFunctionURLRequest {
+	return &events.LambdaFunctionURLRequest{
+		Headers:               map[string]string{"authorization": "Bearer sess-tok"},
+		QueryStringParameters: map[string]string{"force": "true"},
+	}
+}
+
+// runSessionRetryAllowed asserts the success path of retryPurchase given a
+// permission-matrix cell that should be allowed. Captures BOTH saves —
+// the new successor execution AND the original failed row updated with
+// the linkage pointer — so callers can assert linkage invariants
+// (retry_attempt_n stamped to predecessor.n+1, RetryExecutionID on the
+// original points at the successor).
+func runSessionRetryAllowed(t *testing.T, failed *config.PurchaseExecution, session *Session, hasAny, hasOwn bool, req *events.LambdaFunctionURLRequest) (newExec, updatedOriginal *config.PurchaseExecution) {
+	t.Helper()
+	handler, mockConfig, mockAuth := buildSessionRetryHandler(failed, session, hasAny, hasOwn)
+	saved := []*config.PurchaseExecution{}
+	mockConfig.On("SavePurchaseExecution", mock.Anything, mock.AnythingOfType("*config.PurchaseExecution")).
+		Run(func(args mock.Arguments) {
+			// Copy so subsequent in-place mutations by the handler
+			// (e.g. finalizePurchaseStatus flipping status to failed
+			// when the email path errors out) don't retroactively
+			// rewrite the captured record.
+			snap := *args.Get(1).(*config.PurchaseExecution)
+			saved = append(saved, &snap)
+		}).
+		Return(nil)
+
+	result, err := handler.retryPurchase(context.Background(), req, failed.ExecutionID)
+	require.NoError(t, err)
+	resp := result.(map[string]any)
+	assert.NotEmpty(t, resp["execution_id"])
+	assert.Equal(t, failed.ExecutionID, resp["original_execution"])
+	require.GreaterOrEqual(t, len(saved), 2, "expected at least 2 SavePurchaseExecution calls (new + original linkage)")
+
+	// First save is the new successor; second is the original with
+	// retry_execution_id stamped. The retry tx orders them this way
+	// so the FK constraint on retry_execution_id is satisfied.
+	newExec = saved[0]
+	updatedOriginal = saved[1]
+	mockAuth.AssertExpectations(t)
+	return newExec, updatedOriginal
+}
+
+func TestHandler_retryPurchase_Admin_AllowsAny(t *testing.T) {
+	creator := retryOtherID
+	failed := &config.PurchaseExecution{
+		ExecutionID:     retryExecID,
+		Status:          "failed",
+		Error:           "send failed: transient SES throttle",
+		CreatedByUserID: &creator,
+		Recommendations: []config.RecommendationRecord{{Provider: "aws", Service: "ec2", Term: 1}},
+	}
+	session := &Session{UserID: retryCallerID, Role: "admin", Email: "admin@example.com"}
+	newExec, updated := runSessionRetryAllowed(t, failed, session, false, false, sessionRetryReq())
+	assert.Equal(t, "pending", newExec.Status)
+	assert.Equal(t, 1, newExec.RetryAttemptN, "fresh first retry → n=1")
+	require.NotNil(t, updated.RetryExecutionID, "original must carry pointer to successor")
+	assert.Equal(t, newExec.ExecutionID, *updated.RetryExecutionID)
+	assert.Equal(t, "failed", updated.Status, "original keeps failed status as historical record")
+}
+
+func TestHandler_retryPurchase_RetryAny_AllowsAny(t *testing.T) {
+	creator := retryOtherID
+	failed := &config.PurchaseExecution{
+		ExecutionID:     retryExecID,
+		Status:          "failed",
+		Error:           "send failed: transient SES throttle",
+		CreatedByUserID: &creator,
+		Recommendations: []config.RecommendationRecord{{Provider: "aws", Service: "ec2", Term: 1}},
+	}
+	session := &Session{UserID: retryCallerID, Role: "user", Email: "ops@example.com"}
+	runSessionRetryAllowed(t, failed, session, true, false, sessionRetryReq())
+}
+
+func TestHandler_retryPurchase_RetryOwn_AllowsCreator(t *testing.T) {
+	creator := retryCallerID
+	failed := &config.PurchaseExecution{
+		ExecutionID:     retryExecID,
+		Status:          "failed",
+		Error:           "send failed: SES recipient mailbox full",
+		CreatedByUserID: &creator,
+		RetryAttemptN:   2, // already retried twice
+		Recommendations: []config.RecommendationRecord{{Provider: "aws", Service: "ec2", Term: 1}},
+	}
+	session := &Session{UserID: retryCallerID, Role: "user", Email: "u1@example.com"}
+	newExec, updated := runSessionRetryAllowed(t, failed, session, false, true, sessionRetryReq())
+	assert.Equal(t, 3, newExec.RetryAttemptN, "n=2 predecessor → n=3 successor")
+	require.NotNil(t, updated.RetryExecutionID)
+	assert.Equal(t, newExec.ExecutionID, *updated.RetryExecutionID)
+}
+
+func TestHandler_retryPurchase_RetryOwn_RejectsNonCreator(t *testing.T) {
+	creator := retryOtherID
+	failed := &config.PurchaseExecution{
+		ExecutionID:     retryExecID,
+		Status:          "failed",
+		CreatedByUserID: &creator,
+	}
+	session := &Session{UserID: retryCallerID, Role: "user", Email: "u1@example.com"}
+
+	handler, mockConfig, mockAuth := buildSessionRetryHandler(failed, session, false, true)
+	_, err := handler.retryPurchase(context.Background(), sessionRetryReq(), retryExecID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "another user's failed purchase")
+	mockConfig.AssertNotCalled(t, "WithTx")
+	mockConfig.AssertNotCalled(t, "SavePurchaseExecution")
+	mockAuth.AssertExpectations(t)
+}
+
+func TestHandler_retryPurchase_NoVerb_Rejects(t *testing.T) {
+	creator := retryCallerID
+	failed := &config.PurchaseExecution{
+		ExecutionID:     retryExecID,
+		Status:          "failed",
+		CreatedByUserID: &creator,
+	}
+	session := &Session{UserID: retryCallerID, Role: "user", Email: "u1@example.com"}
+
+	handler, mockConfig, mockAuth := buildSessionRetryHandler(failed, session, false, false)
+	_, err := handler.retryPurchase(context.Background(), sessionRetryReq(), retryExecID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "retry-any or retry-own")
+	mockConfig.AssertNotCalled(t, "WithTx")
+	mockConfig.AssertNotCalled(t, "SavePurchaseExecution")
+	mockAuth.AssertExpectations(t)
+}
+
+func TestHandler_retryPurchase_RejectsNonFailedStatus(t *testing.T) {
+	creator := retryCallerID
+	failed := &config.PurchaseExecution{
+		ExecutionID:     retryExecID,
+		Status:          "completed", // already done — no retry from here
+		CreatedByUserID: &creator,
+	}
+	session := &Session{UserID: retryCallerID, Role: "admin"}
+	handler, mockConfig, _ := buildSessionRetryHandler(failed, session, false, false)
+	_, err := handler.retryPurchase(context.Background(), sessionRetryReq(), retryExecID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot be retried")
+	assert.Contains(t, err.Error(), "completed")
+	mockConfig.AssertNotCalled(t, "WithTx")
+}
+
+func TestHandler_retryPurchase_LegacyNullCreator_NonAdminRejected(t *testing.T) {
+	failed := &config.PurchaseExecution{
+		ExecutionID:     retryExecID,
+		Status:          "failed",
+		CreatedByUserID: nil, // pre-migration row
+	}
+	session := &Session{UserID: retryCallerID, Role: "user", Email: "u1@example.com"}
+	handler, mockConfig, mockAuth := buildSessionRetryHandler(failed, session, false, true)
+	_, err := handler.retryPurchase(context.Background(), sessionRetryReq(), retryExecID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "another user's failed purchase")
+	mockConfig.AssertNotCalled(t, "WithTx")
+	mockAuth.AssertExpectations(t)
+}
+
+func TestHandler_retryPurchase_PersistentFailure_BlocksWithOpsHint(t *testing.T) {
+	creator := retryCallerID
+	failed := &config.PurchaseExecution{
+		ExecutionID:     retryExecID,
+		Status:          "failed",
+		Error:           "FROM_EMAIL not configured for this deployment",
+		CreatedByUserID: &creator,
+	}
+	session := &Session{UserID: retryCallerID, Role: "admin"}
+	handler, mockConfig, _ := buildSessionRetryHandler(failed, session, false, false)
+	_, err := handler.retryPurchase(context.Background(), sessionRetryReq(), retryExecID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "operator-fixable")
+	// The structured details carry the ops hint so the frontend can
+	// render the badge without parsing the message.
+	ce, ok := IsClientError(err)
+	require.True(t, ok)
+	assert.Equal(t, 409, ce.code)
+	require.NotNil(t, ce.Details())
+	assert.Equal(t, "Set FROM_EMAIL tfvar then retry", ce.Details()["ops_hint"])
+	mockConfig.AssertNotCalled(t, "WithTx")
+}
+
+func TestHandler_retryPurchase_PersistentFailure_NoMatch_AllowsRetry(t *testing.T) {
+	// Transient SES throttle is NOT in the persistent-failure map →
+	// retry proceeds normally. Sanity check that we don't accidentally
+	// classify all SES errors as persistent.
+	creator := retryCallerID
+	failed := &config.PurchaseExecution{
+		ExecutionID:     retryExecID,
+		Status:          "failed",
+		Error:           "send failed: SES throttle exceeded, please retry",
+		CreatedByUserID: &creator,
+		Recommendations: []config.RecommendationRecord{{Provider: "aws", Service: "ec2", Term: 1}},
+	}
+	session := &Session{UserID: retryCallerID, Role: "admin"}
+	runSessionRetryAllowed(t, failed, session, false, false, sessionRetryReq())
+}
+
+func TestHandler_retryPurchase_Threshold_BlocksAtFive_NoForce(t *testing.T) {
+	creator := retryCallerID
+	failed := &config.PurchaseExecution{
+		ExecutionID:     retryExecID,
+		Status:          "failed",
+		RetryAttemptN:   5, // already at the threshold
+		CreatedByUserID: &creator,
+		Recommendations: []config.RecommendationRecord{{Provider: "aws", Service: "ec2", Term: 1}},
+	}
+	session := &Session{UserID: retryCallerID, Role: "admin"}
+	handler, mockConfig, _ := buildSessionRetryHandler(failed, session, false, false)
+	_, err := handler.retryPurchase(context.Background(), sessionRetryReq(), retryExecID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "force=true")
+	ce, ok := IsClientError(err)
+	require.True(t, ok)
+	assert.Equal(t, 409, ce.code)
+	require.NotNil(t, ce.Details())
+	assert.Equal(t, 5, ce.Details()["retry_attempt_n"])
+	mockConfig.AssertNotCalled(t, "WithTx")
+}
+
+func TestHandler_retryPurchase_Threshold_AllowsWithForce(t *testing.T) {
+	creator := retryCallerID
+	failed := &config.PurchaseExecution{
+		ExecutionID:     retryExecID,
+		Status:          "failed",
+		RetryAttemptN:   5,
+		CreatedByUserID: &creator,
+		Recommendations: []config.RecommendationRecord{{Provider: "aws", Service: "ec2", Term: 1}},
+	}
+	session := &Session{UserID: retryCallerID, Role: "admin"}
+	newExec, _ := runSessionRetryAllowed(t, failed, session, false, false, sessionRetryReqWithForce())
+	assert.Equal(t, 6, newExec.RetryAttemptN, "force=true past threshold still increments the chain count")
+}
+
+func TestHandler_retryPurchase_JustUnderThreshold_AllowsNoForce(t *testing.T) {
+	creator := retryCallerID
+	failed := &config.PurchaseExecution{
+		ExecutionID:     retryExecID,
+		Status:          "failed",
+		RetryAttemptN:   4, // n=4 < threshold=5 → allowed
+		CreatedByUserID: &creator,
+		Recommendations: []config.RecommendationRecord{{Provider: "aws", Service: "ec2", Term: 1}},
+	}
+	session := &Session{UserID: retryCallerID, Role: "admin"}
+	newExec, _ := runSessionRetryAllowed(t, failed, session, false, false, sessionRetryReq())
+	assert.Equal(t, 5, newExec.RetryAttemptN)
+}
+
+func TestHandler_retryPurchase_AlreadyRetried_Rejects(t *testing.T) {
+	// A failed row that already has a retry_execution_id pointer must
+	// not be retried again — that would silently overwrite the linkage
+	// and orphan the previous chain.
+	creator := retryCallerID
+	successor := "11111111-2222-3333-4444-555555555555"
+	failed := &config.PurchaseExecution{
+		ExecutionID:      retryExecID,
+		Status:           "failed",
+		CreatedByUserID:  &creator,
+		RetryExecutionID: &successor,
+		Recommendations:  []config.RecommendationRecord{{Provider: "aws", Service: "ec2", Term: 1}},
+	}
+	session := &Session{UserID: retryCallerID, Role: "admin"}
+	handler, mockConfig, _ := buildSessionRetryHandler(failed, session, false, false)
+	_, err := handler.retryPurchase(context.Background(), sessionRetryReq(), retryExecID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already retried")
+	ce, ok := IsClientError(err)
+	require.True(t, ok)
+	assert.Equal(t, 409, ce.code)
+	assert.Equal(t, successor, ce.Details()["retry_execution_id"])
+	mockConfig.AssertNotCalled(t, "WithTx")
+}
+
+func TestHandler_retryPurchase_RejectsMissingSession(t *testing.T) {
+	failed := &config.PurchaseExecution{ExecutionID: retryExecID, Status: "failed"}
+	mockConfig := new(MockConfigStore)
+	mockConfig.On("GetExecutionByID", mock.Anything, retryExecID).Return(failed, nil)
+	handler := &Handler{config: mockConfig, auth: new(MockAuthService)}
+	_, err := handler.retryPurchase(context.Background(), &events.LambdaFunctionURLRequest{}, retryExecID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no authorization token provided")
+}
+
+func TestResolveOpsHint(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"empty input", "", ""},
+		{"transient SES throttle (no match)", "send failed: SES throttle exceeded", ""},
+		{"FROM_EMAIL exact", "FROM_EMAIL not configured for this deployment", "Set FROM_EMAIL tfvar then retry"},
+		{"SES sandbox case-insensitive", "send failed: ses sandbox active", "Move SES out of sandbox or verify recipient, then retry"},
+		{"domain not verified", "send failed: SES domain not verified", "Verify SES domain in AWS console, then retry"},
+		{"IAM denied", "AssumeRole error: IAM denied", "Grant the deploy role missing IAM permission, then retry"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, resolveOpsHint(tt.input))
+		})
+	}
+}

--- a/internal/api/handler_router.go
+++ b/internal/api/handler_router.go
@@ -44,11 +44,28 @@ type clientError struct {
 
 func (e *clientError) Error() string { return e.message }
 
-// Details returns the structured detail fields attached to this error,
-// or nil when none were set. Callers (the response writer) inspect this
-// to enrich the JSON body — `error: <message>` plus the detail fields
-// flattened at the top level.
-func (e *clientError) Details() map[string]any { return e.details }
+// Details returns a SHALLOW COPY of the structured detail fields
+// attached to this error, or nil when none were set. Callers (the
+// response writer) inspect this to enrich the JSON body — `error:
+// <message>` plus the detail fields flattened at the top level.
+// The copy keeps callers from mutating the error's internal state
+// (CR #168 nit hardening — defends against accidental aliasing of
+// the constructor's input map).
+func (e *clientError) Details() map[string]any { return cloneDetails(e.details) }
+
+// cloneDetails shallow-copies a details map. Returns nil for a nil
+// input so the response writer's `len(details) > 0` check still
+// short-circuits cleanly.
+func cloneDetails(in map[string]any) map[string]any {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
 
 // NewClientError creates a new client-facing error with the given HTTP status code and message.
 func NewClientError(code int, message string) error {
@@ -60,8 +77,10 @@ func NewClientError(code int, message string) error {
 // into the JSON body so consumers can branch on machine-readable hints
 // rather than substring-matching the message. Used by the retry handler
 // (issue #47) for ops_hint + retry_attempt_n / threshold callouts.
+// The details map is copied at construction so caller mutations after
+// the error is created don't leak into the response body.
 func NewClientErrorWithDetails(code int, message string, details map[string]any) error {
-	return &clientError{message: message, code: code, details: details}
+	return &clientError{message: message, code: code, details: cloneDetails(details)}
 }
 
 // IsClientError checks if the error is a client error and returns it.

--- a/internal/api/handler_router.go
+++ b/internal/api/handler_router.go
@@ -34,13 +34,34 @@ func IsNotFoundError(err error) bool {
 type clientError struct {
 	message string
 	code    int
+	// details carries optional structured fields (e.g. ops_hint,
+	// retry_attempt_n) that the response writer surfaces alongside the
+	// human message. Used by retry-soft-block responses (issue #47) so
+	// the frontend can render a confirm-with-warning UX without parsing
+	// the message string.
+	details map[string]any
 }
 
 func (e *clientError) Error() string { return e.message }
 
+// Details returns the structured detail fields attached to this error,
+// or nil when none were set. Callers (the response writer) inspect this
+// to enrich the JSON body — `error: <message>` plus the detail fields
+// flattened at the top level.
+func (e *clientError) Details() map[string]any { return e.details }
+
 // NewClientError creates a new client-facing error with the given HTTP status code and message.
 func NewClientError(code int, message string) error {
 	return &clientError{message: message, code: code}
+}
+
+// NewClientErrorWithDetails creates a client-facing error that also
+// carries structured detail fields. The response writer flattens those
+// into the JSON body so consumers can branch on machine-readable hints
+// rather than substring-matching the message. Used by the retry handler
+// (issue #47) for ops_hint + retry_attempt_n / threshold callouts.
+func NewClientErrorWithDetails(code int, message string, details map[string]any) error {
+	return &clientError{message: message, code: code, details: details}
 }
 
 // IsClientError checks if the error is a client error and returns it.

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -106,6 +106,12 @@ func (r *Router) registerRoutes() {
 		{PathPrefix: "/api/purchases/approve/", Method: "POST", Handler: r.approvePurchaseHandler, Auth: AuthPublic},
 		{PathPrefix: "/api/purchases/cancel/", Method: "GET", Handler: r.cancelPurchaseHandler, Auth: AuthPublic},
 		{PathPrefix: "/api/purchases/cancel/", Method: "POST", Handler: r.cancelPurchaseHandler, Auth: AuthPublic},
+		// Retry a failed purchase execution (issue #47). Session-authed
+		// only — the original failed row's email-token has already been
+		// consumed/expired, so there is no token-mode dispatch here.
+		// AuthUser gates "must be signed in"; the handler then enforces
+		// the retry-any/retry-own RBAC matrix.
+		{PathPrefix: "/api/purchases/retry/", Method: "POST", Handler: r.retryPurchaseHandler, Auth: AuthUser},
 
 		// Planned purchases endpoints (must come before generic /api/purchases/{id})
 		{ExactPath: "/api/purchases/planned", Method: "GET", Handler: r.getPlannedPurchasesHandler},
@@ -365,6 +371,10 @@ func (r *Router) approvePurchaseHandler(ctx context.Context, req *events.LambdaF
 func (r *Router) cancelPurchaseHandler(ctx context.Context, req *events.LambdaFunctionURLRequest, params map[string]string) (any, error) {
 	token := req.QueryStringParameters["token"]
 	return r.h.cancelPurchase(ctx, req, params["id"], token)
+}
+
+func (r *Router) retryPurchaseHandler(ctx context.Context, req *events.LambdaFunctionURLRequest, params map[string]string) (any, error) {
+	return r.h.retryPurchase(ctx, req, params["id"])
 }
 
 func (r *Router) getPlannedPurchasesHandler(ctx context.Context, req *events.LambdaFunctionURLRequest, params map[string]string) (any, error) {

--- a/internal/auth/service_group_test.go
+++ b/internal/auth/service_group_test.go
@@ -255,8 +255,8 @@ func TestService_GetUserPermissions(t *testing.T) {
 
 		permissions, err := service.GetUserPermissions(ctx, "user-123")
 		require.NoError(t, err)
-		// 7 = 6 read/plan-author + cancel-own:purchases (issue #46).
-		assert.Len(t, permissions, 7)
+		// 8 = 6 read/plan-author + cancel-own:purchases (issue #46) + retry-own:purchases (issue #47).
+		assert.Len(t, permissions, 8)
 
 		mockStore.AssertExpectations(t)
 	})
@@ -313,8 +313,8 @@ func TestService_GetUserPermissions(t *testing.T) {
 
 		permissions, err := service.GetUserPermissions(ctx, "user-123")
 		require.NoError(t, err)
-		// 7 user (incl. cancel-own:purchases from issue #46) + 1 group1 + 1 group2
-		assert.Len(t, permissions, 9)
+		// 8 user (incl. cancel-own (#46) + retry-own (#47):purchases) + 1 group1 + 1 group2 = 10
+		assert.Len(t, permissions, 10)
 
 		mockStore.AssertExpectations(t)
 	})
@@ -351,8 +351,8 @@ func TestService_GetUserPermissions(t *testing.T) {
 		permissions, err := service.GetUserPermissions(ctx, "user-123")
 		require.NoError(t, err)
 		// Should have only user permissions, missing group is skipped.
-		// 7 = 6 read/plan-author + cancel-own:purchases (issue #46).
-		assert.Len(t, permissions, 7)
+		// 8 = 6 read/plan-author + cancel-own:purchases (issue #46) + retry-own:purchases (issue #47).
+		assert.Len(t, permissions, 8)
 
 		mockStore.AssertExpectations(t)
 	})
@@ -429,8 +429,8 @@ func TestService_BuildAuthContext(t *testing.T) {
 		assert.Contains(t, authCtx.AllowedAccounts, "111111111111")
 		assert.Contains(t, authCtx.AllowedAccounts, "222222222222")
 		assert.Contains(t, authCtx.AllowedAccounts, "333333333333")
-		// 7 user perms (incl. cancel-own:purchases from issue #46) + 1 from group1 + 1 from group2
-		assert.Len(t, authCtx.Permissions, 9)
+		// 8 user perms (incl. cancel-own (#46) + retry-own (#47):purchases) + 1 group1 + 1 group2 = 10
+		assert.Len(t, authCtx.Permissions, 10)
 
 		mockStore.AssertExpectations(t)
 	})
@@ -452,8 +452,8 @@ func TestService_BuildAuthContext(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, authCtx)
 		assert.Empty(t, authCtx.AllowedAccounts)
-		// 6 read/plan-author + cancel-own:purchases (issue #46) = 7. Only role-based permissions.
-		assert.Len(t, authCtx.Permissions, 7)
+		// 6 read/plan-author + cancel-own:purchases (issue #46) + retry-own:purchases (issue #47) = 8. Only role-based permissions.
+		assert.Len(t, authCtx.Permissions, 8)
 
 		mockStore.AssertExpectations(t)
 	})

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -661,8 +661,8 @@ func TestService_ErrorPaths(t *testing.T) {
 		permissions, err := service.GetUserPermissions(ctx, "user-123")
 		require.NoError(t, err)
 		// Should still return user permissions even if group fetch fails.
-		// 7 = 6 read/plan-author + cancel-own:purchases (issue #46).
-		assert.Len(t, permissions, 7)
+		// 8 = 6 read/plan-author + cancel-own:purchases (issue #46) + retry-own:purchases (issue #47).
+		assert.Len(t, permissions, 8)
 
 		mockStore.AssertExpectations(t)
 	})

--- a/internal/auth/types.go
+++ b/internal/auth/types.go
@@ -297,6 +297,34 @@ const (
 	// hatch and is gated by token possession, not these verbs.
 	ActionCancelOwn = "cancel-own"
 	ActionCancelAny = "cancel-any"
+	// ActionRetryOwn / ActionRetryAny gate the session-authed Retry
+	// button on failed Purchase History rows (issue #47). Mirror image
+	// of the cancel verbs above:
+	//
+	//   * RoleAdmin — implicit via {ActionAdmin, ResourceAll}; covers
+	//     both verbs.
+	//   * RoleUser — DefaultUserPermissions() adds retry-own:purchases.
+	//     Allows retrying failed executions whose created_by_user_id
+	//     matches the session user. Legacy rows with NULL creator are
+	//     out of reach for non-admins via this verb; admins still
+	//     retry them via retry-any.
+	//   * RoleReadOnly — neither verb. Read-only users cannot retry.
+	//
+	// retry-any has no default non-admin grant; the constant exists so
+	// future operator roles can be granted broad retry rights without
+	// escalating to admin.
+	//
+	// Retry creates a NEW purchase execution from the failed row's
+	// stored Recommendations slice; it is NOT a status mutation of the
+	// original row (the original keeps its `failed` status as a
+	// historical record and gains a retry_execution_id pointer to the
+	// successor). The "execute purchases" action is therefore the
+	// natural permission to require, but the retry verbs let us gate
+	// the *source* — a user without retry-own can still trigger fresh
+	// purchases via the Recommendations page; they just can't act on
+	// somebody else's failed row.
+	ActionRetryOwn = "retry-own"
+	ActionRetryAny = "retry-any"
 )
 
 // Predefined resources
@@ -335,6 +363,14 @@ func DefaultUserPermissions() []Permission {
 		// state (pending/notified) and the creator UUID to match the
 		// session UserID before honouring the request.
 		{Action: ActionCancelOwn, Resource: ResourcePurchases},
+		// retry-own:purchases — every authenticated user can retry
+		// failed purchase executions they created themselves (issue #47).
+		// The handler still requires the execution to be in `failed`
+		// state, the creator UUID to match the session UserID, the
+		// failure reason not to match the persistent-misconfig list,
+		// and the retry-attempt counter on the chain to be below the
+		// soft-block threshold (overridable with ?force=true).
+		{Action: ActionRetryOwn, Resource: ResourcePurchases},
 	}
 }
 

--- a/internal/auth/types_test.go
+++ b/internal/auth/types_test.go
@@ -16,8 +16,9 @@ func TestDefaultPermissions(t *testing.T) {
 
 	t.Run("DefaultUserPermissions returns user access", func(t *testing.T) {
 		perms := DefaultUserPermissions()
-		// 6 read/plan-author perms + cancel-own:purchases (issue #46) = 7.
-		assert.Len(t, perms, 7)
+		// 6 read/plan-author perms + cancel-own:purchases (issue #46)
+		// + retry-own:purchases (issue #47) = 8.
+		assert.Len(t, perms, 8)
 
 		actions := make(map[string]bool)
 		for _, p := range perms {
@@ -31,6 +32,7 @@ func TestDefaultPermissions(t *testing.T) {
 		assert.True(t, actions[ActionCreate+":"+ResourcePlans])
 		assert.True(t, actions[ActionUpdate+":"+ResourcePlans])
 		assert.True(t, actions[ActionCancelOwn+":"+ResourcePurchases])
+		assert.True(t, actions[ActionRetryOwn+":"+ResourcePurchases])
 	})
 
 	t.Run("DefaultReadOnlyPermissions returns readonly access", func(t *testing.T) {

--- a/internal/config/store_postgres.go
+++ b/internal/config/store_postgres.go
@@ -657,8 +657,8 @@ func (s *PostgresStore) SavePurchaseExecutionTx(ctx context.Context, tx pgx.Tx, 
 			notification_sent, approval_token, recommendations,
 			total_upfront_cost, estimated_savings, completed_at, error, expires_at,
 			cloud_account_id, source, approved_by, cancelled_by, capacity_percent,
-			created_by_user_id
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)
+			created_by_user_id, retry_execution_id, retry_attempt_n
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)
 		ON CONFLICT (execution_id) DO UPDATE SET
 			status = $3,
 			notification_sent = $6,
@@ -674,6 +674,7 @@ func (s *PostgresStore) SavePurchaseExecutionTx(ctx context.Context, tx pgx.Tx, 
 			approved_by = $16,
 			cancelled_by = $17,
 			capacity_percent = $18,
+			retry_execution_id = $20,
 			updated_at = NOW()
 	`
 
@@ -687,9 +688,16 @@ func (s *PostgresStore) SavePurchaseExecutionTx(ctx context.Context, tx pgx.Tx, 
 		planIDArg = execution.PlanID
 	}
 
-	// created_by_user_id is INSERT-only: the original creator must not be
-	// rewritten by an ON CONFLICT update (e.g. the scheduler upserting status
-	// transitions). The column is omitted from the DO UPDATE SET clause above.
+	// created_by_user_id and retry_attempt_n are INSERT-only: the original
+	// creator and the retry-chain position must not be rewritten by an
+	// ON CONFLICT update (e.g. the scheduler upserting status transitions).
+	// They are omitted from the DO UPDATE SET clause above.
+	//
+	// retry_execution_id IS in the DO UPDATE SET clause because the retry
+	// handler explicitly updates the *original* failed row to point at the
+	// new successor execution after creating it (issue #47). That update
+	// re-saves the failed row through this same path, and the pointer
+	// must persist.
 	_, err = tx.Exec(ctx, query,
 		planIDArg,
 		execution.ExecutionID,
@@ -710,6 +718,8 @@ func (s *PostgresStore) SavePurchaseExecutionTx(ctx context.Context, tx pgx.Tx, 
 		execution.CancelledBy,
 		capacityPercent,
 		execution.CreatedByUserID,
+		execution.RetryExecutionID,
+		execution.RetryAttemptN,
 	)
 
 	if err != nil {
@@ -731,7 +741,7 @@ func (s *PostgresStore) TransitionExecutionStatus(ctx context.Context, execution
 		          notification_sent, approval_token, recommendations,
 		          total_upfront_cost, estimated_savings, completed_at, error, expires_at,
 		          cloud_account_id, source, approved_by, cancelled_by, capacity_percent,
-		          created_by_user_id
+		          created_by_user_id, retry_execution_id, retry_attempt_n
 	`
 
 	records, err := s.queryExecutions(ctx, query, executionID, toStatus, fromStatuses)
@@ -770,7 +780,7 @@ func (s *PostgresStore) GetExecutionsByStatuses(ctx context.Context, statuses []
 		       notification_sent, approval_token, recommendations,
 		       total_upfront_cost, estimated_savings, completed_at, error, expires_at,
 		       cloud_account_id, source, approved_by, cancelled_by, capacity_percent,
-		       created_by_user_id
+		       created_by_user_id, retry_execution_id, retry_attempt_n
 		FROM purchase_executions
 		WHERE status = ANY($1)
 		ORDER BY scheduled_date DESC
@@ -786,7 +796,7 @@ func (s *PostgresStore) GetPendingExecutions(ctx context.Context) ([]PurchaseExe
 		       notification_sent, approval_token, recommendations,
 		       total_upfront_cost, estimated_savings, completed_at, error, expires_at,
 		       cloud_account_id, source, approved_by, cancelled_by, capacity_percent,
-		       created_by_user_id
+		       created_by_user_id, retry_execution_id, retry_attempt_n
 		FROM purchase_executions
 		WHERE status IN ('pending', 'notified')
 		  AND (expires_at IS NULL OR expires_at > NOW())
@@ -804,7 +814,7 @@ func (s *PostgresStore) GetExecutionByID(ctx context.Context, executionID string
 		       notification_sent, approval_token, recommendations,
 		       total_upfront_cost, estimated_savings, completed_at, error, expires_at,
 		       cloud_account_id, source, approved_by, cancelled_by, capacity_percent,
-		       created_by_user_id
+		       created_by_user_id, retry_execution_id, retry_attempt_n
 		FROM purchase_executions
 		WHERE execution_id = $1
 	`
@@ -828,7 +838,7 @@ func (s *PostgresStore) GetExecutionByPlanAndDate(ctx context.Context, planID st
 		       notification_sent, approval_token, recommendations,
 		       total_upfront_cost, estimated_savings, completed_at, error, expires_at,
 		       cloud_account_id, source, approved_by, cancelled_by, capacity_percent,
-		       created_by_user_id
+		       created_by_user_id, retry_execution_id, retry_attempt_n
 		FROM purchase_executions
 		WHERE plan_id = $1 AND scheduled_date = $2
 	`
@@ -882,6 +892,8 @@ func (s *PostgresStore) queryExecutions(ctx context.Context, query string, args 
 			&exec.CancelledBy,
 			&exec.CapacityPercent,
 			&exec.CreatedByUserID,
+			&exec.RetryExecutionID,
+			&exec.RetryAttemptN,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan execution: %w", err)

--- a/internal/config/store_postgres_pgxmock_test.go
+++ b/internal/config/store_postgres_pgxmock_test.go
@@ -385,6 +385,13 @@ func TestPGXMock_GetExecutionByID_Success(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "exec-1", exec.ExecutionID)
 	assert.Equal(t, "tok-123", exec.ApprovalToken)
+	// Retry-linkage scan-order regression guard (CR #168 nit). NULL FK +
+	// default 0 attempt count are the legacy-row case after migration
+	// 000042 — a column reorder upstream would surface as a wrong-type
+	// scan into the wrong field, which assertions on these specific
+	// columns will catch.
+	assert.Nil(t, exec.RetryExecutionID)
+	assert.Equal(t, 0, exec.RetryAttemptN)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -403,13 +410,16 @@ func TestPGXMock_GetExecutionByID_WithTimestamps(t *testing.T) {
 		"cloud_account_id", "source", "approved_by", "cancelled_by", "capacity_percent",
 		"created_by_user_id", "retry_execution_id", "retry_attempt_n",
 	}
+	successorID := "exec-3"
 	rows := pgxmock.NewRows(cols).AddRow(
 		"plan-1", "exec-2", "completed", 1, now,
 		sql.NullTime{Valid: true, Time: now}, "tok", recsJSON,
 		100.0, 200.0, sql.NullTime{Valid: true, Time: now}, "some error",
 		sql.NullTime{Valid: true, Time: future},
 		nil, "cudly-web", nil, nil, 100,
-		nil, nil, 0,
+		// Populated retry-linkage fields (CR #168 nit) — NON-zero
+		// values exercise the scan path for both new columns.
+		nil, &successorID, 2,
 	)
 	mock.ExpectQuery("SELECT").WithArgs(pgxmock.AnyArg()).WillReturnRows(rows)
 
@@ -418,6 +428,14 @@ func TestPGXMock_GetExecutionByID_WithTimestamps(t *testing.T) {
 	require.NotNil(t, exec.NotificationSent)
 	require.NotNil(t, exec.CompletedAt)
 	assert.True(t, exec.TTL > 0)
+	// Retry-linkage scan-order regression guard (CR #168 nit). The
+	// populated case — non-NULL successor pointer + non-zero attempt
+	// count — exercises the scan path for both new columns; a column
+	// reorder upstream would scan into the wrong destination and the
+	// assertions below would fail.
+	require.NotNil(t, exec.RetryExecutionID)
+	assert.Equal(t, "exec-3", *exec.RetryExecutionID)
+	assert.Equal(t, 2, exec.RetryAttemptN)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/internal/config/store_postgres_pgxmock_test.go
+++ b/internal/config/store_postgres_pgxmock_test.go
@@ -370,14 +370,14 @@ func TestPGXMock_GetExecutionByID_Success(t *testing.T) {
 		"notification_sent", "approval_token", "recommendations",
 		"total_upfront_cost", "estimated_savings", "completed_at", "error", "expires_at",
 		"cloud_account_id", "source", "approved_by", "cancelled_by", "capacity_percent",
-		"created_by_user_id",
+		"created_by_user_id", "retry_execution_id", "retry_attempt_n",
 	}
 	rows := pgxmock.NewRows(cols).AddRow(
 		"plan-1", "exec-1", "pending", 1, now,
 		sql.NullTime{}, "tok-123", recsJSON,
 		100.0, 200.0, sql.NullTime{}, "", sql.NullTime{},
 		nil, "", nil, nil, 100,
-		nil,
+		nil, nil, 0,
 	)
 	mock.ExpectQuery("SELECT").WithArgs(pgxmock.AnyArg()).WillReturnRows(rows)
 
@@ -401,7 +401,7 @@ func TestPGXMock_GetExecutionByID_WithTimestamps(t *testing.T) {
 		"notification_sent", "approval_token", "recommendations",
 		"total_upfront_cost", "estimated_savings", "completed_at", "error", "expires_at",
 		"cloud_account_id", "source", "approved_by", "cancelled_by", "capacity_percent",
-		"created_by_user_id",
+		"created_by_user_id", "retry_execution_id", "retry_attempt_n",
 	}
 	rows := pgxmock.NewRows(cols).AddRow(
 		"plan-1", "exec-2", "completed", 1, now,
@@ -409,7 +409,7 @@ func TestPGXMock_GetExecutionByID_WithTimestamps(t *testing.T) {
 		100.0, 200.0, sql.NullTime{Valid: true, Time: now}, "some error",
 		sql.NullTime{Valid: true, Time: future},
 		nil, "cudly-web", nil, nil, 100,
-		nil,
+		nil, nil, 0,
 	)
 	mock.ExpectQuery("SELECT").WithArgs(pgxmock.AnyArg()).WillReturnRows(rows)
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -197,6 +197,25 @@ type PurchaseExecution struct {
 	// — a non-admin may cancel only executions they themselves created.
 	// NULL is treated as "not the current user".
 	CreatedByUserID *string `json:"created_by_user_id,omitempty" dynamodbav:"created_by_user_id,omitempty"`
+	// RetryExecutionID points from a *failed* execution to the new
+	// execution created when the user clicked Retry (issue #47). Set
+	// only on the original failed row; NULL on every other row including
+	// the retry itself (the retry's own RetryAttemptN > 0 is the
+	// "this is a retry" marker). Forms a forward-pointing chain:
+	// failed_v1.retry_execution_id = failed_v2.execution_id, etc.
+	// Migration 000042 self-FKs the column ON DELETE SET NULL so a
+	// cleanup of a successor doesn't cascade-delete its predecessor.
+	RetryExecutionID *string `json:"retry_execution_id,omitempty" dynamodbav:"retry_execution_id,omitempty"`
+	// RetryAttemptN is the position of this execution in a retry chain.
+	// 0 (default) on every fresh execution; 1 on the first retry of any
+	// failed row; n+1 on the n+1-th retry. The handler reads the
+	// predecessor's count and stamps n+1 atomically with the new
+	// INSERT inside the retry transaction. The History UI uses this to
+	// soft-block retries past a threshold so an obviously-stuck
+	// configuration doesn't accumulate dozens of dead retry rows.
+	// Migration 000042 added the column with default 0 so legacy rows
+	// look exactly like fresh first-retry candidates.
+	RetryAttemptN int `json:"retry_attempt_n,omitempty" dynamodbav:"retry_attempt_n,omitempty"`
 	// CapacityPercent records what fraction of the originally-recommended
 	// counts the user chose when the bulk Purchase flow submitted this
 	// execution (1..100). Audit-only: the Recommendations slice already
@@ -356,6 +375,26 @@ type PurchaseHistoryRecord struct {
 	// rows (where the action has already completed). Excluded from DB
 	// persistence.
 	CreatedByUserID string `json:"created_by_user_id,omitempty" dynamodbav:"-"`
+	// RetryExecutionID propagates the originating execution's pointer to
+	// its successor when the user retried it (issue #47). Set only on
+	// the *original* failed row that has been retried; the History UI
+	// renders an inline "Retried as #abc" link to the successor row when
+	// this is non-empty. Excluded from DB persistence (synthesised from
+	// purchase_executions).
+	RetryExecutionID string `json:"retry_execution_id,omitempty" dynamodbav:"-"`
+	// RetryAttemptN propagates the originating execution's retry-chain
+	// position so the History UI can render "↻ Retry of #xyz" inline
+	// links on retry rows (n > 0) and gate the Retry button against the
+	// soft-block threshold (n >= 5). Excluded from DB persistence.
+	RetryAttemptN int `json:"retry_attempt_n,omitempty" dynamodbav:"-"`
+	// OpsHint is a short operator-actionable message rendered inline in
+	// place of the Retry button when the failure reason on the row
+	// matches a known-persistent-misconfiguration pattern (e.g.
+	// "FROM_EMAIL not configured" → "Set FROM_EMAIL tfvar then retry").
+	// Set only on `failed` rows whose Error matches the persistent map;
+	// empty otherwise. Excluded from DB persistence (computed at read
+	// time so updates to the persistent-failure map land instantly).
+	OpsHint string `json:"ops_hint,omitempty" dynamodbav:"-"`
 }
 
 // RIExchangeRecord represents a record in the ri_exchange_history table

--- a/internal/database/postgres/migrations/000042_purchase_executions_retry_linkage.down.sql
+++ b/internal/database/postgres/migrations/000042_purchase_executions_retry_linkage.down.sql
@@ -1,0 +1,7 @@
+DROP INDEX IF EXISTS idx_executions_retry_target;
+
+ALTER TABLE purchase_executions
+    DROP COLUMN IF EXISTS retry_attempt_n;
+
+ALTER TABLE purchase_executions
+    DROP COLUMN IF EXISTS retry_execution_id;

--- a/internal/database/postgres/migrations/000042_purchase_executions_retry_linkage.up.sql
+++ b/internal/database/postgres/migrations/000042_purchase_executions_retry_linkage.up.sql
@@ -1,0 +1,43 @@
+-- 000042: link a failed purchase execution to its retry execution
+--
+-- Adds two columns to purchase_executions so the History UI's inline
+-- Retry button (issue #47) can show provenance and soft-block obvious
+-- retry loops:
+--
+--   * retry_execution_id  — UUID of the new execution that retried this
+--     row. Set on the *original failed* row at the moment a retry is
+--     accepted; NULL on every other row. Forms a singly-linked chain
+--     where each failed→retry edge points forward in time
+--     (failed_v1.retry_execution_id = failed_v2.execution_id, etc.).
+--     Self-FK with ON DELETE SET NULL: cleaning up an execution must
+--     not cascade-delete its predecessor's audit trail.
+--
+--   * retry_attempt_n     — small int; 0 (default) for a fresh
+--     execution, 1 for the first retry of any failed row, n+1 for the
+--     n+1-th retry. The handler reads the predecessor's attempt count
+--     and stamps n+1 atomically with the new INSERT inside the retry
+--     transaction. The History UI uses this to soft-block retries past
+--     a threshold (5 by default — see retryThreshold in handler_purchases.go)
+--     so an obviously-stuck FROM_EMAIL misconfiguration doesn't accumulate
+--     dozens of dead retry rows.
+--
+-- Both columns nullable / default-zero so existing rows don't need
+-- backfilling: legacy failed rows that pre-date this migration look
+-- exactly like a fresh first-retry candidate (retry_execution_id NULL,
+-- retry_attempt_n = 0), which is correct behaviour.
+--
+-- Index choice — partial on retry_execution_id IS NOT NULL — keeps the
+-- index tiny on healthy deployments (most rows never retry) while
+-- still serving the History query "find the descendant of execution X"
+-- in O(log n) on the rare populated case.
+
+ALTER TABLE purchase_executions
+    ADD COLUMN retry_execution_id UUID
+        REFERENCES purchase_executions(execution_id) ON DELETE SET NULL;
+
+ALTER TABLE purchase_executions
+    ADD COLUMN retry_attempt_n INTEGER NOT NULL DEFAULT 0;
+
+CREATE INDEX idx_executions_retry_target
+    ON purchase_executions(retry_execution_id)
+    WHERE retry_execution_id IS NOT NULL;


### PR DESCRIPTION
## Summary

Closes #47.

Adds an inline **Retry** button to failed Purchase History rows, mirroring the cancel-button infrastructure landed in #145. Three reviewer-confirmed design choices (yes / yes / yes) are implemented:

1. **Linkage** — failed→retry chain via `retry_execution_id` (self-FK on `purchase_executions`) + `retry_attempt_n` counter. The History UI renders inline lineage links so users can navigate predecessor↔successor without scrolling.
2. **Threshold soft-block** — `retry_attempt_n >= 5` rejects with a structured 409; the frontend confirms-with-warning then re-POSTs `?force=true`. Prevents an obviously-stuck deployment from accumulating dozens of dead retry rows.
3. **Ops hint** — failures whose `error` matches a known-persistent-misconfig pattern (`FROM_EMAIL not configured`, `SES sandbox`, etc.) replace the Retry button entirely with an operator-actionable badge — retrying without changing config is guaranteed to fail again.

Salvages a previously-stalled agent attempt: rebased onto current `feat/multicloud-web-frontend` tip (which now includes #145 + the `created_by_user_id` migration `000041`). The retry RBAC verbs (`retry-own` / `retry-any`) are added alongside the cancel verbs, with `DefaultUserPermissions()` granting `retry-own:purchases` to every authenticated user.

## Notable details

- **Slice-aliasing fix.** The new execution's `Recommendations` slice is now a defensive deep copy of the failed row's, so the downstream purchase pipeline (`internal/purchase/execution.go`) can't mutate the historical row's in-memory representation through the shared backing array. DB rows were already isolated; this closes the in-process aliasing footgun.
- **`clientError` grew a `details` map** so the API can surface `ops_hint` / `retry_attempt_n` / `threshold` as structured JSON fields rather than substring-matched message text. The response writer flattens those alongside `error` in the body.
- **Already-retried 409 with the descendant ID** prevents a stale-cache double-tap from silently overwriting the linkage pointer and orphaning a chain.
- **Tx ordering** in `persistRetryExecution` guarantees the FK constraint: successor INSERT → predecessor UPSERT → suppression INSERTs in one tx; a crash mid-flow leaves either everything or nothing.
- **Migration `000042`** adds nullable `retry_execution_id` (self-FK ON DELETE SET NULL) + `retry_attempt_n INT NOT NULL DEFAULT 0` + a partial index on the FK. Legacy rows without backfill look like fresh first-retry candidates.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/api/... ./internal/auth/... ./internal/config/...` — 14 new retry tests + bumped permission counts
- [x] `npx tsc --noEmit` clean
- [x] `npx jest` — 1337/1337 frontend tests pass, 11 new retry-button tests
- [x] `npm run build` — webpack production build clean
- [x] gocyclo / gofmt / go vet pre-commit hooks pass
- [x] 3 consecutive clean review passes (Completeness / Correctness / Security / Bugs / Duplication)
- [ ] Deployed-environment smoke after merge (UI: visible Retry on a failed row; click → confirm → toast + reload + descendant created with `retry_attempt_n=1`)

## Salvage notes

The previous agent stalled mid-3-pass-review with the work uncommitted in the worktree. This PR:
1. Stashed the inherited changes,
2. Rebased the branch onto the current integration tip (no conflicts — auto-merge resolved cleanly),
3. Fixed the previous agent's flagged slice-aliasing concern (real bug — would have corrupted in-memory historical row state),
4. Fixed a stale comment on `persistentFailureHints` (case-INsensitive, not case-sensitive),
5. Refactored `retryPurchase` cyclomatic complexity from 20 → ≤10 by extracting `loadAndValidateRetryRequest`, `checkRetryRateGates`, and `persistRetryExecution`,
6. Re-ran the 3-pass review until clean.

Trigger CodeRabbit:

`@coderabbitai review`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now retry failed purchase executions directly from the history view.
  * Inline Retry buttons appear only for authorized users on eligible failed rows.
  * Force-override capability available after reaching the retry attempt threshold.
  * Displays retry lineage and provenance information for traceability.
  * Shows operator guidance for known persistent misconfiguration issues instead of retry option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->