### PR TITLE
fix(recommendations): drop unused formatRelativeTime import (CI build hotfix for #160)

### DIFF
--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -4,7 +4,7 @@
 
 import * as api from './api';
 import * as state from './state';
-import { formatCurrency, formatTerm, escapeHtml, formatRelativeTime } from './utils';
+import { formatCurrency, formatTerm, escapeHtml } from './utils';
 import { renderFreshness } from './freshness';
 import { getRecommendationDetail, type RecommendationDetail } from './api/recommendations';
 import { showToast } from './toast';


### PR DESCRIPTION
## Summary

The merge commit of #160 (`346d1682c`) broke the deploy CI for AWS Lambda / Azure Container Apps / GCP Cloud Run. ts-loader fails with `TS6133: 'formatRelativeTime' is declared but its value is never read` at `recommendations.ts:7`.

## Root cause

Two contributing factors:

1. **Rebase didn't re-run pre-commit.** My Bundle B commit imported `formatRelativeTime` because the pre-rebase base had a detail-drawer provenance line that used it. During the rebase onto the new base (after #80 landed), the provenance code had been replaced with the `getRecommendationDetail` flow which doesn't use `formatRelativeTime`. The rebase preserved the import line untouched, but its sole consumer was gone — leaving an orphaned import. **Pre-commit hooks don't run on `git rebase`**, so the broken state never tripped a local check.

2. **Race between hotfix push and merge.** I'd pushed a follow-up commit (`77ac16bc8`) that already removed the import. The GitHub merge button raced with that push and merged the older HEAD (`034ea00cf`), so the fix never landed.

## Fix

Drop `formatRelativeTime` from the import on `recommendations.ts:7`. One-line change.

## Test plan

- `npx tsc --noEmit` — clean
- `npm run build` — webpack production build succeeds (was reproducing the CI error before this change; clean after)
- `npx jest` — 1356/1356 pass
- Pre-commit `Build frontend` + `Run frontend tests` — green

## Why pre-commit "passed" earlier

Two reasons:

1. **The original Bundle B commit had `formatRelativeTime` actively used** by the recommendations-list rendering's freshness-provenance line. Pre-commit ran and passed against that code legitimately.
2. **The rebase later replaced the consumer code** (PR #80's detail-drawer flow) without touching the import. Since rebase doesn't re-run hooks, the unused-import error sat undetected on `034ea00cf` until CI's deploy build ran on the merge commit.

## Follow-up tracker (out of scope here)

Worth filing: a CI "build sentinel" job triggered on every commit to `main` / `feat/multicloud-web-frontend` that just runs `npm run build` (cheap, ~30 s) and fails the push instead of failing the deploy. The deploy workflows today catch this class of regression but only after the bad commit is on the protected branch.