### PR TITLE
fix(dashboard): clear stale account state on provider switch (#185)

### DIFF
--- a/frontend/src/__tests__/dashboard.test.ts
+++ b/frontend/src/__tests__/dashboard.test.ts
@@ -44,6 +44,7 @@ import { loadSavingsTrendChart, setupSavingsTrendHandlers } from '../dashboard';
 // Mock state module
 jest.mock('../state', () => ({
   getCurrentProvider: jest.fn().mockReturnValue('all'),
+  setCurrentProvider: jest.fn(),
   getCurrentAccountIDs: jest.fn().mockReturnValue([]),
   setCurrentAccountIDs: jest.fn(),
   getSavingsChart: jest.fn().mockReturnValue(null),
@@ -493,6 +494,109 @@ describe('Dashboard Module', () => {
       const call = (api.getSavingsAnalytics as jest.Mock).mock.calls[0]?.[0];
       const span = new Date(call.end).getTime() - new Date(call.start).getTime();
       expect(Math.round(span / 86400_000)).toBe(30);
+    });
+  });
+
+  // Issue #185: provider-change handler must clear state.currentAccountIDs
+  // before loadDashboard reads it, AND must await populateAccountFilter
+  // so the dropdown is in a consistent state with the post-load state.
+  describe('Issue #185: provider switch clears stale account state before reload', () => {
+    let setupDashboardHandlers: typeof import('../dashboard').setupDashboardHandlers;
+
+    beforeEach(async () => {
+      setupDashboardHandlers = (await import('../dashboard')).setupDashboardHandlers;
+      // Build the test DOM via createElement (avoids innerHTML).
+      document.body.replaceChildren();
+      const providerSel = document.createElement('select');
+      providerSel.id = 'dashboard-provider-filter';
+      for (const [v, t] of [['', 'All'], ['aws', 'AWS'], ['azure', 'Azure']] as const) {
+        const opt = document.createElement('option');
+        opt.value = v; opt.textContent = t;
+        providerSel.appendChild(opt);
+      }
+      document.body.appendChild(providerSel);
+      const acctSel = document.createElement('select');
+      acctSel.id = 'dashboard-account-filter';
+      for (const [v, t] of [['', '(All accounts)'], ['aws-acct-1', 'aws-acct-1']] as const) {
+        const opt = document.createElement('option');
+        opt.value = v; opt.textContent = t;
+        acctSel.appendChild(opt);
+      }
+      document.body.appendChild(acctSel);
+      const summaryDiv = document.createElement('div');
+      summaryDiv.id = 'summary';
+      document.body.appendChild(summaryDiv);
+      const upcomingDiv = document.createElement('div');
+      upcomingDiv.id = 'upcoming-list';
+      document.body.appendChild(upcomingDiv);
+      const canvas = document.createElement('canvas');
+      canvas.id = 'savings-chart';
+      document.body.appendChild(canvas);
+
+      // Pre-load with an AWS account selected so we can prove the
+      // handler clears it.
+      (state.getCurrentProvider as jest.Mock).mockReturnValue('aws');
+      (state.getCurrentAccountIDs as jest.Mock).mockReturnValue(['aws-acct-1']);
+      (api.getDashboardSummary as jest.Mock).mockResolvedValue({
+        potential_monthly_savings: 0, total_recommendations: 0, active_commitments: 0,
+        committed_monthly: 0, current_coverage: 0, target_coverage: 0, ytd_savings: 0,
+        by_service: {}
+      });
+      (api.getUpcomingPurchases as jest.Mock).mockResolvedValue({ purchases: [] });
+    });
+
+    test('switching provider clears state.currentAccountIDs and dispatches loadDashboard', async () => {
+      setupDashboardHandlers();
+      const providerSel = document.getElementById('dashboard-provider-filter') as HTMLSelectElement;
+      providerSel.value = 'azure';
+      providerSel.dispatchEvent(new Event('change'));
+
+      // Wait for the async handler chain to settle.
+      await new Promise(r => setTimeout(r, 0));
+      await new Promise(r => setTimeout(r, 0));
+
+      expect(state.setCurrentProvider).toHaveBeenCalledWith('azure');
+      // setCurrentAccountIDs([]) must be called so loadDashboard reads
+      // a clean state.
+      const clearCalls = (state.setCurrentAccountIDs as jest.Mock).mock.calls;
+      expect(clearCalls.some((c: unknown[]) => Array.isArray(c[0]) && (c[0] as unknown[]).length === 0)).toBe(true);
+      // The dashboard summary call must run AFTER the clear.
+      expect(api.getDashboardSummary).toHaveBeenCalled();
+    });
+
+    test('switching provider awaits populateAccountFilter before reloading the dashboard', async () => {
+      let resolvePopulate: (() => void) | undefined;
+      const populateBlocker = new Promise<void>((resolve) => { resolvePopulate = resolve; });
+      const utils = await import('../utils');
+      // setupDashboardHandlers runs an init populateAccountFilter call
+      // before any user interaction — let that one resolve immediately,
+      // and only block the second call (the provider-change one).
+      (utils.populateAccountFilter as jest.Mock)
+        .mockImplementationOnce(() => Promise.resolve())
+        .mockImplementationOnce(() => populateBlocker);
+
+      setupDashboardHandlers();
+      // Yield so the init populate + setupSavingsTrendHandlers settle
+      // (they don't call getDashboardSummary, so the assertion below
+      // is sound).
+      await new Promise(r => setTimeout(r, 0));
+      const providerSel = document.getElementById('dashboard-provider-filter') as HTMLSelectElement;
+      providerSel.value = 'azure';
+      providerSel.dispatchEvent(new Event('change'));
+
+      // Yield once — populateAccountFilter is pending; getDashboardSummary
+      // must NOT have fired yet.
+      await new Promise(r => setTimeout(r, 0));
+      const callsBefore = (api.getDashboardSummary as jest.Mock).mock.calls.length;
+      expect(callsBefore).toBe(0);
+
+      // Resolve populate; loadDashboard runs after.
+      resolvePopulate!();
+      await new Promise(r => setTimeout(r, 0));
+      await new Promise(r => setTimeout(r, 0));
+
+      const callsAfter = (api.getDashboardSummary as jest.Mock).mock.calls.length;
+      expect(callsAfter).toBeGreaterThan(0);
     });
   });
 });

--- a/frontend/src/dashboard.ts
+++ b/frontend/src/dashboard.ts
@@ -29,10 +29,32 @@ export function setupDashboardHandlers(): void {
     // Set initial value from state
     providerFilter.value = state.getCurrentProvider();
 
+    // Issue #185: previously this handler fired populateAccountFilter
+    // and loadDashboard in parallel via two `void` calls. loadDashboard
+    // ran first, reading stale `state.currentAccountIDs` from the
+    // prior provider — so the dashboard rendered with the wrong
+    // account filter. Worse, populateAccountFilter restores
+    // `select.value = current` after repopulating; if the previously-
+    // picked account isn't in the new provider's account list, the
+    // dropdown silently goes empty (programmatic value change → no
+    // `change` event fires) and state never resyncs. The fix:
+    //   (a) clear the account selection in state synchronously so any
+    //       in-flight read sees the cleared value,
+    //   (b) await populateAccountFilter so loadDashboard sees a
+    //       fully-populated dropdown,
+    //   (c) explicitly reset the dropdown's display value to "(All
+    //       accounts)" — no account from the previous provider can
+    //       ever be valid here.
     providerFilter.addEventListener('change', () => {
-      state.setCurrentProvider(providerFilter.value as '' | 'aws' | 'azure' | 'gcp');
-      void populateAccountFilter('dashboard-account-filter', api.listAccounts, providerFilter.value);
-      void loadDashboard();
+      void (async (): Promise<void> => {
+        const newProvider = providerFilter.value as '' | 'aws' | 'azure' | 'gcp';
+        state.setCurrentProvider(newProvider);
+        state.setCurrentAccountIDs([]);
+        await populateAccountFilter('dashboard-account-filter', api.listAccounts, newProvider);
+        const accountSel = document.getElementById('dashboard-account-filter') as HTMLSelectElement | null;
+        if (accountSel) accountSel.value = '';
+        await loadDashboard();
+      })();
     });
   }
 


### PR DESCRIPTION
## Summary

Closes #185. Fix dashboard account-dropdown refresh bug.

The provider-filter `change` handler fired `populateAccountFilter()` and `loadDashboard()` in parallel via two `void` calls. loadDashboard ran FIRST, reading stale `state.currentAccountIDs` (still pointing to an account from the old provider) — so the dashboard refreshed with the wrong account filter. After the silent populateAccountFilter completed, `select.value = current` would either restore the old account if its ID happened to exist in the new provider's list (rare) or silently set the dropdown to empty. Either way no `change` event fires from the programmatic value-set, so state never resyncs.

## What changed

- Wrap the handler in an async IIFE so steps run sequentially.
- Clear `state.currentAccountIDs` to `[]` immediately on provider change (any in-flight read sees the cleared value, and "switch provider" reasonably means "show all accounts of new provider").
- Await `populateAccountFilter` so loadDashboard sees a fully-populated dropdown.
- Set the dropdown's display value to `''` for visual sync — no account from the previous provider is valid here.

The `accountFilter` change handler is unchanged — it was already correct; the bug was only in the provider-change path.

## Tests

2 new tests in `dashboard.test.ts`:
- `switching provider clears state.currentAccountIDs and dispatches loadDashboard` — pins the state-clear behaviour.
- `switching provider awaits populateAccountFilter before reloading the dashboard` — uses an unresolved Promise to gate populateAccountFilter and asserts that `getDashboardSummary` doesn't fire until populate resolves.

All 1358 frontend tests pass.

## Relation to #186

This is the Dashboard slice of the umbrella feature in #186 (consistent provider+account filtering across all 5 main tabs). Other tabs' analogous fixes will land separately.

## Test plan

- [ ] CI green
- [ ] CodeRabbit review clean
- [ ] Manual: pick AWS account on Dashboard, switch provider to Azure → tiles refresh with no account filter, no stale AWS account showing in URL or state.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the dashboard provider filter to properly refresh account selections in the correct sequence when switching providers.
  * Ensured that account data is cleared and reloaded before loading the dashboard, preventing stale information from appearing when switching providers.
  * Improved reliability of provider switching to maintain consistent state between the provider filter and account selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->