### PR TITLE
feat(recommendations): re-enable bulk-buy across SP plan types (#132)

### DIFF
--- a/frontend/src/__tests__/purchase-compatibility.test.ts
+++ b/frontend/src/__tests__/purchase-compatibility.test.ts
@@ -2,7 +2,13 @@
  * Tests for purchase-compatibility.isPaymentSupported — the UI-side
  * guardrail that hides payment options producing zero recommendations.
  */
-import { isPaymentSupported, paymentOptionsFor } from '../lib/purchase-compatibility';
+import {
+  isPaymentSupported,
+  paymentOptionsFor,
+  isSavingsPlanService,
+  savingsPlansBucketLabel,
+  SAVINGS_PLANS_BUCKET_KEY,
+} from '../lib/purchase-compatibility';
 
 describe('isPaymentSupported', () => {
   test('AWS EC2 accepts all payment options for both terms', () => {
@@ -56,5 +62,73 @@ describe('paymentOptionsFor', () => {
 
   test('GCP omits no-upfront + partial-upfront', () => {
     expect(paymentOptionsFor('gcp', 'computeengine', 3)).toEqual(['all-upfront', 'monthly']);
+  });
+});
+
+// Issue #132: bulk-buy bucketing collapses all SP plan-type slugs into
+// one bucket. These tests pin the small predicate + label utility.
+describe('isSavingsPlanService (issue #132)', () => {
+  test('matches every savings-plans-* slug', () => {
+    expect(isSavingsPlanService('savings-plans-compute')).toBe(true);
+    expect(isSavingsPlanService('savings-plans-ec2instance')).toBe(true);
+    expect(isSavingsPlanService('savings-plans-sagemaker')).toBe(true);
+    expect(isSavingsPlanService('savings-plans-database')).toBe(true);
+  });
+
+  test('matches the canonical bucket key itself', () => {
+    expect(isSavingsPlanService(SAVINGS_PLANS_BUCKET_KEY)).toBe(true);
+  });
+
+  test('rejects non-SP slugs', () => {
+    expect(isSavingsPlanService('ec2')).toBe(false);
+    expect(isSavingsPlanService('rds')).toBe(false);
+    expect(isSavingsPlanService('elasticache')).toBe(false);
+    expect(isSavingsPlanService('')).toBe(false);
+  });
+});
+
+describe('savingsPlansBucketLabel (issue #132)', () => {
+  test('renders single plan type without parens being empty', () => {
+    expect(savingsPlansBucketLabel(['savings-plans-compute'])).toBe(
+      'Savings Plans (Compute)',
+    );
+  });
+
+  test('renders mixed plan types in input order', () => {
+    expect(
+      savingsPlansBucketLabel(['savings-plans-compute', 'savings-plans-sagemaker']),
+    ).toBe('Savings Plans (Compute + SageMaker)');
+  });
+
+  test('deduplicates repeated plan types', () => {
+    expect(
+      savingsPlansBucketLabel([
+        'savings-plans-compute',
+        'savings-plans-compute',
+        'savings-plans-ec2instance',
+      ]),
+    ).toBe('Savings Plans (Compute + EC2 Instance)');
+  });
+
+  test('renders all four plan types', () => {
+    expect(
+      savingsPlansBucketLabel([
+        'savings-plans-compute',
+        'savings-plans-ec2instance',
+        'savings-plans-sagemaker',
+        'savings-plans-database',
+      ]),
+    ).toBe('Savings Plans (Compute + EC2 Instance + SageMaker + Database)');
+  });
+
+  test('skips non-SP slugs and falls back when none resolve', () => {
+    expect(savingsPlansBucketLabel(['ec2', 'rds'])).toBe('Savings Plans');
+    expect(savingsPlansBucketLabel([])).toBe('Savings Plans');
+  });
+
+  test('mixed SP and non-SP keeps only SP entries', () => {
+    expect(
+      savingsPlansBucketLabel(['ec2', 'savings-plans-compute', 'rds']),
+    ).toBe('Savings Plans (Compute)');
   });
 });

--- a/frontend/src/__tests__/purchase-compatibility.test.ts
+++ b/frontend/src/__tests__/purchase-compatibility.test.ts
@@ -131,4 +131,15 @@ describe('savingsPlansBucketLabel (issue #132)', () => {
       savingsPlansBucketLabel(['ec2', 'savings-plans-compute', 'rds']),
     ).toBe('Savings Plans (Compute)');
   });
+
+  test('skips the canonical SAVINGS_PLANS_BUCKET_KEY itself', () => {
+    // Defensive: if a caller accidentally passes the bucket key (a
+    // marker, not a plan-type), don't render it as "(savings-plans)".
+    expect(
+      savingsPlansBucketLabel([SAVINGS_PLANS_BUCKET_KEY]),
+    ).toBe('Savings Plans');
+    expect(
+      savingsPlansBucketLabel([SAVINGS_PLANS_BUCKET_KEY, 'savings-plans-compute']),
+    ).toBe('Savings Plans (Compute)');
+  });
 });

--- a/frontend/src/__tests__/recommendations.test.ts
+++ b/frontend/src/__tests__/recommendations.test.ts
@@ -1866,3 +1866,160 @@ describe('Issue #111 (iii): per-row Payment seed in openPurchaseModal', () => {
     // existing handleExecutePurchase tests.
   });
 });
+
+// Issue #132: pre-PR-#123 a 'savings-plans' Compute SP rec and a
+// 'savings-plans' SageMaker SP rec landed in the same bulk-buy
+// bucket. PR #123 split them into per-plan-type service slugs, which
+// silently fanned out into N separate buckets and N separate approval
+// emails. This restores the one-bucket experience.
+describe('Issue #132: bulk-buy collapses SP plan types into one bucket', () => {
+  beforeEach(async () => {
+    document.body.replaceChildren();
+    const recsTab = document.createElement('div');
+    recsTab.id = 'recommendations-tab';
+    recsTab.className = 'tab-content active';
+    const summary = document.createElement('div');
+    summary.id = 'recommendations-summary';
+    const list = document.createElement('div');
+    list.id = 'recommendations-list';
+    recsTab.appendChild(summary);
+    recsTab.appendChild(list);
+    document.body.appendChild(recsTab);
+    const purchaseModal = document.createElement('div');
+    purchaseModal.id = 'purchase-modal';
+    purchaseModal.className = 'hidden';
+    const purchaseDetails = document.createElement('div');
+    purchaseDetails.id = 'purchase-details';
+    purchaseModal.appendChild(purchaseDetails);
+    document.body.appendChild(purchaseModal);
+    jest.clearAllMocks();
+    // Default: empty overrides — issue #132's bucket-key collapse is
+    // independent of the issue #111 override-seed path, but
+    // openFanOutModal still calls listAccountServiceOverrides per
+    // single-account bucket, so we keep the mock primed.
+    (api.listAccountServiceOverrides as jest.Mock).mockResolvedValue([]);
+    // Module-level FanOut state survives test isolation; reset it so
+    // a previous test's openFanOutModal call doesn't leak into a
+    // single-bucket-happy-path assertion here.
+    const { clearFanOutBuckets, clearPurchaseModalRecommendations } = await import('../recommendations');
+    clearFanOutBuckets();
+    clearPurchaseModalRecommendations();
+  });
+
+  test('compute + sagemaker SPs at term=1 share a single bucket (happy path)', async () => {
+    const recs = [
+      { id: 's1', provider: 'aws', cloud_account_id: 'a1', service: 'savings-plans-compute',   resource_type: 'sp', region: 'us-east-1', count: 1, term: 1, savings: 100, upfront_cost: 500 },
+      { id: 's2', provider: 'aws', cloud_account_id: 'a1', service: 'savings-plans-sagemaker', resource_type: 'sp', region: 'us-east-1', count: 1, term: 1, savings: 200, upfront_cost: 800 },
+    ];
+    (api.getRecommendations as jest.Mock).mockResolvedValue({ summary: {}, recommendations: recs, regions: [] });
+    (state.getRecommendations as jest.Mock).mockReturnValue(recs);
+    (state.getVisibleRecommendations as jest.Mock).mockReturnValue(recs);
+    (state.getRecommendationsColumnFilters as jest.Mock).mockReturnValue({});
+    (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set());
+
+    await loadRecommendations();
+    (document.getElementById('bulk-purchase-btn') as HTMLButtonElement).click();
+
+    const { getFanOutBuckets, getPurchaseModalRecommendations } = await import('../recommendations');
+    // 1 collapsed bucket → openPurchaseModal happy path, no fan-out.
+    expect(getFanOutBuckets()).toBeNull();
+    // The single-bucket modal carries BOTH SPs (proves they collapsed).
+    const modalRecs = getPurchaseModalRecommendations();
+    expect(modalRecs.map((r) => r.id).sort()).toEqual(['s1', 's2']);
+    expect(modalRecs.map((r) => r.service).sort()).toEqual([
+      'savings-plans-compute',
+      'savings-plans-sagemaker',
+    ]);
+  });
+
+  test('SP plan types + a non-SP rec produce one SP bucket + one EC2 bucket', async () => {
+    const recs = [
+      { id: 's1', provider: 'aws', cloud_account_id: 'a1', service: 'savings-plans-compute',     resource_type: 'sp', region: 'us-east-1', count: 1, term: 1, savings: 100, upfront_cost: 500 },
+      { id: 's2', provider: 'aws', cloud_account_id: 'a1', service: 'savings-plans-sagemaker',   resource_type: 'sp', region: 'us-east-1', count: 1, term: 1, savings: 150, upfront_cost: 600 },
+      { id: 's3', provider: 'aws', cloud_account_id: 'a1', service: 'savings-plans-ec2instance', resource_type: 'sp', region: 'us-east-1', count: 1, term: 1, savings: 200, upfront_cost: 800 },
+      { id: 'e1', provider: 'aws', cloud_account_id: 'a1', service: 'ec2',                       resource_type: 't3.medium', region: 'us-east-1', count: 1, term: 1, savings:  50, upfront_cost: 300 },
+    ];
+    (api.getRecommendations as jest.Mock).mockResolvedValue({ summary: {}, recommendations: recs, regions: [] });
+    (state.getRecommendations as jest.Mock).mockReturnValue(recs);
+    (state.getVisibleRecommendations as jest.Mock).mockReturnValue(recs);
+    (state.getRecommendationsColumnFilters as jest.Mock).mockReturnValue({});
+    (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set());
+
+    await loadRecommendations();
+    (document.getElementById('bulk-purchase-btn') as HTMLButtonElement).click();
+    // openFanOutModal is async (issue #111 prefetch); wait a tick.
+    await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+
+    const { getFanOutBuckets } = await import('../recommendations');
+    const buckets = getFanOutBuckets();
+    expect(buckets).not.toBeNull();
+    // Expect 2 buckets total: 1 collapsed SP bucket (3 recs) + 1 EC2 bucket (1 rec).
+    expect(buckets!.length).toBe(2);
+
+    const spBucket = buckets!.find((b) => b.service === 'savings-plans');
+    expect(spBucket).toBeDefined();
+    expect(spBucket!.recs).toHaveLength(3);
+    // Per-rec services are preserved — backend audit/suppression keeps
+    // the real plan type per rec.
+    expect(spBucket!.recs.map((r) => r.service).sort()).toEqual([
+      'savings-plans-compute',
+      'savings-plans-ec2instance',
+      'savings-plans-sagemaker',
+    ]);
+
+    const ec2Bucket = buckets!.find((b) => b.service === 'ec2');
+    expect(ec2Bucket).toBeDefined();
+    expect(ec2Bucket!.recs).toHaveLength(1);
+  });
+
+  test('SP recs at different terms still split by term', async () => {
+    const recs = [
+      { id: 's1', provider: 'aws', cloud_account_id: 'a1', service: 'savings-plans-compute',   resource_type: 'sp', region: 'us-east-1', count: 1, term: 1, savings: 100, upfront_cost: 500 },
+      { id: 's2', provider: 'aws', cloud_account_id: 'a1', service: 'savings-plans-sagemaker', resource_type: 'sp', region: 'us-east-1', count: 1, term: 3, savings: 200, upfront_cost: 800 },
+    ];
+    (api.getRecommendations as jest.Mock).mockResolvedValue({ summary: {}, recommendations: recs, regions: [] });
+    (state.getRecommendations as jest.Mock).mockReturnValue(recs);
+    (state.getVisibleRecommendations as jest.Mock).mockReturnValue(recs);
+    (state.getRecommendationsColumnFilters as jest.Mock).mockReturnValue({});
+    (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set());
+
+    await loadRecommendations();
+    (document.getElementById('bulk-purchase-btn') as HTMLButtonElement).click();
+    await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+
+    const { getFanOutBuckets } = await import('../recommendations');
+    const buckets = getFanOutBuckets();
+    expect(buckets).not.toBeNull();
+    // Different terms must still fan out — SP collapsing only joins
+    // recs that share (provider, term).
+    expect(buckets!.length).toBe(2);
+    expect(buckets!.every((b) => b.service === 'savings-plans')).toBe(true);
+    expect(buckets!.map((b) => b.term).sort()).toEqual([1, 3]);
+  });
+
+  test('mixed-SP bucket renders combined plan-type label', async () => {
+    const recs = [
+      { id: 's1', provider: 'aws', cloud_account_id: 'a1', service: 'savings-plans-compute',   resource_type: 'sp', region: 'us-east-1', count: 1, term: 1, savings: 100, upfront_cost: 500 },
+      { id: 's2', provider: 'aws', cloud_account_id: 'a1', service: 'savings-plans-sagemaker', resource_type: 'sp', region: 'us-east-1', count: 1, term: 1, savings: 200, upfront_cost: 800 },
+      { id: 'e1', provider: 'aws', cloud_account_id: 'a1', service: 'ec2',                     resource_type: 't3.medium', region: 'us-east-1', count: 1, term: 1, savings:  50, upfront_cost: 300 },
+    ];
+    (api.getRecommendations as jest.Mock).mockResolvedValue({ summary: {}, recommendations: recs, regions: [] });
+    (state.getRecommendations as jest.Mock).mockReturnValue(recs);
+    (state.getVisibleRecommendations as jest.Mock).mockReturnValue(recs);
+    (state.getRecommendationsColumnFilters as jest.Mock).mockReturnValue({});
+    (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set());
+
+    await loadRecommendations();
+    (document.getElementById('bulk-purchase-btn') as HTMLButtonElement).click();
+    await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+
+    // The fan-out modal renders one section per bucket; the SP section
+    // title carries the combined plan-type label.
+    const sectionTitles = Array.from(
+      document.querySelectorAll('.fanout-bucket h4'),
+    ).map((el) => el.textContent || '');
+    expect(sectionTitles.some((t) => t.includes('Savings Plans (Compute + SageMaker)'))).toBe(true);
+    // Non-SP bucket title still uses the raw service slug.
+    expect(sectionTitles.some((t) => t.includes('AWS / ec2'))).toBe(true);
+  });
+});

--- a/frontend/src/lib/purchase-compatibility.ts
+++ b/frontend/src/lib/purchase-compatibility.ts
@@ -106,6 +106,10 @@ export function savingsPlansBucketLabel(serviceSlugs: readonly string[]): string
   const parts: string[] = [];
   for (const slug of serviceSlugs) {
     if (!isSavingsPlanService(slug) || seen.has(slug)) continue;
+    // Skip the canonical bucket key itself if it shows up in the input
+    // — it's a marker, not a plan-type label, so rendering it as
+    // "savings-plans" inside the parentheses would be ugly.
+    if (slug === SAVINGS_PLANS_BUCKET_KEY) continue;
     seen.add(slug);
     parts.push(SP_SHORT_LABEL[slug] ?? slug);
   }

--- a/frontend/src/lib/purchase-compatibility.ts
+++ b/frontend/src/lib/purchase-compatibility.ts
@@ -69,10 +69,46 @@ export function paymentOptionsFor(provider: Provider, service: string, term: Ter
 // single 'savings-plans' service into four plan-type slugs
 // (savings-plans-{compute,ec2instance,sagemaker,database}). Code that
 // needs to treat all four as one logical group — service-filter
-// "All Savings Plans" affordance, bulk-buy bucketing — uses this
-// predicate. Kept as a `startsWith` rather than a hardcoded set so a
-// future plan type added on the backend (`common.IsSavingsPlan` is
-// also `HasPrefix`) is picked up without a frontend edit.
+// "All Savings Plans" affordance, bulk-buy bucketing, aggregate
+// filters — uses this predicate. Kept as a `startsWith` rather than a
+// hardcoded set so a future plan type added on the backend
+// (`common.IsSavingsPlan` is also `HasPrefix`) is picked up without a
+// frontend edit.
 export function isSavingsPlanService(service: string): boolean {
   return service.startsWith('savings-plans');
+}
+
+// SAVINGS_PLANS_BUCKET_KEY is the canonical service slug used in the
+// bulk-buy bucket key for any SP rec, so all four plan types collapse
+// into one bucket. Each rec keeps its real per-plan-type service slug
+// — only the bucket key is canonicalized.
+export const SAVINGS_PLANS_BUCKET_KEY = 'savings-plans';
+
+// Pretty short label per SP plan type used inside the mixed-bucket
+// label (e.g. "Savings Plans (Compute + SageMaker)"). Mirrors the
+// abbreviations in plans.ts:planServiceLabel without coupling to it.
+const SP_SHORT_LABEL: Record<string, string> = {
+  'savings-plans-compute':     'Compute',
+  'savings-plans-ec2instance': 'EC2 Instance',
+  'savings-plans-sagemaker':   'SageMaker',
+  'savings-plans-database':    'Database',
+};
+
+// savingsPlansBucketLabel formats the bulk-buy bucket title for one
+// or more SP plan types. Returns:
+//   - 'Savings Plans (Compute)' for a single plan type
+//   - 'Savings Plans (Compute + SageMaker)' for a mixed bucket
+//   - 'Savings Plans' if no plan types resolve (defensive fallback)
+// Plan-type order in the output follows insertion order of the input
+// slugs — caller controls the order.
+export function savingsPlansBucketLabel(serviceSlugs: readonly string[]): string {
+  const seen = new Set<string>();
+  const parts: string[] = [];
+  for (const slug of serviceSlugs) {
+    if (!isSavingsPlanService(slug) || seen.has(slug)) continue;
+    seen.add(slug);
+    parts.push(SP_SHORT_LABEL[slug] ?? slug);
+  }
+  if (parts.length === 0) return 'Savings Plans';
+  return `Savings Plans (${parts.join(' + ')})`;
 }

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -1201,8 +1201,23 @@ const BULK_PURCHASE_LS_KEY = 'cudly.recommendations.bulkPurchase.v1';
 // handleBulkPurchaseClick). loadBulkPurchaseState explicitly picks known
 // fields so any legacy `term` from older localStorage values is silently
 // ignored on read — no migration shim needed.
+type BulkPurchasePayment = 'all-upfront' | 'partial-upfront' | 'no-upfront' | 'monthly';
+
+// Centralized bucket-level payment compatibility check. A bucket is
+// compatible iff EVERY rec in it has a supported (provider, service,
+// term, payment) combination. Used by the bulk-buy fan-out path to
+// flag buckets the user has built but won't be allowed to submit.
+function isBucketPaymentCompatible(
+  recs: readonly LocalRecommendation[],
+  payment: BulkPurchasePayment,
+): boolean {
+  return recs.every((r) =>
+    isPaymentSupported(r.provider as CompatProvider, r.service, r.term as 1 | 3, payment),
+  );
+}
+
 interface BulkPurchaseToolbarState {
-  payment: 'all-upfront' | 'partial-upfront' | 'no-upfront' | 'monthly';
+  payment: BulkPurchasePayment;
   capacity: number; // 1..100
 }
 
@@ -1485,11 +1500,7 @@ function handleBulkPurchaseClick(recommendations: LocalRecommendation[]): void {
   // rules today (no SP variant rejects no-upfront the way RDS 3yr does),
   // so this is a defensive belt-and-suspenders check rather than a
   // common case.
-  const incompatible = bucketEntries.filter(([_key, recs]) => {
-    return recs.some(
-      (r) => !isPaymentSupported(r.provider as CompatProvider, r.service, r.term as 1 | 3, tb.payment),
-    );
-  });
+  const incompatible = bucketEntries.filter(([_key, recs]) => !isBucketPaymentCompatible(recs, tb.payment));
 
   if (bucketEntries.length > 1 || incompatible.length > 0) {
     // Multi-bucket / incompatible path: open the fan-out modal so the
@@ -1762,10 +1773,9 @@ function renderFanOutBucketSection(b: FanOutBucket): HTMLElement {
   const renderStatus = (): void => {
     // For mixed-SP buckets check compatibility per rec — every rec must
     // be supported. For non-SP buckets every rec shares b.service so a
-    // single check is equivalent.
-    const compat = b.recs.every((r) =>
-      isPaymentSupported(b.provider, r.service, b.term, b.payment),
-    );
+    // single check is equivalent. The shared helper keeps this in sync
+    // with the same check at handleBulkPurchaseClick.
+    const compat = isBucketPaymentCompatible(b.recs, b.payment);
     status.className = compat ? 'fanout-bucket-ok' : 'fanout-bucket-error';
     status.textContent = compat
       ? `${b.capacityPercent}% capacity · ${b.term}yr · ${b.payment}`

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -12,6 +12,8 @@ import {
   isPaymentSupported,
   isSavingsPlanService,
   paymentOptionsFor,
+  SAVINGS_PLANS_BUCKET_KEY,
+  savingsPlansBucketLabel,
   type Payment as CompatPayment,
   type Provider as CompatProvider,
 } from './lib/purchase-compatibility';
@@ -1455,20 +1457,38 @@ function handleBulkPurchaseClick(recommendations: LocalRecommendation[]): void {
   // each rec is purchased with its OWN per-row term (the toolbar Term
   // selector is gone). Multi-term selections legitimately fan out into
   // multiple buckets, e.g. AWS EC2 1y + AWS EC2 3y → 2 buckets.
+  //
+  // Issue #132: SP recs (savings-plans-{compute,ec2instance,sagemaker,
+  // database}) collapse into a single bucket per (provider, term) so an
+  // operator who used to bulk-buy SP pre-PR-#123 (when there was one
+  // 'savings-plans' service) keeps the one-click experience. Each rec
+  // retains its real per-plan-type service slug — only the bucket key
+  // is canonicalized via SAVINGS_PLANS_BUCKET_KEY. The backend
+  // executePurchase loops per rec and uses rec.service for the
+  // suppression and audit records, so a mixed-SP POST behaves
+  // identically to four separate POSTs except that there's only one
+  // approval token / email.
   const buckets = new Map<string, LocalRecommendation[]>();
   for (const r of scaled) {
-    const key = `${r.provider}|${r.service}|${r.term}`;
+    const bucketService = isSavingsPlanService(r.service) ? SAVINGS_PLANS_BUCKET_KEY : r.service;
+    const key = `${r.provider}|${bucketService}|${r.term}`;
     const existing = buckets.get(key);
     if (existing) existing.push(r);
     else buckets.set(key, [r]);
   }
   const bucketEntries = Array.from(buckets.entries());
 
-  // Per-bucket compatibility check using the bucket's own term.
+  // Per-bucket compatibility check using the bucket's own term. For a
+  // mixed-SP bucket we check every rec's service — if ANY rec's
+  // (provider, service, term, payment) is unsupported, the whole bucket
+  // is flagged incompatible. SP plan types share the same compatibility
+  // rules today (no SP variant rejects no-upfront the way RDS 3yr does),
+  // so this is a defensive belt-and-suspenders check rather than a
+  // common case.
   const incompatible = bucketEntries.filter(([_key, recs]) => {
-    const r = recs[0];
-    if (!r) return false;
-    return !isPaymentSupported(r.provider as CompatProvider, r.service, r.term as 1 | 3, tb.payment);
+    return recs.some(
+      (r) => !isPaymentSupported(r.provider as CompatProvider, r.service, r.term as 1 | 3, tb.payment),
+    );
   });
 
   if (bucketEntries.length > 1 || incompatible.length > 0) {
@@ -1494,6 +1514,13 @@ function handleBulkPurchaseClick(recommendations: LocalRecommendation[]): void {
 // FanOutBucket groups one batch of recs under a single (provider,
 // service, term, payment, capacity) choice. A multi-bucket Purchase
 // fires one executePurchase POST per bucket.
+//
+// `service` is the canonical bucket slug — equal to the rec's service
+// for non-SP buckets, or `SAVINGS_PLANS_BUCKET_KEY` for any bucket
+// containing one or more savings-plans-* recs (issue #132). Per-rec
+// service slugs are preserved on `recs[].service` and round-trip into
+// the executePurchase POST body — the backend uses each rec's own
+// service for suppression and audit records.
 //
 // `paymentSource` (issue #111) records WHERE this bucket's payment
 // default came from:
@@ -1640,9 +1667,13 @@ async function openFanOutModal(
     .map(([_key, recs]) => {
       const r = recs[0]!;
       const seed = resolveBucketPaymentSeed(recs, toolbar, overridesByAccount);
+      // SP buckets carry the canonical bucket key as `service` so the
+      // section header can render the mixed-plan-type label; the per-
+      // rec slugs on recs[].service are what the backend sees.
+      const bucketService = isSavingsPlanService(r.service) ? SAVINGS_PLANS_BUCKET_KEY : r.service;
       return {
         provider: r.provider as CompatProvider,
-        service: r.service,
+        service: bucketService,
         // Each bucket is now term-uniform (key includes term), so we read
         // the term from the bucket itself rather than from the dropped
         // toolbar override.
@@ -1714,17 +1745,31 @@ function renderFanOutBucketSection(b: FanOutBucket): HTMLElement {
   const section = document.createElement('section');
   section.className = 'fanout-bucket form-section';
 
+  // Service label: SP bucket → "Savings Plans (Compute + SageMaker)"
+  // listing only the plan types actually present in this bucket;
+  // non-SP bucket → the raw service slug (e.g. "ec2", "rds"). Order
+  // follows the recs' insertion order so it tracks the table.
+  const isSPBucket = b.service === SAVINGS_PLANS_BUCKET_KEY;
+  const serviceLabel = isSPBucket
+    ? savingsPlansBucketLabel(b.recs.map((r) => r.service))
+    : b.service;
+
   const title = document.createElement('h4');
-  title.textContent = `${b.provider.toUpperCase()} / ${b.service} — ${b.recs.length} commitment${b.recs.length === 1 ? '' : 's'}`;
+  title.textContent = `${b.provider.toUpperCase()} / ${serviceLabel} — ${b.recs.length} commitment${b.recs.length === 1 ? '' : 's'}`;
   section.appendChild(title);
 
   const status = document.createElement('p');
   const renderStatus = (): void => {
-    const compat = isPaymentSupported(b.provider, b.service, b.term, b.payment);
+    // For mixed-SP buckets check compatibility per rec — every rec must
+    // be supported. For non-SP buckets every rec shares b.service so a
+    // single check is equivalent.
+    const compat = b.recs.every((r) =>
+      isPaymentSupported(b.provider, r.service, b.term, b.payment),
+    );
     status.className = compat ? 'fanout-bucket-ok' : 'fanout-bucket-error';
     status.textContent = compat
       ? `${b.capacityPercent}% capacity · ${b.term}yr · ${b.payment}`
-      : `Invalid combo: ${b.provider} / ${b.service} doesn't support ${b.term}yr + ${b.payment}. This bucket will be skipped.`;
+      : `Invalid combo: ${b.provider} / ${serviceLabel} doesn't support ${b.term}yr + ${b.payment}. This bucket will be skipped.`;
   };
   renderStatus();
   section.appendChild(status);


### PR DESCRIPTION
## Summary

Closes #132. Restores the pre-PR-#123 one-click bulk-buy experience for AWS Savings Plans by collapsing all four per-plan-type slugs (`savings-plans-{compute,ec2instance,sagemaker,database}`) into a single bulk-buy bucket per `(provider, term)` pair.

## What changed

- **Bucket key collapses SP slugs** in `frontend/src/recommendations.ts`: any rec with `isSavingsPlanService(rec.service) === true` uses the canonical `'savings-plans'` slug in the bucket key instead of its per-plan-type slug. Compute + SageMaker SPs at term=1 now share one bucket. Different terms still split.
- **Per-rec service preserved**: `recs[].service` keeps the real per-plan-type slug. The backend `executePurchase` handler iterates per rec and uses `rec.service` for suppressions, audit records and the email summary, so a mixed-SP POST is functionally identical to four separate POSTs except that there's only one approval token / one approval email / one click in the inbox.
- **Mixed-SP bucket label**: `renderFanOutBucketSection` shows `"AWS / Savings Plans (Compute + SageMaker) — N commitments"` instead of `"AWS / savings-plans-compute — N"`. Single-plan buckets render as `"Savings Plans (Compute)"`. Non-SP buckets keep their raw service slug.
- **Per-rec compatibility check**: bucket-level compatibility now `every`-checks every rec's service, defending against a future provider-side asymmetry between SP plan types (today they share AWS's payment rules — only RDS 3yr rejects no-upfront).

## New utilities (`frontend/src/lib/purchase-compatibility.ts`)

- `isSavingsPlanService(service)` — `startsWith('savings-plans')`, mirror of Go's `common.IsSavingsPlan` (`pkg/common/types.go`). `startsWith` rather than a hardcoded set so a future plan type added on the backend is picked up automatically.
- `SAVINGS_PLANS_BUCKET_KEY = 'savings-plans'` — canonical bucket slug.
- `savingsPlansBucketLabel(slugs)` — formats the mixed-plan-type label, dedupes and preserves input order.

## Tests

- 9 new tests in `purchase-compatibility.test.ts` pinning the predicate and label utility.
- 4 new tests in `recommendations.test.ts` driving the actual bulk-buy flow: (a) two SPs at term=1 collapse into one bucket and hit the single-bucket happy path with both recs preserved, (b) three SPs + one EC2 produce 1 SP bucket + 1 EC2 bucket, (c) different SP terms still split by term, (d) the mixed-SP fan-out modal renders the combined plan-type label.
- All 1369 existing frontend tests still pass.
- TypeScript typecheck + webpack build clean.

## Backend untouched

Per-card save path, `executePurchase` handler, suppression machinery and email summary all consume `rec.service` unchanged.

## Test plan

- [ ] CodeRabbit review clean
- [ ] CI green
- [ ] Verify in browser: bulk-buy with mixed SP plan-type recs produces a single bucket and one approval email.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added regression coverage for Savings Plans bucketing, label formatting, fan-out scenarios, term-splitting, and purchase-modal rendering.

* **Improvements**
  * Consolidated Savings Plans variants into a single canonical bulk-buy bucket by provider and term.
  * UI shows consolidated Savings Plans labels (e.g., "Savings Plans (X)"), preserves first-seen order, deduplicates plan types, ignores non‑SP entries, and falls back to "Savings Plans" when none resolve.
  * Compatibility gating now validates every item in a bucket.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->