### PR TITLE
fix(aws): gate /api/scheduled/* with bearer mode + Secrets Manager

### DIFF
--- a/terraform/environments/aws/compute.tf
+++ b/terraform/environments/aws/compute.tf
@@ -77,6 +77,12 @@ module "compute_lambda" {
   enable_org_discovery                 = true
   credential_encryption_key_secret_arn = module.secrets.credential_encryption_key_secret_arn
 
+  # Scheduled-task bearer secret. The HTTP /api/scheduled/* path is reachable
+  # via the public Lambda URL; bearer mode + Secrets Manager keeps it gated
+  # without putting the secret in Lambda env or Terraform state.
+  scheduled_task_secret_arn  = coalesce(module.secrets.scheduled_task_secret_arn, "")
+  scheduled_task_secret_name = coalesce(module.secrets.scheduled_task_secret_name, "")
+
   # SES From domain — scopes the Lambda's SES policy to identity/{domain}
   # plus configuration-set/{stack}*. Leave empty to disable SES entirely
   # (deployments without email notifications don't get any SES permissions).
@@ -185,6 +191,12 @@ module "compute_fargate" {
   enable_org_discovery                 = true
   credential_encryption_key_secret_arn = module.secrets.credential_encryption_key_secret_arn
   email_from_domain                    = local.effective_email_from_domain
+
+  # Scheduled-task bearer secret. The HTTP /api/scheduled/* path is
+  # exposed via the public ALB; bearer mode + Secrets Manager keeps it
+  # gated without putting the secret in the task definition or state.
+  scheduled_task_secret_arn  = coalesce(module.secrets.scheduled_task_secret_arn, "")
+  scheduled_task_secret_name = coalesce(module.secrets.scheduled_task_secret_name, "")
 
   tags = local.common_tags
 

--- a/terraform/modules/compute/aws/fargate/main.tf
+++ b/terraform/modules/compute/aws/fargate/main.tf
@@ -154,6 +154,8 @@ resource "aws_iam_role_policy" "task_secrets" {
           var.admin_password_secret_arn != "" ? "${var.admin_password_secret_arn}-*" : "",
           var.credential_encryption_key_secret_arn,
           var.credential_encryption_key_secret_arn != "" ? "${var.credential_encryption_key_secret_arn}*" : "",
+          var.scheduled_task_secret_arn,
+          var.scheduled_task_secret_arn != "" ? "${var.scheduled_task_secret_arn}*" : "",
         ])
       },
       {
@@ -561,6 +563,21 @@ resource "aws_ecs_task_definition" "main" {
           {
             name  = "TASK_TIMEOUT"
             value = tostring(var.task_timeout)
+          },
+          # Scheduled-task auth: same model as Lambda. AWS schedules
+          # via EventBridge -> direct invocation; the HTTP path is
+          # exposed via the public ALB and needs an app-level gate.
+          # Bearer mode resolves the value from Secrets Manager at
+          # startup (resolveScheduledTaskSecret in
+          # internal/server/app.go); the plaintext never lives in the
+          # task definition or Terraform state.
+          {
+            name  = "SCHEDULED_TASK_AUTH_MODE"
+            value = "bearer"
+          },
+          {
+            name  = "SCHEDULED_TASK_SECRET_NAME"
+            value = var.scheduled_task_secret_name
           }
         ],
         [

--- a/terraform/modules/compute/aws/fargate/variables.tf
+++ b/terraform/modules/compute/aws/fargate/variables.tf
@@ -245,6 +245,18 @@ variable "credential_encryption_key_secret_arn" {
   default     = ""
 }
 
+variable "scheduled_task_secret_arn" {
+  description = "ARN of Secrets Manager secret holding the bearer secret for /api/scheduled/* (required when SCHEDULED_TASK_AUTH_MODE=bearer; resolved at runtime via SecretResolver)"
+  type        = string
+  default     = ""
+}
+
+variable "scheduled_task_secret_name" {
+  description = "Name of the scheduled-task bearer secret. Passed to compute as SCHEDULED_TASK_SECRET_NAME and resolved by internal/server.resolveScheduledTaskSecret on cold start."
+  type        = string
+  default     = ""
+}
+
 variable "enable_cross_account_sts" {
   description = "Grant the task role sts:AssumeRole on IAM roles whose name starts with cross_account_role_name_prefix. Required for multi-account plan execution."
   type        = bool

--- a/terraform/modules/compute/aws/lambda/main.tf
+++ b/terraform/modules/compute/aws/lambda/main.tf
@@ -54,6 +54,19 @@ resource "aws_lambda_function" "main" {
         # cycle with aws_lambda_function.main. The server resolves the
         # issuer URL lazily from the first inbound request's
         # DomainName and caches it — see internal/oidc.IssuerCache.
+
+        # Scheduled-task auth: AWS uses EventBridge -> direct Lambda
+        # invocation (lambda:InvokeFunction, see
+        # scheduled_recommendations / ri_exchange event_target rules
+        # below), so no real scheduler hits /api/scheduled/*. The HTTP
+        # path IS reachable on the public Lambda URL
+        # (authorization_type=NONE) and would be an unauthenticated
+        # public trigger without a gate. Bearer mode resolves the
+        # value from Secrets Manager at startup
+        # (resolveScheduledTaskSecret in internal/server/app.go); the
+        # plaintext never lives in Lambda env or Terraform state.
+        SCHEDULED_TASK_AUTH_MODE   = "bearer"
+        SCHEDULED_TASK_SECRET_NAME = var.scheduled_task_secret_name
       },
       var.additional_env_vars
     )
@@ -203,6 +216,8 @@ resource "aws_iam_role_policy" "secrets_access" {
           var.admin_password_secret_arn != "" ? "${var.admin_password_secret_arn}*" : "",
           var.credential_encryption_key_secret_arn,
           var.credential_encryption_key_secret_arn != "" ? "${var.credential_encryption_key_secret_arn}*" : "",
+          var.scheduled_task_secret_arn,
+          var.scheduled_task_secret_arn != "" ? "${var.scheduled_task_secret_arn}*" : "",
         ])
       },
       {

--- a/terraform/modules/compute/aws/lambda/variables.tf
+++ b/terraform/modules/compute/aws/lambda/variables.tf
@@ -154,6 +154,18 @@ variable "credential_encryption_key_secret_arn" {
   default     = ""
 }
 
+variable "scheduled_task_secret_arn" {
+  description = "ARN of Secrets Manager secret holding the bearer secret for /api/scheduled/* (required when SCHEDULED_TASK_AUTH_MODE=bearer; resolved at runtime via SecretResolver)"
+  type        = string
+  default     = ""
+}
+
+variable "scheduled_task_secret_name" {
+  description = "Name of the scheduled-task bearer secret. Passed to compute as SCHEDULED_TASK_SECRET_NAME and resolved by internal/server.resolveScheduledTaskSecret on cold start."
+  type        = string
+  default     = ""
+}
+
 variable "enable_cross_account_sts" {
   description = "Allow Lambda to assume roles in remote AWS accounts (required for multi-account support)"
   type        = bool

--- a/terraform/modules/secrets/aws/main.tf
+++ b/terraform/modules/secrets/aws/main.tf
@@ -148,6 +148,50 @@ resource "aws_secretsmanager_secret_version" "session_secret" {
 }
 
 # ==============================================
+# Scheduled-Task Bearer Secret
+# ==============================================
+#
+# Bearer secret for /api/scheduled/* on the AWS Lambda URL / Fargate ALB.
+# AWS schedules tasks via EventBridge -> direct Lambda invocation, which
+# bypasses the HTTP middleware entirely — so no scheduler ever needs this
+# value. The HTTP path itself, however, IS reachable on the public Lambda
+# URL (authorization_type=NONE) and would be an unauthenticated public
+# trigger without something gating it. We pre-generate a random secret,
+# store it in Secrets Manager, and pass only the ARN to compute via the
+# resolver pattern (see resolveScheduledTaskSecret in internal/server/app.go);
+# the runtime resolves it on cold start, so the plaintext never lands in
+# Lambda env / Terraform state. End result: every /api/scheduled/* request
+# from outside the runtime is rejected by scheduledauth in bearer mode.
+
+resource "random_password" "scheduled_task_secret" {
+  count = var.create_scheduled_task_secret ? 1 : 0
+
+  length  = 64
+  special = false # base64-friendly; becomes a static Bearer header value
+}
+
+resource "aws_secretsmanager_secret" "scheduled_task_secret" {
+  count = var.create_scheduled_task_secret ? 1 : 0
+
+  name_prefix             = "${var.stack_name}-scheduled-task-secret-"
+  description             = "Bearer secret for /api/scheduled/* on ${var.stack_name} (HTTP path; EventBridge invocations bypass it)"
+  recovery_window_in_days = var.recovery_window_days
+
+  tags = merge(var.tags, {
+    Name        = "${var.stack_name}-scheduled-task-secret"
+    ManagedBy   = "terraform"
+    Environment = var.environment
+  })
+}
+
+resource "aws_secretsmanager_secret_version" "scheduled_task_secret" {
+  count = var.create_scheduled_task_secret ? 1 : 0
+
+  secret_id     = aws_secretsmanager_secret.scheduled_task_secret[0].id
+  secret_string = random_password.scheduled_task_secret[0].result
+}
+
+# ==============================================
 # Credential Encryption Key (Multi-Account)
 # ==============================================
 
@@ -388,6 +432,7 @@ data "aws_iam_policy_document" "secret_read" {
       var.create_admin_password_secret ? [aws_secretsmanager_secret.admin_password[0].arn] : [],
       var.create_jwt_secret ? [aws_secretsmanager_secret.jwt_secret[0].arn] : [],
       var.create_session_secret ? [aws_secretsmanager_secret.session_secret[0].arn] : [],
+      var.create_scheduled_task_secret ? [aws_secretsmanager_secret.scheduled_task_secret[0].arn] : [],
       [for secret in aws_secretsmanager_secret.additional : secret.arn]
     )
   }

--- a/terraform/modules/secrets/aws/outputs.tf
+++ b/terraform/modules/secrets/aws/outputs.tf
@@ -44,6 +44,16 @@ output "session_secret_name" {
   value       = var.create_session_secret ? aws_secretsmanager_secret.session_secret[0].name : null
 }
 
+output "scheduled_task_secret_arn" {
+  description = "ARN of the scheduled-task bearer secret (if created)"
+  value       = var.create_scheduled_task_secret ? aws_secretsmanager_secret.scheduled_task_secret[0].arn : null
+}
+
+output "scheduled_task_secret_name" {
+  description = "Name of the scheduled-task bearer secret (if created); pass into compute as SCHEDULED_TASK_SECRET_NAME"
+  value       = var.create_scheduled_task_secret ? aws_secretsmanager_secret.scheduled_task_secret[0].name : null
+}
+
 output "additional_secret_arns" {
   description = "Map of additional secret ARNs"
   value       = { for k, v in aws_secretsmanager_secret.additional : k => v.arn }

--- a/terraform/modules/secrets/aws/variables.tf
+++ b/terraform/modules/secrets/aws/variables.tf
@@ -62,6 +62,20 @@ variable "create_session_secret" {
   default     = true
 }
 
+variable "create_scheduled_task_secret" {
+  description = <<-EOT
+    Create the bearer secret for /api/scheduled/* on AWS compute. Default
+    true: the HTTP path is exposed via the Lambda URL (auth NONE) and
+    needs an app-level gate even though no real scheduler hits it (AWS
+    uses EventBridge -> direct Lambda invocation). Set false ONLY for
+    deployments where /api/scheduled/* is genuinely unreachable from the
+    public internet (e.g. Fargate behind a private ALB), and pair that
+    with SCHEDULED_TASK_AUTH_MODE=disabled set explicitly downstream.
+  EOT
+  type        = bool
+  default     = true
+}
+
 variable "additional_secrets" {
   description = "Map of additional secrets to create (map keys are not sensitive, only values are)"
   type = map(object({


### PR DESCRIPTION
Hotfix for the failing Lambda health check on `feat/multicloud-web-frontend` after #161 merged: https://github.com/LeanerCloud/CUDly/actions/runs/25148590105/job/73714185103.

## Root cause

#161 made `SCHEDULED_TASK_AUTH_MODE` required at startup (fail-closed `LoadConfig`) but only wired the env var on the GCP and Azure compute modules. AWS Lambda was missed → boot fails:

```
scheduledauth: invalid configuration: SCHEDULED_TASK_AUTH_MODE is unset
```

## Why not `SCHEDULED_TASK_AUTH_MODE = "disabled"`

That was my first attempt (force-pushed away). It would have shipped a production auth bypass: `ModeDisabled` lets every `/api/scheduled/*` request through, and the Lambda Function URL has `authorization_type = NONE` (the same module documents this). Even though pre-#161 the bearer check was a no-op when the secret was empty, codifying that state under the new validator is actively wrong.

## Fix: bearer mode + Secrets Manager (Azure-pattern)

* `terraform/modules/secrets/aws/` — provision a `random_password` + `aws_secretsmanager_secret` + version for the scheduled-task bearer (gated by `var.create_scheduled_task_secret`, default `true`). Include in `secret_read` policy. Expose `scheduled_task_secret_arn` + `_name` outputs.
* `terraform/modules/compute/aws/lambda/` — set `SCHEDULED_TASK_AUTH_MODE = "bearer"` + `SCHEDULED_TASK_SECRET_NAME = var.scheduled_task_secret_name` on the Lambda env block. Add the secret ARN to the `secrets_access` IAM policy. Add the corresponding variables.
* `terraform/modules/compute/aws/fargate/` — same wiring on the task definition env block + IAM policy + variables, so Fargate doesn't regress when selected.
* `terraform/environments/aws/compute.tf` — pass `module.secrets.scheduled_task_secret_arn` / `_name` into both `compute_lambda` and `compute_fargate`.

## Runtime path (already in place from #161)

`internal/server/app.go` reads `SCHEDULED_TASK_SECRET_NAME`, `resolveScheduledTaskSecret` fetches the plaintext from AWS Secrets Manager via the `SecretResolver`, and `buildScheduledAuth` overrides `saCfg.Bearer` with that value before calling `scheduledauth.New`. **The plaintext never lives in Lambda env or Terraform state.**

## Result

* `/api/scheduled/*` on the public Lambda URL rejects every request that doesn't carry the resolved bearer secret.
* AWS schedulers (EventBridge → direct `lambda:InvokeFunction`) bypass the HTTP middleware entirely and are unaffected.
* Runtime IAM (Lambda task role) gains `secretsmanager:GetSecretValue` on the new secret only — least privilege.

## Validation

* `terraform validate` clean for `terraform/modules/{secrets/aws, compute/aws/lambda, compute/aws/fargate}` and `terraform/environments/aws/`
* Pre-commit hooks all passed locally
* Branch name remains `fix/aws-scheduled-auth-mode-disabled` for PR continuity, but the title now accurately reflects the implemented fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced bearer token authentication for scheduled tasks, with secrets securely managed in cloud secret storage rather than embedded in configuration
  * Added configurable option to enable or disable scheduled task authentication across Lambda and Fargate deployment platforms
  * Enhanced security for scheduled task endpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->