### PR TITLE
feat(recommendations): per-account service override pre-populated at purchase time (#111, ii+iii)

### DIFF
--- a/frontend/src/__tests__/recommendations.test.ts
+++ b/frontend/src/__tests__/recommendations.test.ts
@@ -7,7 +7,13 @@ import { loadRecommendations, openPurchaseModal, refreshRecommendations, setupRe
 jest.mock('../api', () => ({
   getRecommendations: jest.fn(),
   refreshRecommendations: jest.fn(),
-  listAccounts: jest.fn().mockResolvedValue([])
+  listAccounts: jest.fn().mockResolvedValue([]),
+  // Issue #111: openFanOutModal now pre-fetches per-account service
+  // overrides to seed each bucket's Payment default. Default-empty so
+  // pre-#111 tests retain their toolbar-seeded behavior without any
+  // mock setup; tests that specifically exercise the override seed
+  // override this mock per-test.
+  listAccountServiceOverrides: jest.fn().mockResolvedValue([]),
 }));
 
 // Mock the per-id detail endpoint module so the drawer-fetch tests can
@@ -1311,6 +1317,11 @@ describe('Bundle B: term-aware bucketing in the Purchase flow', () => {
     await loadRecommendations();
     const purchaseBtn = document.getElementById('bulk-purchase-btn') as HTMLButtonElement;
     purchaseBtn.click();
+    // openFanOutModal is async (issue #111: pre-fetches per-account
+    // overrides). Yield twice so the awaits inside resolve before
+    // we read getFanOutBuckets().
+    await Promise.resolve();
+    await Promise.resolve();
 
     const { getFanOutBuckets } = await import('../recommendations');
     const buckets = getFanOutBuckets();
@@ -1322,5 +1333,195 @@ describe('Bundle B: term-aware bucketing in the Purchase flow', () => {
     const b1 = buckets![1]!;
     expect(b0.recs.every((r) => r.term === b0.term)).toBe(true);
     expect(b1.recs.every((r) => r.term === b1.term)).toBe(true);
+  });
+});
+
+// Issue #111: per-bucket Payment dropdown in the fan-out modal,
+// seeded from the per-account service override when all recs in a
+// bucket share one cloud_account_id and that account has a saved
+// override matching the bucket's (provider, service). Otherwise
+// (multi-account, no override, override has no payment, override
+// payment unsupported by the (provider, service, term) cell) the
+// bucket falls back to the toolbar payment.
+describe('Issue #111: per-bucket Payment seed from per-account service override', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+    const recsTab = document.createElement('div');
+    recsTab.id = 'recommendations-tab';
+    recsTab.className = 'tab-content active';
+    const summary = document.createElement('div');
+    summary.id = 'recommendations-summary';
+    const list = document.createElement('div');
+    list.id = 'recommendations-list';
+    recsTab.appendChild(summary);
+    recsTab.appendChild(list);
+    document.body.appendChild(recsTab);
+    const purchaseModal = document.createElement('div');
+    purchaseModal.id = 'purchase-modal';
+    purchaseModal.className = 'hidden';
+    const purchaseDetails = document.createElement('div');
+    purchaseDetails.id = 'purchase-details';
+    purchaseModal.appendChild(purchaseDetails);
+    document.body.appendChild(purchaseModal);
+    jest.clearAllMocks();
+    // Default: empty overrides — overridden per-test.
+    (api.listAccountServiceOverrides as jest.Mock).mockResolvedValue([]);
+  });
+
+  // Force a multi-bucket fan-out by mixing terms (1yr + 3yr both
+  // present); this drives openFanOutModal rather than the
+  // single-bucket happy path. Each test seeds overrides differently
+  // to exercise the (override / no-override / multi-account / edit)
+  // matrix.
+  const setupMixedTermRecs = (recs: Array<Record<string, unknown>>): void => {
+    (api.getRecommendations as jest.Mock).mockResolvedValue({ summary: {}, recommendations: recs, regions: [] });
+    (state.getRecommendations as jest.Mock).mockReturnValue(recs);
+    (state.getVisibleRecommendations as jest.Mock).mockReturnValue(recs);
+    (state.getRecommendationsColumnFilters as jest.Mock).mockReturnValue({});
+    (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set());
+  };
+
+  test('(a) single-account bucket with matching override → bucket payment seeded from override', async () => {
+    const recs = [
+      { id: 'a', provider: 'aws', cloud_account_id: 'test-account-a', service: 'ec2', resource_type: 't3.medium', region: 'us-east-1', count: 1, term: 1, savings: 100, upfront_cost: 500 },
+      { id: 'b', provider: 'aws', cloud_account_id: 'test-account-a', service: 'ec2', resource_type: 't3.medium', region: 'us-east-1', count: 1, term: 3, savings: 200, upfront_cost: 800 },
+    ];
+    setupMixedTermRecs(recs);
+    // Override pins payment=partial-upfront for AWS EC2 on this
+    // account. partial-upfront is supported for both 1yr and 3yr.
+    (api.listAccountServiceOverrides as jest.Mock).mockImplementation(async (id: string) => {
+      if (id === 'test-account-a') {
+        return [{ id: 'ovr-1', account_id: 'test-account-a', provider: 'aws', service: 'ec2', payment: 'partial-upfront' }];
+      }
+      return [];
+    });
+
+    await loadRecommendations();
+    (document.getElementById('bulk-purchase-btn') as HTMLButtonElement).click();
+    await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+
+    const { getFanOutBuckets } = await import('../recommendations');
+    const buckets = getFanOutBuckets();
+    expect(buckets).not.toBeNull();
+    expect(buckets!.length).toBe(2);
+    for (const b of buckets!) {
+      expect(b.payment).toBe('partial-upfront');
+      expect(b.paymentSource).toBe('override');
+    }
+    // Source-note span renders.
+    const noteSpans = document.querySelectorAll('.fanout-bucket-payment-source');
+    expect(noteSpans.length).toBe(2);
+    expect((noteSpans[0] as HTMLElement).textContent).toContain('account override');
+    // Dropdown's selected value matches.
+    const selects = document.querySelectorAll<HTMLSelectElement>('.fanout-bucket-payment');
+    expect(selects.length).toBe(2);
+    expect(selects[0]!.value).toBe('partial-upfront');
+  });
+
+  test('(b) single-account bucket with NO matching override → bucket payment seeded from toolbar', async () => {
+    const recs = [
+      { id: 'a', provider: 'aws', cloud_account_id: 'test-account-a', service: 'ec2', resource_type: 't3.medium', region: 'us-east-1', count: 1, term: 1, savings: 100, upfront_cost: 500 },
+      { id: 'b', provider: 'aws', cloud_account_id: 'test-account-a', service: 'ec2', resource_type: 't3.medium', region: 'us-east-1', count: 1, term: 3, savings: 200, upfront_cost: 800 },
+    ];
+    setupMixedTermRecs(recs);
+    // Account exists but has overrides for a DIFFERENT service — the
+    // ec2 lookup should miss and fall back.
+    (api.listAccountServiceOverrides as jest.Mock).mockImplementation(async (id: string) => {
+      if (id === 'test-account-a') {
+        return [{ id: 'ovr-1', account_id: 'test-account-a', provider: 'aws', service: 'rds', payment: 'no-upfront' }];
+      }
+      return [];
+    });
+
+    await loadRecommendations();
+    (document.getElementById('bulk-purchase-btn') as HTMLButtonElement).click();
+    await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+
+    const { getFanOutBuckets } = await import('../recommendations');
+    const buckets = getFanOutBuckets();
+    expect(buckets).not.toBeNull();
+    for (const b of buckets!) {
+      // Toolbar default is 'all-upfront' (loadBulkPurchaseState's
+      // defaultBulkPurchaseState).
+      expect(b.payment).toBe('all-upfront');
+      expect(b.paymentSource).toBe('toolbar');
+    }
+    // No source-note rendered.
+    expect(document.querySelectorAll('.fanout-bucket-payment-source').length).toBe(0);
+  });
+
+  test('(c) multi-account bucket → bucket payment seeded from toolbar regardless of any override', async () => {
+    // Two recs, same (provider, service, term) — bucket-key match —
+    // but different cloud_account_ids. resolveBucketPaymentSeed must
+    // return toolbar (the documented multi-account fallback).
+    // Pair with a third 3yr rec to force multi-bucket fan-out.
+    const recs = [
+      { id: 'a', provider: 'aws', cloud_account_id: 'test-account-a', service: 'ec2', resource_type: 't3.medium', region: 'us-east-1', count: 1, term: 1, savings: 100, upfront_cost: 500 },
+      { id: 'b', provider: 'aws', cloud_account_id: 'test-account-b', service: 'ec2', resource_type: 't3.medium', region: 'us-east-1', count: 1, term: 1, savings: 150, upfront_cost: 600 },
+      { id: 'c', provider: 'aws', cloud_account_id: 'test-account-a', service: 'ec2', resource_type: 't3.medium', region: 'us-east-1', count: 1, term: 3, savings: 200, upfront_cost: 800 },
+    ];
+    setupMixedTermRecs(recs);
+    // Both accounts have ec2 overrides — the multi-account bucket
+    // must NOT pick either; only the single-account 3yr bucket may
+    // honour the override.
+    (api.listAccountServiceOverrides as jest.Mock).mockImplementation(async (id: string) => {
+      if (id === 'test-account-a') return [{ id: 'ovr-a', account_id: 'test-account-a', provider: 'aws', service: 'ec2', payment: 'partial-upfront' }];
+      if (id === 'test-account-b') return [{ id: 'ovr-b', account_id: 'test-account-b', provider: 'aws', service: 'ec2', payment: 'no-upfront' }];
+      return [];
+    });
+
+    await loadRecommendations();
+    (document.getElementById('bulk-purchase-btn') as HTMLButtonElement).click();
+    await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+
+    const { getFanOutBuckets } = await import('../recommendations');
+    const buckets = getFanOutBuckets();
+    expect(buckets).not.toBeNull();
+    expect(buckets!.length).toBe(2);
+    const bucket1yr = buckets!.find((b) => b.term === 1)!;
+    const bucket3yr = buckets!.find((b) => b.term === 3)!;
+    // 1yr bucket: 2 recs, 2 distinct accounts → toolbar.
+    expect(bucket1yr.recs.length).toBe(2);
+    expect(bucket1yr.payment).toBe('all-upfront');
+    expect(bucket1yr.paymentSource).toBe('toolbar');
+    // 3yr bucket: 1 rec, single account a → override honoured.
+    expect(bucket3yr.recs.length).toBe(1);
+    expect(bucket3yr.payment).toBe('partial-upfront');
+    expect(bucket3yr.paymentSource).toBe('override');
+  });
+
+  test('(d) user-edited Payment dropdown is reflected in module state', async () => {
+    const recs = [
+      { id: 'a', provider: 'aws', cloud_account_id: 'test-account-a', service: 'ec2', resource_type: 't3.medium', region: 'us-east-1', count: 1, term: 1, savings: 100, upfront_cost: 500 },
+      { id: 'b', provider: 'aws', cloud_account_id: 'test-account-a', service: 'ec2', resource_type: 't3.medium', region: 'us-east-1', count: 1, term: 3, savings: 200, upfront_cost: 800 },
+    ];
+    setupMixedTermRecs(recs);
+
+    await loadRecommendations();
+    (document.getElementById('bulk-purchase-btn') as HTMLButtonElement).click();
+    await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+
+    const { getFanOutBuckets } = await import('../recommendations');
+    const before = getFanOutBuckets();
+    expect(before).not.toBeNull();
+    expect(before![0]!.payment).toBe('all-upfront');
+
+    // Pick the dropdown for the 1yr bucket and switch to no-upfront
+    // (a supported value for AWS EC2 1yr).
+    const selects = Array.from(document.querySelectorAll<HTMLSelectElement>('.fanout-bucket-payment'));
+    expect(selects.length).toBe(2);
+    const firstSel = selects[0]!;
+    firstSel.value = 'no-upfront';
+    firstSel.dispatchEvent(new Event('change'));
+
+    const after = getFanOutBuckets();
+    expect(after).not.toBeNull();
+    // The bucket whose dropdown we changed now reports 'no-upfront'.
+    // We don't rely on bucket[0] vs bucket[1] order; pick by recs
+    // identity to find which bucket the first select belonged to.
+    const firstBucketIdx = before!.findIndex((b) => b.recs[0]?.id === recs[0]!.id || b.recs[0]?.id === recs[1]!.id);
+    expect(firstBucketIdx).toBeGreaterThanOrEqual(0);
+    // At least one bucket payment must now be 'no-upfront'.
+    expect(after!.some((b) => b.payment === 'no-upfront')).toBe(true);
   });
 });

--- a/frontend/src/__tests__/recommendations.test.ts
+++ b/frontend/src/__tests__/recommendations.test.ts
@@ -1,7 +1,7 @@
 /**
  * Recommendations module tests
  */
-import { loadRecommendations, openPurchaseModal, refreshRecommendations, setupRecommendationsHandlers, clearRecommendationDetailCache } from '../recommendations';
+import { loadRecommendations, openPurchaseModal, getPurchaseModalRecommendations, refreshRecommendations, setupRecommendationsHandlers, clearRecommendationDetailCache } from '../recommendations';
 
 // Mock the api module
 jest.mock('../api', () => ({
@@ -391,6 +391,9 @@ describe('Recommendations Module', () => {
       const purchaseBtn = document.querySelector('#bulk-purchase-btn') as HTMLButtonElement;
       expect(purchaseBtn).not.toBeNull();
       purchaseBtn.click();
+      // Issue #111 (iii): openPurchaseModal is async; flush microtasks
+      // so the modal-open call lands before we assert visibility.
+      await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
 
       const modal = document.getElementById('purchase-modal');
       expect(modal?.classList.contains('hidden')).toBe(false);
@@ -633,7 +636,10 @@ describe('Recommendations Module', () => {
   });
 
   describe('openPurchaseModal', () => {
-    test('displays purchase modal', () => {
+    // Issue #111 (iii): openPurchaseModal is now async (it pre-fetches
+    // per-account service overrides to seed each row's Payment default).
+    // Tests must `await` it so the DOM is populated before assertions.
+    test('displays purchase modal', async () => {
       const recommendations = [
         { id: 'rec-1', provider: 'aws' as const,
           service: 'ec2',
@@ -646,42 +652,42 @@ describe('Recommendations Module', () => {
         }
       ];
 
-      openPurchaseModal(recommendations);
+      await openPurchaseModal(recommendations);
 
       const modal = document.getElementById('purchase-modal');
       expect(modal?.classList.contains('hidden')).toBe(false);
     });
 
-    test('shows purchase summary', () => {
+    test('shows purchase summary', async () => {
       const recommendations = [
         { id: 'rec-2', provider: 'aws' as const, service: 'ec2', resource_type: 't3.medium', region: 'us-east-1', count: 5, term: 1, savings: 100, upfront_cost: 500 },
         { id: 'rec-3', provider: 'aws' as const, service: 'rds', resource_type: 'db.r5.large', region: 'us-east-1', count: 2, term: 1, savings: 200, upfront_cost: 1000 }
       ];
 
-      openPurchaseModal(recommendations);
+      await openPurchaseModal(recommendations);
 
       const details = document.getElementById('purchase-details');
-      expect(details?.innerHTML).toContain('2'); // count of commitments
-      expect(details?.innerHTML).toContain('Purchase Summary');
+      expect(details?.textContent).toContain('2'); // count of commitments
+      expect(details?.textContent).toContain('Purchase Summary');
     });
 
-    test('lists individual recommendations', () => {
+    test('lists individual recommendations', async () => {
       const recommendations = [
         { id: 'rec-4', provider: 'aws' as const, service: 'ec2', resource_type: 't3.medium', region: 'us-east-1', count: 5, term: 1, savings: 100, upfront_cost: 500 }
       ];
 
-      openPurchaseModal(recommendations);
+      await openPurchaseModal(recommendations);
 
       const details = document.getElementById('purchase-details');
-      expect(details?.innerHTML).toContain('ec2');
-      expect(details?.innerHTML).toContain('t3.medium');
-      expect(details?.innerHTML).toContain('us-east-1');
+      expect(details?.textContent).toContain('ec2');
+      expect(details?.textContent).toContain('t3.medium');
+      expect(details?.textContent).toContain('us-east-1');
     });
 
-    test('handles missing modal element', () => {
-      document.body.innerHTML = '';
+    test('handles missing modal element', async () => {
+      document.body.replaceChildren();
 
-      expect(() => openPurchaseModal([])).not.toThrow();
+      await expect(openPurchaseModal([])).resolves.not.toThrow();
     });
   });
 
@@ -1523,5 +1529,170 @@ describe('Issue #111: per-bucket Payment seed from per-account service override'
     expect(firstBucketIdx).toBeGreaterThanOrEqual(0);
     // At least one bucket payment must now be 'no-upfront'.
     expect(after!.some((b) => b.payment === 'no-upfront')).toBe(true);
+  });
+});
+
+// Issue #111 (iii): per-row Payment seed in openPurchaseModal — the
+// single-bucket / single-rec purchase modal renders editable Term and
+// Payment dropdowns. Each row's defaults walk the precedence
+// override → rec.payment → paymentOptionsFor[0]. Edits mutate
+// currentPurchaseRecommendations[idx] in place; getPurchaseModalRecommendations()
+// returns the user's choices; app.ts::handleExecutePurchase posts
+// `r.payment` per rec (no longer hardcoded 'all-upfront').
+describe('Issue #111 (iii): per-row Payment seed in openPurchaseModal', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+    const purchaseModal = document.createElement('div');
+    purchaseModal.id = 'purchase-modal';
+    purchaseModal.className = 'hidden';
+    const purchaseDetails = document.createElement('div');
+    purchaseDetails.id = 'purchase-details';
+    purchaseModal.appendChild(purchaseDetails);
+    document.body.appendChild(purchaseModal);
+    jest.clearAllMocks();
+    (api.listAccountServiceOverrides as jest.Mock).mockResolvedValue([]);
+  });
+
+  test('(a) single rec with matching override → row Payment seeded from override; source-note rendered', async () => {
+    (api.listAccountServiceOverrides as jest.Mock).mockImplementation(async (id: string) => {
+      if (id === 'test-account-a') {
+        return [{ id: 'ovr-1', account_id: 'test-account-a', provider: 'aws', service: 'ec2', payment: 'partial-upfront' }];
+      }
+      return [];
+    });
+
+    const rec = {
+      id: 'rec-1', provider: 'aws' as const, cloud_account_id: 'test-account-a',
+      service: 'ec2', resource_type: 't3.medium', region: 'us-east-1',
+      count: 5, term: 1, payment: 'all-upfront', savings: 100, upfront_cost: 500,
+    };
+
+    await openPurchaseModal([rec]);
+
+    const live = getPurchaseModalRecommendations();
+    expect(live).toHaveLength(1);
+    expect(live[0]!.payment).toBe('partial-upfront');
+
+    const select = document.querySelector<HTMLSelectElement>('.purchase-row-payment');
+    expect(select).not.toBeNull();
+    expect(select!.value).toBe('partial-upfront');
+
+    const note = document.querySelector<HTMLElement>('.purchase-row-payment-source');
+    expect(note).not.toBeNull();
+    expect(note!.textContent).toContain('account override');
+  });
+
+  test('(b) single rec with NO matching override → row Payment seeded from rec.payment; no source-note', async () => {
+    // Override exists but for a different service — the lookup misses
+    // and the rec's own payment ('partial-upfront') wins.
+    (api.listAccountServiceOverrides as jest.Mock).mockImplementation(async (id: string) => {
+      if (id === 'test-account-a') {
+        return [{ id: 'ovr-1', account_id: 'test-account-a', provider: 'aws', service: 'rds', payment: 'no-upfront' }];
+      }
+      return [];
+    });
+
+    const rec = {
+      id: 'rec-2', provider: 'aws' as const, cloud_account_id: 'test-account-a',
+      service: 'ec2', resource_type: 't3.medium', region: 'us-east-1',
+      count: 5, term: 1, payment: 'partial-upfront', savings: 100, upfront_cost: 500,
+    };
+
+    await openPurchaseModal([rec]);
+
+    const live = getPurchaseModalRecommendations();
+    expect(live[0]!.payment).toBe('partial-upfront');
+
+    const select = document.querySelector<HTMLSelectElement>('.purchase-row-payment');
+    expect(select!.value).toBe('partial-upfront');
+
+    const note = document.querySelector('.purchase-row-payment-source');
+    expect(note).toBeNull();
+  });
+
+  test('(c) override has unsupported payment for the (provider,service,term) cell → falls back to rec.payment', async () => {
+    // AWS RDS 3yr does NOT support no-upfront (per
+    // isPaymentSupported / cmd/validators.go:warnRDS3YearNoUpfront).
+    // The override pins no-upfront → must be ignored; rec.payment wins.
+    (api.listAccountServiceOverrides as jest.Mock).mockImplementation(async (id: string) => {
+      if (id === 'test-account-a') {
+        return [{ id: 'ovr-1', account_id: 'test-account-a', provider: 'aws', service: 'rds', payment: 'no-upfront' }];
+      }
+      return [];
+    });
+
+    const rec = {
+      id: 'rec-3', provider: 'aws' as const, cloud_account_id: 'test-account-a',
+      service: 'rds', resource_type: 'db.r5.large', region: 'us-east-1',
+      count: 1, term: 3, payment: 'all-upfront', savings: 200, upfront_cost: 1000,
+    };
+
+    await openPurchaseModal([rec]);
+
+    const live = getPurchaseModalRecommendations();
+    expect(live[0]!.payment).toBe('all-upfront');
+
+    const note = document.querySelector('.purchase-row-payment-source');
+    expect(note).toBeNull();
+  });
+
+  test('(d) user changes Term 1→3 → row Payment options rebuilt; live state still consistent', async () => {
+    const rec = {
+      id: 'rec-4', provider: 'aws' as const, cloud_account_id: 'test-account-a',
+      service: 'ec2', resource_type: 't3.medium', region: 'us-east-1',
+      count: 5, term: 1, payment: 'all-upfront', savings: 100, upfront_cost: 500,
+    };
+
+    await openPurchaseModal([rec]);
+
+    const termSelect = document.querySelector<HTMLSelectElement>('.purchase-row-term');
+    const paymentSelect = document.querySelector<HTMLSelectElement>('.purchase-row-payment');
+    expect(termSelect).not.toBeNull();
+    expect(paymentSelect).not.toBeNull();
+
+    // Switch term to 3yr.
+    termSelect!.value = '3';
+    termSelect!.dispatchEvent(new Event('change'));
+
+    const live = getPurchaseModalRecommendations();
+    expect(live[0]!.term).toBe(3);
+    // Payment is set to a value supported for AWS EC2 3yr — the
+    // exact value depends on whether 'all-upfront' (the prior value)
+    // remained valid for the new term; we only require that:
+    //   (i) live.payment is non-empty
+    //   (ii) live.payment matches the dropdown's current value
+    //   (iii) the dropdown's options are now the 3yr-supported set.
+    expect(live[0]!.payment).toBeTruthy();
+    expect(paymentSelect!.value).toBe(live[0]!.payment);
+    const options = Array.from(paymentSelect!.options).map((o) => o.value);
+    expect(options.length).toBeGreaterThan(0);
+  });
+
+  test('(e) user changes Payment dropdown → live state reflects new value (and would round-trip via handleExecutePurchase)', async () => {
+    const rec = {
+      id: 'rec-5', provider: 'aws' as const, cloud_account_id: 'test-account-a',
+      service: 'ec2', resource_type: 't3.medium', region: 'us-east-1',
+      count: 5, term: 1, payment: 'all-upfront', savings: 100, upfront_cost: 500,
+    };
+
+    await openPurchaseModal([rec]);
+
+    const paymentSelect = document.querySelector<HTMLSelectElement>('.purchase-row-payment');
+    expect(paymentSelect).not.toBeNull();
+
+    // Change to 'no-upfront' (always supported for AWS EC2 1yr).
+    paymentSelect!.value = 'no-upfront';
+    paymentSelect!.dispatchEvent(new Event('change'));
+
+    const live = getPurchaseModalRecommendations();
+    expect(live[0]!.payment).toBe('no-upfront');
+
+    // The mapping in app.ts::handleExecutePurchase reads this value
+    // verbatim (`payment: r.payment ?? 'all-upfront'`), so a downstream
+    // assertion that the API call carries 'no-upfront' is implicit in
+    // (a) the live state above and (b) the source-of-truth read at
+    // app.ts:289-303. No separate mock-call assertion needed here —
+    // the integration of that mapping is exercised by app.ts'
+    // existing handleExecutePurchase tests.
   });
 });

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -286,6 +286,12 @@ async function handleExecutePurchase(): Promise<void> {
   // Map LocalRecommendation to API Recommendation format. The counts +
   // costs here are already scaled by the bulk-toolbar's capacity % so
   // the backend records exactly what the user saw in the preview.
+  // Issue #111 (iii): payment now reads `r.payment` (set by
+  // `openPurchaseModal`'s per-row seed and live edits), replacing the
+  // historical hardcoded 'all-upfront' that silently dropped the
+  // toolbar's Payment for the single-bucket path. The `?? 'all-upfront'`
+  // is defensive only — direct test-harness callers that bypass the
+  // modal may not set `payment`; the production path always does.
   const apiRecs: api.Recommendation[] = localRecs.map((r) => ({
     id: r.id,
     provider: r.provider,
@@ -294,7 +300,7 @@ async function handleExecutePurchase(): Promise<void> {
     resource_type: r.resource_type,
     count: r.count,
     term: r.term,
-    payment: 'all-upfront',
+    payment: r.payment ?? 'all-upfront',
     upfront_cost: r.upfront_cost,
     monthly_cost: r.monthly_cost ?? 0,
     savings: r.savings,

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -8,7 +8,8 @@ import { formatCurrency, formatTerm, escapeHtml } from './utils';
 import { renderFreshness } from './freshness';
 import { getRecommendationDetail, type RecommendationDetail } from './api/recommendations';
 import { showToast } from './toast';
-import { isPaymentSupported, type Provider as CompatProvider } from './lib/purchase-compatibility';
+import { isPaymentSupported, paymentOptionsFor, type Provider as CompatProvider, type Payment as CompatPayment } from './lib/purchase-compatibility';
+import type { AccountServiceOverride } from './api/accounts';
 import type { RecommendationsResponse, LocalRecommendation, RecommendationsSummary } from './types';
 import { openModal } from './modal';
 
@@ -1398,7 +1399,11 @@ function handleBulkPurchaseClick(recommendations: LocalRecommendation[]): void {
     // Multi-bucket / incompatible path: open the fan-out modal so the
     // user can review per-bucket details before submitting one
     // executePurchase call per bucket in parallel.
-    openFanOutModal(bucketEntries, tb);
+    // openFanOutModal is async (issue #111: it pre-fetches per-account
+    // service overrides to seed each bucket's Payment default); the
+    // returned promise is fire-and-forget — the modal is the surface
+    // the user interacts with.
+    void openFanOutModal(bucketEntries, tb);
     return;
   }
 
@@ -1411,6 +1416,23 @@ function handleBulkPurchaseClick(recommendations: LocalRecommendation[]): void {
 // FanOutBucket groups one batch of recs under a single (provider,
 // service, term, payment, capacity) choice. A multi-bucket Purchase
 // fires one executePurchase POST per bucket.
+//
+// `paymentSource` (issue #111) records WHERE this bucket's payment
+// default came from:
+//   - 'override': all recs share one cloud_account_id, that account
+//     has an AccountServiceOverride matching the bucket's
+//     (provider, service), and the override's payment is supported by
+//     the (provider, service, term) cell. The bucket section renders
+//     a small "(from account override)" note next to the Payment
+//     dropdown.
+//   - 'toolbar': fallback — multi-account bucket, no override, override
+//     has no payment, or the override's payment is unsupported for
+//     this cell. Bucket inherits the bulk-toolbar Payment, today's
+//     pre-#111 behavior.
+//
+// The user can change the per-bucket Payment via the dropdown
+// rendered in the modal; the `change` handler updates `payment` (and
+// keeps `paymentSource` so the source note doesn't lie about origin).
 export interface FanOutBucket {
   provider: CompatProvider;
   service: string;
@@ -1418,6 +1440,7 @@ export interface FanOutBucket {
   payment: 'all-upfront' | 'partial-upfront' | 'no-upfront' | 'monthly';
   capacityPercent: number;
   recs: LocalRecommendation[]; // scaled by capacityPercent
+  paymentSource: 'override' | 'toolbar';
 }
 
 // Fan-out modal state. app.ts's Execute Purchase click reads these
@@ -1433,14 +1456,112 @@ export function clearFanOutBuckets(): void {
   currentFanOutBuckets = null;
 }
 
-function openFanOutModal(
+// resolveBucketPaymentSeed picks the default Payment value for a
+// bucket per issue #111 sub-option (ii):
+//   - When all recs in the bucket share one non-empty cloud_account_id
+//     AND that account has a saved AccountServiceOverride matching
+//     `(provider, recs[0].service)` AND the override's `payment` is a
+//     non-empty value supported by the (provider, service, term) cell:
+//     seed from override.
+//   - Otherwise: seed from the toolbar payment (today's behavior).
+//
+// IMPORTANT: the override-lookup uses `recs[0].service` (the per-rec
+// service slug), NOT `bucket.service`. That's a future-proofing choice
+// for the post-#132 SP-canonical-bucket-key landing in PR #180 — when
+// `bucket.service` becomes the canonical `'savings-plans'` for a
+// mixed-plan-type SP bucket, the override is still keyed on the
+// per-plan-type slug (`savings-plans-compute`, etc.), so this lookup
+// stays correct under either bucket-key encoding.
+//
+// Multi-account fallback: if recs span 2+ distinct cloud_account_id
+// values, no single account's override applies cleanly. Falling back
+// to toolbar avoids surprising the user. TODO(#111-followup): consider
+// per-rec seeding inside a multi-account bucket — would need either
+// per-rec dropdowns or a "split this bucket by account" UX.
+function resolveBucketPaymentSeed(
+  recs: LocalRecommendation[],
+  toolbar: BulkPurchaseToolbarState,
+  overridesByAccount: Map<string, AccountServiceOverride[]>,
+): { payment: BulkPurchaseToolbarState['payment']; source: 'override' | 'toolbar' } {
+  const fallback = { payment: toolbar.payment, source: 'toolbar' as const };
+  if (recs.length === 0) return fallback;
+  const r0 = recs[0]!;
+  const provider = r0.provider as CompatProvider;
+  const term = r0.term as 1 | 3;
+
+  // Single-account check: every rec must carry the same non-empty cloud_account_id.
+  const accountIDs = new Set<string>();
+  for (const r of recs) {
+    if (!r.cloud_account_id) return fallback; // any rec missing an id → toolbar
+    accountIDs.add(r.cloud_account_id);
+  }
+  if (accountIDs.size !== 1) return fallback;
+  const accountID = recs[0]!.cloud_account_id!;
+
+  const overrides = overridesByAccount.get(accountID);
+  if (!overrides) return fallback;
+
+  // Match on the per-rec service (NOT bucket.service) — see the comment
+  // above for the SP-canonical-bucket-key future-proofing rationale.
+  const match = overrides.find(
+    (o) => o.provider === provider && o.service === r0.service,
+  );
+  if (!match || !match.payment) return fallback;
+
+  // Defensive: only honour the override when the (provider, service,
+  // term, payment) combo is actually supported. A stale or hand-saved
+  // override pointing at an unsupported payment for this term shouldn't
+  // poison the dropdown — fall back to toolbar.
+  if (!isPaymentSupported(provider, r0.service, term, match.payment as CompatPayment)) {
+    return fallback;
+  }
+  return {
+    payment: match.payment as BulkPurchaseToolbarState['payment'],
+    source: 'override',
+  };
+}
+
+async function openFanOutModal(
   bucketEntries: Array<[string, LocalRecommendation[]]>,
   toolbar: BulkPurchaseToolbarState,
-): void {
+): Promise<void> {
+  // Pre-fetch service-overrides for every account that's the SOLE
+  // account in any bucket — these are the only buckets eligible for
+  // the override seed (multi-account buckets always fall back to
+  // toolbar). One fetch per distinct accountID; cached for the
+  // lifetime of this openFanOutModal call. Errors are swallowed: the
+  // toolbar-seed fallback always works, so a transient API failure
+  // shouldn't block the modal.
+  const eligibleAccountIDs = new Set<string>();
+  for (const [, recs] of bucketEntries) {
+    if (recs.length === 0) continue;
+    const ids = new Set<string>();
+    for (const r of recs) {
+      if (r.cloud_account_id) ids.add(r.cloud_account_id);
+    }
+    if (ids.size === 1) {
+      const only = recs[0]?.cloud_account_id;
+      if (only) eligibleAccountIDs.add(only);
+    }
+  }
+  const overridesByAccount = new Map<string, AccountServiceOverride[]>();
+  await Promise.all(
+    Array.from(eligibleAccountIDs).map(async (id) => {
+      try {
+        const list = await api.listAccountServiceOverrides(id);
+        overridesByAccount.set(id, list);
+      } catch {
+        // Silent fallback to toolbar seed — a network blip shouldn't
+        // block the user from purchasing.
+      }
+    }),
+  );
+
   const buckets: FanOutBucket[] = bucketEntries
     .filter(([_key, recs]) => recs.length > 0)
     .map(([_key, recs]) => {
       const r = recs[0]!;
+      const seed = resolveBucketPaymentSeed(recs, toolbar, overridesByAccount);
       return {
         provider: r.provider as CompatProvider,
         service: r.service,
@@ -1448,7 +1569,8 @@ function openFanOutModal(
         // the term from the bucket itself rather than from the dropped
         // toolbar override.
         term: r.term as 1 | 3,
-        payment: toolbar.payment,
+        payment: seed.payment,
+        paymentSource: seed.source,
         capacityPercent: toolbar.capacity,
         recs,
       };
@@ -1460,10 +1582,7 @@ function openFanOutModal(
   if (!container || !modal) return;
 
   // Build the modal body via createElement so the innerHTML hook
-  // doesn't flag any template-literal HTML. The bucket summary is
-  // pure data (provider, service, counts, totals) — no edit controls
-  // in this initial drop. A later iteration can add per-bucket
-  // Term/Payment/Capacity edits.
+  // doesn't flag any template-literal HTML.
   while (container.firstChild) container.removeChild(container.firstChild);
 
   const summary = document.createElement('div');
@@ -1521,13 +1640,63 @@ function renderFanOutBucketSection(b: FanOutBucket): HTMLElement {
   title.textContent = `${b.provider.toUpperCase()} / ${b.service} — ${b.recs.length} commitment${b.recs.length === 1 ? '' : 's'}`;
   section.appendChild(title);
 
-  const compat = isPaymentSupported(b.provider, b.service, b.term, b.payment);
   const status = document.createElement('p');
-  status.className = compat ? 'fanout-bucket-ok' : 'fanout-bucket-error';
-  status.textContent = compat
-    ? `${b.capacityPercent}% capacity · ${b.term}yr · ${b.payment}`
-    : `Invalid combo: ${b.provider} / ${b.service} doesn't support ${b.term}yr + ${b.payment}. This bucket will be skipped.`;
+  const renderStatus = (): void => {
+    const compat = isPaymentSupported(b.provider, b.service, b.term, b.payment);
+    status.className = compat ? 'fanout-bucket-ok' : 'fanout-bucket-error';
+    status.textContent = compat
+      ? `${b.capacityPercent}% capacity · ${b.term}yr · ${b.payment}`
+      : `Invalid combo: ${b.provider} / ${b.service} doesn't support ${b.term}yr + ${b.payment}. This bucket will be skipped.`;
+  };
+  renderStatus();
   section.appendChild(status);
+
+  // Issue #111: Per-bucket Payment dropdown. Default-selected =
+  // bucket.payment (seeded by resolveBucketPaymentSeed: override →
+  // toolbar). Options come from paymentOptionsFor, which already
+  // filters to the supported (provider, service, term) Payment values
+  // — so the user can never pick an unsupported combo here. The
+  // change handler updates the bucket's payment in module state
+  // (`currentFanOutBuckets`) so getFanOutBuckets() returns the
+  // user's choice and handleFanOutExecute (in app.ts) reads the
+  // right value per POST.
+  const paymentRow = document.createElement('div');
+  paymentRow.className = 'fanout-bucket-payment-row';
+  const paymentLabel = document.createElement('label');
+  paymentLabel.className = 'fanout-bucket-payment-label';
+  paymentLabel.appendChild(document.createTextNode('Payment: '));
+  const paymentSelect = document.createElement('select');
+  paymentSelect.className = 'fanout-bucket-payment';
+  for (const opt of paymentOptionsFor(b.provider, b.service, b.term)) {
+    const option = document.createElement('option');
+    option.value = opt;
+    option.textContent = opt;
+    if (opt === b.payment) option.selected = true;
+    paymentSelect.appendChild(option);
+  }
+  paymentSelect.addEventListener('change', () => {
+    const next = paymentSelect.value as FanOutBucket['payment'];
+    // Find this bucket in module state by reference equality on the
+    // recs array (the recs array is preserved across the b ↔
+    // currentFanOutBuckets[i] mapping; identity comparison is safe).
+    if (currentFanOutBuckets) {
+      const idx = currentFanOutBuckets.findIndex((cb) => cb.recs === b.recs);
+      if (idx >= 0) {
+        currentFanOutBuckets[idx]!.payment = next;
+      }
+    }
+    b.payment = next;
+    renderStatus();
+  });
+  paymentLabel.appendChild(paymentSelect);
+  paymentRow.appendChild(paymentLabel);
+  if (b.paymentSource === 'override') {
+    const sourceNote = document.createElement('span');
+    sourceNote.className = 'fanout-bucket-payment-source';
+    sourceNote.textContent = ' (from account override)';
+    paymentRow.appendChild(sourceNote);
+  }
+  section.appendChild(paymentRow);
 
   const bucketTotal = b.recs.reduce(
     (acc, r) => ({

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -1410,7 +1410,9 @@ function handleBulkPurchaseClick(recommendations: LocalRecommendation[]): void {
   // Single-bucket happy path: open the preview modal + submit via the
   // existing execute-purchase flow. The modal's "Execute Purchase" button
   // (wired in app.ts) picks up the recs via getPurchaseModalRecommendations.
-  openPurchaseModal(scaled);
+  // openPurchaseModal is async (issue #111 (iii): per-rec override
+  // prefetch); fire-and-forget — the modal is the user's surface.
+  void openPurchaseModal(scaled);
 }
 
 // FanOutBucket groups one batch of recs under a single (provider,
@@ -1837,47 +1839,297 @@ function renderRecommendationsList(loadedRecs: LocalRecommendation[]): void {
   });
 }
 
+// resolvePerRecPaymentSeed picks the default Payment value for one rec
+// in the per-row purchase modal (issue #111 sub-option (iii)). The
+// precedence:
+//   1. Account override: rec carries a non-empty cloud_account_id, that
+//      account has an AccountServiceOverride matching
+//      `(rec.provider, rec.service)`, the override's `payment` is
+//      non-empty, AND `(provider, service, term, payment)` is supported
+//      by isPaymentSupported. → seed from override; the row's source-
+//      note span renders "(from account override)".
+//   2. Rec's own payment: the API stamps payment at collection time;
+//      use it if non-empty AND supported for `(provider, service, term)`.
+//   3. paymentOptionsFor(provider, service, term)[0]: defensive fallback
+//      for malformed test fixtures or pre-#111 cached responses where
+//      the rec lacks a payment. paymentOptionsFor returns at least one
+//      option for every provider/service the recommendations engine
+//      generates rows for.
+//
+// NOTE: this helper duplicates the override-fetch shape from
+// resolveBucketPaymentSeed (per-bucket, used by the fan-out modal). The
+// two are kept separate by deliberate scope discipline; a follow-up
+// issue will consolidate them into a single
+// `frontend/src/lib/overrides.ts` helper once both surfaces have shipped.
+function resolvePerRecPaymentSeed(
+  rec: LocalRecommendation,
+  overridesByAccount: Map<string, AccountServiceOverride[]>,
+): { payment: CompatPayment; source: 'override' | 'rec' | 'fallback' } {
+  const provider = rec.provider as CompatProvider;
+  const term = rec.term as 1 | 3;
+
+  if (rec.cloud_account_id) {
+    const overrides = overridesByAccount.get(rec.cloud_account_id);
+    if (overrides) {
+      const match = overrides.find(
+        (o) => o.provider === provider && o.service === rec.service,
+      );
+      if (
+        match
+        && match.payment
+        && isPaymentSupported(provider, rec.service, term, match.payment as CompatPayment)
+      ) {
+        return { payment: match.payment as CompatPayment, source: 'override' };
+      }
+    }
+  }
+
+  if (rec.payment && isPaymentSupported(provider, rec.service, term, rec.payment as CompatPayment)) {
+    return { payment: rec.payment as CompatPayment, source: 'rec' };
+  }
+
+  // Defensive fallback: rec is missing/has-unsupported payment AND no
+  // matching override. paymentOptionsFor always returns at least one
+  // option for the (provider, service, term) cells the engine emits.
+  const options = paymentOptionsFor(provider, rec.service, term);
+  return { payment: (options[0] ?? 'all-upfront') as CompatPayment, source: 'fallback' };
+}
+
 /**
- * Open purchase modal
+ * Open the single-bucket purchase modal with editable per-row Term and
+ * Payment dropdowns (issue #111 sub-option (iii)).
+ *
+ * Defaults are seeded by resolvePerRecPaymentSeed:
+ *   override → rec's own payment → paymentOptionsFor[0] fallback.
+ *
+ * On change, handlers mutate `currentPurchaseRecommendations[idx]` in
+ * place so `getPurchaseModalRecommendations()` returns the user's
+ * edits, and `app.ts::handleExecutePurchase` posts those values per row
+ * (replacing the historical hardcoded `'all-upfront'` on that path).
+ *
+ * Async because it pre-fetches per-account overrides — same pattern as
+ * `openFanOutModal`. Errors swallowed: the rec-payment fallback always
+ * works, so a transient API blip shouldn't block the modal.
  */
-export function openPurchaseModal(recommendations: LocalRecommendation[]): void {
+export async function openPurchaseModal(recommendations: LocalRecommendation[]): Promise<void> {
   currentPurchaseRecommendations = [...recommendations];
   const container = document.getElementById('purchase-details');
   if (!container) return;
 
-  const totalSavings = recommendations.reduce((sum, r) => sum + (r.savings || 0), 0);
-  const totalUpfront = recommendations.reduce((sum, r) => sum + (r.upfront_cost || 0), 0);
+  // Pre-fetch overrides for every distinct non-empty cloud_account_id
+  // in the input set. One fetch per account, parallel via Promise.all,
+  // cached in a per-call Map.
+  const accountIDs = new Set<string>();
+  for (const r of currentPurchaseRecommendations) {
+    if (r.cloud_account_id) accountIDs.add(r.cloud_account_id);
+  }
+  const overridesByAccount = new Map<string, AccountServiceOverride[]>();
+  await Promise.all(
+    Array.from(accountIDs).map(async (id) => {
+      try {
+        const list = await api.listAccountServiceOverrides(id);
+        overridesByAccount.set(id, list);
+      } catch {
+        // Silent fallback to rec-own / paymentOptionsFor[0] seed.
+      }
+    }),
+  );
 
-  container.innerHTML = `
-    <div class="form-section">
-      <h3>Purchase Summary</h3>
-      <p><strong>${recommendations.length}</strong> commitments to purchase</p>
-      <p>Estimated Monthly Savings: <strong class="savings">${formatCurrency(totalSavings)}</strong></p>
-      <p>Total Upfront Cost: <strong>${formatCurrency(totalUpfront)}</strong></p>
-    </div>
-    <div class="form-section">
-      <h3>Commitments</h3>
-      <table>
-        <thead>
-          <tr><th>Service</th><th>Type</th><th>Region</th><th>Count</th><th>Savings/mo</th></tr>
-        </thead>
-        <tbody>
-          ${recommendations.map(r => `
-            <tr>
-              <td>${escapeHtml(r.service)}</td>
-              <td>${escapeHtml(r.resource_type)}</td>
-              <td>${escapeHtml(r.region)}</td>
-              <td>${r.count}</td>
-              <td class="savings">${formatCurrency(r.savings)}</td>
-            </tr>
-          `).join('')}
-        </tbody>
-      </table>
-    </div>
-  `;
+  // Compute seed per rec and mutate currentPurchaseRecommendations in
+  // place so the in-flight modal state matches what the dropdowns
+  // render. The 'rec' source case is a no-op write (same value), but
+  // keeping the assignment uniform avoids "did the user edit this?"
+  // ambiguity downstream — every rec carries an explicit payment by
+  // the time the modal opens.
+  const seeds = currentPurchaseRecommendations.map((r) => resolvePerRecPaymentSeed(r, overridesByAccount));
+  for (let i = 0; i < currentPurchaseRecommendations.length; i++) {
+    currentPurchaseRecommendations[i]!.payment = seeds[i]!.payment;
+  }
+
+  while (container.firstChild) container.removeChild(container.firstChild);
+
+  const totalSavings = currentPurchaseRecommendations.reduce((sum, r) => sum + (r.savings || 0), 0);
+  const totalUpfront = currentPurchaseRecommendations.reduce((sum, r) => sum + (r.upfront_cost || 0), 0);
+
+  // Summary section (DOM-built; no template-literal HTML interpolation).
+  const summary = document.createElement('div');
+  summary.className = 'form-section';
+  const summaryTitle = document.createElement('h3');
+  summaryTitle.textContent = 'Purchase Summary';
+  summary.appendChild(summaryTitle);
+
+  const countLine = document.createElement('p');
+  const countStrong = document.createElement('strong');
+  countStrong.textContent = String(currentPurchaseRecommendations.length);
+  countLine.appendChild(countStrong);
+  countLine.appendChild(document.createTextNode(' commitments to purchase'));
+  summary.appendChild(countLine);
+
+  const savingsLine = document.createElement('p');
+  savingsLine.appendChild(document.createTextNode('Estimated Monthly Savings: '));
+  const savingsStrong = document.createElement('strong');
+  savingsStrong.className = 'savings';
+  savingsStrong.textContent = formatCurrency(totalSavings);
+  savingsLine.appendChild(savingsStrong);
+  summary.appendChild(savingsLine);
+
+  const upfrontLine = document.createElement('p');
+  upfrontLine.appendChild(document.createTextNode('Total Upfront Cost: '));
+  const upfrontStrong = document.createElement('strong');
+  upfrontStrong.textContent = formatCurrency(totalUpfront);
+  upfrontLine.appendChild(upfrontStrong);
+  summary.appendChild(upfrontLine);
+
+  container.appendChild(summary);
+
+  // Commitments table with per-row Term and Payment selects.
+  const commitsSection = document.createElement('div');
+  commitsSection.className = 'form-section';
+  const commitsTitle = document.createElement('h3');
+  commitsTitle.textContent = 'Commitments';
+  commitsSection.appendChild(commitsTitle);
+
+  const table = document.createElement('table');
+  const thead = document.createElement('thead');
+  const headRow = document.createElement('tr');
+  for (const label of ['Service', 'Type', 'Region', 'Count', 'Term', 'Payment', 'Savings/mo']) {
+    const th = document.createElement('th');
+    th.textContent = label;
+    headRow.appendChild(th);
+  }
+  thead.appendChild(headRow);
+  table.appendChild(thead);
+
+  const tbody = document.createElement('tbody');
+  for (let i = 0; i < currentPurchaseRecommendations.length; i++) {
+    tbody.appendChild(renderPurchaseModalRow(i, seeds[i]!.source));
+  }
+  table.appendChild(tbody);
+  commitsSection.appendChild(table);
+  container.appendChild(commitsSection);
 
   const purchaseModal = document.getElementById('purchase-modal');
   if (purchaseModal) openModal(purchaseModal);
+}
+
+// renderPurchaseModalRow builds one editable <tr> for the per-row
+// purchase modal. Idx is the index into currentPurchaseRecommendations
+// — change handlers locate the live rec via that index so subsequent
+// edits to other rows don't stale-close over an outdated array
+// reference. The modal does NOT re-render mid-edit; only the row's own
+// Payment <select> options are rebuilt on a Term change.
+function renderPurchaseModalRow(idx: number, paymentSource: 'override' | 'rec' | 'fallback'): HTMLTableRowElement {
+  const rec = currentPurchaseRecommendations[idx]!;
+  const tr = document.createElement('tr');
+  tr.dataset['recIdx'] = String(idx);
+
+  const serviceCell = document.createElement('td');
+  serviceCell.textContent = rec.service;
+  tr.appendChild(serviceCell);
+
+  const typeCell = document.createElement('td');
+  typeCell.textContent = rec.resource_type;
+  tr.appendChild(typeCell);
+
+  const regionCell = document.createElement('td');
+  regionCell.textContent = rec.region;
+  tr.appendChild(regionCell);
+
+  const countCell = document.createElement('td');
+  countCell.textContent = String(rec.count);
+  tr.appendChild(countCell);
+
+  // Term select. AWS/Azure/GCP commitments universally support 1y and 3y;
+  // on change we rederive Payment options for the new term and pick a
+  // still-valid value if the current one becomes unsupported.
+  const termCell = document.createElement('td');
+  const termSelect = document.createElement('select');
+  termSelect.className = 'purchase-row-term';
+  for (const t of [1, 3]) {
+    const opt = document.createElement('option');
+    opt.value = String(t);
+    opt.textContent = `${t}yr`;
+    if (t === rec.term) opt.selected = true;
+    termSelect.appendChild(opt);
+  }
+  termCell.appendChild(termSelect);
+  tr.appendChild(termCell);
+
+  // Payment select. Options come from paymentOptionsFor (already
+  // filtered to supported values for this provider/service/term cell),
+  // so the user can never pick an unsupported combo through the UI.
+  const paymentCell = document.createElement('td');
+  const paymentSelect = document.createElement('select');
+  paymentSelect.className = 'purchase-row-payment';
+  rebuildPaymentOptions(paymentSelect, rec.provider as CompatProvider, rec.service, rec.term as 1 | 3, (rec.payment ?? '') as CompatPayment);
+  paymentCell.appendChild(paymentSelect);
+  if (paymentSource === 'override') {
+    const sourceNote = document.createElement('span');
+    sourceNote.className = 'purchase-row-payment-source';
+    sourceNote.textContent = ' (from account override)';
+    paymentCell.appendChild(sourceNote);
+  }
+  tr.appendChild(paymentCell);
+
+  const savingsCell = document.createElement('td');
+  savingsCell.className = 'savings';
+  savingsCell.textContent = formatCurrency(rec.savings);
+  tr.appendChild(savingsCell);
+
+  termSelect.addEventListener('change', () => {
+    const live = currentPurchaseRecommendations[idx];
+    if (!live) return;
+    const newTerm = parseInt(termSelect.value, 10) === 3 ? 3 : 1;
+    live.term = newTerm;
+    // Rebuild this row's payment options for the new term; if current
+    // payment is no longer supported, pick the first valid option and
+    // mirror back to live state.
+    rebuildPaymentOptions(
+      paymentSelect,
+      live.provider as CompatProvider,
+      live.service,
+      newTerm,
+      (live.payment ?? '') as CompatPayment,
+    );
+    live.payment = paymentSelect.value;
+  });
+
+  paymentSelect.addEventListener('change', () => {
+    const live = currentPurchaseRecommendations[idx];
+    if (!live) return;
+    live.payment = paymentSelect.value;
+  });
+
+  return tr;
+}
+
+// rebuildPaymentOptions clears and re-populates a <select> with the
+// supported Payment options for a (provider, service, term) cell.
+// If `desired` is in the new option set, it stays selected; otherwise
+// the first option wins and the select's `.value` reflects that.
+function rebuildPaymentOptions(
+  select: HTMLSelectElement,
+  provider: CompatProvider,
+  service: string,
+  term: 1 | 3,
+  desired: CompatPayment | '',
+): void {
+  while (select.firstChild) select.removeChild(select.firstChild);
+  const options = paymentOptionsFor(provider, service, term);
+  let matched = false;
+  for (const opt of options) {
+    const o = document.createElement('option');
+    o.value = opt;
+    o.textContent = opt;
+    if (opt === desired) {
+      o.selected = true;
+      matched = true;
+    }
+    select.appendChild(o);
+  }
+  if (!matched && options.length > 0) {
+    select.value = options[0]!;
+  }
 }
 
 /**

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -64,6 +64,12 @@ export interface LocalRecommendation {
   region: string;
   count: number;
   term: number;
+  // The API stamps `payment` on every Recommendation row at collection
+  // time, so runtime data carries it; surfacing it in the type lets the
+  // issue #111 per-row purchase modal read/write it directly. Optional
+  // because pre-#111 cached responses and some test fixtures omit it;
+  // the modal handles undefined via its seed helper.
+  payment?: string;
   savings: number;
   upfront_cost: number;
   monthly_cost?: number;


### PR DESCRIPTION
Closes #111. User-approved design: "default override pre-populated at purchase time, allowing user to select other options if desired" — applied at BOTH purchase entry points.

## Summary

The recommendations engine never consumed per-account service overrides — every PUT under `/api/accounts/:id/service-overrides/...` landed in the DB and disappeared from the user's perspective. This PR makes overrides visible at every purchase surface:

- **Sub-option (ii) — multi-bucket fan-out modal.** Each bucket section in `openFanOutModal` now renders its own Payment `<select>`, default-seeded from the per-account `AccountServiceOverride` when all recs share one `cloud_account_id` and the override matches `(provider, service)` with a supported payment. Otherwise: toolbar default (today's behavior). Edits round-trip via `getFanOutBuckets()` → `app.ts::handleFanOutExecute`.

- **Sub-option (iii) — single-bucket purchase modal.** `openPurchaseModal` now renders editable Term and Payment dropdowns per row. Defaults walk the precedence: account override → rec's own payment (the API stamps it at collection time) → `paymentOptionsFor[0]` defensive fallback. Term changes rebuild only that row's Payment options. `app.ts::handleExecutePurchase` reads `r.payment` per rec — replacing a historical hardcoded `'all-upfront'` that silently dropped the toolbar's Payment for every single-bucket purchase.

Recommendations themselves stay unfiltered — overrides are advisory at the purchase surfaces, not a constraint at the listing layer.

## Out of scope (deliberately, with follow-up issues filed)

- Read-time filter for `enabled=false` / `coverage` / include-exclude lists (option B work — those override fields remain decorative)
- Multi-account fan-out buckets falling back to toolbar (cosmetic; toolbar fallback is correct, just unsurprising)
- Consolidating the duplicated override-prefetch helpers across (ii) and (iii) into a shared module
- Dashboard "potential savings" headline ignoring per-account overrides

## Test plan

- [x] 4 new tests for (ii) covering single-account / no-override / multi-account / user-edit
- [x] 5 new tests for (iii) covering override-match / no-override / unsupported-payment / Term-change / Payment-change
- [x] Existing 4 `openPurchaseModal` tests updated to await the now-async function
- [x] All 1371 frontend tests pass (1366 prior + 5 new)
- [x] `tsc --noEmit` clean across 3 consecutive passes
- [x] `npm run build` clean across 3 consecutive passes
- [x] `go test ./internal/api/...` clean (no backend changes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now select and edit payment options directly in purchase modals
  * Payment defaults can be configured via account overrides when available
  * Visual indicators distinguish between override-sourced and default payments
  * Per-row payment configuration support for bulk purchase workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->