### PR TITLE
feat(accounts): wire AWS Organizations discovery endpoint (closes #208)

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/LeanerCloud/CUDly/internal/accounts"
 	"github.com/LeanerCloud/CUDly/internal/config"
 	"github.com/LeanerCloud/CUDly/internal/credentials"
 	"github.com/LeanerCloud/CUDly/internal/email"
@@ -77,6 +78,12 @@ type Handler struct {
 	// without AWS credentials. Tests set this to a fixed-result fake so
 	// the integration suite runs hermetically.
 	reshapeAccountResolver func(context.Context) (string, error)
+
+	// Optional org-discovery factory used by tests to avoid live AWS
+	// Organizations API calls. When nil (production default), the handler
+	// falls back to accounts.DiscoverOrgAccounts which dials Organizations
+	// via the credentials resolved for the org-root account.
+	discoverOrgFn func(context.Context, aws.Config) (*accounts.OrgDiscoveryResult, error)
 
 	// commitmentOpts discovers which AWS (term, payment) combinations
 	// each service actually sells and validates saves against that data.

--- a/internal/api/handler_accounts.go
+++ b/internal/api/handler_accounts.go
@@ -1139,6 +1139,9 @@ func (h *Handler) discoverOrgAccounts(ctx context.Context, req *events.LambdaFun
 	if err != nil {
 		return nil, err
 	}
+	if disco == nil {
+		return DiscoverOrgResult{}, nil
+	}
 
 	return h.persistDiscoveredMembers(ctx, root, disco.Accounts)
 }

--- a/internal/api/handler_accounts.go
+++ b/internal/api/handler_accounts.go
@@ -1117,7 +1117,11 @@ type DiscoverOrgResult struct {
 // #208 for the spec; see specs/multi-account-execution/acceptance.md F-1..F-3
 // for the acceptance criteria.
 func (h *Handler) discoverOrgAccounts(ctx context.Context, req *events.LambdaFunctionURLRequest) (any, error) {
-	if _, err := h.requirePermission(ctx, req, "create", "accounts"); err != nil {
+	// Admin-only: org discovery can create N cloud_accounts rows in one call
+	// and may bring unfamiliar accounts into the roster. Even though those
+	// rows boot disabled, the elevated privilege makes admin-scope the right
+	// gate (CR pass 1 on PR #212).
+	if _, err := h.requireAdmin(ctx, req); err != nil {
 		return nil, err
 	}
 
@@ -1171,6 +1175,17 @@ func (h *Handler) parseDiscoverOrgRoot(ctx context.Context, rawBody string) (*co
 
 // buildOrgRootAWSConfig resolves the org-root account's stored credentials and
 // returns an aws.Config configured to call AWS APIs as that account.
+//
+// Returns the resolver's error wrapped as a regular Go error (which the
+// handler-default mapping surfaces as 500) — NOT a 400 ClientError — because
+// ResolveAWSCredentialProvider mixes definite client-side validation
+// failures (e.g., missing aws_role_arn for role_arn mode) with transient
+// server-side failures (credential store unavailable, network errors during
+// access-key load). Without a sentinel/typed error in the credentials
+// package today, blanket-400 was misleading; 5xx is the safer default and
+// retries are possible. Refining this to a proper 400/500 split is tracked
+// in the credentials-package error-type cleanup (out of scope for this PR;
+// see CR pass 1 on #212).
 func (h *Handler) buildOrgRootAWSConfig(ctx context.Context, root *config.CloudAccount) (aws.Config, error) {
 	baseCfg, err := h.getBaseAWSConfig(ctx)
 	if err != nil {
@@ -1179,7 +1194,7 @@ func (h *Handler) buildOrgRootAWSConfig(ctx context.Context, root *config.CloudA
 	stsClient := sts.NewFromConfig(baseCfg)
 	credProvider, err := credentials.ResolveAWSCredentialProvider(ctx, root, h.credStore, stsClient)
 	if err != nil {
-		return aws.Config{}, NewClientError(400, fmt.Sprintf("resolve credentials for account %s: %v", root.ID, err))
+		return aws.Config{}, fmt.Errorf("accounts: resolve credentials for org root %s: %w", root.ID, err)
 	}
 	cfg := baseCfg.Copy()
 	cfg.Credentials = credProvider
@@ -1224,11 +1239,20 @@ func (h *Handler) persistDiscoveredMembers(ctx context.Context, root *config.Clo
 			continue
 		}
 		// Defaults the spec mandates: persist disabled (operator review gate)
-		// + bastion mode chained off this org root. The operator fills in
-		// AWSRoleARN before flipping enabled=true; until then the scheduler
-		// silently skips disabled rows.
+		// + bastion-id pre-filled with this org root's ID. AWSAuthMode is
+		// LEFT EMPTY on purpose — pre-setting it to "bastion" while
+		// AWSRoleARN is empty would cause awsAmbientCredResult to falsely
+		// classify the row as having valid ambient creds (the role_arn /
+		// bastion + empty-AWSRoleARN branch returns OK with the "ambient
+		// host" message, which is wrong for a discovered member account).
+		// The operator's review step must set both AWSAuthMode="bastion"
+		// AND a non-empty AWSRoleARN before flipping enabled=true; the
+		// scheduler silently skips disabled rows in the meantime, and an
+		// empty AWSAuthMode also fails ResolveAWSCredentialProvider's
+		// switch with a clear "unsupported aws_auth_mode" error if the
+		// row is enabled prematurely. (CR pass 1 on PR #212.)
 		member.Enabled = false
-		member.AWSAuthMode = "bastion"
+		member.AWSAuthMode = ""
 		member.AWSBastionID = root.ID
 		if err := h.config.CreateCloudAccount(ctx, &member); err != nil {
 			return DiscoverOrgResult{}, fmt.Errorf("accounts: persist discovered %s: %w", member.ExternalID, err)

--- a/internal/api/handler_accounts.go
+++ b/internal/api/handler_accounts.go
@@ -1110,12 +1110,12 @@ type DiscoverOrgResult struct {
 // (1) validates the named cloud account is an AWS org root, (2) resolves its
 // stored credentials, (3) calls AWS Organizations ListAccounts via the
 // credentials, (4) deduplicates against existing aws cloud_accounts rows by
-// external_id, and (5) persists the new ones with enabled=false +
-// aws_auth_mode=bastion + aws_bastion_id pointing at the org root, so an
-// operator must review/approve each discovered account (and fill in the
-// target role ARN) before it'll be picked up by the scheduler. See issue
-// #208 for the spec; see specs/multi-account-execution/acceptance.md F-1..F-3
-// for the acceptance criteria.
+// external_id, and (5) persists the new ones with enabled=false, an empty
+// aws_auth_mode, and aws_bastion_id pointing at the org root, so an operator
+// must review/approve each discovered account and explicitly choose the
+// bastion auth mode plus role ARN before it'll be picked up by the scheduler.
+// See issue #208 for the spec; see specs/multi-account-execution/
+// acceptance.md F-1..F-3 for the acceptance criteria.
 func (h *Handler) discoverOrgAccounts(ctx context.Context, req *events.LambdaFunctionURLRequest) (any, error) {
 	// Admin-only: org discovery can create N cloud_accounts rows in one call
 	// and may bring unfamiliar accounts into the roster. Even though those
@@ -1218,8 +1218,8 @@ func (h *Handler) runOrgDiscovery(ctx context.Context, cfg aws.Config) (*account
 
 // persistDiscoveredMembers dedupes the discovered list against existing aws
 // rows and persists each new one with the spec-mandated defaults
-// (enabled=false, aws_auth_mode=bastion, aws_bastion_id=root.ID). Returns
-// the {discovered, created, skipped} summary.
+// (enabled=false, aws_auth_mode="", aws_bastion_id=root.ID). Returns the
+// {discovered, created, skipped} summary.
 func (h *Handler) persistDiscoveredMembers(ctx context.Context, root *config.CloudAccount, members []config.CloudAccount) (DiscoverOrgResult, error) {
 	awsProvider := "aws"
 	existing, err := h.config.ListCloudAccounts(ctx, config.CloudAccountFilter{Provider: &awsProvider})
@@ -1232,6 +1232,7 @@ func (h *Handler) persistDiscoveredMembers(ctx context.Context, root *config.Clo
 	}
 
 	result := DiscoverOrgResult{Discovered: len(members)}
+	now := time.Now()
 	for i := range members {
 		member := members[i]
 		if _, found := knownExternal[member.ExternalID]; found {
@@ -1247,11 +1248,15 @@ func (h *Handler) persistDiscoveredMembers(ctx context.Context, root *config.Clo
 		// host" message, which is wrong for a discovered member account).
 		// The operator's review step must set both AWSAuthMode="bastion"
 		// AND a non-empty AWSRoleARN before flipping enabled=true; the
-		// scheduler silently skips disabled rows in the meantime, and an
-		// empty AWSAuthMode also fails ResolveAWSCredentialProvider's
-		// switch with a clear "unsupported aws_auth_mode" error if the
-		// row is enabled prematurely. (CR pass 1 on PR #212.)
+		// scheduler silently skips disabled rows in the meantime, and the
+		// empty AWSAuthMode we persist here also fails
+		// ResolveAWSCredentialProvider's switch with a clear
+		// "unsupported aws_auth_mode" error if the row is enabled
+		// prematurely. (CR pass 1 on PR #212.)
 		member.Enabled = false
+		member.ID = uuid.New().String()
+		member.CreatedAt = now
+		member.UpdatedAt = now
 		member.AWSAuthMode = ""
 		member.AWSBastionID = root.ID
 		if err := h.config.CreateCloudAccount(ctx, &member); err != nil {

--- a/internal/api/handler_accounts.go
+++ b/internal/api/handler_accounts.go
@@ -1260,8 +1260,14 @@ func (h *Handler) persistDiscoveredMembers(ctx context.Context, root *config.Clo
 		member.AWSAuthMode = ""
 		member.AWSBastionID = root.ID
 		if err := h.config.CreateCloudAccount(ctx, &member); err != nil {
+			if isDuplicateKeyError(err) {
+				knownExternal[member.ExternalID] = struct{}{}
+				result.Skipped++
+				continue
+			}
 			return DiscoverOrgResult{}, fmt.Errorf("accounts: persist discovered %s: %w", member.ExternalID, err)
 		}
+		knownExternal[member.ExternalID] = struct{}{}
 		result.Created++
 	}
 	return result, nil

--- a/internal/api/handler_accounts.go
+++ b/internal/api/handler_accounts.go
@@ -10,11 +10,14 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"golang.org/x/oauth2"
 
+	"github.com/LeanerCloud/CUDly/internal/accounts"
 	"github.com/LeanerCloud/CUDly/internal/auth"
 	"github.com/LeanerCloud/CUDly/internal/config"
 	"github.com/LeanerCloud/CUDly/internal/credentials"
 	"github.com/LeanerCloud/CUDly/internal/oidc"
 	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/google/uuid"
 )
 
@@ -1086,13 +1089,153 @@ func (h *Handler) listPlanAccounts(ctx context.Context, req *events.LambdaFuncti
 	return accounts, nil
 }
 
-// discoverOrgAccounts handles POST /api/accounts/discover-org.
+// DiscoverOrgRequest is the request body for POST /api/accounts/discover-org.
+// AccountID is the UUID of the org-root cloud account whose stored credentials
+// will be used to call AWS Organizations.
+type DiscoverOrgRequest struct {
+	AccountID string `json:"account_id"`
+}
+
+// DiscoverOrgResult is the response shape for POST /api/accounts/discover-org.
+// Discovered is the total number of member accounts the AWS Organizations API
+// returned; Created is the number of new cloud_accounts rows persisted; Skipped
+// is the number that already existed (matched by provider+external_id).
+type DiscoverOrgResult struct {
+	Discovered int `json:"discovered"`
+	Created    int `json:"created"`
+	Skipped    int `json:"skipped"`
+}
+
+// discoverOrgAccounts handles POST /api/accounts/discover-org. The endpoint
+// (1) validates the named cloud account is an AWS org root, (2) resolves its
+// stored credentials, (3) calls AWS Organizations ListAccounts via the
+// credentials, (4) deduplicates against existing aws cloud_accounts rows by
+// external_id, and (5) persists the new ones with enabled=false +
+// aws_auth_mode=bastion + aws_bastion_id pointing at the org root, so an
+// operator must review/approve each discovered account (and fill in the
+// target role ARN) before it'll be picked up by the scheduler. See issue
+// #208 for the spec; see specs/multi-account-execution/acceptance.md F-1..F-3
+// for the acceptance criteria.
 func (h *Handler) discoverOrgAccounts(ctx context.Context, req *events.LambdaFunctionURLRequest) (any, error) {
 	if _, err := h.requirePermission(ctx, req, "create", "accounts"); err != nil {
 		return nil, err
 	}
 
-	return map[string]string{"message": "org discovery not yet implemented"}, nil
+	root, err := h.parseDiscoverOrgRoot(ctx, req.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg, err := h.buildOrgRootAWSConfig(ctx, root)
+	if err != nil {
+		return nil, err
+	}
+
+	disco, err := h.runOrgDiscovery(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return h.persistDiscoveredMembers(ctx, root, disco.Accounts)
+}
+
+// parseDiscoverOrgRoot decodes the request body, loads the named account, and
+// validates it's a usable AWS org root. Returns ClientErrors for the four
+// failure modes the spec enumerates (bad JSON / bad UUID / not-aws / not-root)
+// + 404 for missing-account. Pulled out of discoverOrgAccounts to keep that
+// function under the gocyclo budget.
+func (h *Handler) parseDiscoverOrgRoot(ctx context.Context, rawBody string) (*config.CloudAccount, error) {
+	var body DiscoverOrgRequest
+	if err := json.Unmarshal([]byte(rawBody), &body); err != nil {
+		return nil, NewClientError(400, "invalid JSON body")
+	}
+	if err := validateUUID(body.AccountID); err != nil {
+		return nil, err
+	}
+
+	root, err := h.config.GetCloudAccount(ctx, body.AccountID)
+	if err != nil {
+		return nil, fmt.Errorf("accounts: get cloud account: %w", err)
+	}
+	if root == nil {
+		return nil, NewClientError(404, "cloud account not found")
+	}
+	if root.Provider != "aws" {
+		return nil, NewClientError(400, "discover-org requires an aws account")
+	}
+	if !root.AWSIsOrgRoot {
+		return nil, NewClientError(400, "account is not configured as an org root (set aws_is_org_root=true)")
+	}
+	return root, nil
+}
+
+// buildOrgRootAWSConfig resolves the org-root account's stored credentials and
+// returns an aws.Config configured to call AWS APIs as that account.
+func (h *Handler) buildOrgRootAWSConfig(ctx context.Context, root *config.CloudAccount) (aws.Config, error) {
+	baseCfg, err := h.getBaseAWSConfig(ctx)
+	if err != nil {
+		return aws.Config{}, fmt.Errorf("accounts: load base aws config: %w", err)
+	}
+	stsClient := sts.NewFromConfig(baseCfg)
+	credProvider, err := credentials.ResolveAWSCredentialProvider(ctx, root, h.credStore, stsClient)
+	if err != nil {
+		return aws.Config{}, NewClientError(400, fmt.Sprintf("resolve credentials for account %s: %v", root.ID, err))
+	}
+	cfg := baseCfg.Copy()
+	cfg.Credentials = credProvider
+	return cfg, nil
+}
+
+// runOrgDiscovery dispatches to the configured discovery function — the
+// injectable seam Handler.discoverOrgFn for tests, falling back to the real
+// accounts.DiscoverOrgAccounts in production.
+func (h *Handler) runOrgDiscovery(ctx context.Context, cfg aws.Config) (*accounts.OrgDiscoveryResult, error) {
+	discoverFn := h.discoverOrgFn
+	if discoverFn == nil {
+		discoverFn = accounts.DiscoverOrgAccounts
+	}
+	disco, err := discoverFn(ctx, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("accounts: org discovery failed: %w", err)
+	}
+	return disco, nil
+}
+
+// persistDiscoveredMembers dedupes the discovered list against existing aws
+// rows and persists each new one with the spec-mandated defaults
+// (enabled=false, aws_auth_mode=bastion, aws_bastion_id=root.ID). Returns
+// the {discovered, created, skipped} summary.
+func (h *Handler) persistDiscoveredMembers(ctx context.Context, root *config.CloudAccount, members []config.CloudAccount) (DiscoverOrgResult, error) {
+	awsProvider := "aws"
+	existing, err := h.config.ListCloudAccounts(ctx, config.CloudAccountFilter{Provider: &awsProvider})
+	if err != nil {
+		return DiscoverOrgResult{}, fmt.Errorf("accounts: list existing aws accounts: %w", err)
+	}
+	knownExternal := make(map[string]struct{}, len(existing))
+	for i := range existing {
+		knownExternal[existing[i].ExternalID] = struct{}{}
+	}
+
+	result := DiscoverOrgResult{Discovered: len(members)}
+	for i := range members {
+		member := members[i]
+		if _, found := knownExternal[member.ExternalID]; found {
+			result.Skipped++
+			continue
+		}
+		// Defaults the spec mandates: persist disabled (operator review gate)
+		// + bastion mode chained off this org root. The operator fills in
+		// AWSRoleARN before flipping enabled=true; until then the scheduler
+		// silently skips disabled rows.
+		member.Enabled = false
+		member.AWSAuthMode = "bastion"
+		member.AWSBastionID = root.ID
+		if err := h.config.CreateCloudAccount(ctx, &member); err != nil {
+			return DiscoverOrgResult{}, fmt.Errorf("accounts: persist discovered %s: %w", member.ExternalID, err)
+		}
+		result.Created++
+	}
+	return result, nil
 }
 
 // parseServiceOverridePath parses "uuid/service-overrides/provider/service"

--- a/internal/api/handler_accounts_test.go
+++ b/internal/api/handler_accounts_test.go
@@ -683,6 +683,69 @@ func TestDiscoverOrgAccounts_HappyPathDedupesAndPersists(t *testing.T) {
 	}
 }
 
+func TestDiscoverOrgAccounts_SkipsDuplicateKeyOnInsert(t *testing.T) {
+	ctx := context.Background()
+	mockAuth := new(MockAuthService)
+	setupAdminAuth(ctx, mockAuth)
+
+	root := &config.CloudAccount{
+		ID:           "11111111-1111-1111-1111-111111111111",
+		Name:         "Org Root",
+		Provider:     "aws",
+		ExternalID:   "999999999999",
+		AWSAuthMode:  "access_keys",
+		AWSIsOrgRoot: true,
+	}
+
+	store := setupAdminMock(ctx)
+	store.GetCloudAccountFn = func(_ context.Context, _ string) (*config.CloudAccount, error) {
+		return root, nil
+	}
+	store.ListCloudAccountsFn = func(_ context.Context, _ config.CloudAccountFilter) ([]config.CloudAccount, error) {
+		return nil, nil
+	}
+
+	var created []config.CloudAccount
+	store.CreateCloudAccountFn = func(_ context.Context, a *config.CloudAccount) error {
+		created = append(created, *a)
+		if a.ExternalID == "300000000003" {
+			return errors.New("duplicate key value violates unique constraint")
+		}
+		return nil
+	}
+
+	handler := &Handler{
+		auth:   mockAuth,
+		config: store,
+		credStore: &fakeCredStore{
+			data: map[string][]byte{
+				root.ID + "::aws_access_keys": []byte(`{"access_key_id":"AKIATEST","secret_access_key":"shh"}`),
+			},
+		},
+		discoverOrgFn: func(_ context.Context, _ aws.Config) (*accounts.OrgDiscoveryResult, error) {
+			return &accounts.OrgDiscoveryResult{
+				Accounts: []config.CloudAccount{
+					{Provider: "aws", ExternalID: "300000000003", Name: "Dup On Insert"},
+					{Provider: "aws", ExternalID: "300000000003", Name: "Dup In Batch"},
+					{Provider: "aws", ExternalID: "400000000004", Name: "Created"},
+				},
+			}, nil
+		},
+	}
+
+	result, err := handler.discoverOrgAccounts(ctx, adminRequest(`{"account_id":"`+root.ID+`"}`))
+	require.NoError(t, err)
+
+	dr, ok := result.(DiscoverOrgResult)
+	require.True(t, ok, "result type = %T", result)
+	assert.Equal(t, 3, dr.Discovered)
+	assert.Equal(t, 1, dr.Created)
+	assert.Equal(t, 2, dr.Skipped)
+	require.Len(t, created, 2)
+	assert.Equal(t, "300000000003", created[0].ExternalID)
+	assert.Equal(t, "400000000004", created[1].ExternalID)
+}
+
 // fakeCredStore is a minimal CredentialStore for the discover-org happy-path
 // test. It only exists to satisfy ResolveAWSCredentialProvider's access_keys
 // mode without dragging in the real Secrets Manager / Postgres dependency.

--- a/internal/api/handler_accounts_test.go
+++ b/internal/api/handler_accounts_test.go
@@ -2,12 +2,13 @@ package api
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"testing"
 
+	"github.com/LeanerCloud/CUDly/internal/accounts"
 	"github.com/LeanerCloud/CUDly/internal/config"
 	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -506,21 +507,187 @@ func TestListPlanAccounts_Success(t *testing.T) {
 
 // --- discoverOrgAccounts ---
 
-func TestDiscoverOrgAccounts_ReturnsStub(t *testing.T) {
+// orgRootAccount is an org-root fixture used by the discover-org tests.
+// access_keys auth mode + a stored credential is the simplest path through
+// ResolveAWSCredentialProvider that doesn't require an STS round-trip.
+func orgRootAccount() *config.CloudAccount {
+	return &config.CloudAccount{
+		ID:           "11111111-1111-1111-1111-111111111111",
+		Provider:     "aws",
+		ExternalID:   "100000000001",
+		Name:         "Org Root",
+		Enabled:      true,
+		AWSAuthMode:  "access_keys",
+		AWSIsOrgRoot: true,
+	}
+}
+
+func TestDiscoverOrgAccounts_RejectsInvalidBody(t *testing.T) {
+	ctx := context.Background()
+	mockAuth := new(MockAuthService)
+	setupAdminAuth(ctx, mockAuth)
+	handler := &Handler{auth: mockAuth, config: setupAdminMock(ctx)}
+
+	_, err := handler.discoverOrgAccounts(ctx, adminRequest("not json"))
+	require.Error(t, err)
+	ce, ok := IsClientError(err)
+	require.True(t, ok)
+	assert.Equal(t, 400, ce.code)
+}
+
+func TestDiscoverOrgAccounts_RejectsInvalidAccountID(t *testing.T) {
+	ctx := context.Background()
+	mockAuth := new(MockAuthService)
+	setupAdminAuth(ctx, mockAuth)
+	handler := &Handler{auth: mockAuth, config: setupAdminMock(ctx)}
+
+	_, err := handler.discoverOrgAccounts(ctx, adminRequest(`{"account_id":"not-a-uuid"}`))
+	require.Error(t, err)
+	ce, ok := IsClientError(err)
+	require.True(t, ok)
+	assert.Equal(t, 400, ce.code)
+}
+
+func TestDiscoverOrgAccounts_RejectsNonAWSAccount(t *testing.T) {
+	ctx := context.Background()
+	mockAuth := new(MockAuthService)
+	setupAdminAuth(ctx, mockAuth)
+	store := setupAdminMock(ctx)
+	store.GetCloudAccountFn = func(_ context.Context, id string) (*config.CloudAccount, error) {
+		return &config.CloudAccount{ID: id, Provider: "azure", AWSIsOrgRoot: true}, nil
+	}
+	handler := &Handler{auth: mockAuth, config: store}
+
+	_, err := handler.discoverOrgAccounts(ctx, adminRequest(`{"account_id":"11111111-1111-1111-1111-111111111111"}`))
+	require.Error(t, err)
+	ce, ok := IsClientError(err)
+	require.True(t, ok)
+	assert.Equal(t, 400, ce.code)
+	assert.Contains(t, ce.Error(), "aws")
+}
+
+func TestDiscoverOrgAccounts_RejectsNonOrgRoot(t *testing.T) {
+	ctx := context.Background()
+	mockAuth := new(MockAuthService)
+	setupAdminAuth(ctx, mockAuth)
+	store := setupAdminMock(ctx)
+	store.GetCloudAccountFn = func(_ context.Context, id string) (*config.CloudAccount, error) {
+		return &config.CloudAccount{ID: id, Provider: "aws", AWSIsOrgRoot: false}, nil
+	}
+	handler := &Handler{auth: mockAuth, config: store}
+
+	_, err := handler.discoverOrgAccounts(ctx, adminRequest(`{"account_id":"11111111-1111-1111-1111-111111111111"}`))
+	require.Error(t, err)
+	ce, ok := IsClientError(err)
+	require.True(t, ok)
+	assert.Equal(t, 400, ce.code)
+	assert.Contains(t, ce.Error(), "org root")
+}
+
+func TestDiscoverOrgAccounts_NotFound(t *testing.T) {
+	ctx := context.Background()
+	mockAuth := new(MockAuthService)
+	setupAdminAuth(ctx, mockAuth)
+	store := setupAdminMock(ctx)
+	store.GetCloudAccountFn = func(_ context.Context, _ string) (*config.CloudAccount, error) {
+		return nil, nil
+	}
+	handler := &Handler{auth: mockAuth, config: store}
+
+	_, err := handler.discoverOrgAccounts(ctx, adminRequest(`{"account_id":"11111111-1111-1111-1111-111111111111"}`))
+	require.Error(t, err)
+	ce, ok := IsClientError(err)
+	require.True(t, ok)
+	assert.Equal(t, 404, ce.code)
+}
+
+func TestDiscoverOrgAccounts_HappyPathDedupesAndPersists(t *testing.T) {
 	ctx := context.Background()
 	mockAuth := new(MockAuthService)
 	setupAdminAuth(ctx, mockAuth)
 
+	root := orgRootAccount()
+
+	// Bypass the credentials resolver: with access_keys auth mode and a
+	// stored cred, ResolveAWSCredentialProvider would try to load from the
+	// CredentialStore. Inject a CredentialStore that returns a valid blob
+	// so resolution succeeds in-process. The store doesn't matter beyond
+	// "doesn't error" — the discoverOrgFn injection bypasses the real AWS
+	// API call anyway.
+	credStore := &fakeCredStore{
+		data: map[string][]byte{
+			root.ID + "::aws_access_keys": []byte(`{"access_key_id":"AKIATEST","secret_access_key":"shh"}`),
+		},
+	}
+
 	store := setupAdminMock(ctx)
-	handler := &Handler{auth: mockAuth, config: store}
+	store.GetCloudAccountFn = func(_ context.Context, _ string) (*config.CloudAccount, error) {
+		return root, nil
+	}
+	store.ListCloudAccountsFn = func(_ context.Context, _ config.CloudAccountFilter) ([]config.CloudAccount, error) {
+		// One member already exists — should be skipped on the dedupe pass.
+		return []config.CloudAccount{
+			{ID: "22222222-2222-2222-2222-222222222222", Provider: "aws", ExternalID: "200000000002"},
+		}, nil
+	}
 
-	result, err := handler.discoverOrgAccounts(ctx, adminRequest(""))
+	var created []config.CloudAccount
+	store.CreateCloudAccountFn = func(_ context.Context, a *config.CloudAccount) error {
+		created = append(created, *a)
+		return nil
+	}
+
+	handler := &Handler{
+		auth:      mockAuth,
+		config:    store,
+		credStore: credStore,
+		discoverOrgFn: func(_ context.Context, _ aws.Config) (*accounts.OrgDiscoveryResult, error) {
+			return &accounts.OrgDiscoveryResult{
+				Accounts: []config.CloudAccount{
+					{Provider: "aws", ExternalID: "200000000002", Name: "Already Known"}, // dedupe: skipped
+					{Provider: "aws", ExternalID: "300000000003", Name: "Brand New"},     // create
+					{Provider: "aws", ExternalID: "400000000004", Name: "Brand New Two"}, // create
+				},
+			}, nil
+		},
+	}
+
+	result, err := handler.discoverOrgAccounts(ctx, adminRequest(`{"account_id":"`+root.ID+`"}`))
 	require.NoError(t, err)
 
-	data, err := json.Marshal(result)
-	require.NoError(t, err)
-	assert.Contains(t, string(data), "not yet implemented")
+	dr, ok := result.(DiscoverOrgResult)
+	require.True(t, ok, "result type = %T", result)
+	assert.Equal(t, 3, dr.Discovered)
+	assert.Equal(t, 2, dr.Created)
+	assert.Equal(t, 1, dr.Skipped)
+
+	// Inspect the persisted rows: each must have enabled=false +
+	// aws_auth_mode=bastion + aws_bastion_id pointing at the org root.
+	require.Len(t, created, 2)
+	for _, a := range created {
+		assert.False(t, a.Enabled, "discovered accounts must boot disabled (operator gate)")
+		assert.Equal(t, "bastion", a.AWSAuthMode, "discovered accounts must default to bastion mode")
+		assert.Equal(t, root.ID, a.AWSBastionID, "bastion_id must point at the org root that discovered them")
+		assert.Equal(t, "aws", a.Provider)
+	}
 }
+
+// fakeCredStore is a minimal CredentialStore for the discover-org happy-path
+// test. It only exists to satisfy ResolveAWSCredentialProvider's access_keys
+// mode without dragging in the real Secrets Manager / Postgres dependency.
+type fakeCredStore struct {
+	data map[string][]byte
+}
+
+func (f *fakeCredStore) LoadRaw(_ context.Context, accountID, credType string) ([]byte, error) {
+	return f.data[accountID+"::"+credType], nil
+}
+
+func (f *fakeCredStore) SaveCredential(_ context.Context, _, _ string, _ []byte) error { return nil }
+func (f *fakeCredStore) DeleteCredential(_ context.Context, _, _ string) error         { return nil }
+func (f *fakeCredStore) HasCredential(_ context.Context, _, _ string) (bool, error)    { return true, nil }
+func (f *fakeCredStore) EncryptPayload(_ []byte) (string, error)                       { return "", nil }
+func (f *fakeCredStore) DecryptPayload(_ string) ([]byte, error)                       { return nil, nil }
 
 // --- buildAccountFilter ---
 

--- a/internal/api/handler_accounts_test.go
+++ b/internal/api/handler_accounts_test.go
@@ -661,13 +661,21 @@ func TestDiscoverOrgAccounts_HappyPathDedupesAndPersists(t *testing.T) {
 	assert.Equal(t, 2, dr.Created)
 	assert.Equal(t, 1, dr.Skipped)
 
-	// Inspect the persisted rows: each must have enabled=false +
-	// aws_auth_mode=bastion + aws_bastion_id pointing at the org root.
+	// Inspect the persisted rows. Defaults locked in (CR pass 1):
+	//   * enabled=false   — operator review gate
+	//   * AWSAuthMode=""  — NOT "bastion": setting bastion mode while the
+	//                       row's AWSRoleARN is empty would cause
+	//                       awsAmbientCredResult to mis-classify the
+	//                       account as "ambient host" creds. Operator must
+	//                       set BOTH mode and role ARN before enabling.
+	//   * AWSBastionID=<root.ID> — pre-filled so the operator only needs
+	//                              to add the role ARN, not chase the
+	//                              bastion-id linkage.
 	require.Len(t, created, 2)
 	for _, a := range created {
 		assert.False(t, a.Enabled, "discovered accounts must boot disabled (operator gate)")
-		assert.Equal(t, "bastion", a.AWSAuthMode, "discovered accounts must default to bastion mode")
-		assert.Equal(t, root.ID, a.AWSBastionID, "bastion_id must point at the org root that discovered them")
+		assert.Empty(t, a.AWSAuthMode, "discovered accounts must boot with empty AWSAuthMode (operator must set it explicitly with a role ARN)")
+		assert.Equal(t, root.ID, a.AWSBastionID, "bastion_id must be pre-filled with the org root that discovered them")
 		assert.Equal(t, "aws", a.Provider)
 	}
 }

--- a/internal/api/handler_accounts_test.go
+++ b/internal/api/handler_accounts_test.go
@@ -746,6 +746,48 @@ func TestDiscoverOrgAccounts_SkipsDuplicateKeyOnInsert(t *testing.T) {
 	assert.Equal(t, "400000000004", created[1].ExternalID)
 }
 
+func TestDiscoverOrgAccounts_AllowsNilDiscoveryResult(t *testing.T) {
+	ctx := context.Background()
+	mockAuth := new(MockAuthService)
+	setupAdminAuth(ctx, mockAuth)
+
+	root := &config.CloudAccount{
+		ID:           "11111111-1111-1111-1111-111111111111",
+		Name:         "Org Root",
+		Provider:     "aws",
+		ExternalID:   "999999999999",
+		AWSAuthMode:  "access_keys",
+		AWSIsOrgRoot: true,
+	}
+
+	store := setupAdminMock(ctx)
+	store.GetCloudAccountFn = func(_ context.Context, _ string) (*config.CloudAccount, error) {
+		return root, nil
+	}
+
+	handler := &Handler{
+		auth:   mockAuth,
+		config: store,
+		credStore: &fakeCredStore{
+			data: map[string][]byte{
+				root.ID + "::aws_access_keys": []byte(`{"access_key_id":"AKIATEST","secret_access_key":"shh"}`),
+			},
+		},
+		discoverOrgFn: func(_ context.Context, _ aws.Config) (*accounts.OrgDiscoveryResult, error) {
+			return nil, nil
+		},
+	}
+
+	result, err := handler.discoverOrgAccounts(ctx, adminRequest(`{"account_id":"`+root.ID+`"}`))
+	require.NoError(t, err)
+
+	dr, ok := result.(DiscoverOrgResult)
+	require.True(t, ok, "result type = %T", result)
+	assert.Zero(t, dr.Discovered)
+	assert.Zero(t, dr.Created)
+	assert.Zero(t, dr.Skipped)
+}
+
 // fakeCredStore is a minimal CredentialStore for the discover-org happy-path
 // test. It only exists to satisfy ResolveAWSCredentialProvider's access_keys
 // mode without dragging in the real Secrets Manager / Postgres dependency.

--- a/internal/api/handler_accounts_test.go
+++ b/internal/api/handler_accounts_test.go
@@ -674,6 +674,9 @@ func TestDiscoverOrgAccounts_HappyPathDedupesAndPersists(t *testing.T) {
 	require.Len(t, created, 2)
 	for _, a := range created {
 		assert.False(t, a.Enabled, "discovered accounts must boot disabled (operator gate)")
+		assert.NotEmpty(t, a.ID, "discovered accounts must be assigned an ID before persistence")
+		assert.False(t, a.CreatedAt.IsZero(), "discovered accounts must carry CreatedAt metadata")
+		assert.False(t, a.UpdatedAt.IsZero(), "discovered accounts must carry UpdatedAt metadata")
 		assert.Empty(t, a.AWSAuthMode, "discovered accounts must boot with empty AWSAuthMode (operator must set it explicitly with a role ARN)")
 		assert.Equal(t, root.ID, a.AWSBastionID, "bastion_id must be pre-filled with the org root that discovered them")
 		assert.Equal(t, "aws", a.Provider)

--- a/internal/api/mocks_test.go
+++ b/internal/api/mocks_test.go
@@ -21,6 +21,12 @@ type MockConfigStore struct {
 	// DeleteCloudAccountFn overrides DeleteCloudAccount when non-nil (used to assert
 	// delete was/was not invoked).
 	DeleteCloudAccountFn func(ctx context.Context, id string) error
+	// ListCloudAccountsFn overrides ListCloudAccounts when non-nil (used by
+	// org-discovery dedupe tests to inject a known-roster fixture).
+	ListCloudAccountsFn func(ctx context.Context, filter config.CloudAccountFilter) ([]config.CloudAccount, error)
+	// CreateCloudAccountFn overrides CreateCloudAccount when non-nil (used by
+	// org-discovery tests to capture the new rows the handler persists).
+	CreateCloudAccountFn func(ctx context.Context, account *config.CloudAccount) error
 }
 
 func (m *MockConfigStore) GetGlobalConfig(ctx context.Context) (*config.GlobalConfig, error) {
@@ -236,6 +242,9 @@ func (m *MockConfigStore) GetStaleProcessingExchanges(ctx context.Context, older
 }
 
 func (m *MockConfigStore) CreateCloudAccount(ctx context.Context, account *config.CloudAccount) error {
+	if m.CreateCloudAccountFn != nil {
+		return m.CreateCloudAccountFn(ctx, account)
+	}
 	return nil
 }
 func (m *MockConfigStore) GetCloudAccount(ctx context.Context, id string) (*config.CloudAccount, error) {
@@ -254,6 +263,9 @@ func (m *MockConfigStore) DeleteCloudAccount(ctx context.Context, id string) err
 	return nil
 }
 func (m *MockConfigStore) ListCloudAccounts(ctx context.Context, filter config.CloudAccountFilter) ([]config.CloudAccount, error) {
+	if m.ListCloudAccountsFn != nil {
+		return m.ListCloudAccountsFn(ctx, filter)
+	}
 	return nil, nil
 }
 func (m *MockConfigStore) SaveAccountCredential(ctx context.Context, accountID, credentialType, encryptedBlob string) error {

--- a/internal/api/router_handlers_test.go
+++ b/internal/api/router_handlers_test.go
@@ -255,6 +255,11 @@ func TestRouter_createAccountHandler(t *testing.T) {
 }
 
 func TestRouter_discoverOrgAccountsHandler(t *testing.T) {
+	// Routing-only smoke test: verifies the dispatcher reaches the
+	// handler. The handler itself returns 400 on the empty body the
+	// router test sends — that's fine for proving dispatch worked
+	// (the call reached past auth and into the body parser). Full
+	// behaviour is exercised in handler_accounts_test.go.
 	ctx := context.Background()
 	mockAuth := new(MockAuthService)
 	adminSession := &Session{UserID: "uid", Role: "admin"}
@@ -266,9 +271,11 @@ func TestRouter_discoverOrgAccountsHandler(t *testing.T) {
 	req := &events.LambdaFunctionURLRequest{
 		Headers: map[string]string{"Authorization": "Bearer admin-token"},
 	}
-	result, err := r.discoverOrgAccountsHandler(ctx, req, nil)
-	require.NoError(t, err)
-	assert.NotNil(t, result)
+	_, err := r.discoverOrgAccountsHandler(ctx, req, nil)
+	require.Error(t, err, "empty body should fail JSON parse → ClientError")
+	ce, ok := IsClientError(err)
+	require.True(t, ok)
+	assert.Equal(t, 400, ce.code)
 }
 
 func TestRouter_getAccountHandler(t *testing.T) {


### PR DESCRIPTION
Closes #208 — wires `POST /api/accounts/discover-org` to the already-shipped `accounts.DiscoverOrgAccounts` function. Replaces the stub at `internal/api/handler_accounts.go:1089` that returned `"org discovery not yet implemented"`.

## What the endpoint does

Given `{"account_id": "<org-root-uuid>"}`:

1. **Validate** — body parses, `account_id` is a UUID, named account exists, `provider == "aws"`, `aws_is_org_root == true`. Each failure returns the right ClientError code (400 for parse/UUID/non-aws/non-root, 404 for missing).
2. **Resolve** — load the org-root's stored credentials via `credentials.ResolveAWSCredentialProvider`; build an `aws.Config` for the call.
3. **Discover** — call `accounts.DiscoverOrgAccounts(ctx, cfg)` (the existing function with full Organizations API pagination + tests at `internal/accounts/org_discovery_test.go`). Injectable seam: `Handler.discoverOrgFn` for tests; nil-default falls back to the real call in production.
4. **Dedupe** — load existing aws cloud_accounts via `ListCloudAccounts(provider="aws")`; skip member accounts whose `external_id` already exists.
5. **Persist** — for each new member, force `enabled=false` + `aws_auth_mode="bastion"` + `aws_bastion_id=<org-root.ID>` and call `CreateCloudAccount`. The operator must review/approve and fill in `aws_role_arn` before the row participates in scheduled collection.
6. **Return** `{discovered, created, skipped}` counts.

Spec sections: `specs/multi-account-execution/acceptance.md` F-1, F-2, F-3.

## Why these defaults

- **`enabled=false`**: gates the operator into reviewing each discovered account before the scheduler picks it up. Spec requirement.
- **`aws_auth_mode="bastion"` + `aws_bastion_id=<org-root>`**: signals the intended cred-resolution path (the org-root assumes a role in the member). The operator fills in `aws_role_arn` before flipping `enabled=true`. The scheduler silently skips disabled rows so a half-configured account never causes a runtime error.
- **`Created` excludes skipped rows**: dedupe is by `(provider="aws", external_id)`, matching the spec's natural-key semantics. Re-running the endpoint is idempotent.

## Refactor for gocyclo

The handler logic split into four helpers to fit the project's gocyclo budget (≤10):

- `parseDiscoverOrgRoot` — body decode + validate
- `buildOrgRootAWSConfig` — credential resolution + `aws.Config` build
- `runOrgDiscovery` — `discoverOrgFn` dispatcher
- `persistDiscoveredMembers` — dedupe + persist loop

The main `discoverOrgAccounts` is now a 5-step coordinator.

## Tests

Six new test cases in `internal/api/handler_accounts_test.go` cover the spec's acceptance dimensions:

| Test | Asserts |
|---|---|
| `TestDiscoverOrgAccounts_RejectsInvalidBody` | 400 ClientError on non-JSON body |
| `TestDiscoverOrgAccounts_RejectsInvalidAccountID` | 400 on `account_id` that isn't a UUID |
| `TestDiscoverOrgAccounts_RejectsNonAWSAccount` | 400 + "aws" in message when provider != "aws" |
| `TestDiscoverOrgAccounts_RejectsNonOrgRoot` | 400 + "org root" in message when `aws_is_org_root == false` |
| `TestDiscoverOrgAccounts_NotFound` | 404 when the named account doesn't exist |
| `TestDiscoverOrgAccounts_HappyPathDedupesAndPersists` | 3 discovered → 1 skipped (already exists) → 2 created. Each persisted row has `enabled=false`, `aws_auth_mode="bastion"`, `aws_bastion_id=<root.ID>` |

`MockConfigStore` gains `ListCloudAccountsFn` + `CreateCloudAccountFn` injection points; `fakeCredStore` is a minimal `CredentialStore` satisfying access_keys mode without dragging in Postgres / Secrets Manager.

`TestRouter_discoverOrgAccountsHandler` (routing-only smoke) updated to assert the dispatcher reaches the handler — now expects a 400 ClientError on the empty body it sends, instead of the prior `NotNil` result from the stub.

## Verification

- `go build ./...` clean
- `go test ./...` (full repo) — all green
- Pre-commit (gocyclo / gosec / trivy / migration-conflicts / go-test) — all green

## Triage

`type/feat`, `severity/high`, `urgency/this-sprint`, `impact/many`, `effort/m`, `priority/p1`, `triaged`. Closes #208.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin-only AWS Organizations discovery endpoint to import member accounts with input validation, deduplication, safe defaults, and summary counts for discovered/created/skipped.
  * Configurable discovery hook to allow tests to run without calling live AWS.

* **Tests**
  * Expanded handler tests and improved test mocks covering request validation, error cases, deduplication, creation behavior, and persistence verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->