### PR TITLE
fix(ux/settings): reset-override dialog wording matches DELETE semantics (closes #114)

### DIFF
--- a/frontend/src/__tests__/settings-accounts.test.ts
+++ b/frontend/src/__tests__/settings-accounts.test.ts
@@ -4,6 +4,7 @@
  */
 import {
   loadAccountsForProvider,
+  loadOverridesPanel,
   setupSettingsHandlers
 } from '../settings';
 
@@ -924,5 +925,51 @@ describe('Account overrides modal', () => {
     // The inline expandable panel was the cause of the panel-stacking bug.
     // Verify it is gone — the only override container is the modal body.
     expect(document.querySelector('.account-overrides-panel')).toBeNull();
+  });
+
+  test('Delete-override button + dialog wording match the actual data semantics (issue #114)', async () => {
+    // The action DELETEs the override row; pre-#114 the dialog said
+    // "Reset … will be replaced" which implied a stuck-around row with
+    // new values. Pin the post-fix wording so a future regression doesn't
+    // silently re-introduce the mismatch.
+    (api.listAccountServiceOverrides as jest.Mock).mockResolvedValue([
+      {
+        account_id: 'acc-1',
+        provider: 'aws',
+        service: 'ec2',
+        term: 1,
+        payment: 'no-upfront',
+        coverage: 80,
+      },
+    ]);
+    mockConfirmDialog.mockResolvedValue(false); // user cancels — we don't need the API call to fire
+
+    const panel = document.createElement('div');
+    document.body.appendChild(panel);
+    await loadOverridesPanel('acc-1', panel, 'aws');
+
+    // The action button now reads "Delete" (not "Reset").
+    const buttons = Array.from(panel.querySelectorAll('button'));
+    const deleteBtn = buttons.find(b => b.textContent === 'Delete');
+    expect(deleteBtn).toBeDefined();
+    expect(buttons.find(b => b.textContent === 'Reset')).toBeUndefined();
+
+    // Click it and inspect the confirmDialog opts.
+    deleteBtn!.click();
+    await Promise.resolve(); // let the click handler's await chain start
+    expect(mockConfirmDialog).toHaveBeenCalledTimes(1);
+    const opts = mockConfirmDialog.mock.calls[0]![0] as {
+      title: string;
+      body: string;
+      confirmLabel: string;
+    };
+    expect(opts.title).toBe('Delete override?');
+    expect(opts.confirmLabel).toBe('Delete override');
+    expect(opts.body).toContain('Delete the aws/ec2 override');
+    expect(opts.body).toContain('revert to the global default');
+    expect(opts.body).toContain('removed');
+    // Pre-#114 wording must not appear.
+    expect(opts.body).not.toContain('replaced');
+    expect(opts.body).not.toContain('Reset');
   });
 });

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -4,7 +4,7 @@
 
 import * as api from './api';
 import * as state from './state';
-import { formatCurrency, formatTerm, escapeHtml, formatRelativeTime } from './utils';
+import { formatCurrency, formatTerm, escapeHtml } from './utils';
 import { renderFreshness } from './freshness';
 import { getRecommendationDetail, type RecommendationDetail } from './api/recommendations';
 import { showToast } from './toast';

--- a/frontend/src/settings.ts
+++ b/frontend/src/settings.ts
@@ -537,7 +537,7 @@ function buildPaymentOverrideSelect(
   // payment value but can't accidentally pick a no-op state.
   if (initial !== '') {
     inheritOpt.disabled = true;
-    inheritOpt.title = 'Use Reset to clear all override fields including payment';
+    inheritOpt.title = 'Use Delete to remove the override entirely (clears all fields including payment)';
   }
 
   select.addEventListener('change', () => {
@@ -640,7 +640,7 @@ function closeAccountOverridesModal(): void {
   closeOverrideModal();
 }
 
-async function loadOverridesPanel(accountId: string, panel: HTMLElement, provider: AccountProvider): Promise<void> {
+export async function loadOverridesPanel(accountId: string, panel: HTMLElement, provider: AccountProvider): Promise<void> {
   panel.textContent = 'Loading\u2026';
   try {
     const overrides = await api.listAccountServiceOverrides(accountId);
@@ -721,12 +721,17 @@ async function loadOverridesPanel(accountId: string, panel: HTMLElement, provide
       const resetBtn = document.createElement('button');
       resetBtn.type = 'button';
       resetBtn.className = 'btn btn-small btn-danger';
-      resetBtn.textContent = 'Reset';
+      // Button + dialog wording aligned with the actual data semantics
+      // (DELETE on account_service_overrides) per #114. The previous
+      // "Reset … will be replaced" copy implied the row stuck around
+      // with new values; in fact the row goes away entirely and the
+      // engine reads the global default as a side effect of its absence.
+      resetBtn.textContent = 'Delete';
       resetBtn.addEventListener('click', async () => {
         const ok = await confirmDialog({
-          title: 'Reset override?',
-          body: `Reset ${o.provider}/${o.service} override to the global default? Any per-service values you set will be replaced.`,
-          confirmLabel: 'Reset override',
+          title: 'Delete override?',
+          body: `Delete the ${o.provider}/${o.service} override? This account's recommendations will revert to the global default. The override row and any per-service values you set will be removed.`,
+          confirmLabel: 'Delete override',
           destructive: true,
         });
         if (!ok) return;
@@ -734,7 +739,7 @@ async function loadOverridesPanel(accountId: string, panel: HTMLElement, provide
           await api.deleteAccountServiceOverride(accountId, o.provider, o.service);
           await loadOverridesPanel(accountId, panel, provider);
         } catch (err) {
-          showToast({ message: `Failed to reset override: ${(err as Error).message}`, kind: 'error' });
+          showToast({ message: `Failed to delete override: ${(err as Error).message}`, kind: 'error' });
         }
       });
       actionTd.appendChild(resetBtn);


### PR DESCRIPTION
## Summary

Closes #114.

The Reset confirmation dialog said:

> *"Reset {provider}/{service} override to the global default? Any per-service values you set will be replaced."*

But the action DELETEs the override row from `account_service_overrides` — the engine then reads the global default as a side effect of the row's absence, not as a "reset" operation. *"Replaced"* implied the row stuck around with new values.

## Fix (Option A — tighten wording)

Per the issue's recommended path:

| | Before | After |
|---|---|---|
| Button label | `Reset` | `Delete` |
| Dialog title | `Reset override?` | `Delete override?` |
| Dialog body | "Reset … will be replaced" | "Delete the {provider}/{service} override? This account's recommendations will revert to the global default. The override row and any per-service values you set will be removed." |
| Confirm label | `Reset override` | `Delete override` |
| Toast on failure | `Failed to reset override` | `Failed to delete override` |
| Inherit-payment tooltip | `Use Reset to clear all override fields including payment` | `Use Delete to remove the override entirely (clears all fields including payment)` |

Backend (`DELETE /api/accounts/:id/service-overrides/:provider/:service`) unchanged.

## Tests

- New `Delete-override button + dialog wording match the actual data semantics (issue #114)` test pins the post-fix wording: button reads "Delete" (not "Reset"), dialog title/body/confirm label all match, body must NOT contain "replaced" or "Reset". Drives via the now-exported `loadOverridesPanel` (small accessibility change to enable the test — same approach used elsewhere).
- All 41 existing settings-accounts tests still pass.

## Drive-by

Removed unused `formatRelativeTime` import in `frontend/src/recommendations.ts`. It was a pre-existing TS6133 error blocking `recommendations.test.ts` from compiling, which in turn blocked the pre-commit `Run frontend tests` hook on every commit on this branch. One-line fix; not strictly part of #114, but the alternative was to skip the hook.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)