### PR TITLE
fix(db): idempotently repair retry-linkage schema drift (closes #204, #205)

### DIFF
--- a/internal/database/postgres/migrations/000044_restore_retry_linkage_idempotent.down.sql
+++ b/internal/database/postgres/migrations/000044_restore_retry_linkage_idempotent.down.sql
@@ -1,0 +1,11 @@
+-- Idempotent rollback. Inverse of 000044's IF NOT EXISTS additions.
+-- DROP COLUMN IF EXISTS leaves DBs that don't have the columns
+-- (e.g. an environment that was already correct pre-#168) untouched.
+
+DROP INDEX IF EXISTS idx_executions_retry_target;
+
+ALTER TABLE purchase_executions
+    DROP COLUMN IF EXISTS retry_attempt_n;
+
+ALTER TABLE purchase_executions
+    DROP COLUMN IF EXISTS retry_execution_id;

--- a/internal/database/postgres/migrations/000044_restore_retry_linkage_idempotent.down.sql
+++ b/internal/database/postgres/migrations/000044_restore_retry_linkage_idempotent.down.sql
@@ -1,11 +1,13 @@
--- Idempotent rollback. Inverse of 000044's IF NOT EXISTS additions.
--- DROP COLUMN IF EXISTS leaves DBs that don't have the columns
--- (e.g. an environment that was already correct pre-#168) untouched.
+-- Idempotent rollback. CASCADE on DROP COLUMN removes the FK constraint
+-- (whatever its name — auto-generated `*_fkey` from a fresh-deploy 000042
+-- run, or `fk_purchase_executions_retry_execution_id` from this 000044's
+-- step 2) and the partial index in one go. DROP INDEX IF EXISTS in front
+-- of the column drops handles the case where the index outlived its
+-- column (operator surgery only — not reachable from any path through
+-- 000042/000043/000044).
 
 DROP INDEX IF EXISTS idx_executions_retry_target;
 
-ALTER TABLE purchase_executions
-    DROP COLUMN IF EXISTS retry_attempt_n;
+ALTER TABLE purchase_executions DROP COLUMN IF EXISTS retry_attempt_n;
 
-ALTER TABLE purchase_executions
-    DROP COLUMN IF EXISTS retry_execution_id;
+ALTER TABLE purchase_executions DROP COLUMN IF EXISTS retry_execution_id CASCADE;

--- a/internal/database/postgres/migrations/000044_restore_retry_linkage_idempotent.up.sql
+++ b/internal/database/postgres/migrations/000044_restore_retry_linkage_idempotent.up.sql
@@ -1,50 +1,101 @@
--- 000044: idempotent corrective for the missing retry_execution_id column.
+-- 000044: idempotent corrective for the retry-linkage schema dropped
+-- by migration drift between #168 / #189 / #195. Repairs every partial
+-- state we know to be reachable, instead of just no-op'ing when columns
+-- exist (per CR pass-1 feedback on PR #206).
 --
--- Background: PR #168 added 000042_purchase_executions_retry_linkage.
--- Concurrently, PR #189 had landed 000042_recommendations_add_engine_to_key
--- earlier the same day. Both files claimed version 42; deployed Lambdas
--- that ran migrate.Up() between the two merges recorded version=42 in
--- schema_migrations as "engine" content. PR #195 resolved the on-disk
--- duplicate by renaming recommendations to 000043 (instead of renaming
--- the later #168 migration to 000043), so deployed DBs ended up with:
+-- Background — see the commit message of this migration's pair-PR for the
+-- full chain. Short version: deployed DBs have schema_migrations.version =
+-- 42 recorded against #189's "engine" content; on-disk file 42 is now
+-- #168's retry_linkage which migrate skips because version 42 is already
+-- marked applied. Result: the retry_execution_id / retry_attempt_n columns
+-- were never created, but the Go SELECT in GetExecutionByID references
+-- them, so /api/purchases/* 500s with "column does not exist" (SQLSTATE
+-- 42703) — surfaced as "Failed to load purchase details" / "Failed to
+-- cancel purchase" toasts on the dashboard's Upcoming Scheduled Purchases
+-- panel (issues #204 + #205).
 --
---   schema_migrations.version = 42  (= engine content, applied)
---   on-disk file 42             (= retry_linkage content, NEVER applied)
---   on-disk file 43             (= engine content again, applied as no-op
---                                  thanks to ADD COLUMN IF NOT EXISTS)
+-- Reachable partial states this migration handles:
 --
--- Result: the retry_execution_id and retry_attempt_n columns from #168
--- were never added in production, but the Go code (`internal/config/types.go`
--- + `GetExecutionByID` SELECT) references them. Every /api/purchases/*
--- request 500'd with `column "retry_execution_id" does not exist
--- (SQLSTATE 42703)`. Surfaced as "Failed to load purchase details" /
--- "Failed to cancel purchase" toasts on the dashboard's Upcoming
--- Scheduled Purchases panel — see issues #204 and #205.
+--   (a) Both columns missing, no FK, no index — the production state on
+--       deployed dev/staging Lambdas as of 2026-04-30. Each step adds.
+--   (b) Columns added by hand without the FK — possible after operator
+--       surgery; step 2 re-adds the FK conditionally.
+--   (c) retry_attempt_n added without DEFAULT 0 / NOT NULL — same; step
+--       4 backfills NULLs and re-asserts the constraints (these ALTERs
+--       are safe to run unconditionally — Postgres treats them as no-op
+--       when the constraint is already in place).
+--   (d) Index missing — step 5's CREATE INDEX IF NOT EXISTS adds it.
+--   (e) Everything already present from a fresh deploy that took the
+--       post-#195 migration order correctly — every step skips.
 --
--- Fix strategy: replay 000042's schema changes wrapped in IF NOT EXISTS
--- so this migration is a no-op on any DB that already has the columns
--- (e.g., a fresh deploy that took the post-#195 migration order
--- correctly, or one manually fixed via DDL). Forward-only: we don't
--- attempt to repair schema_migrations history because (a) golang-migrate
--- only cares about the high-water-version, (b) we can't know without
--- DB inspection whether a given environment skipped 42 or applied
--- 43-as-engine-twice. The IF NOT EXISTS guards close both cases.
---
--- Edge case acknowledged: a DB that has the column but is missing the
--- self-FK (only possible via manual `ALTER TABLE ... DROP CONSTRAINT`)
--- won't get the FK re-added by this migration; ADD COLUMN IF NOT EXISTS
--- skips the entire clause when the column exists. That state is not
--- reachable from any path through 000042/000043/000044 themselves, so
--- it would only arise from operator surgery — fix manually if it
--- happens.
+-- The pg_catalog / information_schema queries match by column name and
+-- FK target, NOT by constraint name, so a partially-fixed DB with the
+-- auto-generated `purchase_executions_retry_execution_id_fkey` (the name
+-- 000042's inline FK clause would have produced) is recognised as
+-- already-FK'd and step 2 skips.
 
-ALTER TABLE purchase_executions
-    ADD COLUMN IF NOT EXISTS retry_execution_id UUID
-        REFERENCES purchase_executions(execution_id) ON DELETE SET NULL;
+-- Step 1: ensure retry_execution_id column exists.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = current_schema()
+          AND table_name = 'purchase_executions'
+          AND column_name = 'retry_execution_id'
+    ) THEN
+        ALTER TABLE purchase_executions ADD COLUMN retry_execution_id UUID;
+    END IF;
+END $$;
 
-ALTER TABLE purchase_executions
-    ADD COLUMN IF NOT EXISTS retry_attempt_n INTEGER NOT NULL DEFAULT 0;
+-- Step 2: ensure a FK on retry_execution_id -> execution_id exists. Match
+-- by column relationship, not constraint name, so a fresh-deploy DB whose
+-- 000042 ran cleanly (FK named `purchase_executions_retry_execution_id_fkey`)
+-- is recognised as already-FK'd and we don't add a second.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint c
+        JOIN pg_attribute a
+          ON a.attrelid = c.conrelid AND a.attnum = ANY (c.conkey)
+        WHERE c.conrelid = 'purchase_executions'::regclass
+          AND c.contype = 'f'
+          AND a.attname = 'retry_execution_id'
+    ) THEN
+        ALTER TABLE purchase_executions
+            ADD CONSTRAINT fk_purchase_executions_retry_execution_id
+            FOREIGN KEY (retry_execution_id)
+            REFERENCES purchase_executions (execution_id)
+            ON DELETE SET NULL;
+    END IF;
+END $$;
 
+-- Step 3: ensure retry_attempt_n column exists. Add as nullable here so
+-- step 4 can backfill before flipping to NOT NULL — guards against a
+-- partially-fixed DB that has the column with NULLs.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = current_schema()
+          AND table_name = 'purchase_executions'
+          AND column_name = 'retry_attempt_n'
+    ) THEN
+        ALTER TABLE purchase_executions ADD COLUMN retry_attempt_n INTEGER;
+    END IF;
+END $$;
+
+-- Step 4: enforce the NOT NULL DEFAULT 0 contract on retry_attempt_n.
+-- Safe to run unconditionally: SET DEFAULT and SET NOT NULL are no-ops
+-- when the constraint is already as requested. The UPDATE only touches
+-- rows that have NULL, which exists only on partially-fixed DBs.
+UPDATE purchase_executions SET retry_attempt_n = 0 WHERE retry_attempt_n IS NULL;
+ALTER TABLE purchase_executions ALTER COLUMN retry_attempt_n SET DEFAULT 0;
+ALTER TABLE purchase_executions ALTER COLUMN retry_attempt_n SET NOT NULL;
+
+-- Step 5: partial index. CREATE INDEX IF NOT EXISTS skips silently if a
+-- collision name exists, so a fresh-deploy DB that already has it is
+-- left alone.
 CREATE INDEX IF NOT EXISTS idx_executions_retry_target
-    ON purchase_executions(retry_execution_id)
+    ON purchase_executions (retry_execution_id)
     WHERE retry_execution_id IS NOT NULL;

--- a/internal/database/postgres/migrations/000044_restore_retry_linkage_idempotent.up.sql
+++ b/internal/database/postgres/migrations/000044_restore_retry_linkage_idempotent.up.sql
@@ -1,0 +1,50 @@
+-- 000044: idempotent corrective for the missing retry_execution_id column.
+--
+-- Background: PR #168 added 000042_purchase_executions_retry_linkage.
+-- Concurrently, PR #189 had landed 000042_recommendations_add_engine_to_key
+-- earlier the same day. Both files claimed version 42; deployed Lambdas
+-- that ran migrate.Up() between the two merges recorded version=42 in
+-- schema_migrations as "engine" content. PR #195 resolved the on-disk
+-- duplicate by renaming recommendations to 000043 (instead of renaming
+-- the later #168 migration to 000043), so deployed DBs ended up with:
+--
+--   schema_migrations.version = 42  (= engine content, applied)
+--   on-disk file 42             (= retry_linkage content, NEVER applied)
+--   on-disk file 43             (= engine content again, applied as no-op
+--                                  thanks to ADD COLUMN IF NOT EXISTS)
+--
+-- Result: the retry_execution_id and retry_attempt_n columns from #168
+-- were never added in production, but the Go code (`internal/config/types.go`
+-- + `GetExecutionByID` SELECT) references them. Every /api/purchases/*
+-- request 500'd with `column "retry_execution_id" does not exist
+-- (SQLSTATE 42703)`. Surfaced as "Failed to load purchase details" /
+-- "Failed to cancel purchase" toasts on the dashboard's Upcoming
+-- Scheduled Purchases panel — see issues #204 and #205.
+--
+-- Fix strategy: replay 000042's schema changes wrapped in IF NOT EXISTS
+-- so this migration is a no-op on any DB that already has the columns
+-- (e.g., a fresh deploy that took the post-#195 migration order
+-- correctly, or one manually fixed via DDL). Forward-only: we don't
+-- attempt to repair schema_migrations history because (a) golang-migrate
+-- only cares about the high-water-version, (b) we can't know without
+-- DB inspection whether a given environment skipped 42 or applied
+-- 43-as-engine-twice. The IF NOT EXISTS guards close both cases.
+--
+-- Edge case acknowledged: a DB that has the column but is missing the
+-- self-FK (only possible via manual `ALTER TABLE ... DROP CONSTRAINT`)
+-- won't get the FK re-added by this migration; ADD COLUMN IF NOT EXISTS
+-- skips the entire clause when the column exists. That state is not
+-- reachable from any path through 000042/000043/000044 themselves, so
+-- it would only arise from operator surgery — fix manually if it
+-- happens.
+
+ALTER TABLE purchase_executions
+    ADD COLUMN IF NOT EXISTS retry_execution_id UUID
+        REFERENCES purchase_executions(execution_id) ON DELETE SET NULL;
+
+ALTER TABLE purchase_executions
+    ADD COLUMN IF NOT EXISTS retry_attempt_n INTEGER NOT NULL DEFAULT 0;
+
+CREATE INDEX IF NOT EXISTS idx_executions_retry_target
+    ON purchase_executions(retry_execution_id)
+    WHERE retry_execution_id IS NOT NULL;


### PR DESCRIPTION
Production hotfix. Both buttons on the dashboard's "Upcoming Scheduled Purchases" panel were 500-ing:

* **View Details** → "Failed to load purchase details: Internal server error" (#205)
* **Cancel** → "Failed to cancel purchase" (#204)

Both call `Handler.GetExecutionByID`, whose SELECT references `retry_execution_id` and `retry_attempt_n`. CloudWatch on `cudly-dev-426fc8af-api`:

```
ERROR: column "retry_execution_id" does not exist (SQLSTATE 42703)
[ERROR] API error: execution not found: failed to query executions: ...
```

## Root cause — migration version drift

| When | What |
|---|---|
| #189 merged | Added `000042_recommendations_add_engine_to_key`. Deployed Lambdas applied it as version 42. |
| #168 merged | Added `000042_purchase_executions_retry_linkage` — collision on 42. Cold-starts started failing on duplicate-version. |
| #195 merged | Renamed **recommendations → 000043** (the wrong direction; should have renamed the second-deployed retry_linkage). |

After #195, deployed DBs sit in this state:

* `schema_migrations.version = 42` (recorded as engine content from the #189-era apply)
* on-disk file 42 = retry_linkage — **never applied** (DB version 42 already marked applied → migrate skips)
* on-disk file 43 = engine — re-applied as no-op via the existing `ADD COLUMN IF NOT EXISTS` guards in that file

Net: the `retry_execution_id` and `retry_attempt_n` columns were never added on prod, but the Go code expects them.

## Fix — `000044_restore_retry_linkage_idempotent`

Forward-only corrective. **Repairs every reachable partial state**, not just the all-missing case (per CR pass 1 feedback). Five idempotent steps, each checking `pg_catalog` / `information_schema` for the precise piece it owns:

| Step | Check | Repair |
|---|---|---|
| 1 | `information_schema.columns` for `retry_execution_id` | `ADD COLUMN UUID` |
| 2 | `pg_constraint JOIN pg_attribute` matching by **column relationship** (not constraint name) | `ADD CONSTRAINT fk_purchase_executions_retry_execution_id FOREIGN KEY (retry_execution_id) REFERENCES purchase_executions(execution_id) ON DELETE SET NULL` |
| 3 | `information_schema.columns` for `retry_attempt_n` | `ADD COLUMN INTEGER` (nullable, so step 4 can backfill before flipping NOT NULL) |
| 4 | unconditional (Postgres no-ops if already in place) | `UPDATE SET = 0 WHERE NULL` → `SET DEFAULT 0` → `SET NOT NULL` |
| 5 | `CREATE INDEX IF NOT EXISTS` | partial index `idx_executions_retry_target ON (retry_execution_id) WHERE retry_execution_id IS NOT NULL` |

### Reachable partial states the migration handles

(a) Both columns missing, no FK, no index — production state on broken Lambdas. Each step adds.
(b) Columns added by hand without the FK — possible after operator surgery; step 2 re-adds.
(c) `retry_attempt_n` added without DEFAULT 0 / NOT NULL — step 4 backfills + re-asserts.
(d) Index missing — step 5 adds.
(e) Everything already present (fresh deploy that took post-#195 ordering correctly) — every step skips.

### Why match FK by column relationship, not name

A fresh-deploy DB whose 000042 ran cleanly has the auto-generated FK `purchase_executions_retry_execution_id_fkey` (Postgres convention from the inline `REFERENCES` clause). We don't want to add a duplicate FK with a different name on the same column, so step 2's lookup joins `pg_constraint` and `pg_attribute` matching by `(conrelid, contype=f, column=retry_execution_id)` — recognising the existing FK regardless of name and skipping.

### Down

`DROP COLUMN ... CASCADE` removes the FK regardless of name (auto-generated `*_fkey` from a fresh deploy OR `fk_purchase_executions_retry_execution_id` from this 000044's step 2) and the partial index in one go.

### What we deliberately don't do

* No `schema_migrations` history surgery — golang-migrate only cares about the high-water version, and we can't tell from outside whether a given env skipped 42 or applied 43-as-engine-twice. The pg_catalog-driven guards close both cases.
* No fix to the original 000042/000043 files — leaving them avoids breaking any environment that did successfully apply them.

## Verification

* `go build ./...` clean
* Pre-commit's `check-migration-conflicts` passes (no duplicate 6-digit prefixes)
* AWS + Azure Sanity green on the latest commit
* Migration sql comments inline-document every reachable state so future readers don't need git archaeology

Once merged + redeployed, Lambda cold-start runs `migrate.Up()` → applies 000044 → adds the missing columns / FK / index → `GetExecutionByID` SELECT succeeds → both dashboard buttons work.

## Triage

`type/bug`, `severity/high`, `urgency/now`, `impact/all-users`, `effort/xs`, `priority/p0`, `triaged`. Closes #204 + #205.