### PR TITLE
docs(security/azure): fix post-apply recipe (Consumption SKU)

### DIFF
--- a/terraform/modules/compute/azure/container-apps/scheduled-tasks.tf
+++ b/terraform/modules/compute/azure/container-apps/scheduled-tasks.tf
@@ -10,9 +10,15 @@
 # user-assigned identity, and the call-endpoint action references
 # `@body('get-secret')['value']` in the outgoing Authorization header.
 #
-# Effect: `terraform show` / `az logicapp show` only ever reveal the Key Vault
-# URL the workflow is going to call — the actual secret value is fetched
-# in-process by the Logic Apps engine and never lands in any persisted artifact.
+# Effect: `terraform show` / `az resource show --resource-type
+# Microsoft.Logic/workflows --api-version 2019-05-01 -g <rg> -n <wf>` only ever
+# reveal the Key Vault URL the workflow is going to call — the actual secret
+# value is fetched in-process by the Logic Apps engine and never lands in any
+# persisted artifact. Note: `az logicapp show` is for Logic Apps Standard
+# (`Microsoft.Web/sites`); these workflows are Consumption-tier
+# (`Microsoft.Logic/workflows`), and `az logic workflow show` requires the
+# `logic` cli extension which can fail to install in some environments —
+# `az resource show` works without extensions. See issue #183.
 
 # Parse cron schedule into Logic Apps recurrence format
 # Azure Logic Apps uses a different format than cron


### PR DESCRIPTION
## Summary

Fixes the post-apply verification command in the security header comment of `scheduled-tasks.tf`. The original comment (added in PR #74) told operators to use `az logicapp show`, but that subcommand targets Logic Apps **Standard** (`Microsoft.Web/sites` with `kind=workflowapp`); these workflows are Consumption-tier (`Microsoft.Logic/workflows` via `azurerm_logic_app_workflow`). Running `az logicapp show -n <wf>` against one returns `ResourceNotFound`.

The replacement uses `az resource show --resource-type Microsoft.Logic/workflows --api-version 2019-05-01`, which:

- Works against the right SKU.
- Needs no `az` cli extension. (`az logic workflow show` does, and the `logic` extension can fail to install on Python 3.12+ azure-cli builds — the standard install path on macOS Homebrew today, which is exactly when an operator would reach for the post-apply check.)

Closes #183.

## Scope

Comment-only — no resource, state, output, or runtime change. `terraform fmt -check` and `terraform validate` both clean (the pre-commit hooks ran them).

The two other surfaces called out in #183 (issue #50 "Steps to reproduce" and PR #74 "Test plan") are historical text — both will be addressed via corrective comments on those threads, not via code.

## Test plan

- [x] `terraform fmt -check` clean (pre-commit `Terraform format` passed).
- [x] `terraform validate` clean (pre-commit `Terraform validate` passed).
- [ ] CodeRabbit review with no actionable findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified guidance for inspecting Azure Logic Apps: prefer the generic resource inspection command for Consumption-tier workflows rather than the Logic Apps Standard inspection command.
  * Added a note that the Logic CLI extension may be required and that the workflow-inspection command can fail in some environments; emphasized that only Key Vault URLs are exposed and secrets are fetched at runtime.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/184?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->