### PR TITLE
fix(docker): work around npm "Exit handler never called" with serial fetch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,7 +80,21 @@ FROM --platform=$BUILDPLATFORM node:24-alpine AS frontend-builder
 
 WORKDIR /frontend
 COPY frontend/package*.json ./
-RUN npm ci && test -x node_modules/.bin/webpack
+# `--no-progress`: disables the npm progress reporter, whose worker has a
+#   long-standing race condition in npm 10/11 that surfaces as
+#   `npm error Exit handler never called!` on memory-constrained hosts
+#   (Linux VMs, low-RAM CI runners). See npm/cli issues for the bug; the
+#   fix is "don't run that worker".
+# `--maxsockets 1`: serialise registry fetches so peak memory during the
+#   install stays low. With 810 lockfile entries, parallel fetch + the
+#   gzip-decode workers race the OOM killer on hosts with <2 GB free.
+# `--no-audit --no-fund`: skip post-install network calls that aren't
+#   relevant to a build context.
+# `test -x`: existing guard against silent zero-exit npm failures
+#   (kept from #044dc583c — addresses a different failure mode where
+#   npm exits 0 but leaves node_modules empty).
+RUN npm ci --no-progress --maxsockets 1 --no-audit --no-fund && \
+    test -x node_modules/.bin/webpack
 COPY frontend/ ./
 RUN npm run build
 


### PR DESCRIPTION
## Summary

A colleague hit the frontend-builder stage failing with the npm "Exit handler never called!" bug while running `terraform apply` from `terraform/environments/aws/`. They're on a Linux VM (`itachi-VMware-Virtual-Platform`), where memory pressure is higher than on bare-metal dev boxes.

```text
#21 [frontend-builder 4/6] RUN npm ci && test -x node_modules/.bin/webpack
#21 80.08 npm error Exit handler never called!
#21 80.08 npm error This is an error with npm itself. Please report this error at:
#21 80.08 npm error   <https://github.com/npm/cli/issues>
#21 ERROR: process "/bin/sh -c npm ci && test -x node_modules/.bin/webpack" did not complete successfully: exit code: 1
```

## Why the previous fix didn't fully close it

We hit this exact symptom before in `044dc583c` (`fix(docker): upgrade Node to 24-alpine and guard npm ci`). That commit:

1. Added the `test -x node_modules/.bin/webpack` guard so silent zero-exit npm failures surface as build errors instead of producing an empty node_modules that fails at webpack-time. ✅ Still doing its job.
2. Upgraded Node 20→24 hoping the bundled npm would be less buggy. ❌ Doesn't help — npm 10/11's progress reporter has a long-standing race that fires under memory pressure regardless of Node version.

The colleague's failure is the same bug the prior fix was intended to mitigate, recurring on a memory-constrained host where the prior mitigation wasn't sufficient.

## What this PR changes

Single 1-line change to `Dockerfile`'s frontend-builder stage:

```diff
-RUN npm ci && test -x node_modules/.bin/webpack
+RUN npm ci --no-progress --maxsockets 1 --no-audit --no-fund && \
+    test -x node_modules/.bin/webpack
```

- **`--no-progress`**: disables the npm progress reporter, whose worker is the one that races with npm's exit handler in npm 10/11 — the documented mitigation for "Exit handler never called!".
- **`--maxsockets 1`**: serialise registry fetches. With 810 lockfile entries, parallel fetch + gzip-decode workers race the OOM killer on hosts with <2 GB free.
- **`--no-audit --no-fund`**: skip post-install network calls that aren't relevant to a build context.

The existing `test -x` guard from `d703e2425` is kept — it addresses a different failure mode (npm exits 0 but leaves node_modules empty) that's still worth catching.

## What's NOT in this PR

- **SHA256-pinning of `node:24-alpine`**: the `# TODO: Pin to SHA256 digest` comment at line 77 is still TODO. If we still see Exit-handler-never-called after this lands, that's the next escalation — pinning means we stop chasing the moving npm version inside the floating tag. Filed for follow-up rather than bundled here so this PR stays small and reviewable.

## Test plan

- [ ] Colleague re-runs `terraform apply` from `terraform/environments/aws/` after this lands. Expect the frontend-builder stage to complete past the 80s mark where it previously crashed.
- [ ] CI's docker-build job runs the same Dockerfile path; pre-commit + CI green is the canonical signal.
- [ ] If the bug recurs even with `--no-progress`, that's the signal to escalate to the SHA256 pin (see "What's NOT in this PR" above).

I'd give this 80% confidence the colleague's symptom resolves with this single change. The remaining 20% is "the actual root cause is something more specific to their VM" (e.g., genuinely OOM'd at the kernel level, in which case `--maxsockets 1` slows the install but a 1.5GB-RAM VM might still not be enough to hold 810 deps in node_modules).

Closes the colleague's blocker; refs (and partially mitigates) any recurrence of the npm Exit-handler bug previously seen in `044dc583c`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized frontend build process by refining dependency installation configuration, improving build efficiency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->