### PR TITLE
fix(dashboard): wire upcoming-purchase buttons to plan endpoints (closes #204, #205)

### DIFF
--- a/frontend/src/__tests__/dashboard.test.ts
+++ b/frontend/src/__tests__/dashboard.test.ts
@@ -36,6 +36,9 @@ jest.mock('../api', () => ({
   getUpcomingPurchases: jest.fn(),
   getPurchaseDetails: jest.fn(),
   cancelPurchase: jest.fn(),
+  // Plan-level cancel — the dashboard upcoming-list now targets plan
+  // endpoints (issues #204 + #205), not execution endpoints.
+  deletePlannedPurchase: jest.fn(),
   listAccounts: jest.fn().mockResolvedValue([]),
   getSavingsAnalytics: jest.fn().mockResolvedValue({ data_points: [] }),
 }));
@@ -168,7 +171,7 @@ describe('Dashboard Module', () => {
       (api.getUpcomingPurchases as jest.Mock).mockResolvedValue({
         purchases: [
           {
-            execution_id: 'exec-1',
+            plan_id: 'plan-1',
             plan_name: 'Test Plan',
             provider: 'aws',
             service: 'ec2',
@@ -235,7 +238,7 @@ describe('Dashboard Module', () => {
       (api.getUpcomingPurchases as jest.Mock).mockResolvedValue({
         purchases: [
           {
-            execution_id: 'exec-1',
+            plan_id: 'plan-1',
             plan_name: 'Test Plan',
             provider: 'aws',
             service: 'ec2',
@@ -279,7 +282,7 @@ describe('Dashboard Module', () => {
       (api.getUpcomingPurchases as jest.Mock).mockResolvedValue({
         purchases: [
           {
-            execution_id: 'exec-123',
+            plan_id: 'plan-123',
             plan_name: 'Test Plan',
             provider: 'aws',
             service: 'ec2',
@@ -290,61 +293,29 @@ describe('Dashboard Module', () => {
           }
         ]
       });
-      (api.getPurchaseDetails as jest.Mock).mockResolvedValue({
-        execution_id: 'exec-123',
-        status: 'pending'
-      });
 
       await loadDashboard();
 
       const viewBtn = document.querySelector('[data-action="view-purchase"]') as HTMLButtonElement;
       viewBtn?.click();
 
-      await new Promise(resolve => setTimeout(resolve, 50));
-
-      expect(api.getPurchaseDetails).toHaveBeenCalledWith('exec-123');
-      // Modal should be rendered in the DOM instead of alert
+      // viewPurchaseDetails is sync now — renders from the in-memory
+      // upcoming-purchases index (issues #204 + #205). No API call to
+      // /api/purchases/{id}, since the row identifier is a plan_id and
+      // there's no execution row yet for an upcoming purchase.
+      expect(api.getPurchaseDetails).not.toHaveBeenCalled();
       const modal = document.getElementById('purchase-details-modal');
       expect(modal).toBeTruthy();
-      expect(modal?.textContent).toContain('exec-123');
-      expect(modal?.textContent).toContain('pending');
+      expect(modal?.textContent).toContain('Test Plan');
+      expect(modal?.textContent).toContain('plan-123');
     });
 
-    test('view purchase button shows error on failure', async () => {
-      (api.getDashboardSummary as jest.Mock).mockResolvedValue({
-        potential_monthly_savings: 1000,
-        by_service: {}
-      });
-      (api.getUpcomingPurchases as jest.Mock).mockResolvedValue({
-        purchases: [
-          {
-            execution_id: 'exec-123',
-            plan_name: 'Test Plan',
-            provider: 'aws',
-            service: 'ec2',
-            step_number: 1,
-            total_steps: 4,
-            estimated_savings: 100,
-            scheduled_date: '2024-02-15'
-          }
-        ]
-      });
-      (api.getPurchaseDetails as jest.Mock).mockRejectedValue(new Error('API Error'));
-      console.error = jest.fn();
-
-      await loadDashboard();
-
-      const viewBtn = document.querySelector('[data-action="view-purchase"]') as HTMLButtonElement;
-      viewBtn?.click();
-
-      await new Promise(resolve => setTimeout(resolve, 50));
-
-      // Q7: alert() migrated to showToast with kind:'error'.
-      expect(mockShowToast).toHaveBeenCalledWith(expect.objectContaining({
-        message: 'Failed to load purchase details: API Error',
-        kind: 'error',
-      }));
-    });
+    // (The previous "shows error on failure" test exercised an API
+    // rejection path that no longer exists — viewPurchaseDetails is
+    // synchronous after the data-flow fix. The graceful-fallback for a
+    // pruned-from-index plan_id is enforced by the `if (!purchase) {
+    // showToast(...) }` guard in dashboard.ts but isn't easily reached
+    // through the public surface, so it's covered by code-review only.)
 
     test('cancel purchase button cancels and reloads', async () => {
       (api.getDashboardSummary as jest.Mock).mockResolvedValue({
@@ -354,7 +325,7 @@ describe('Dashboard Module', () => {
       (api.getUpcomingPurchases as jest.Mock).mockResolvedValue({
         purchases: [
           {
-            execution_id: 'exec-123',
+            plan_id: 'plan-123',
             plan_name: 'Test Plan',
             provider: 'aws',
             service: 'ec2',
@@ -365,7 +336,7 @@ describe('Dashboard Module', () => {
           }
         ]
       });
-      (api.cancelPurchase as jest.Mock).mockResolvedValue({});
+      (api.deletePlannedPurchase as jest.Mock).mockResolvedValue({});
       window.confirm = jest.fn().mockReturnValue(true);
 
       await loadDashboard();
@@ -379,7 +350,7 @@ describe('Dashboard Module', () => {
 
       await new Promise(resolve => setTimeout(resolve, 50));
 
-      expect(api.cancelPurchase).toHaveBeenCalledWith('exec-123');
+      expect(api.deletePlannedPurchase).toHaveBeenCalledWith('plan-123');
       expect(mockShowToast).toHaveBeenCalledWith(expect.objectContaining({
         message: 'Purchase cancelled successfully',
         kind: 'success',
@@ -394,7 +365,7 @@ describe('Dashboard Module', () => {
       (api.getUpcomingPurchases as jest.Mock).mockResolvedValue({
         purchases: [
           {
-            execution_id: 'exec-123',
+            plan_id: 'plan-123',
             plan_name: 'Test Plan',
             provider: 'aws',
             service: 'ec2',
@@ -414,7 +385,7 @@ describe('Dashboard Module', () => {
 
       await new Promise(resolve => setTimeout(resolve, 50));
 
-      expect(api.cancelPurchase).not.toHaveBeenCalled();
+      expect(api.deletePlannedPurchase).not.toHaveBeenCalled();
     });
 
     test('cancel purchase shows error on failure', async () => {
@@ -425,7 +396,7 @@ describe('Dashboard Module', () => {
       (api.getUpcomingPurchases as jest.Mock).mockResolvedValue({
         purchases: [
           {
-            execution_id: 'exec-123',
+            plan_id: 'plan-123',
             plan_name: 'Test Plan',
             provider: 'aws',
             service: 'ec2',
@@ -436,7 +407,7 @@ describe('Dashboard Module', () => {
           }
         ]
       });
-      (api.cancelPurchase as jest.Mock).mockRejectedValue(new Error('API Error'));
+      (api.deletePlannedPurchase as jest.Mock).mockRejectedValue(new Error('API Error'));
       window.confirm = jest.fn().mockReturnValue(true);
       console.error = jest.fn();
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -32,7 +32,7 @@ export interface DashboardSummary {
 }
 
 export interface UpcomingPurchase {
-  execution_id: string;
+  plan_id: string;
   plan_name: string;
   scheduled_date: string;
   provider: string;

--- a/frontend/src/dashboard.ts
+++ b/frontend/src/dashboard.ts
@@ -20,6 +20,16 @@ Chart.register(...registerables);
 let savingsTrendChart: Chart | null = null;
 let savingsTrendRange: '7' | '30' | '90' | 'all' = '90';
 
+// In-memory index of the currently-rendered upcoming purchases, keyed by
+// plan_id. The "View Details" affordance renders from this — the
+// /api/dashboard/upcoming response already carries every field the
+// dialog needs (plan name, scheduled date, provider/service, ramp
+// step), and there is no execution row to look up yet (the upcoming
+// list shows plans whose next execution hasn't fired). Issues #204 +
+// #205 surfaced when we tried to look these up via /api/purchases/{id}
+// using the plan_id — no row, 500.
+let upcomingPurchasesIndex: Map<string, UpcomingPurchase> = new Map();
+
 /**
  * Setup dashboard event handlers
  */
@@ -215,6 +225,11 @@ function renderUpcomingPurchases(purchases: UpcomingPurchase[]): void {
   const container = document.getElementById('upcoming-list');
   if (!container) return;
 
+  // Refresh the in-memory index so viewPurchaseDetails can render its
+  // dialog from local data — there is no execution row to look up yet
+  // (the upcoming list shows plans whose next execution hasn't fired).
+  upcomingPurchasesIndex = new Map(purchases.map(p => [p.plan_id, p]));
+
   if (!purchases || purchases.length === 0) {
     container.innerHTML = '<p class="empty">No upcoming scheduled purchases</p>';
     return;
@@ -239,8 +254,8 @@ function renderUpcomingPurchases(purchases: UpcomingPurchase[]): void {
           <div class="label">Est. monthly savings</div>
         </div>
         <div class="upcoming-actions">
-          <button data-action="view-purchase" data-id="${p.execution_id}">View Details</button>
-          <button data-action="cancel-purchase" data-id="${p.execution_id}" class="danger">Cancel</button>
+          <button data-action="view-purchase" data-id="${p.plan_id}">View Details</button>
+          <button data-action="cancel-purchase" data-id="${p.plan_id}" class="danger">Cancel</button>
         </div>
       </div>
     `;
@@ -248,98 +263,128 @@ function renderUpcomingPurchases(purchases: UpcomingPurchase[]): void {
 
   // Add event listeners
   container.querySelectorAll<HTMLButtonElement>('[data-action="view-purchase"]').forEach(btn => {
-    btn.addEventListener('click', () => void viewPurchaseDetails(btn.dataset['id'] || ''));
+    btn.addEventListener('click', () => viewPurchaseDetails(btn.dataset['id'] || ''));
   });
   container.querySelectorAll<HTMLButtonElement>('[data-action="cancel-purchase"]').forEach(btn => {
     btn.addEventListener('click', () => void cancelScheduledPurchase(btn.dataset['id'] || ''));
   });
 }
 
-async function viewPurchaseDetails(executionId: string): Promise<void> {
-  try {
-    const purchase = await api.getPurchaseDetails(executionId);
-
-    // Remove any existing details modal
-    document.getElementById('purchase-details-modal')?.remove();
-
-    const modal = document.createElement('div');
-    modal.id = 'purchase-details-modal';
-    modal.className = 'modal';
-    modal.innerHTML = `
-      <div class="modal-content modal-wide">
-        <h2>Purchase Details</h2>
-        <div class="form-section">
-          <h3>Execution Info</h3>
-          <table>
-            <tbody>
-              <tr><td><strong>Execution ID</strong></td><td>${escapeHtml(purchase.execution_id)}</td></tr>
-              <tr><td><strong>Status</strong></td><td><span class="status-badge ${purchase.status.toLowerCase().replace(/[^a-z-]/g, '')}">${escapeHtml(purchase.status)}</span></td></tr>
-              <tr><td><strong>Created</strong></td><td>${escapeHtml(purchase.created_at)}</td></tr>
-              ${purchase.completed_at ? `<tr><td><strong>Completed</strong></td><td>${escapeHtml(purchase.completed_at)}</td></tr>` : ''}
-            </tbody>
-          </table>
-        </div>
-        ${purchase.results && purchase.results.length > 0 ? `
-        <div class="form-section">
-          <h3>Results</h3>
-          <table>
-            <thead>
-              <tr><th>Recommendation ID</th><th>Status</th><th>Confirmation ID</th><th>Error</th></tr>
-            </thead>
-            <tbody>
-              ${purchase.results.map(r => `
-                <tr>
-                  <td>${escapeHtml(r.recommendation_id)}</td>
-                  <td><span class="status-badge ${r.status.toLowerCase().replace(/[^a-z-]/g, '')}">${escapeHtml(r.status)}</span></td>
-                  <td>${r.confirmation_id ? escapeHtml(r.confirmation_id) : '-'}</td>
-                  <td>${r.error ? escapeHtml(r.error) : '-'}</td>
-                </tr>
-              `).join('')}
-            </tbody>
-          </table>
-        </div>
-        ` : ''}
-        <div class="modal-buttons">
-          ${purchase.status.toLowerCase() === 'pending' ? '<button type="button" id="cancel-purchase-detail-btn" class="danger">Cancel Purchase</button>' : ''}
-          <button type="button" id="close-purchase-details-btn">Close</button>
-        </div>
-      </div>
-    `;
-    document.body.appendChild(modal);
-
-    modal.querySelector('#close-purchase-details-btn')?.addEventListener('click', () => {
-      modal.remove();
-    });
-
-    const cancelBtn = modal.querySelector('#cancel-purchase-detail-btn') as HTMLButtonElement | null;
-    if (cancelBtn) {
-      cancelBtn.addEventListener('click', async () => {
-        const ok = await confirmDialog({
-          title: 'Cancel this purchase?',
-          body: 'Cancelling a scheduled purchase cannot be undone. Any upfront cost already committed will not be refunded.',
-          confirmLabel: 'Cancel purchase',
-          destructive: true,
-        });
-        if (!ok) return;
-        try {
-          await api.cancelPurchase(executionId);
-          modal.remove();
-          await loadDashboard();
-          showToast({ message: 'Purchase cancelled successfully', kind: 'success', timeout: 5_000 });
-        } catch (cancelError) {
-          console.error('Failed to cancel purchase:', cancelError);
-          showToast({ message: 'Failed to cancel purchase', kind: 'error' });
-        }
-      });
-    }
-  } catch (error) {
-    console.error('Failed to load purchase details:', error);
-    const err = error as Error;
-    showToast({ message: `Failed to load purchase details: ${err.message}`, kind: 'error' });
+function viewPurchaseDetails(planId: string): void {
+  // The "upcoming" widget shows PurchasePlans whose next execution hasn't
+  // fired — there's no purchase_executions row to look up. Render the
+  // dialog from the in-memory snapshot the renderer just stored
+  // (issues #204 + #205).
+  const purchase = upcomingPurchasesIndex.get(planId);
+  if (!purchase) {
+    showToast({ message: 'Failed to load purchase details: not in current view', kind: 'error' });
+    return;
   }
+
+  // Remove any existing details modal
+  document.getElementById('purchase-details-modal')?.remove();
+
+  const modal = buildUpcomingDetailsModal(purchase, planId);
+  document.body.appendChild(modal);
 }
 
-async function cancelScheduledPurchase(executionId: string): Promise<void> {
+// buildUpcomingDetailsModal constructs the dialog via DOM-API, not
+// innerHTML, so user-controlled fields (plan_name, service) can never be
+// interpreted as HTML — closes a class of XSS regressions that the
+// previous escapeHtml-+-innerHTML pattern only avoided by convention.
+function buildUpcomingDetailsModal(p: UpcomingPurchase, planId: string): HTMLDivElement {
+  const modal = document.createElement('div');
+  modal.id = 'purchase-details-modal';
+  modal.className = 'modal';
+
+  const content = document.createElement('div');
+  content.className = 'modal-content modal-wide';
+  modal.appendChild(content);
+
+  const h2 = document.createElement('h2');
+  h2.textContent = 'Upcoming Purchase Details';
+  content.appendChild(h2);
+
+  const section = document.createElement('div');
+  section.className = 'form-section';
+  content.appendChild(section);
+
+  const sectionH3 = document.createElement('h3');
+  sectionH3.textContent = 'Plan Info';
+  section.appendChild(sectionH3);
+
+  const table = document.createElement('table');
+  const tbody = document.createElement('tbody');
+  table.appendChild(tbody);
+  section.appendChild(table);
+
+  const addRow = (label: string, value: string): void => {
+    const tr = document.createElement('tr');
+    const tdLabel = document.createElement('td');
+    const strong = document.createElement('strong');
+    strong.textContent = label;
+    tdLabel.appendChild(strong);
+    const tdValue = document.createElement('td');
+    tdValue.textContent = value;
+    tr.appendChild(tdLabel);
+    tr.appendChild(tdValue);
+    tbody.appendChild(tr);
+  };
+
+  addRow('Plan name', p.plan_name);
+  addRow('Plan ID', planId);
+  addRow('Scheduled', p.scheduled_date);
+  addRow('Provider', p.provider.toUpperCase());
+  addRow('Service', p.service);
+  addRow('Step', `${p.step_number} of ${p.total_steps}`);
+  addRow('Est. monthly savings', formatCurrency(p.estimated_savings));
+
+  // Buttons row
+  const btnRow = document.createElement('div');
+  btnRow.className = 'modal-buttons';
+  content.appendChild(btnRow);
+
+  const cancelBtn = document.createElement('button');
+  cancelBtn.type = 'button';
+  cancelBtn.id = 'cancel-purchase-detail-btn';
+  cancelBtn.className = 'danger';
+  cancelBtn.textContent = 'Cancel Purchase';
+  cancelBtn.addEventListener('click', async () => {
+    const ok = await confirmDialog({
+      title: 'Cancel this scheduled purchase?',
+      body: 'Cancelling a scheduled purchase cannot be undone. Any upfront cost already committed will not be refunded.',
+      confirmLabel: 'Cancel purchase',
+      destructive: true,
+    });
+    if (!ok) return;
+    try {
+      await api.deletePlannedPurchase(planId);
+      modal.remove();
+      await loadDashboard();
+      showToast({ message: 'Purchase cancelled successfully', kind: 'success', timeout: 5_000 });
+    } catch (cancelError) {
+      console.error('Failed to cancel purchase:', cancelError);
+      showToast({ message: 'Failed to cancel purchase', kind: 'error' });
+    }
+  });
+  btnRow.appendChild(cancelBtn);
+
+  const closeBtn = document.createElement('button');
+  closeBtn.type = 'button';
+  closeBtn.id = 'close-purchase-details-btn';
+  closeBtn.textContent = 'Close';
+  closeBtn.addEventListener('click', () => modal.remove());
+  btnRow.appendChild(closeBtn);
+
+  return modal;
+}
+
+async function cancelScheduledPurchase(planId: string): Promise<void> {
+  // Plan-level cancel: the row-on-the-Cancel-button is a PurchasePlan
+  // whose next execution hasn't fired yet, so there's no
+  // purchase_executions row to cancel. deletePlannedPurchase is the
+  // correct endpoint — `cancelPurchase` here would 500 with
+  // "execution not found" (issue #204).
   const ok = await confirmDialog({
     title: 'Cancel this scheduled purchase?',
     body: 'Cancelling a scheduled purchase cannot be undone. Any upfront cost already committed will not be refunded.',
@@ -349,7 +394,7 @@ async function cancelScheduledPurchase(executionId: string): Promise<void> {
   if (!ok) return;
 
   try {
-    await api.cancelPurchase(executionId);
+    await api.deletePlannedPurchase(planId);
     await loadDashboard();
     showToast({ message: 'Purchase cancelled successfully', kind: 'success', timeout: 5_000 });
   } catch (error) {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -38,7 +38,7 @@ export interface ServiceSavings {
 }
 
 export interface UpcomingPurchase {
-  execution_id: string;
+  plan_id: string;
   plan_name: string;
   scheduled_date: string;
   provider: api.Provider;

--- a/internal/api/handler_dashboard.go
+++ b/internal/api/handler_dashboard.go
@@ -258,7 +258,7 @@ func upcomingFromPlan(plan config.PurchasePlan) UpcomingPurchase {
 		break
 	}
 	return UpcomingPurchase{
-		ExecutionID:      plan.ID,
+		PlanID:           plan.ID,
 		PlanName:         plan.Name,
 		ScheduledDate:    plan.NextExecutionDate.Format("2006-01-02"),
 		Provider:         provider,

--- a/internal/api/handler_dashboard_test.go
+++ b/internal/api/handler_dashboard_test.go
@@ -254,7 +254,7 @@ func TestHandler_getUpcomingPurchases(t *testing.T) {
 
 	// Only enabled plans should be returned
 	assert.Len(t, result.Purchases, 1)
-	assert.Equal(t, "11111111-1111-1111-1111-111111111111", result.Purchases[0].ExecutionID)
+	assert.Equal(t, "11111111-1111-1111-1111-111111111111", result.Purchases[0].PlanID)
 	assert.Equal(t, "Test Plan 1", result.Purchases[0].PlanName)
 	assert.Equal(t, "aws", result.Purchases[0].Provider)
 	assert.Equal(t, "rds", result.Purchases[0].Service)

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -417,9 +417,16 @@ type UpcomingPurchaseResponse struct {
 	Purchases []UpcomingPurchase `json:"purchases"`
 }
 
-// UpcomingPurchase represents a scheduled purchase
+// UpcomingPurchase represents a scheduled purchase that has not yet
+// produced a purchase_executions row. The identifier is therefore the
+// PurchasePlan.ID, not an execution ID — the dashboard's Cancel / View
+// Details affordances must target plan-level endpoints
+// (DELETE /api/purchases/planned/{id}, etc.), NOT execution-level ones
+// (/api/purchases/{id}, /api/purchases/cancel/{id}). Wiring plan IDs to
+// execution endpoints surfaces as a 500 from the SELECT-by-execution-id
+// path returning no row, exactly what issues #204 and #205 reported.
 type UpcomingPurchase struct {
-	ExecutionID      string  `json:"execution_id"`
+	PlanID           string  `json:"plan_id"`
 	PlanName         string  `json:"plan_name"`
 	ScheduledDate    string  `json:"scheduled_date"`
 	Provider         string  `json:"provider"`


### PR DESCRIPTION
Real fix for the dashboard "Upcoming Scheduled Purchases" 500-on-click pair (#204, #205). Supersedes the surface symptom that PR #206 cleared.

## What was actually broken

`internal/api/handler_dashboard.go:upcomingFromPlan` emitted the `PurchasePlan.ID` as the JSON field `execution_id`. The frontend bound that to View Details / Cancel buttons which called execution-level endpoints (`/api/purchases/{id}`, `/api/purchases/cancel/{id}`). Those endpoints look the value up in `purchase_executions`, but **no execution row exists yet for an upcoming purchase** — the execution is created when the schedule fires. Every click 500-ed.

PR #206 cleared the column-doesn't-exist symptom. After that, the same buttons surfaced the underlying logic error directly:

```
[ERROR] API error: execution not found:
        execution not found: 1cf88fc4-b48e-4303-9ba0-32f000ccaf31
```

(`1cf88fc4-…` was a plan_id all along.)

## Backend

* `internal/api/types.go`: `UpcomingPurchase.ExecutionID` → `PlanID`; JSON tag `execution_id` → `plan_id`. Doc comment now warns that wiring this to execution endpoints is exactly the #204/#205 bug pattern.
* `internal/api/handler_dashboard.go:upcomingFromPlan`: emit `PlanID: plan.ID`.
* `internal/api/handler_dashboard_test.go`: assertion updated.

## Frontend

* `types.ts` + `api/types.ts`: `UpcomingPurchase.execution_id` → `plan_id`.
* `dashboard.ts`:
  - Added `upcomingPurchasesIndex: Map<string, UpcomingPurchase>` populated by `renderUpcomingPurchases`. The dialog renders from this snapshot — no API call is needed (every field is in the upcoming-list response) and there's no execution row to fetch.
  - Buttons now carry `data-id="${p.plan_id}"`.
  - `viewPurchaseDetails(planId)` is now sync; the modal is built via DOM API (`createElement` + `textContent`) instead of `innerHTML`. Closes a class of XSS regressions and avoids reliance on the `escapeHtml`-by-convention pattern.
  - `cancelScheduledPurchase(planId)` calls `api.deletePlannedPurchase(planId)` instead of `api.cancelPurchase(executionId)`.
  - In-modal cancel button likewise routes to `deletePlannedPurchase`.
* `dashboard.test.ts`: fixtures + mocks updated; the now-impossible "API rejection" failure-mode test for view-details was removed (the call path is sync); cancel tests assert `deletePlannedPurchase` is called with the plan_id.

## Verification

* `go build ./...` clean
* `go test ./...` — every package green (incl. handler_dashboard_test.go)
* `tsc --noEmit` clean
* `npx jest` — **1386/1386** tests pass, including the 18 dashboard tests
* Pre-commit (gosec / trivy / migration-conflicts / go-test / build frontend / frontend tests) — all green

Once deployed, the two dashboard buttons will hit the right endpoints and stop returning 500s.

## Triage

`type/bug`, `severity/high`, `urgency/now`, `impact/all-users`, `effort/s`, `priority/p0`, `triaged`. Closes #204 + #205 — the column-doesn't-exist fix in #206 is still correct (defends against any future migration drift), but this PR is what actually makes the buttons work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refactored upcoming purchases management to use plan identifiers for more reliable action handling.
  * Optimized purchase details view to load from local data, eliminating unnecessary API calls.
  * Updated purchase cancellation to operate at the plan level for better consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->