### PR TITLE
feat(recommendations): All Savings Plans tri-state in service column-filter (#137)

### DIFF
--- a/frontend/src/__tests__/recommendations.test.ts
+++ b/frontend/src/__tests__/recommendations.test.ts
@@ -1233,6 +1233,12 @@ describe('Bundle B: column header filter triggers', () => {
       });
       (state.getRecommendations as jest.Mock).mockReturnValue(spRecs);
       (state.getVisibleRecommendations as jest.Mock).mockReturnValue(spRecs);
+      // Reset the column-filters mock to a deterministic empty state so a
+      // prior test in this describe block leaving a custom mockReturnValue
+      // (e.g. the indeterminate test setting `service: { values: [...] }`)
+      // doesn't bleed into a later test's popover-build that reads
+      // getRecommendationsColumnFilters() during resync.
+      (state.getRecommendationsColumnFilters as jest.Mock).mockReturnValue({});
     });
 
     test('service popover renders the All Savings Plans group toggle when 2+ SP slugs present', async () => {

--- a/frontend/src/__tests__/recommendations.test.ts
+++ b/frontend/src/__tests__/recommendations.test.ts
@@ -1212,6 +1212,136 @@ describe('Bundle B: column header filter triggers', () => {
     expect(live?.getAttribute('aria-live')).toBe('polite');
     expect(live?.textContent).toMatch(/Showing \d+ of \d+/);
   });
+
+  // Issue #137: 'All Savings Plans' affordance in the service column-filter
+  // popover. PR #123 split a single 'savings-plans' service into four per-
+  // plan-type slugs, so the user lost the one-click "filter to all SP recs"
+  // affordance. These tests pin the new tri-state group toggle.
+  describe('Issue #137: All Savings Plans tri-state in service column-filter', () => {
+    const spRecs = [
+      { id: 'rec-aws-1',  provider: 'aws', cloud_account_id: 'a1', service: 'ec2',                        resource_type: 't3.medium', region: 'us-east-1', count: 1, term: 1, savings: 100, upfront_cost: 500 },
+      { id: 'rec-sp-c',   provider: 'aws', cloud_account_id: 'a1', service: 'savings-plans-compute',      resource_type: 'sp',        region: 'us-east-1', count: 1, term: 1, savings: 200, upfront_cost: 800 },
+      { id: 'rec-sp-e',   provider: 'aws', cloud_account_id: 'a1', service: 'savings-plans-ec2instance',  resource_type: 'sp',        region: 'us-east-1', count: 1, term: 1, savings: 150, upfront_cost: 700 },
+      { id: 'rec-sp-s',   provider: 'aws', cloud_account_id: 'a1', service: 'savings-plans-sagemaker',    resource_type: 'sp',        region: 'us-east-1', count: 1, term: 1, savings: 250, upfront_cost: 900 },
+    ];
+
+    beforeEach(() => {
+      (api.getRecommendations as jest.Mock).mockResolvedValue({
+        summary: {},
+        recommendations: spRecs,
+        regions: [],
+      });
+      (state.getRecommendations as jest.Mock).mockReturnValue(spRecs);
+      (state.getVisibleRecommendations as jest.Mock).mockReturnValue(spRecs);
+    });
+
+    test('service popover renders the All Savings Plans group toggle when 2+ SP slugs present', async () => {
+      await loadRecommendations();
+      const serviceBtn = document.querySelector<HTMLButtonElement>('th .column-filter-btn[data-column="service"]');
+      serviceBtn?.click();
+      const groupBox = document.querySelector<HTMLInputElement>('.column-filter-popover input[data-role="sp-group"]');
+      expect(groupBox).not.toBeNull();
+      const groupLabel = groupBox?.closest('label');
+      expect(groupLabel?.textContent).toContain('All Savings Plans');
+    });
+
+    test('group toggle does NOT render for non-service columns', async () => {
+      await loadRecommendations();
+      const providerBtn = document.querySelector<HTMLButtonElement>('th .column-filter-btn[data-column="provider"]');
+      providerBtn?.click();
+      const groupBox = document.querySelector('.column-filter-popover input[data-role="sp-group"]');
+      expect(groupBox).toBeNull();
+    });
+
+    test('group toggle does NOT render when only 0 or 1 SP slugs present', async () => {
+      const oneSPRec = [
+        { id: 'rec1', provider: 'aws', cloud_account_id: 'a1', service: 'ec2',                   resource_type: 't3.medium', region: 'us-east-1', count: 1, term: 1, savings: 100, upfront_cost: 500 },
+        { id: 'rec2', provider: 'aws', cloud_account_id: 'a1', service: 'savings-plans-compute', resource_type: 'sp',        region: 'us-east-1', count: 1, term: 1, savings: 200, upfront_cost: 800 },
+      ];
+      (api.getRecommendations as jest.Mock).mockResolvedValue({ summary: {}, recommendations: oneSPRec, regions: [] });
+      (state.getRecommendations as jest.Mock).mockReturnValue(oneSPRec);
+      (state.getVisibleRecommendations as jest.Mock).mockReturnValue(oneSPRec);
+
+      await loadRecommendations();
+      const serviceBtn = document.querySelector<HTMLButtonElement>('th .column-filter-btn[data-column="service"]');
+      serviceBtn?.click();
+      const groupBox = document.querySelector('.column-filter-popover input[data-role="sp-group"]');
+      expect(groupBox).toBeNull();
+    });
+
+    test('clicking group toggle commits a filter with all SP slug values', async () => {
+      await loadRecommendations();
+      const serviceBtn = document.querySelector<HTMLButtonElement>('th .column-filter-btn[data-column="service"]');
+      serviceBtn?.click();
+      const groupBox = document.querySelector<HTMLInputElement>('.column-filter-popover input[data-role="sp-group"]');
+      expect(groupBox).not.toBeNull();
+      // Browser flips checked → true on first click; simulate that.
+      groupBox!.checked = true;
+      groupBox!.dispatchEvent(new Event('change'));
+
+      // Filter committed with the three SP values (in any order). Asserting
+      // on the mock rather than cb.checked because rerenderRecommendations
+      // → resyncOpenPopover resets cb state from the (mocked) filter
+      // accessor — the mock call args are the canonical signal of what
+      // the click handler did.
+      const calls = (state.setRecommendationsColumnFilter as jest.Mock).mock.calls;
+      const lastCall = calls[calls.length - 1];
+      expect(lastCall[0]).toBe('service');
+      expect(lastCall[1]?.kind).toBe('set');
+      expect((lastCall[1]?.values as string[]).sort()).toEqual([
+        'savings-plans-compute',
+        'savings-plans-ec2instance',
+        'savings-plans-sagemaker',
+      ]);
+    });
+
+    test('clicking group toggle (off) clears the SP filter', async () => {
+      // Pre-set the filter so the SP tri-state renders as checked.
+      (state.getRecommendationsColumnFilters as jest.Mock).mockReturnValue({
+        service: { kind: 'set', values: ['savings-plans-compute', 'savings-plans-ec2instance', 'savings-plans-sagemaker'] },
+      });
+      await loadRecommendations();
+      const serviceBtn = document.querySelector<HTMLButtonElement>('th .column-filter-btn[data-column="service"]');
+      serviceBtn?.click();
+      const groupBox = document.querySelector<HTMLInputElement>('.column-filter-popover input[data-role="sp-group"]');
+      expect(groupBox?.checked).toBe(true);
+      // Browser flips → unchecked on click of an already-checked tri-state.
+      groupBox!.checked = false;
+      groupBox!.dispatchEvent(new Event('change'));
+
+      // No SP boxes selected → commit() treats "no selections" as "no
+      // narrowing" and persists null (filter cleared).
+      expect(state.setRecommendationsColumnFilter).toHaveBeenLastCalledWith('service', null);
+    });
+
+    test('group toggle resyncs to indeterminate when only some SPs are filter-active', async () => {
+      (state.getRecommendationsColumnFilters as jest.Mock).mockReturnValue({
+        service: { kind: 'set', values: ['savings-plans-compute'] },
+      });
+      await loadRecommendations();
+      const serviceBtn = document.querySelector<HTMLButtonElement>('th .column-filter-btn[data-column="service"]');
+      serviceBtn?.click();
+      const groupBox = document.querySelector<HTMLInputElement>('.column-filter-popover input[data-role="sp-group"]');
+      expect(groupBox?.checked).toBe(false);
+      expect(groupBox?.indeterminate).toBe(true);
+    });
+
+    test('individual SP checkbox change commits the partial-SP filter', async () => {
+      await loadRecommendations();
+      const serviceBtn = document.querySelector<HTMLButtonElement>('th .column-filter-btn[data-column="service"]');
+      serviceBtn?.click();
+      const cbCompute = document.querySelector<HTMLInputElement>('.column-filter-popover input[data-value="savings-plans-compute"]');
+      cbCompute!.checked = true;
+      cbCompute!.dispatchEvent(new Event('change'));
+      // 1 of 4 service distinct values selected → filter committed with
+      // just that slug.
+      const calls = (state.setRecommendationsColumnFilter as jest.Mock).mock.calls;
+      const lastCall = calls[calls.length - 1];
+      expect(lastCall[0]).toBe('service');
+      expect(lastCall[1]?.kind).toBe('set');
+      expect(lastCall[1]?.values).toEqual(['savings-plans-compute']);
+    });
+  });
 });
 
 describe('Bundle B: sticky bottom action box', () => {

--- a/frontend/src/lib/purchase-compatibility.ts
+++ b/frontend/src/lib/purchase-compatibility.ts
@@ -64,3 +64,15 @@ export function paymentOptionsFor(provider: Provider, service: string, term: Ter
   const candidates: Payment[] = ['all-upfront', 'partial-upfront', 'no-upfront', 'monthly'];
   return candidates.filter((p) => isPaymentSupported(provider, service, term, p));
 }
+
+// Mirror of common.IsSavingsPlan (pkg/common/types.go). PR #123 split a
+// single 'savings-plans' service into four plan-type slugs
+// (savings-plans-{compute,ec2instance,sagemaker,database}). Code that
+// needs to treat all four as one logical group — service-filter
+// "All Savings Plans" affordance, bulk-buy bucketing — uses this
+// predicate. Kept as a `startsWith` rather than a hardcoded set so a
+// future plan type added on the backend (`common.IsSavingsPlan` is
+// also `HasPrefix`) is picked up without a frontend edit.
+export function isSavingsPlanService(service: string): boolean {
+  return service.startsWith('savings-plans');
+}

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -8,7 +8,13 @@ import { formatCurrency, formatTerm, escapeHtml } from './utils';
 import { renderFreshness } from './freshness';
 import { getRecommendationDetail, type RecommendationDetail } from './api/recommendations';
 import { showToast } from './toast';
-import { isPaymentSupported, paymentOptionsFor, type Provider as CompatProvider, type Payment as CompatPayment } from './lib/purchase-compatibility';
+import {
+  isPaymentSupported,
+  isSavingsPlanService,
+  paymentOptionsFor,
+  type Payment as CompatPayment,
+  type Provider as CompatProvider,
+} from './lib/purchase-compatibility';
 import type { AccountServiceOverride } from './api/accounts';
 import type { RecommendationsResponse, LocalRecommendation, RecommendationsSummary } from './types';
 import { openModal } from './modal';
@@ -479,6 +485,31 @@ function buildPopoverContent(
     allLabel.appendChild(allText);
     popover.appendChild(allLabel);
 
+    // Issue #137: when the service column popover lists 2+ SP plan-type
+    // slugs, render a second tri-state row "All Savings Plans" between
+    // (All) and the individual list. PR #123 split the single
+    // 'savings-plans' option into per-plan-type slugs, removing the
+    // one-click "filter to all SP recommendations" affordance — this
+    // restores it as a group-level toggle scoped to SP slugs only.
+    // Per-plan-type checkboxes remain individually selectable for
+    // narrowing.
+    const spSlugs: string[] = column === 'service'
+      ? distinct.filter((v) => isSavingsPlanService(v))
+      : [];
+    let spBox: HTMLInputElement | null = null;
+    if (spSlugs.length >= 2) {
+      const spLabel = document.createElement('label');
+      spLabel.className = 'column-filter-group';
+      spBox = document.createElement('input');
+      spBox.type = 'checkbox';
+      spBox.dataset['role'] = 'sp-group';
+      spLabel.appendChild(spBox);
+      const spText = document.createElement('span');
+      spText.textContent = 'All Savings Plans';
+      spLabel.appendChild(spText);
+      popover.appendChild(spLabel);
+    }
+
     const list = document.createElement('div');
     list.className = 'column-filter-list';
     for (const value of distinct) {
@@ -504,6 +535,20 @@ function buildPopoverContent(
       allBox.checked = checked === total && total > 0;
     };
 
+    // SP-group tri-state mirrors updateAllTriState but is scoped to the
+    // savings-plans-* boxes only. checked = every SP box ticked,
+    // indeterminate = some-but-not-all, unchecked = none.
+    const updateSPTriState = (): void => {
+      if (!spBox) return;
+      let checked = 0;
+      for (const slug of spSlugs) {
+        const cb = checkboxes.get(slug);
+        if (cb && cb.checked) checked++;
+      }
+      spBox.indeterminate = checked > 0 && checked < spSlugs.length;
+      spBox.checked = checked === spSlugs.length && spSlugs.length > 0;
+    };
+
     const commit = (): void => {
       const selected: string[] = [];
       checkboxes.forEach((cb, value) => { if (cb.checked) selected.push(value); });
@@ -514,6 +559,7 @@ function buildPopoverContent(
         state.setRecommendationsColumnFilter(column, { kind: 'set', values: selected });
       }
       updateAllTriState();
+      updateSPTriState();
       rerenderRecommendations();
     };
 
@@ -526,6 +572,21 @@ function buildPopoverContent(
       // After (All) flips, update underlying filter once.
       commit();
     });
+    if (spBox) {
+      spBox.addEventListener('change', () => {
+        // Clicking SP tri-state ticks ALL SP boxes when transitioning
+        // from unchecked/indeterminate → checked, and unticks all SP
+        // boxes when transitioning checked → unchecked. The browser
+        // resolves indeterminate to checked on click, so spBox.checked
+        // after the click is the desired target state for SP boxes.
+        const target = spBox!.checked;
+        for (const slug of spSlugs) {
+          const cb = checkboxes.get(slug);
+          if (cb) cb.checked = target;
+        }
+        commit();
+      });
+    }
   }
 
   // Footer with Clear button.
@@ -579,6 +640,21 @@ function resyncOpenPopover(): void {
     openPopover.checkboxes.forEach((cb) => { if (cb.checked) checked++; });
     allBox.indeterminate = checked > 0 && checked < total;
     allBox.checked = checked === total && total > 0;
+  }
+  // Issue #137: also resync the "All Savings Plans" tri-state when the
+  // service column has the SP-group affordance rendered.
+  const spBox = openPopover.el.querySelector<HTMLInputElement>('input[data-role="sp-group"]');
+  if (spBox) {
+    let spTotal = 0;
+    let spChecked = 0;
+    openPopover.checkboxes.forEach((cb, value) => {
+      if (isSavingsPlanService(value)) {
+        spTotal++;
+        if (cb.checked) spChecked++;
+      }
+    });
+    spBox.indeterminate = spChecked > 0 && spChecked < spTotal;
+    spBox.checked = spChecked === spTotal && spTotal > 0;
   }
 }
 


### PR DESCRIPTION
## Summary

Closes #137. Restores the one-click "filter to all Savings Plans" affordance that PR #123 removed when it split the single `savings-plans` service slug into four per-plan-type slugs (`savings-plans-{compute,ec2instance,sagemaker,database}`). The original issue proposed adding `<option value="all-sp">` to the optgroup — but Bundle B replaced the legacy service-filter dropdown with the per-column popover (checkbox list of distinct service values), so the equivalent affordance for a checkbox UI is a tri-state group toggle.

## What changed

In `frontend/src/recommendations.ts:buildPopoverContent`, when the column is `service` AND 2+ SP slugs are in the distinct values, render a new "All Savings Plans" tri-state checkbox between the existing `(All)` row and the per-value list:

- **checked**: every SP slug is in the active filter
- **indeterminate**: a strict subset of SP slugs is in the filter
- **unchecked**: no SP slug is in the filter
- **click ON**: ticks every SP box and commits the resulting filter (preserving any non-SP boxes already ticked)
- **click OFF**: unticks every SP box; if no other slugs were ticked, the filter is cleared (treated as "no narrowing")

Per-plan-type checkboxes remain individually selectable for narrowing — the group toggle is purely a bulk-select shortcut.

The toggle does NOT render in non-service columns or when fewer than 2 SP slugs are present.

## New utility

`isSavingsPlanService(service)` in `frontend/src/lib/purchase-compatibility.ts` — `startsWith('savings-plans')`, mirror of Go's `common.IsSavingsPlan` (`pkg/common/types.go`). `startsWith` form so a future plan type added on the backend is picked up automatically.

## Tests

7 new tests in `recommendations.test.ts` pinning:
- group toggle renders when 2+ SP slugs present
- does NOT render for non-service columns
- does NOT render when 0 or 1 SP slugs present
- click ON commits filter with all 3 SP slug values
- click OFF (when all SPs were filter-active) clears the filter
- resyncs to indeterminate when only some SPs are filter-active
- individual SP checkbox change commits the partial-SP filter

All 1363 frontend tests pass. TypeScript typecheck + webpack build clean.

## Conflict notice

The small `isSavingsPlanService` predicate is also added by PR #180 (issue #132 — bulk-buy across SP plan types). Whichever lands first, the second hits a trivial 3-line conflict in `lib/purchase-compatibility.ts`; either version of the export is correct to keep.

## Test plan

- [ ] CodeRabbit review clean
- [ ] CI green
- [ ] Verify in browser: open service column filter on a recs view that has 2+ SP plan-type entries, click "All Savings Plans", confirm all SP rows pass the filter and non-SP rows don't.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "All Savings Plans" tri-state group toggle to the Service column filter popover, letting users select/deselect all savings-plan types at once; the toggle appears only when multiple savings-plan types exist and reflects checked/indeterminate/unchecked states.

* **Tests**
  * Added end-to-end test coverage validating the group toggle’s visibility, tri-state behavior, synchronization, and individual checkbox interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->