### PR TITLE
chore(tests): parallelize pkg/config tests (partial — t.Setenv users stay serial)

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -38,6 +38,7 @@ func writeYAML(t *testing.T, content string) string {
 }
 
 func TestLoad_Defaults(t *testing.T) {
+	t.Parallel()
 	cfg, err := Load("", newFlags())
 	require.NoError(t, err)
 	assert.True(t, cfg.DryRun)
@@ -51,6 +52,7 @@ func TestLoad_Defaults(t *testing.T) {
 }
 
 func TestLoad_MissingDefaultFile_NoError(t *testing.T) {
+	// NOT parallel: uses os.Chdir which mutates process-wide working directory.
 	// No ./cudly.yaml in temp dir; should silently use defaults
 	dir := t.TempDir()
 	orig, _ := os.Getwd()
@@ -63,12 +65,14 @@ func TestLoad_MissingDefaultFile_NoError(t *testing.T) {
 }
 
 func TestLoad_ExplicitMissingFile_Error(t *testing.T) {
+	t.Parallel()
 	_, err := Load("/nonexistent/path/cudly.yaml", newFlags())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "config file not found")
 }
 
 func TestLoad_YAMLFile(t *testing.T) {
+	t.Parallel()
 	path := writeYAML(t, `
 scorer:
   min_savings_pct: 15
@@ -84,12 +88,14 @@ dry_run: false
 }
 
 func TestLoad_InvalidYAML_Error(t *testing.T) {
+	t.Parallel()
 	path := writeYAML(t, "dry_run: [not a bool")
 	_, err := Load(path, newFlags())
 	require.Error(t, err)
 }
 
 func TestLoad_EnvOverridesYAML(t *testing.T) {
+	// NOT parallel: uses t.Setenv (process-wide env mutation panics with t.Parallel).
 	path := writeYAML(t, "scorer:\n  min_savings_pct: 10\n")
 	t.Setenv("CUDLY_MIN_SAVINGS_PCT", "20")
 	cfg, err := Load(path, newFlags())
@@ -98,6 +104,7 @@ func TestLoad_EnvOverridesYAML(t *testing.T) {
 }
 
 func TestLoad_EnvVars(t *testing.T) {
+	// NOT parallel: uses t.Setenv (process-wide env mutation panics with t.Parallel).
 	t.Setenv("CUDLY_DRY_RUN", "false")
 	t.Setenv("CUDLY_AUTO_APPROVE", "true")
 	t.Setenv("CUDLY_AUDIT_LOG", "/tmp/my.jsonl")
@@ -126,6 +133,7 @@ func TestLoad_EnvVars(t *testing.T) {
 }
 
 func TestLoad_InvalidEnvVar_Error(t *testing.T) {
+	// NOT parallel: uses t.Setenv (process-wide env mutation panics with t.Parallel).
 	t.Setenv("CUDLY_MIN_SAVINGS_PCT", "abc")
 	_, err := Load("", newFlags())
 	require.Error(t, err)
@@ -133,6 +141,7 @@ func TestLoad_InvalidEnvVar_Error(t *testing.T) {
 }
 
 func TestLoad_InvalidDurationEnvVar_Error(t *testing.T) {
+	// NOT parallel: uses t.Setenv (process-wide env mutation panics with t.Parallel).
 	t.Setenv("CUDLY_IDEMPOTENCY_WINDOW", "notaduration")
 	_, err := Load("", newFlags())
 	require.Error(t, err)
@@ -140,6 +149,7 @@ func TestLoad_InvalidDurationEnvVar_Error(t *testing.T) {
 }
 
 func TestLoad_FlagOverridesEnvAndYAML(t *testing.T) {
+	// NOT parallel: uses t.Setenv (process-wide env mutation panics with t.Parallel).
 	path := writeYAML(t, "scorer:\n  min_savings_pct: 10\n")
 	t.Setenv("CUDLY_MIN_SAVINGS_PCT", "20")
 	fs := newFlags()
@@ -150,6 +160,7 @@ func TestLoad_FlagOverridesEnvAndYAML(t *testing.T) {
 }
 
 func TestLoad_DryRunAndPurchaseConflict(t *testing.T) {
+	t.Parallel()
 	fs := newFlags()
 	require.NoError(t, fs.Parse([]string{"--dry-run=true", "--purchase"}))
 	_, err := Load("", fs)
@@ -159,6 +170,7 @@ func TestLoad_DryRunAndPurchaseConflict(t *testing.T) {
 }
 
 func TestLoad_PurchaseFlagSetsDryRunFalse(t *testing.T) {
+	t.Parallel()
 	fs := newFlags()
 	require.NoError(t, fs.Parse([]string{"--purchase"}))
 	cfg, err := Load("", fs)
@@ -167,6 +179,7 @@ func TestLoad_PurchaseFlagSetsDryRunFalse(t *testing.T) {
 }
 
 func TestLoad_UnknownCloud_Error(t *testing.T) {
+	t.Parallel()
 	path := writeYAML(t, "enabled_clouds:\n  - oracle\n")
 	_, err := Load(path, newFlags())
 	require.Error(t, err)
@@ -174,6 +187,7 @@ func TestLoad_UnknownCloud_Error(t *testing.T) {
 }
 
 func TestLoad_NegativeThreshold_Error(t *testing.T) {
+	t.Parallel()
 	path := writeYAML(t, "scorer:\n  min_savings_pct: -5\n")
 	_, err := Load(path, newFlags())
 	require.Error(t, err)
@@ -181,6 +195,7 @@ func TestLoad_NegativeThreshold_Error(t *testing.T) {
 }
 
 func TestValidate_EmptyEnabledClouds_Error(t *testing.T) {
+	t.Parallel()
 	// validate() is called by Load; test it directly since empty clouds
 	// cannot be produced by env/YAML (empty overrides are ignored to protect defaults)
 	err := validate(Config{EnabledClouds: []string{}})
@@ -189,6 +204,7 @@ func TestValidate_EmptyEnabledClouds_Error(t *testing.T) {
 }
 
 func TestLoad_CUDLYCONFIGEnv(t *testing.T) {
+	// NOT parallel: uses t.Setenv (process-wide env mutation panics with t.Parallel).
 	path := writeYAML(t, "scorer:\n  min_savings_pct: 7\n")
 	t.Setenv("CUDLY_CONFIG", path)
 	cfg, err := Load("", newFlags())
@@ -197,6 +213,7 @@ func TestLoad_CUDLYCONFIGEnv(t *testing.T) {
 }
 
 func TestLoad_ArgPathTakesPrecedenceOverCUDLYCONFIG(t *testing.T) {
+	// NOT parallel: uses t.Setenv (process-wide env mutation panics with t.Parallel).
 	path1 := writeYAML(t, "scorer:\n  min_savings_pct: 5\n")
 	path2 := writeYAML(t, "scorer:\n  min_savings_pct: 99\n")
 	t.Setenv("CUDLY_CONFIG", path2)
@@ -206,6 +223,7 @@ func TestLoad_ArgPathTakesPrecedenceOverCUDLYCONFIG(t *testing.T) {
 }
 
 func TestLoad_YAMLRoundtrip(t *testing.T) {
+	t.Parallel()
 	content := `dry_run: false
 auto_approve: true
 audit_log: /tmp/audit.jsonl

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -55,9 +55,10 @@ func TestLoad_MissingDefaultFile_NoError(t *testing.T) {
 	// NOT parallel: uses os.Chdir which mutates process-wide working directory.
 	// No ./cudly.yaml in temp dir; should silently use defaults
 	dir := t.TempDir()
-	orig, _ := os.Getwd()
+	orig, err := os.Getwd()
+	require.NoError(t, err)
 	require.NoError(t, os.Chdir(dir))
-	t.Cleanup(func() { os.Chdir(orig) })
+	t.Cleanup(func() { require.NoError(t, os.Chdir(orig)) })
 
 	cfg, err := Load("", newFlags())
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

Continues the `t.Parallel()` adoption sweep from #58. This PR targets `pkg/config/` and uses the standard Go testing **mixed-mode** pattern: 10 pure tests are parallelised, while 8 tests that mutate process-wide state (`t.Setenv` / `os.Chdir`) intentionally remain serial — Go's `t.Setenv` panics if combined with `t.Parallel()`, so making them parallel is not a "fix" but a regression.

To prevent future contributors from accidentally adding `t.Parallel()` to the serial tests, each one carries an inline `// NOT parallel: ...` comment explaining why.

### Per-test classification

**Parallel (10) — pure, no env/chdir/global mutation:**
- `TestLoad_Defaults`
- `TestLoad_ExplicitMissingFile_Error`
- `TestLoad_YAMLFile`
- `TestLoad_InvalidYAML_Error`
- `TestLoad_DryRunAndPurchaseConflict`
- `TestLoad_PurchaseFlagSetsDryRunFalse`
- `TestLoad_UnknownCloud_Error`
- `TestLoad_NegativeThreshold_Error`
- `TestValidate_EmptyEnabledClouds_Error`
- `TestLoad_YAMLRoundtrip`

**Serial (8) — documented in-source:**
- `TestLoad_MissingDefaultFile_NoError` — `os.Chdir`
- `TestLoad_EnvOverridesYAML` — `t.Setenv`
- `TestLoad_EnvVars` — `t.Setenv` (×11)
- `TestLoad_InvalidEnvVar_Error` — `t.Setenv`
- `TestLoad_InvalidDurationEnvVar_Error` — `t.Setenv`
- `TestLoad_FlagOverridesEnvAndYAML` — `t.Setenv`
- `TestLoad_CUDLYCONFIGEnv` — `t.Setenv`
- `TestLoad_ArgPathTakesPrecedenceOverCUDLYCONFIG` — `t.Setenv`

### Out of scope

- `internal/config/` (Postgres integration tests — explicitly deferred per #58 body, needs a separate refactor).
- Refactoring `t.Setenv` users to a different env-injection pattern — would change the test design rather than just parallelise.

### Test plan

- [x] `cd pkg && go test -race -count=2 ./config/...` passes cleanly twice locally
- [x] All pre-commit hooks pass (gosec, trivy, complexity, full Go tests)
- [ ] CI green on PR

Refs #58


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal test infrastructure optimizations with no impact on user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->