### PR TITLE
chore(db): drop deprecated (aws, sagemaker) service_configs row (closes #133)

### DIFF
--- a/internal/database/postgres/migrations/000045_drop_aws_sagemaker_service_config.down.sql
+++ b/internal/database/postgres/migrations/000045_drop_aws_sagemaker_service_config.down.sql
@@ -1,0 +1,30 @@
+-- Rollback: recreate the deprecated `(aws, sagemaker)` ServiceConfig
+-- row from `(aws, savings-plans-sagemaker)` for emergency rollback.
+--
+-- Lossy by design: the original PR #71 row's term/payment were copied
+-- forward into `(aws, savings-plans-sagemaker)` by migration 000040,
+-- but any divergence between that row and a hypothetical edited
+-- `(aws, sagemaker)` row at the time of 000045 is not recoverable —
+-- only the post-040 term/payment survive in the split row.
+--
+-- Idempotent in two directions:
+--   * If `(aws, savings-plans-sagemaker)` does not exist (e.g. someone
+--     rolled back past migration 000040 before invoking this down),
+--     the SELECT returns zero rows and the INSERT is a no-op.
+--   * If `(aws, sagemaker)` already exists (manual restore, or this
+--     down was already run), `ON CONFLICT (provider, service) DO
+--     NOTHING` keeps the existing row untouched.
+
+INSERT INTO service_configs (
+    provider, service, enabled, term, payment, coverage, ramp_schedule,
+    include_engines, exclude_engines, include_regions, exclude_regions,
+    include_types, exclude_types, created_at, updated_at
+)
+SELECT 'aws', 'sagemaker',
+    enabled, term, payment, coverage, ramp_schedule,
+    include_engines, exclude_engines, include_regions, exclude_regions,
+    include_types, exclude_types,
+    NOW(), NOW()
+FROM service_configs
+WHERE provider = 'aws' AND service = 'savings-plans-sagemaker'
+ON CONFLICT (provider, service) DO NOTHING;

--- a/internal/database/postgres/migrations/000045_drop_aws_sagemaker_service_config.up.sql
+++ b/internal/database/postgres/migrations/000045_drop_aws_sagemaker_service_config.up.sql
@@ -1,0 +1,23 @@
+-- Drop the deprecated `(aws, sagemaker)` ServiceConfig row left behind
+-- by migration 000040.
+--
+-- Background: PR #71 introduced an interim `(aws, sagemaker)` row with
+-- its own term/payment selects. Migration 000040 (PR #123) split the
+-- legacy `(aws, savings-plans)` umbrella into four per-plan-type rows
+-- and copied the sagemaker row's term/payment forward into the new
+-- `(aws, savings-plans-sagemaker)` row, but intentionally KEPT the
+-- `(aws, sagemaker)` row for one stable release as a backward-compat
+-- safety net for users mid-rollout. See the `Deprecation follow-up`
+-- comment at the bottom of 000040_split_savingsplans.up.sql.
+--
+-- This migration removes that deprecated row now that the per-plan-type
+-- cards are the canonical source of SageMaker SP defaults.
+--
+-- Idempotent: the WHERE clause matches zero rows on installations that
+-- never had PR #71's row (or that already ran this migration), so the
+-- DELETE is a safe no-op.
+--
+-- Tracked in issue #133.
+
+DELETE FROM service_configs
+    WHERE provider = 'aws' AND service = 'sagemaker';

--- a/internal/database/postgres/migrations/split_savingsplans_test.go
+++ b/internal/database/postgres/migrations/split_savingsplans_test.go
@@ -137,14 +137,20 @@ func TestMigration_SplitSavingsPlans(t *testing.T) {
 		require.NoError(t, migrations.RunMigrations(ctx, pool, migrationsPath, "", ""))
 
 		got := queryAWSSPRows(t, pool)
-		// Expect: 4 split rows + sagemaker (kept). Umbrella deleted.
-		require.Len(t, got, 5)
+		// Expect: 4 split rows. Umbrella deleted by 000040; PR #71's
+		// `(aws, sagemaker)` row is also deleted by 000045 (issue #133)
+		// after 000040 has copied its term/payment forward into the
+		// new `savings-plans-sagemaker` slot.
+		require.Len(t, got, 4)
 		_, hasUmbrella := got["savings-plans"]
 		assert.False(t, hasUmbrella, "umbrella should be deleted")
 		_, hasSagemaker := got["sagemaker"]
-		assert.True(t, hasSagemaker, "PR #71 sagemaker row must be kept for one release")
+		assert.False(t, hasSagemaker, "PR #71 sagemaker row should be deleted by 000045 (issue #133)")
 
 		// sagemaker slot inherits from PR #71's row (1, partial-upfront).
+		// The inheritance happens during 000040, which runs before
+		// 000045 deletes the source row, so the values still flow
+		// through into the persisted split row.
 		smRow := got["savings-plans-sagemaker"]
 		assert.Equal(t, 1, smRow.term, "sagemaker slot should inherit term from (aws, sagemaker)")
 		assert.Equal(t, "partial-upfront", smRow.payment, "sagemaker slot should inherit payment from (aws, sagemaker)")


### PR DESCRIPTION
## Summary

Closes #133.

Migration 000040 (PR #123) split `(aws, savings-plans)` into four
per-plan-type rows and copied PR #71's `(aws, sagemaker)` term/payment
forward into `(aws, savings-plans-sagemaker)`, but intentionally KEPT
the deprecated `(aws, sagemaker)` row for one stable release as a
backward-compat safety net (see the `Deprecation follow-up` comment at
the bottom of `000040_split_savingsplans.up.sql`). This PR ships the
follow-up migration that removes that deprecated row now that the
per-plan-type cards are canonical.

## Gap

`(aws, sagemaker)` still exists in `service_configs` after PR #123
landed. Per-plan-type cards now drive SageMaker SP defaults via the
`(aws, savings-plans-sagemaker)` row, so the legacy row is dead state.

## Fix

New migration `000045_drop_aws_sagemaker_service_config.{up,down}.sql`:

- **Up**: idempotent `DELETE FROM service_configs WHERE provider = 'aws'
  AND service = 'sagemaker'`. WHERE clause makes it a safe no-op on
  installations that never had PR #71's row, or that already ran this
  migration.
- **Down**: emergency rollback that recreates the row by
  `INSERT...SELECT` from `(aws, savings-plans-sagemaker)`, lossy by
  design (only post-040 term/payment survive — any divergent edits to
  `(aws, sagemaker)` between 000040 and 000045 are not recoverable).
  Idempotent in two directions:
  - Empty source row → no-op INSERT (graceful when 000040 was rolled
    back first).
  - Existing target row → `ON CONFLICT (provider, service) DO NOTHING`
    keeps it untouched.

Also updates `split_savingsplans_test.go` scenario 2 (integration-tagged
test) to reflect the new post-migration state: `(aws, sagemaker)` is now
absent after running all migrations. The "sagemaker slot inherits 1,
partial-upfront" assertion still holds because 000040 runs before
000045 and copies the values forward into the persisted split row
before the source row is deleted.

## Blast-radius check (production code paths)

Grepped `internal/`, `pkg/`, `cmd/` (excluding `_test.go`) for
references to the bare `'sagemaker'` service slug — zero hits. All
production references are to:

- `pkg/common/types.go`: `ServiceSavingsPlansSageMaker = "savings-plans-sagemaker"`
- `cmd/main.go`, `internal/purchase/execution.go`: maps from
  `"savings-plans-sagemaker"` and `"savingsplans-sagemaker"` to the
  typed constant.
- `internal/config/defaults.go`, `internal/config/README.md`:
  `aws.savings_plans.sagemaker_enabled` config key (independent of the
  service_configs row).

The only callers of the bare `(aws, sagemaker)` service_configs row
were the SQL paths inside migration 000040 (now historic), which read
it during the split and are not re-run.

## Test plan

- [x] `go build ./...` — green.
- [x] `go vet -tags=integration ./internal/database/postgres/migrations/...` — green; integration-tagged test compiles with the updated scenario 2 expectations.
- [x] Production-code grep for bare `'sagemaker'` — empty.
- [ ] (CI) integration test suite runs scenario 1 / 2 / 3 of `TestMigration_SplitSavingsPlans` plus the JSONB rewrite test against a real Postgres container; scenario 2 now requires 4 rows (down from 5) and `hasSagemaker == false`.
- [ ] (Operator) on rollback past 000045, the down migration recreates `(aws, sagemaker)` from the current `(aws, savings-plans-sagemaker)` row.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed deprecated AWS SageMaker service configuration from the database.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->