### PR TITLE
docs(README): document per-account service overrides (closes #117)

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,8 +329,8 @@ your fleet:
 - **Pilot rollouts**: enable a new SP plan-type on one account first,
   leave it disabled globally, then promote when proven.
 
-If every account should get the same change, edit the **global** Settings →
-Purchasing card instead — that propagates without per-account work.
+If every account should get the same change, edit the **global** Settings ->
+Purchasing card instead; that propagates without per-account work.
 
 ### How to create an override (web UI)
 
@@ -339,28 +339,25 @@ Purchasing card instead — that propagates without per-account work.
    **Service overrides**.
 3. The override modal opens. Pick the (provider, service) pair you want
    to override and fill in any of `term`, `payment`, `coverage`,
-   `enabled`. Fields you leave blank inherit the global default — see
-   "What 'Inherit' means" below.
+   `enabled`. Fields you leave blank inherit the global default (see
+   "What 'Inherit' means" below).
 4. Click **Save**. The override row appears under the account; the
    recommendation engine reads it on the next refresh.
 
-> **AWS-only V1 boundary**: the override modal currently lists AWS
-> services. Azure and GCP override UIs are tracked in #109. The
-> backend already accepts overrides for any provider via the API, so
-> scripted setups work today; only the UI is gated.
+> **All providers supported**: the override modal lists services for
+> the account's provider (AWS, Azure, GCP). The UI and the backend
+> both accept overrides for any provider.
 
 ### How to edit an existing override
 
-- **AWS overrides support inline edit** of Term, Payment, Coverage, and
-  Enabled directly on the row — each field persists immediately on change.
-- **Non-AWS overrides** (Azure, GCP) display field values as read-only text;
-  per-provider editing is tracked in #109.
+- All override rows support **inline edit** of Term, Payment, Coverage, and
+  Enabled directly on the row. Each field persists immediately on change.
 - **Delete** removes the override entirely; the account falls back to
   the global default for that (provider, service) pair.
 
 ### What "Inherit" means
 
-A blank field on an override is **not stored** as a sentinel value — the
+A blank field on an override is **not stored** as a sentinel value. The
 PUT request omits the field, the row stays sparse, and the recommendation
 engine reads the global default at evaluation time. So if you set the
 global default from `3yr no-upfront` to `1yr no-upfront`, every override
@@ -371,7 +368,7 @@ automatically. Overrides that explicitly set `term: 3yr` keep that.
 
 The override modal targets the same endpoint as scripted setups:
 `PUT /api/accounts/{id}/service-overrides/{provider}/{service}`. Existing
-automation continues to work without change — the UI and the API write to
+automation continues to work without change; the UI and the API write to
 the same `account_service_overrides` row.
 
 ## Safety Features

--- a/README.md
+++ b/README.md
@@ -311,6 +311,69 @@ The coverage percentage controls what portion of recommendations to act on:
 | 25% | Quarter of recommendations | Testing/validation |
 | 0% | Skip service entirely | Exclude from processing |
 
+## Per-Account Service Overrides
+
+Per-account service overrides let you tweak the global Settings → Purchasing
+defaults (term, payment, coverage) on a per-account, per-service basis.
+
+### When to use them
+
+Use overrides when an account's purchasing policy differs from the rest of
+your fleet:
+
+- **Dev/staging accounts**: prefer 1-year, no-upfront for RDS to keep
+  flexibility cheap, while production uses the global 3-year all-upfront.
+- **Workload-shape outliers**: an account that runs a steady ElastiCache
+  cluster can override to 3-year all-upfront for ElastiCache only, while
+  the same account inherits the global default for everything else.
+- **Pilot rollouts**: enable a new SP plan-type on one account first,
+  leave it disabled globally, then promote when proven.
+
+If every account should get the same change, edit the **global** Settings →
+Purchasing card instead — that propagates without per-account work.
+
+### How to create an override (web UI)
+
+1. Open the dashboard → **Settings → Accounts**.
+2. Find the account row → click the row to expand it → click
+   **Service overrides**.
+3. The override modal opens. Pick the (provider, service) pair you want
+   to override and fill in any of `term`, `payment`, `coverage`,
+   `enabled`. Fields you leave blank inherit the global default — see
+   "What 'Inherit' means" below.
+4. Click **Save**. The override row appears under the account; the
+   recommendation engine reads it on the next refresh.
+
+> **AWS-only V1 boundary**: the override modal currently lists AWS
+> services. Azure and GCP override UIs are tracked in #109. The
+> backend already accepts overrides for any provider via the API, so
+> scripted setups work today; only the UI is gated.
+
+### How to edit an existing override
+
+- **Inline edit Payment** on an existing override row (per #72) — pick
+  the new value from the dropdown and it persists immediately.
+- **Reset** deletes the override entirely; the account falls back to
+  the global default for that (provider, service) pair.
+- Inline edit for **Term / Coverage / Enabled** is tracked in #110 —
+  for now those fields require deleting and recreating the override.
+
+### What "Inherit" means
+
+A blank field on an override is **not stored** as a sentinel value — the
+PUT request omits the field, the row stays sparse, and the recommendation
+engine reads the global default at evaluation time. So if you set the
+global default from `3yr no-upfront` to `1yr no-upfront`, every override
+that left `term` blank starts producing 1-year recommendations
+automatically. Overrides that explicitly set `term: 3yr` keep that.
+
+### API parity
+
+The override modal targets the same endpoint as scripted setups:
+`PUT /api/accounts/{id}/service-overrides/{provider}/{service}`. Existing
+automation continues to work without change — the UI and the API write to
+the same `account_service_overrides` row.
+
 ## Safety Features
 
 CUDly includes multiple safety mechanisms to prevent unintended purchases:

--- a/README.md
+++ b/README.md
@@ -351,12 +351,12 @@ Purchasing card instead — that propagates without per-account work.
 
 ### How to edit an existing override
 
-- **Inline edit Payment** on an existing override row (per #72) — pick
-  the new value from the dropdown and it persists immediately.
-- **Reset** deletes the override entirely; the account falls back to
+- **AWS overrides support inline edit** of Term, Payment, Coverage, and
+  Enabled directly on the row — each field persists immediately on change.
+- **Non-AWS overrides** (Azure, GCP) display field values as read-only text;
+  per-provider editing is tracked in #109.
+- **Delete** removes the override entirely; the account falls back to
   the global default for that (provider, service) pair.
-- Inline edit for **Term / Coverage / Enabled** is tracked in #110 —
-  for now those fields require deleting and recreating the override.
 
 ### What "Inherit" means
 


### PR DESCRIPTION
## Summary

Closes #117.

Per-account service overrides have been a feature since migration `000011_cloud_accounts.up.sql` (mid-2024) and now have full UI coverage thanks to #72 (inline payment edit) and #106 (create modal). None of it was documented, so users landing on the dashboard saw the panel + the Add modal with no narrative for what overrides ARE, when to use them, or how they interact with the global defaults.

## What's added

A new "Per-Account Service Overrides" section between "Coverage Percentage" and "Safety Features" covering:

- **Concept + when to use** vs the global Settings → Purchasing card (with examples: dev/staging carve-outs, workload-shape outliers, pilot rollouts).
- **Web-UI walkthrough**: Settings → Accounts → expand → Service overrides → modal.
- **AWS-only V1 boundary** callout pointing at #109 for Azure/GCP UI.
- **How to edit existing overrides**: inline Payment per #72, Reset deletes, #110 widens to Term/Coverage/Enabled.
- **"Inherit" semantics**: blank fields are NOT stored as a sentinel — the PUT stays sparse; the engine reads the global default at evaluation time, so changes to global defaults flow through automatically.
- **API parity** note: the modal targets the same endpoint as scripted setups; both write the same row.

## .markdownlint.yaml

Disables MD060 (table-column-style) — same rationale as PR #169. Landing here too in case the PRs merge in a different order; both diffs are idempotent.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on using per-account service overrides to customize purchasing defaults (term, payment, coverage, enabled status) beyond global settings
  * Documented web UI workflows for creating, editing, and resetting overrides
  * Clarified "Inherit" behavior for blank fields and API endpoint usage

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->