### PR TITLE
fix(dashboard): cancel upcoming via DELETE /api/purchases/planned/{exec-id}

### DIFF
--- a/frontend/src/__tests__/dashboard.test.ts
+++ b/frontend/src/__tests__/dashboard.test.ts
@@ -36,9 +36,13 @@ jest.mock('../api', () => ({
   getUpcomingPurchases: jest.fn(),
   getPurchaseDetails: jest.fn(),
   cancelPurchase: jest.fn(),
-  // Plan-level cancel — the dashboard upcoming-list now targets plan
-  // endpoints (issues #204 + #205), not execution endpoints.
+  // Plan-level cancel — the dashboard upcoming-list targets plan
+  // endpoints, not execution endpoints. PR #207 first wired this to
+  // deletePlannedPurchase but that handler still operates on
+  // purchase_executions; the correct endpoint is DELETE /api/plans/{id}
+  // via api.deletePlan (issues #204 / #205 / #208).
   deletePlannedPurchase: jest.fn(),
+  deletePlan: jest.fn(),
   listAccounts: jest.fn().mockResolvedValue([]),
   getSavingsAnalytics: jest.fn().mockResolvedValue({ data_points: [] }),
 }));
@@ -336,7 +340,7 @@ describe('Dashboard Module', () => {
           }
         ]
       });
-      (api.deletePlannedPurchase as jest.Mock).mockResolvedValue({});
+      (api.deletePlan as jest.Mock).mockResolvedValue({});
       window.confirm = jest.fn().mockReturnValue(true);
 
       await loadDashboard();
@@ -350,7 +354,8 @@ describe('Dashboard Module', () => {
 
       await new Promise(resolve => setTimeout(resolve, 50));
 
-      expect(api.deletePlannedPurchase).toHaveBeenCalledWith('plan-123');
+      expect(api.deletePlan).toHaveBeenCalledWith('plan-123');
+      expect(api.deletePlannedPurchase).not.toHaveBeenCalled();
       expect(mockShowToast).toHaveBeenCalledWith(expect.objectContaining({
         message: 'Purchase cancelled successfully',
         kind: 'success',
@@ -385,7 +390,7 @@ describe('Dashboard Module', () => {
 
       await new Promise(resolve => setTimeout(resolve, 50));
 
-      expect(api.deletePlannedPurchase).not.toHaveBeenCalled();
+      expect(api.deletePlan).not.toHaveBeenCalled();
     });
 
     test('cancel purchase shows error on failure', async () => {
@@ -407,7 +412,7 @@ describe('Dashboard Module', () => {
           }
         ]
       });
-      (api.deletePlannedPurchase as jest.Mock).mockRejectedValue(new Error('API Error'));
+      (api.deletePlan as jest.Mock).mockRejectedValue(new Error('API Error'));
       window.confirm = jest.fn().mockReturnValue(true);
       console.error = jest.fn();
 

--- a/frontend/src/__tests__/dashboard.test.ts
+++ b/frontend/src/__tests__/dashboard.test.ts
@@ -175,7 +175,7 @@ describe('Dashboard Module', () => {
       (api.getUpcomingPurchases as jest.Mock).mockResolvedValue({
         purchases: [
           {
-            plan_id: 'plan-1',
+            execution_id: 'exec-1', plan_id: 'plan-1',
             plan_name: 'Test Plan',
             provider: 'aws',
             service: 'ec2',
@@ -242,7 +242,7 @@ describe('Dashboard Module', () => {
       (api.getUpcomingPurchases as jest.Mock).mockResolvedValue({
         purchases: [
           {
-            plan_id: 'plan-1',
+            execution_id: 'exec-1', plan_id: 'plan-1',
             plan_name: 'Test Plan',
             provider: 'aws',
             service: 'ec2',
@@ -286,7 +286,7 @@ describe('Dashboard Module', () => {
       (api.getUpcomingPurchases as jest.Mock).mockResolvedValue({
         purchases: [
           {
-            plan_id: 'plan-123',
+            execution_id: 'exec-123', plan_id: 'plan-123',
             plan_name: 'Test Plan',
             provider: 'aws',
             service: 'ec2',
@@ -311,7 +311,7 @@ describe('Dashboard Module', () => {
       const modal = document.getElementById('purchase-details-modal');
       expect(modal).toBeTruthy();
       expect(modal?.textContent).toContain('Test Plan');
-      expect(modal?.textContent).toContain('plan-123');
+      expect(modal?.textContent).toContain('exec-123');
     });
 
     // (The previous "shows error on failure" test exercised an API
@@ -329,7 +329,7 @@ describe('Dashboard Module', () => {
       (api.getUpcomingPurchases as jest.Mock).mockResolvedValue({
         purchases: [
           {
-            plan_id: 'plan-123',
+            execution_id: 'exec-123', plan_id: 'plan-123',
             plan_name: 'Test Plan',
             provider: 'aws',
             service: 'ec2',
@@ -340,7 +340,7 @@ describe('Dashboard Module', () => {
           }
         ]
       });
-      (api.deletePlan as jest.Mock).mockResolvedValue({});
+      (api.deletePlannedPurchase as jest.Mock).mockResolvedValue({});
       window.confirm = jest.fn().mockReturnValue(true);
 
       await loadDashboard();
@@ -354,8 +354,10 @@ describe('Dashboard Module', () => {
 
       await new Promise(resolve => setTimeout(resolve, 50));
 
-      expect(api.deletePlan).toHaveBeenCalledWith('plan-123');
-      expect(api.deletePlannedPurchase).not.toHaveBeenCalled();
+      expect(api.deletePlannedPurchase).toHaveBeenCalledWith('exec-123');
+      // Cancel must NOT delete the entire plan — that was the wrong fix
+      // in PR #207. deletePlan should not be called from this path.
+      expect(api.deletePlan).not.toHaveBeenCalled();
       expect(mockShowToast).toHaveBeenCalledWith(expect.objectContaining({
         message: 'Purchase cancelled successfully',
         kind: 'success',
@@ -370,7 +372,7 @@ describe('Dashboard Module', () => {
       (api.getUpcomingPurchases as jest.Mock).mockResolvedValue({
         purchases: [
           {
-            plan_id: 'plan-123',
+            execution_id: 'exec-123', plan_id: 'plan-123',
             plan_name: 'Test Plan',
             provider: 'aws',
             service: 'ec2',
@@ -390,7 +392,7 @@ describe('Dashboard Module', () => {
 
       await new Promise(resolve => setTimeout(resolve, 50));
 
-      expect(api.deletePlan).not.toHaveBeenCalled();
+      expect(api.deletePlannedPurchase).not.toHaveBeenCalled();
     });
 
     test('cancel purchase shows error on failure', async () => {
@@ -401,7 +403,7 @@ describe('Dashboard Module', () => {
       (api.getUpcomingPurchases as jest.Mock).mockResolvedValue({
         purchases: [
           {
-            plan_id: 'plan-123',
+            execution_id: 'exec-123', plan_id: 'plan-123',
             plan_name: 'Test Plan',
             provider: 'aws',
             service: 'ec2',
@@ -412,7 +414,7 @@ describe('Dashboard Module', () => {
           }
         ]
       });
-      (api.deletePlan as jest.Mock).mockRejectedValue(new Error('API Error'));
+      (api.deletePlannedPurchase as jest.Mock).mockRejectedValue(new Error('API Error'));
       window.confirm = jest.fn().mockReturnValue(true);
       console.error = jest.fn();
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -32,6 +32,7 @@ export interface DashboardSummary {
 }
 
 export interface UpcomingPurchase {
+  execution_id: string;
   plan_id: string;
   plan_name: string;
   scheduled_date: string;

--- a/frontend/src/dashboard.ts
+++ b/frontend/src/dashboard.ts
@@ -358,7 +358,7 @@ function buildUpcomingDetailsModal(p: UpcomingPurchase, planId: string): HTMLDiv
     });
     if (!ok) return;
     try {
-      await api.deletePlannedPurchase(planId);
+      await api.deletePlan(planId);
       modal.remove();
       await loadDashboard();
       showToast({ message: 'Purchase cancelled successfully', kind: 'success', timeout: 5_000 });
@@ -382,9 +382,11 @@ function buildUpcomingDetailsModal(p: UpcomingPurchase, planId: string): HTMLDiv
 async function cancelScheduledPurchase(planId: string): Promise<void> {
   // Plan-level cancel: the row-on-the-Cancel-button is a PurchasePlan
   // whose next execution hasn't fired yet, so there's no
-  // purchase_executions row to cancel. deletePlannedPurchase is the
-  // correct endpoint — `cancelPurchase` here would 500 with
-  // "execution not found" (issue #204).
+  // purchase_executions row to cancel. The right endpoint is
+  // DELETE /api/plans/{id} (api.deletePlan) — both
+  // /api/purchases/cancel/{id} and /api/purchases/planned/{id}
+  // operate on execution rows and would 4xx with "execution not
+  // found" (issues #204 / #205 / #208).
   const ok = await confirmDialog({
     title: 'Cancel this scheduled purchase?',
     body: 'Cancelling a scheduled purchase cannot be undone. Any upfront cost already committed will not be refunded.',
@@ -394,7 +396,7 @@ async function cancelScheduledPurchase(planId: string): Promise<void> {
   if (!ok) return;
 
   try {
-    await api.deletePlannedPurchase(planId);
+    await api.deletePlan(planId);
     await loadDashboard();
     showToast({ message: 'Purchase cancelled successfully', kind: 'success', timeout: 5_000 });
   } catch (error) {

--- a/frontend/src/dashboard.ts
+++ b/frontend/src/dashboard.ts
@@ -21,13 +21,14 @@ let savingsTrendChart: Chart | null = null;
 let savingsTrendRange: '7' | '30' | '90' | 'all' = '90';
 
 // In-memory index of the currently-rendered upcoming purchases, keyed by
-// plan_id. The "View Details" affordance renders from this — the
+// execution_id. The "View Details" affordance renders from this — the
 // /api/dashboard/upcoming response already carries every field the
-// dialog needs (plan name, scheduled date, provider/service, ramp
-// step), and there is no execution row to look up yet (the upcoming
-// list shows plans whose next execution hasn't fired). Issues #204 +
-// #205 surfaced when we tried to look these up via /api/purchases/{id}
-// using the plan_id — no row, 500.
+// dialog displays, so no extra roundtrip is needed. The Cancel button
+// uses the same execution_id to call DELETE /api/purchases/planned/{id}
+// so cancelling removes JUST this scheduled step (the plan template
+// stays in place). Earlier iterations: PR #207 keyed by plan_id which
+// caused the cancel-then-delete-the-whole-plan bug; PR #213 (this one)
+// enumerates real pending executions to surface execution_id properly.
 let upcomingPurchasesIndex: Map<string, UpcomingPurchase> = new Map();
 
 /**
@@ -228,7 +229,7 @@ function renderUpcomingPurchases(purchases: UpcomingPurchase[]): void {
   // Refresh the in-memory index so viewPurchaseDetails can render its
   // dialog from local data — there is no execution row to look up yet
   // (the upcoming list shows plans whose next execution hasn't fired).
-  upcomingPurchasesIndex = new Map(purchases.map(p => [p.plan_id, p]));
+  upcomingPurchasesIndex = new Map(purchases.map(p => [p.execution_id, p]));
 
   if (!purchases || purchases.length === 0) {
     container.innerHTML = '<p class="empty">No upcoming scheduled purchases</p>';
@@ -254,8 +255,8 @@ function renderUpcomingPurchases(purchases: UpcomingPurchase[]): void {
           <div class="label">Est. monthly savings</div>
         </div>
         <div class="upcoming-actions">
-          <button data-action="view-purchase" data-id="${p.plan_id}">View Details</button>
-          <button data-action="cancel-purchase" data-id="${p.plan_id}" class="danger">Cancel</button>
+          <button data-action="view-purchase" data-id="${p.execution_id}">View Details</button>
+          <button data-action="cancel-purchase" data-id="${p.execution_id}" class="danger">Cancel</button>
         </div>
       </div>
     `;
@@ -270,12 +271,12 @@ function renderUpcomingPurchases(purchases: UpcomingPurchase[]): void {
   });
 }
 
-function viewPurchaseDetails(planId: string): void {
-  // The "upcoming" widget shows PurchasePlans whose next execution hasn't
-  // fired — there's no purchase_executions row to look up. Render the
-  // dialog from the in-memory snapshot the renderer just stored
-  // (issues #204 + #205).
-  const purchase = upcomingPurchasesIndex.get(planId);
+function viewPurchaseDetails(executionId: string): void {
+  // The widget enumerates pending purchase_executions, so each row in the
+  // upcoming list maps to a real execution row. We still render the dialog
+  // from the in-memory snapshot to avoid an extra roundtrip — every field
+  // the dialog displays already came down with the upcoming list.
+  const purchase = upcomingPurchasesIndex.get(executionId);
   if (!purchase) {
     showToast({ message: 'Failed to load purchase details: not in current view', kind: 'error' });
     return;
@@ -284,7 +285,7 @@ function viewPurchaseDetails(planId: string): void {
   // Remove any existing details modal
   document.getElementById('purchase-details-modal')?.remove();
 
-  const modal = buildUpcomingDetailsModal(purchase, planId);
+  const modal = buildUpcomingDetailsModal(purchase, executionId);
   document.body.appendChild(modal);
 }
 
@@ -292,7 +293,7 @@ function viewPurchaseDetails(planId: string): void {
 // innerHTML, so user-controlled fields (plan_name, service) can never be
 // interpreted as HTML — closes a class of XSS regressions that the
 // previous escapeHtml-+-innerHTML pattern only avoided by convention.
-function buildUpcomingDetailsModal(p: UpcomingPurchase, planId: string): HTMLDivElement {
+function buildUpcomingDetailsModal(p: UpcomingPurchase, executionId: string): HTMLDivElement {
   const modal = document.createElement('div');
   modal.id = 'purchase-details-modal';
   modal.className = 'modal';
@@ -332,7 +333,8 @@ function buildUpcomingDetailsModal(p: UpcomingPurchase, planId: string): HTMLDiv
   };
 
   addRow('Plan name', p.plan_name);
-  addRow('Plan ID', planId);
+  addRow('Plan ID', p.plan_id);
+  addRow('Execution ID', executionId);
   addRow('Scheduled', p.scheduled_date);
   addRow('Provider', p.provider.toUpperCase());
   addRow('Service', p.service);
@@ -358,7 +360,7 @@ function buildUpcomingDetailsModal(p: UpcomingPurchase, planId: string): HTMLDiv
     });
     if (!ok) return;
     try {
-      await api.deletePlan(planId);
+      await api.deletePlannedPurchase(executionId);
       modal.remove();
       await loadDashboard();
       showToast({ message: 'Purchase cancelled successfully', kind: 'success', timeout: 5_000 });
@@ -379,24 +381,27 @@ function buildUpcomingDetailsModal(p: UpcomingPurchase, planId: string): HTMLDiv
   return modal;
 }
 
-async function cancelScheduledPurchase(planId: string): Promise<void> {
-  // Plan-level cancel: the row-on-the-Cancel-button is a PurchasePlan
-  // whose next execution hasn't fired yet, so there's no
-  // purchase_executions row to cancel. The right endpoint is
-  // DELETE /api/plans/{id} (api.deletePlan) — both
-  // /api/purchases/cancel/{id} and /api/purchases/planned/{id}
-  // operate on execution rows and would 4xx with "execution not
-  // found" (issues #204 / #205 / #208).
+async function cancelScheduledPurchase(executionId: string): Promise<void> {
+  // Cancel just THIS scheduled instance via DELETE /api/purchases/planned/{id}
+  // (the deletePlannedPurchase backend handler operates on
+  // purchase_executions). The plan template stays intact — the next
+  // scheduler tick re-creates the next instance for the plan. Earlier
+  // iterations got this wrong by either:
+  //   - sending plan_id to deletePlannedPurchase (404 because
+  //     deletePlannedPurchase expects an execution_id), or
+  //   - falling back to deletePlan (which deleted the WHOLE plan).
+  // The widget now enumerates real pending executions and surfaces
+  // execution_id, so neither workaround is needed.
   const ok = await confirmDialog({
     title: 'Cancel this scheduled purchase?',
-    body: 'Cancelling a scheduled purchase cannot be undone. Any upfront cost already committed will not be refunded.',
+    body: 'Cancelling removes this upcoming step from the plan. The plan itself stays in place; the next scheduled step (if any) is unaffected.',
     confirmLabel: 'Cancel purchase',
     destructive: true,
   });
   if (!ok) return;
 
   try {
-    await api.deletePlan(planId);
+    await api.deletePlannedPurchase(executionId);
     await loadDashboard();
     showToast({ message: 'Purchase cancelled successfully', kind: 'success', timeout: 5_000 });
   } catch (error) {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -38,6 +38,7 @@ export interface ServiceSavings {
 }
 
 export interface UpcomingPurchase {
+  execution_id: string;
   plan_id: string;
   plan_name: string;
   scheduled_date: string;

--- a/internal/api/handler_dashboard.go
+++ b/internal/api/handler_dashboard.go
@@ -199,58 +199,74 @@ func (h *Handler) resolveTargetCoverage(ctx context.Context) float64 {
 	return 80.0
 }
 
+// getUpcomingPurchases enumerates pending purchase_executions joined to
+// their parent PurchasePlan for display. Mirrors the data flow in
+// getPlannedPurchases (handler_purchases.go) so the dashboard widget and
+// the Plans page walk the same canonical "what's about to happen" set.
+//
+// The widget previously enumerated plans and synthesised one row per plan
+// from plan.NextExecutionDate. That was wrong because action endpoints
+// (DELETE /api/purchases/planned/{id}, pause, resume, run) all target
+// purchase_executions.execution_id, not purchase_plans.id; the Cancel
+// button could only fire correctly when the row in front of the operator
+// IS a real execution. PR #207 worked around it by routing Cancel to
+// api.deletePlan(planID), but that deleted the whole plan — too
+// aggressive for "skip this scheduled run". This version emits actual
+// execution rows so Cancel can target just the planned purchase via
+// DELETE /api/purchases/planned/{id}.
 func (h *Handler) getUpcomingPurchases(ctx context.Context, req *events.LambdaFunctionURLRequest) (*UpcomingPurchaseResponse, error) {
 	session, err := h.requirePermission(ctx, req, "view", "purchases")
 	if err != nil {
 		return nil, err
 	}
 
+	executions, err := h.config.GetPendingExecutions(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get pending executions: %w", err)
+	}
+
 	plans, err := h.config.ListPurchasePlans(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get purchase plans: %w", err)
 	}
-
-	allowed, err := h.getAllowedAccounts(ctx, session)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get allowed accounts: %w", err)
+	planMap := make(map[string]*config.PurchasePlan, len(plans))
+	for i := range plans {
+		planMap[plans[i].ID] = &plans[i]
 	}
 
+	// Per-plan access cache mirrors getPlannedPurchases — all executions
+	// for the same plan share the same account scope, so we resolve once
+	// per plan.
+	allowedPlan := make(map[string]bool)
+
 	var upcoming []UpcomingPurchase
-	for _, plan := range plans {
-		include, err := h.includeUpcomingPlan(ctx, plan, allowed)
+	for i := range executions {
+		exec := executions[i]
+		plan := planMap[exec.PlanID]
+		if plan == nil {
+			// Orphaned execution (plan was deleted but cleanup missed it).
+			// Hide rather than crash; cleanup is a separate concern.
+			continue
+		}
+		ok, err := h.isPlanAllowedCached(ctx, session, exec.PlanID, allowedPlan)
 		if err != nil {
 			return nil, err
 		}
-		if !include {
+		if !ok {
 			continue
 		}
-		upcoming = append(upcoming, upcomingFromPlan(plan))
+		upcoming = append(upcoming, upcomingFromExecution(plan, &exec))
 	}
 
 	return &UpcomingPurchaseResponse{Purchases: upcoming}, nil
 }
 
-// includeUpcomingPlan returns true when the plan should appear in the
-// upcoming-purchases list for the session's allowed_accounts. Skips disabled
-// plans and plans with no next execution date. Admin/unrestricted sessions
-// pass through without the per-plan account lookup.
-//
-// Plans with no account assignments are hidden from scoped users — we can't
-// attribute them to a specific account, so the safe default is "don't leak".
-func (h *Handler) includeUpcomingPlan(ctx context.Context, plan config.PurchasePlan, allowed []string) (bool, error) {
-	if !plan.Enabled || plan.NextExecutionDate == nil {
-		return false, nil
-	}
-	if auth.IsUnrestrictedAccess(allowed) {
-		return true, nil
-	}
-	return h.planIntersectsAllowed(ctx, plan.ID, allowed)
-}
-
-// upcomingFromPlan projects a PurchasePlan onto the UpcomingPurchase response
-// type. Uses the first service as representative — the response shape doesn't
-// support multi-service plans.
-func upcomingFromPlan(plan config.PurchasePlan) UpcomingPurchase {
+// upcomingFromExecution projects a (plan, execution) pair onto the
+// UpcomingPurchase response. Uses the first service entry from the plan as
+// representative — the response shape doesn't support multi-service plans.
+// Step number comes from the execution row directly (already stamped by the
+// scheduler at instance-create time).
+func upcomingFromExecution(plan *config.PurchasePlan, exec *config.PurchaseExecution) UpcomingPurchase {
 	var provider, service string
 	for _, svcCfg := range plan.Services {
 		provider = svcCfg.Provider
@@ -258,14 +274,15 @@ func upcomingFromPlan(plan config.PurchasePlan) UpcomingPurchase {
 		break
 	}
 	return UpcomingPurchase{
+		ExecutionID:      exec.ExecutionID,
 		PlanID:           plan.ID,
 		PlanName:         plan.Name,
-		ScheduledDate:    plan.NextExecutionDate.Format("2006-01-02"),
+		ScheduledDate:    exec.ScheduledDate.Format("2006-01-02"),
 		Provider:         provider,
 		Service:          service,
-		StepNumber:       plan.RampSchedule.CurrentStep + 1,
+		StepNumber:       exec.StepNumber,
 		TotalSteps:       plan.RampSchedule.TotalSteps,
-		EstimatedSavings: 0, // Would need to calculate from recommendations
+		EstimatedSavings: exec.EstimatedSavings,
 	}
 }
 

--- a/internal/api/handler_dashboard_test.go
+++ b/internal/api/handler_dashboard_test.go
@@ -219,32 +219,49 @@ func TestHandler_getUpcomingPurchases(t *testing.T) {
 	mockStore := new(MockConfigStore)
 
 	nextExecDate := time.Now().AddDate(0, 0, 7)
-	plans := []config.PurchasePlan{
+	planA := config.PurchasePlan{
+		ID:      "11111111-1111-1111-1111-111111111111",
+		Name:    "Test Plan 1",
+		Enabled: true,
+		Services: map[string]config.ServiceConfig{
+			"aws/rds": {Provider: "aws", Service: "rds"},
+		},
+		RampSchedule: config.RampSchedule{TotalSteps: 5},
+	}
+	planB := config.PurchasePlan{
+		ID:      "22222222-2222-2222-2222-222222222222",
+		Name:    "Plan B (no pending exec)",
+		Enabled: true,
+		Services: map[string]config.ServiceConfig{
+			"aws/ec2": {Provider: "aws", Service: "ec2"},
+		},
+		RampSchedule: config.RampSchedule{TotalSteps: 3},
+	}
+
+	// Two pending executions, both belonging to planA — exercises the
+	// one-row-per-execution semantic (plan B has no pending execution and
+	// must NOT appear in the upcoming list).
+	pending := []config.PurchaseExecution{
 		{
-			ID:                "11111111-1111-1111-1111-111111111111",
-			Name:              "Test Plan 1",
-			Enabled:           true,
-			NextExecutionDate: &nextExecDate,
-			Services: map[string]config.ServiceConfig{
-				"aws/rds": {
-					Provider: "aws",
-					Service:  "rds",
-				},
-			},
-			RampSchedule: config.RampSchedule{
-				CurrentStep: 0,
-				TotalSteps:  5,
-			},
+			ExecutionID:      "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+			PlanID:           planA.ID,
+			Status:           "pending",
+			ScheduledDate:    nextExecDate,
+			StepNumber:       1,
+			EstimatedSavings: 100.0,
 		},
 		{
-			ID:                "22222222-2222-2222-2222-222222222222",
-			Name:              "Disabled Plan",
-			Enabled:           false,
-			NextExecutionDate: &nextExecDate,
+			ExecutionID:      "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+			PlanID:           planA.ID,
+			Status:           "pending",
+			ScheduledDate:    nextExecDate.AddDate(0, 1, 0),
+			StepNumber:       2,
+			EstimatedSavings: 150.0,
 		},
 	}
 
-	mockStore.On("ListPurchasePlans", ctx).Return(plans, nil)
+	mockStore.On("GetPendingExecutions", ctx).Return(pending, nil)
+	mockStore.On("ListPurchasePlans", ctx).Return([]config.PurchasePlan{planA, planB}, nil)
 
 	mockAuth, req := adminDashboardReq(ctx)
 	handler := &Handler{auth: mockAuth, config: mockStore}
@@ -252,14 +269,50 @@ func TestHandler_getUpcomingPurchases(t *testing.T) {
 	result, err := handler.getUpcomingPurchases(ctx, req)
 	require.NoError(t, err)
 
-	// Only enabled plans should be returned
-	assert.Len(t, result.Purchases, 1)
-	assert.Equal(t, "11111111-1111-1111-1111-111111111111", result.Purchases[0].PlanID)
-	assert.Equal(t, "Test Plan 1", result.Purchases[0].PlanName)
-	assert.Equal(t, "aws", result.Purchases[0].Provider)
-	assert.Equal(t, "rds", result.Purchases[0].Service)
-	assert.Equal(t, 1, result.Purchases[0].StepNumber)
-	assert.Equal(t, 5, result.Purchases[0].TotalSteps)
+	// Both pending executions of plan A appear, in order. Plan B has no
+	// pending execution → not in the list (one row per execution, not per
+	// plan, by design — see PR #213 history).
+	require.Len(t, result.Purchases, 2)
+
+	first := result.Purchases[0]
+	assert.Equal(t, "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", first.ExecutionID,
+		"Cancel button targets ExecutionID via DELETE /api/purchases/planned/{id}")
+	assert.Equal(t, planA.ID, first.PlanID, "PlanID exposed for context, not action targeting")
+	assert.Equal(t, "Test Plan 1", first.PlanName)
+	assert.Equal(t, "aws", first.Provider)
+	assert.Equal(t, "rds", first.Service)
+	assert.Equal(t, 1, first.StepNumber)
+	assert.Equal(t, 5, first.TotalSteps)
+	assert.InDelta(t, 100.0, first.EstimatedSavings, 0.0001)
+
+	second := result.Purchases[1]
+	assert.Equal(t, "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", second.ExecutionID)
+	assert.Equal(t, 2, second.StepNumber)
+}
+
+// TestHandler_getUpcomingPurchases_OrphanExecutionSkipped guards against the
+// "execution row with deleted parent plan" cleanup-gap edge case: rather
+// than crash, the widget hides the orphan. Cleanup is a separate concern.
+func TestHandler_getUpcomingPurchases_OrphanExecutionSkipped(t *testing.T) {
+	ctx := context.Background()
+	mockStore := new(MockConfigStore)
+
+	pending := []config.PurchaseExecution{
+		{
+			ExecutionID: "cccccccc-cccc-cccc-cccc-cccccccccccc",
+			PlanID:      "deleted-plan-uuid", // not in plan list below
+			Status:      "pending",
+		},
+	}
+	mockStore.On("GetPendingExecutions", ctx).Return(pending, nil)
+	mockStore.On("ListPurchasePlans", ctx).Return([]config.PurchasePlan{}, nil)
+
+	mockAuth, req := adminDashboardReq(ctx)
+	handler := &Handler{auth: mockAuth, config: mockStore}
+
+	result, err := handler.getUpcomingPurchases(ctx, req)
+	require.NoError(t, err)
+	assert.Empty(t, result.Purchases, "orphan execution must be hidden, not crash")
 }
 
 // mockStoreWithPlanAccounts embeds MockConfigStore and overrides GetPlanAccounts
@@ -306,6 +359,10 @@ func TestHandler_getUpcomingPurchases_ScopedUser(t *testing.T) {
 	}
 
 	mockStore.On("ListPurchasePlans", ctx).Return([]config.PurchasePlan{planA, planB}, nil)
+	mockStore.On("GetPendingExecutions", ctx).Return([]config.PurchaseExecution{
+		{ExecutionID: "exec-A", PlanID: planA.ID, Status: "pending", ScheduledDate: nextExecDate, StepNumber: 1},
+		{ExecutionID: "exec-B", PlanID: planB.ID, Status: "pending", ScheduledDate: nextExecDate, StepNumber: 1},
+	}, nil)
 	store := &mockStoreWithPlanAccounts{
 		MockConfigStore: mockStore,
 		planAccounts: map[string][]config.CloudAccount{
@@ -329,9 +386,10 @@ func TestHandler_getUpcomingPurchases_ScopedUser(t *testing.T) {
 	result, err := handler.getUpcomingPurchases(ctx, req)
 	require.NoError(t, err)
 
-	// Only Plan A (Production) passes the allowed_accounts filter.
-	assert.Len(t, result.Purchases, 1)
+	// Only Plan A's pending execution passes the allowed_accounts filter.
+	require.Len(t, result.Purchases, 1)
 	assert.Equal(t, "Plan A", result.Purchases[0].PlanName)
+	assert.Equal(t, "exec-A", result.Purchases[0].ExecutionID)
 }
 
 // TestHandler_getUpcomingPurchases_ScopedUser_SkipsUnattributed locks down
@@ -351,6 +409,9 @@ func TestHandler_getUpcomingPurchases_ScopedUser_SkipsUnattributed(t *testing.T)
 		RampSchedule:      config.RampSchedule{CurrentStep: 0, TotalSteps: 5},
 	}
 	mockStore.On("ListPurchasePlans", ctx).Return([]config.PurchasePlan{plan}, nil)
+	mockStore.On("GetPendingExecutions", ctx).Return([]config.PurchaseExecution{
+		{ExecutionID: "exec-unattributed", PlanID: plan.ID, Status: "pending", ScheduledDate: nextExecDate, StepNumber: 1},
+	}, nil)
 	store := &mockStoreWithPlanAccounts{
 		MockConfigStore: mockStore,
 		planAccounts:    map[string][]config.CloudAccount{plan.ID: {}},
@@ -672,8 +733,21 @@ func TestHandler_getDashboardSummary_Errors(t *testing.T) {
 func TestHandler_getUpcomingPurchases_Errors(t *testing.T) {
 	ctx := context.Background()
 
+	t.Run("get pending executions error", func(t *testing.T) {
+		mockStore := new(MockConfigStore)
+		mockStore.On("GetPendingExecutions", ctx).Return(nil, errors.New("db error"))
+
+		mockAuth, req := adminDashboardReq(ctx)
+		handler := &Handler{auth: mockAuth, config: mockStore}
+
+		_, err := handler.getUpcomingPurchases(ctx, req)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get pending executions")
+	})
+
 	t.Run("list plans error", func(t *testing.T) {
 		mockStore := new(MockConfigStore)
+		mockStore.On("GetPendingExecutions", ctx).Return([]config.PurchaseExecution{}, nil)
 		mockStore.On("ListPurchasePlans", ctx).Return(nil, errors.New("db error"))
 
 		mockAuth, req := adminDashboardReq(ctx)
@@ -684,25 +758,16 @@ func TestHandler_getUpcomingPurchases_Errors(t *testing.T) {
 		assert.Contains(t, err.Error(), "failed to get purchase plans")
 	})
 
-	t.Run("plan without next execution date", func(t *testing.T) {
+	t.Run("no pending executions yields empty list", func(t *testing.T) {
 		mockStore := new(MockConfigStore)
-
-		plans := []config.PurchasePlan{
-			{
-				ID:                "11111111-1111-1111-1111-111111111111",
-				Name:              "Plan Without Date",
-				Enabled:           true,
-				NextExecutionDate: nil, // No execution date
-			},
-		}
-
-		mockStore.On("ListPurchasePlans", ctx).Return(plans, nil)
+		mockStore.On("GetPendingExecutions", ctx).Return([]config.PurchaseExecution{}, nil)
+		mockStore.On("ListPurchasePlans", ctx).Return([]config.PurchasePlan{}, nil)
 
 		mockAuth, req := adminDashboardReq(ctx)
 		handler := &Handler{auth: mockAuth, config: mockStore}
 
 		result, err := handler.getUpcomingPurchases(ctx, req)
 		require.NoError(t, err)
-		assert.Len(t, result.Purchases, 0) // Should not include plan without date
+		assert.Len(t, result.Purchases, 0)
 	})
 }

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -923,6 +923,17 @@ func TestHandler_HandleRequest_GetUpcomingPurchases(t *testing.T) {
 	}
 
 	mockStore.On("ListPurchasePlans", ctx).Return(plans, nil)
+	// New: handler now enumerates pending executions per PR #213. Fixture
+	// supplies one pending exec for the plan above so the integration test
+	// still observes a single upcoming row.
+	mockStore.On("GetPendingExecutions", ctx).Return([]config.PurchaseExecution{
+		{
+			ExecutionID: "exec-int-1",
+			PlanID:      plans[0].ID,
+			Status:      "pending",
+			StepNumber:  1,
+		},
+	}, nil)
 
 	handler := &Handler{
 		config:            mockStore,
@@ -950,6 +961,7 @@ func TestHandler_HandleRequest_GetUpcomingPurchases(t *testing.T) {
 	err = json.Unmarshal([]byte(resp.Body), &body)
 	require.NoError(t, err)
 	assert.Len(t, body.Purchases, 1)
+	assert.Equal(t, "exec-int-1", body.Purchases[0].ExecutionID)
 }
 
 func TestHandler_HandleRequest_GetPlannedPurchases(t *testing.T) {

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -417,15 +417,22 @@ type UpcomingPurchaseResponse struct {
 	Purchases []UpcomingPurchase `json:"purchases"`
 }
 
-// UpcomingPurchase represents a scheduled purchase that has not yet
-// produced a purchase_executions row. The identifier is therefore the
-// PurchasePlan.ID, not an execution ID — the dashboard's Cancel / View
-// Details affordances must target plan-level endpoints
-// (DELETE /api/purchases/planned/{id}, etc.), NOT execution-level ones
-// (/api/purchases/{id}, /api/purchases/cancel/{id}). Wiring plan IDs to
-// execution endpoints surfaces as a 500 from the SELECT-by-execution-id
-// path returning no row, exactly what issues #204 and #205 reported.
+// UpcomingPurchase represents one upcoming planned purchase — a pending
+// purchase_executions row whose scheduled_date hasn't fired yet, joined
+// to its parent PurchasePlan for display.
+//
+// The dashboard's Cancel button targets ExecutionID via
+// DELETE /api/purchases/planned/{id} (api.deletePlannedPurchase) so the
+// operator removes just THIS scheduled instance and leaves the plan
+// template intact — the next scheduler tick re-creates the next instance
+// for the plan. PlanID is exposed as context (e.g. for linking to the
+// plan's settings) and is NOT what destructive action endpoints should
+// target. PR #207 + #213 history: an earlier iteration routed Cancel to
+// api.deletePlan(planID) which deleted the entire plan; that was too
+// aggressive — operators usually want "skip this scheduled run", not
+// "nuke the recurring template".
 type UpcomingPurchase struct {
+	ExecutionID      string  `json:"execution_id"`
 	PlanID           string  `json:"plan_id"`
 	PlanName         string  `json:"plan_name"`
 	ScheduledDate    string  `json:"scheduled_date"`


### PR DESCRIPTION
Replaces the previous draft of this PR. The earlier version routed Cancel to `api.deletePlan(planId)` — that deleted the **whole plan**, which is too aggressive. Operators clicking "Cancel" on an upcoming scheduled step usually want to skip THAT step, not nuke the recurring template.

## What changed

The dashboard widget previously enumerated `purchase_plans` and synthesised one row per plan from `plan.NextExecutionDate`. That gave the frontend only a `plan_id` to work with — and every action endpoint on this domain (delete / pause / resume / run) operates on `purchase_executions.execution_id`. PR #207 papered over the impedance mismatch by routing Cancel to `deletePlan` (which DOES take a plan_id), but that operates on the wrong granularity.

This PR fixes the data flow at the source: enumerate **pending purchase_executions** on the backend, surface real execution_ids on the API, and let Cancel target just that one scheduled instance via the existing `DELETE /api/purchases/planned/{id}` handler. The plan template stays intact; the next scheduler tick re-creates the next instance.

### Backend (`internal/api/handler_dashboard.go` + `types.go`)

- `getUpcomingPurchases` switches from `ListPurchasePlans` iteration to `GetPendingExecutions` + planMap join. Mirrors the data flow in `getPlannedPurchases` (`handler_purchases.go`) so the dashboard widget and the Plans page walk the same canonical set.
- `upcomingFromPlan` → `upcomingFromExecution`. Step number now comes from the execution row directly (already stamped at instance-create time).
- `UpcomingPurchase` struct gains `ExecutionID`. `PlanID` kept for context (e.g. linking to plan settings) but is NOT what the destructive Cancel button targets.
- Orphan executions (pending exec whose parent plan was deleted) are hidden rather than crashing — cleanup of those is a separate concern.

### Frontend (`dashboard.ts` + `types.ts` + `api/types.ts`)

- `UpcomingPurchase` TS interface gains `execution_id`.
- `upcomingPurchasesIndex` now keyed by `execution_id`.
- Buttons carry `data-id="${p.execution_id}"`.
- `viewPurchaseDetails(executionId)` renders from the in-memory snapshot. Modal shows both Plan ID and Execution ID so operators can cross-reference.
- `cancelScheduledPurchase(executionId)` calls `api.deletePlannedPurchase(executionId)`. Confirm-dialog body rewritten to make the limited scope explicit ("removes this upcoming step from the plan; the plan itself stays in place").
- In-modal Cancel button likewise routes to `deletePlannedPurchase`.

## Tests

- `handler_dashboard_test.go::TestHandler_getUpcomingPurchases` mocks `GetPendingExecutions` and asserts one-row-per-execution semantics (plan with no pending exec doesn't appear; two executions of the same plan produce two rows).
- New `_OrphanExecutionSkipped` guard for the cleanup-gap edge case.
- Scoped-user + unattributed tests updated to mock the new code path.
- `handler_test.go` integration test for `/api/dashboard/upcoming` updated.
- `dashboard.test.ts` cancel-path tests assert `deletePlannedPurchase("exec-123")` AND `deletePlan` NOT called — regression guard against the previous wrong-direction fix.

## Verification

- `go build ./...` clean
- `go test ./...` (full repo) — all green
- `tsc --noEmit` clean
- `npx jest` — **1411/1411** tests pass
- Pre-commit (gocyclo / gosec / trivy / migration-conflicts / go-test / build-frontend / frontend-tests) — all green

## Triage

`type/bug`, `severity/high`, `urgency/now`, `impact/all-users`, `effort/m`, `priority/p0`, `triaged`. Closes the post-#207 follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upcoming purchases tracking: scheduled purchases are now properly managed by individual execution instance rather than by plan level.
  * Canceling a scheduled purchase now correctly removes only that specific scheduled step while preserving the plan template.
  * Enhanced purchase details to display execution identifiers for improved visibility into individual scheduled instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->