### PR TITLE
test(accounts): regression guards for discover-org admin scope + 5xx-on-cred-failure (post-#212 CR)

### DIFF
--- a/internal/api/handler_accounts_test.go
+++ b/internal/api/handler_accounts_test.go
@@ -601,6 +601,98 @@ func TestDiscoverOrgAccounts_NotFound(t *testing.T) {
 	assert.Equal(t, 404, ce.code)
 }
 
+// TestDiscoverOrgAccounts_RejectsNonAdmin locks down the admin-only gate
+// added in PR #212 CR pass 1 (handler.go switched from
+// requirePermission("create","accounts") to requireAdmin). Without this
+// regression guard, a future refactor that swaps requireAdmin back to
+// requirePermission would silently re-open org discovery to non-admin
+// users — and discovered rows go straight into cloud_accounts, so this
+// is a privilege-escalation surface, not just a UX preference.
+func TestDiscoverOrgAccounts_RejectsNonAdmin(t *testing.T) {
+	ctx := context.Background()
+	mockAuth := new(MockAuthService)
+	// Non-admin session: ValidateSession returns Role="user", which
+	// requireAdmin (middleware.go:227-256) explicitly rejects with 403.
+	mockAuth.On("ValidateSession", ctx, "admin-token").Return(&Session{
+		UserID: "regular-user",
+		Email:  "user@example.com",
+		Role:   "user",
+	}, nil)
+
+	handler := &Handler{auth: mockAuth, config: setupAdminMock(ctx)}
+
+	_, err := handler.discoverOrgAccounts(ctx, adminRequest(`{"account_id":"11111111-1111-1111-1111-111111111111"}`))
+	require.Error(t, err)
+	ce, ok := IsClientError(err)
+	require.True(t, ok, "non-admin must get a ClientError, not a 5xx")
+	assert.Equal(t, 403, ce.code, "non-admin must be rejected with 403, not 401/400/404")
+}
+
+// TestDiscoverOrgAccounts_CredResolutionFailureIs5xx locks down the
+// 400→5xx remap in buildOrgRootAWSConfig from PR #212 CR pass 1. The
+// credentials resolver mixes definite client-side validation failures
+// (missing aws_role_arn) with transient server-side ones (credential
+// store unavailable, network errors during access-key load); blanket-400
+// was misleading. The current implementation wraps the resolver error as
+// a regular Go error which the handler-default mapping surfaces as 5xx,
+// preserving retryability. Without this regression guard, a future
+// refactor that wraps it as ClientError(400) would silently make
+// transient failures non-retryable.
+func TestDiscoverOrgAccounts_CredResolutionFailureIs5xx(t *testing.T) {
+	ctx := context.Background()
+	mockAuth := new(MockAuthService)
+	setupAdminAuth(ctx, mockAuth)
+
+	root := orgRootAccount()
+	store := setupAdminMock(ctx)
+	store.GetCloudAccountFn = func(_ context.Context, _ string) (*config.CloudAccount, error) {
+		return root, nil
+	}
+
+	// access_keys mode + a credStore that returns a transient error from
+	// LoadRaw simulates a Secrets Manager / Postgres outage —
+	// ResolveAWSCredentialProvider wraps the store error and returns it,
+	// and buildOrgRootAWSConfig must not classify that as a 4xx.
+	credStore := &errCredStore{err: errors.New("simulated secrets manager outage")}
+
+	handler := &Handler{
+		auth:      mockAuth,
+		config:    store,
+		credStore: credStore,
+		// discoverOrgFn must NOT be reached — credential resolution fails
+		// upstream of it. If the test triggers this, the test is
+		// mis-wired (or the handler stopped failing on cred error).
+		discoverOrgFn: func(_ context.Context, _ aws.Config) (*accounts.OrgDiscoveryResult, error) {
+			t.Fatal("discoverOrgFn must not be called when credential resolution fails")
+			return nil, nil
+		},
+	}
+
+	_, err := handler.discoverOrgAccounts(ctx, adminRequest(`{"account_id":"`+root.ID+`"}`))
+	require.Error(t, err)
+	_, isClientErr := IsClientError(err)
+	assert.False(t, isClientErr, "transient credential-resolution failures must surface as 5xx (retryable), not 4xx — they're not the caller's fault")
+	assert.Contains(t, err.Error(), "resolve credentials", "error message should identify the credential-resolution stage so operators can find it in logs")
+}
+
+// errCredStore satisfies CredentialStore by always returning the same
+// error from LoadRaw. Used to simulate a transient store/network failure
+// in ResolveAWSCredentialProvider — exercises the 5xx-not-4xx contract
+// in TestDiscoverOrgAccounts_CredResolutionFailureIs5xx.
+type errCredStore struct {
+	err error
+}
+
+func (e *errCredStore) LoadRaw(_ context.Context, _, _ string) ([]byte, error) {
+	return nil, e.err
+}
+
+func (e *errCredStore) SaveCredential(_ context.Context, _, _ string, _ []byte) error { return nil }
+func (e *errCredStore) DeleteCredential(_ context.Context, _, _ string) error         { return nil }
+func (e *errCredStore) HasCredential(_ context.Context, _, _ string) (bool, error)    { return false, nil }
+func (e *errCredStore) EncryptPayload(_ []byte) (string, error)                       { return "", nil }
+func (e *errCredStore) DecryptPayload(_ string) ([]byte, error)                       { return nil, nil }
+
 func TestDiscoverOrgAccounts_HappyPathDedupesAndPersists(t *testing.T) {
 	ctx := context.Background()
 	mockAuth := new(MockAuthService)


### PR DESCRIPTION
Follow-up to PR #212 — addresses the only un-applied CR finding from that PR's reviews.

## Background

PR #212 wired the AWS Organizations discovery endpoint and went through three CR rounds (15:25Z, 19:32Z, 19:42Z on 2026-04-30). It was merged at 20:34Z with most CR findings addressed in-line, but one nitpick from the 19:32Z review didn't make it into the merge:

> Add regression tests for the admin-only and 5xx behaviors. This block locks down the 400/404 paths, but it still doesn't assert the two review fixes that changed the handler contract: non-admin callers must be rejected, and credential-resolution failures must not surface as client errors.

Both behaviours are correctly implemented in the merged code; without tests they're a refactor away from quietly regressing.

## What this PR adds

Two test cases in `internal/api/handler_accounts_test.go`:

### `TestDiscoverOrgAccounts_RejectsNonAdmin`

Non-admin session must hit a 403 ClientError. Without this guard, a refactor that swaps `requireAdmin` back to `requirePermission("create","accounts")` silently re-opens org discovery to non-admin users — and discovered rows go straight into `cloud_accounts`, which is a privilege-escalation surface (not just a UX preference).

### `TestDiscoverOrgAccounts_CredResolutionFailureIs5xx`

Credential-resolution failures must surface as 5xx (retryable), not 4xx. Wraps a `CredentialStore` stub (`errCredStore`) whose `LoadRaw` returns a transient-style error; asserts the handler returns a non-`ClientError` carrying the `"resolve credentials"` stage marker so operators can find it in logs. Without this, a future refactor that re-applies `NewClientError(400, ...)` on resolver errors would silently make transient store/network failures non-retryable.

The test's `discoverOrgFn` injection is a `t.Fatal` — proving the failure path exits before reaching discovery (and that the test is exercising the credential-resolution failure path specifically, not a different shortcut).

## Notes on the other CR findings

PR #212 had 5 distinct CR concerns across 3 reviews. Status:

| # | Concern | Status |
|---|---|---|
| 1 | Member ID/CreatedAt/UpdatedAt init missing | ✅ fixed in #212 |
| 2 | Duplicate-key race not handled in persist loop | ✅ fixed in #212 |
| 3 | `AWSAuthMode = ""` will fail DB CHECK constraint | ⚠️ **false alarm** — see below |
| 4 | Nil guard on `disco.Accounts` | ✅ fixed in #212 |
| 5 | Stale `aws_auth_mode=bastion` comments | ✅ fixed in #212 |
| 6 | Tests for admin-only + cred-resolution → 5xx | ❌ **this PR** |

### #3 false alarm

The store layer uses `nullStringFromString(account.AWSAuthMode)` for the INSERT (`internal/config/store_postgres.go:CreateCloudAccount`). That converts `""` → `sql.NullString{Valid: false}` → SQL `NULL`. The `cloud_accounts.aws_auth_mode` column allows `NULL` (no `NOT NULL` constraint in `migrations/000011_cloud_accounts.up.sql:18-19`), and Postgres `CHECK (col IN (...))` constraints satisfy `NULL` by default (the constraint is vacuously true on `NULL`). So persisting `member.AWSAuthMode = ""` is correct as-is. I'll reply on the CR thread with this rationale.

## Verification

- `go build ./...` clean
- `go test ./internal/api/...` — full package green (incl. the two new cases + all PR #212 cases)
- Pre-commit (gocyclo / gosec / trivy / migration-conflicts / go-test) — green

## Triage

`type/chore`, `severity/medium`, `urgency/this-sprint`, `impact/internal`, `effort/xs`, `priority/p2`, `triaged`. Pure-test PR; no behaviour change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression tests for organization account discovery to verify non-admin access is properly rejected with appropriate error codes and credential resolution failures are handled as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->