### PR TITLE
feat(azure compute): populate vCPU + MemoryGB via cached SKU catalogue (closes #148)

### DIFF
--- a/providers/azure/services/compute/client.go
+++ b/providers/azure/services/compute/client.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -20,6 +21,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/LeanerCloud/CUDly/pkg/common"
+	"github.com/LeanerCloud/CUDly/pkg/logging"
 	"github.com/LeanerCloud/CUDly/providers/azure/internal/httpclient"
 	"github.com/LeanerCloud/CUDly/providers/azure/internal/pricing"
 	"github.com/LeanerCloud/CUDly/providers/azure/internal/recommendations"
@@ -48,6 +50,20 @@ type HTTPClient interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
+// vmSKUEntry holds the SKU-catalogue-derived fields the converter
+// wants for each VM SKU. Sourced from
+// armcompute.ResourceSKU.Capabilities (a name/value-pair list):
+//   - vCPUs: Capabilities[Name=="vCPUs"].Value, parsed as int.
+//   - memoryGB: Capabilities[Name=="MemoryGB"].Value, parsed as float64.
+//
+// Either field stays at the zero value when the capability is missing
+// or unparseable; common.ComputeDetails treats 0 as "unknown" (the
+// JSON tags on VCPU/MemoryGB are omitempty).
+type vmSKUEntry struct {
+	vCPUs    int
+	memoryGB float64
+}
+
 // ComputeClient handles Azure VM Reserved Instances
 type ComputeClient struct {
 	cred           azcore.TokenCredential
@@ -63,6 +79,17 @@ type ComputeClient struct {
 	// Microsoft.Capacity provider registration check (cached per client lifetime)
 	capacityProviderOnce sync.Once
 	capacityProviderErr  error
+
+	// Lazy SKU catalogue cache. armcompute.ResourceSKUsClient.NewListPager
+	// returns every SKU available to the subscription with its
+	// Capabilities (vCPUs, MemoryGB). Fetched ONCE per client lifetime;
+	// subsequent converter calls in the same GetRecommendations run hit
+	// the in-memory map. A failed fetch leaves skuCacheMap nil and
+	// converters fall back to VCPU=0/MemoryGB=0 with a WARN log — the
+	// conversion itself does NOT fail (graceful-degradation contract,
+	// matches cache/cosmosdb/database from PR #81).
+	skuCacheOnce sync.Once
+	skuCacheMap  map[string]vmSKUEntry
 }
 
 // NewClient creates a new Azure Compute client
@@ -672,20 +699,34 @@ func extractVMPricing(items []AzureRetailPriceItem, termYears int) (onDemand, re
 // providers/azure/internal/recommendations so the four Azure service
 // converters share the same type-assertion + nil-guard ladder.
 //
-// Compute is NOT yet wired to the batched-SKU-catalogue lookup landed
-// for cache/cosmosdb/database. Reason: common.ComputeDetails (in
-// pkg/common/types.go) currently only exposes InstanceType, Platform,
-// Tenancy, Scope. The two enrichments the SKU catalogue would supply
-// for compute are vCPU and MemoryGB — neither of which has a field on
-// ComputeDetails to write into. Adding new fields to a shared struct
-// touches every cloud provider + every consumer (frontend, common
-// matchers, three other providers' converters), which is well outside
-// the scope of this perf change. Tracked as a follow-up — see
-// known_issues/10_azure_provider.md.
-func (c *ComputeClient) convertAzureVMRecommendation(_ context.Context, azureRec armconsumption.ReservationRecommendationClassification) *common.Recommendation {
+// Details.VCPU and Details.MemoryGB are enriched from a lazily-cached
+// armcompute.ResourceSKUsClient catalogue (cachedSKULookup). The
+// catalogue is fetched ONCE per client lifetime; converter calls in
+// the same GetRecommendations run share the in-memory map (the N+1
+// invariant pinned by TestComputeClient_CachedSKULookup_FetchedOnce).
+// On catalogue-fetch failure or cache miss, both fields stay at 0
+// (the omitempty JSON tags hide them from API payloads) and the
+// conversion still succeeds — matches the graceful-degradation
+// contract from cache/cosmosdb/database in PR #81.
+//
+// Platform / Tenancy / Scope still require additional Azure data
+// sources (consumption usage records, dedicated-host inventory) and
+// remain unpopulated — out of scope for this issue.
+func (c *ComputeClient) convertAzureVMRecommendation(ctx context.Context, azureRec armconsumption.ReservationRecommendationClassification) *common.Recommendation {
 	f := recommendations.Extract(azureRec)
 	if f == nil {
 		return nil
+	}
+	details := common.ComputeDetails{
+		InstanceType: f.ResourceType,
+	}
+	if entry, ok := c.cachedSKULookup(ctx, f.ResourceType); ok {
+		if entry.vCPUs > 0 {
+			details.VCPU = entry.vCPUs
+		}
+		if entry.memoryGB > 0 {
+			details.MemoryGB = entry.memoryGB
+		}
 	}
 	return &common.Recommendation{
 		Provider:         common.ProviderAzure,
@@ -701,11 +742,111 @@ func (c *ComputeClient) convertAzureVMRecommendation(_ context.Context, azureRec
 		Term:             f.Term,
 		PaymentOption:    "upfront",
 		Timestamp:        time.Now(),
-		// Only InstanceType is safely derivable from the payload. Platform,
-		// Tenancy, Scope are armcompute.ResourceSKUsClient territory and
-		// are deferred — see the function godoc for the scope decision.
-		Details: common.ComputeDetails{
-			InstanceType: f.ResourceType,
-		},
+		Details:          details,
 	}
+}
+
+// cachedSKULookup returns the SKU catalogue entry for skuName, fetching
+// the catalogue lazily on first call. The catalogue is fetched ONCE per
+// client lifetime via armcompute.ResourceSKUsClient.NewListPager;
+// subsequent calls are O(1) map lookups. ok=false on cache miss OR
+// catalogue-fetch failure — the caller falls back to VCPU=0 / MemoryGB=0
+// rather than failing the whole conversion.
+func (c *ComputeClient) cachedSKULookup(ctx context.Context, skuName string) (vmSKUEntry, bool) {
+	c.skuCacheOnce.Do(func() {
+		c.skuCacheMap = c.fetchSKUCatalogue(ctx)
+	})
+	if c.skuCacheMap == nil {
+		return vmSKUEntry{}, false
+	}
+	entry, ok := c.skuCacheMap[skuName]
+	return entry, ok
+}
+
+// fetchSKUCatalogue performs the single ResourceSKUsClient.NewListPager
+// walk and reduces the response into a name->vmSKUEntry map keyed by
+// SKU.Name (matches the recommendation engine's ResourceType output).
+//
+// Filters out non-VM resource types and SKUs not available in c.region
+// (mirrors the existing extractVMSizeIfValid filter used by
+// GetValidResourceTypes — a SKU listed for a different region is not
+// safe to attribute to a recommendation in this client's region).
+//
+// Returns nil on pager-create or page-fetch error so the
+// sync.Once-gated cache field stays nil and cachedSKULookup falls back
+// to the empty-fields path. The fetch error is logged WARN once.
+func (c *ComputeClient) fetchSKUCatalogue(ctx context.Context) map[string]vmSKUEntry {
+	pager, err := c.createResourceSKUsPager()
+	if err != nil {
+		logging.Warnf("azure compute: SKU catalogue pager create failed for region %s: %v — Details.VCPU/MemoryGB left at 0", c.region, err)
+		return nil
+	}
+	out := make(map[string]vmSKUEntry)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			logging.Warnf("azure compute: SKU catalogue page fetch failed for region %s: %v — partial cache (%d entries) discarded, Details.VCPU/MemoryGB left at 0", c.region, err, len(out))
+			return nil
+		}
+		c.populateVMSKUMapFromPage(out, page.Value)
+	}
+	return out
+}
+
+// populateVMSKUMapFromPage writes one vmSKUEntry per qualifying VM SKU
+// found in the page into out. Filters non-VM resource types and SKUs
+// not available in c.region. First-write-wins on duplicate SKU names —
+// ResourceSKUs returns each SKU once per subscription, but defending
+// against duplicates keeps the cache deterministic regardless of pager
+// order. Extracted out of fetchSKUCatalogue to keep that function
+// under the cyclomatic-complexity threshold enforced by the
+// pre-commit hook (matches the cache/database extraction pattern from
+// PR #81).
+func (c *ComputeClient) populateVMSKUMapFromPage(out map[string]vmSKUEntry, skus []*armcompute.ResourceSKU) {
+	for _, sku := range skus {
+		if sku == nil || sku.Name == nil {
+			continue
+		}
+		if sku.ResourceType == nil || *sku.ResourceType != "virtualMachines" {
+			continue
+		}
+		if !c.isAvailableInRegion(sku, c.region) {
+			continue
+		}
+		if _, exists := out[*sku.Name]; exists {
+			continue
+		}
+		vCPUs, memoryGB := extractVMSKUCapabilities(sku)
+		out[*sku.Name] = vmSKUEntry{vCPUs: vCPUs, memoryGB: memoryGB}
+	}
+}
+
+// extractVMSKUCapabilities pulls the vCPUs and MemoryGB capabilities
+// out of an armcompute.ResourceSKU's Capabilities name/value list.
+// Returns (0, 0) when the capability is missing or unparseable —
+// callers treat the zero value as "unknown" (omitempty JSON tag on
+// common.ComputeDetails).
+//
+// Extracted out of fetchSKUCatalogue to keep that function under the
+// cyclomatic-complexity threshold enforced by the pre-commit hook
+// (matches the cache/database extraction pattern from PR #81).
+func extractVMSKUCapabilities(sku *armcompute.ResourceSKU) (int, float64) {
+	var vCPUs int
+	var memoryGB float64
+	for _, cb := range sku.Capabilities {
+		if cb == nil || cb.Name == nil || cb.Value == nil {
+			continue
+		}
+		switch *cb.Name {
+		case "vCPUs":
+			if v, err := strconv.Atoi(*cb.Value); err == nil {
+				vCPUs = v
+			}
+		case "MemoryGB":
+			if v, err := strconv.ParseFloat(*cb.Value, 64); err == nil {
+				memoryGB = v
+			}
+		}
+	}
+	return vCPUs, memoryGB
 }

--- a/providers/azure/services/compute/client_test.go
+++ b/providers/azure/services/compute/client_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strconv"
 	"testing"
 	"time"
 
@@ -660,4 +661,175 @@ func TestBuildReservationBody_OmitsTagsWhenSourceEmpty(t *testing.T) {
 	require.NoError(t, json.Unmarshal(body, &got))
 	_, present := got["tags"]
 	assert.False(t, present, "tags must be absent when source is empty")
+}
+
+// --- Issue #148: VCPU/MemoryGB enrichment via cached SKU catalogue ---
+
+// vmSKUCatalogueMockPager is a multi-page-and-error-capable mock used
+// only by the issue-148 SKU-catalogue tests below. The shared
+// mocks.MockResourceSKUsPager doesn't expose its page counter and
+// can't simulate a NextPage error — file-scoped here keeps the shared
+// mock surface untouched (matches the cosmosdb / cache test pattern
+// where each service defines its own catalogue mock).
+type vmSKUCatalogueMockPager struct {
+	pages    []armcompute.ResourceSKUsClientListResponse
+	index    int
+	err      error
+	pageHits int // count of NextPage invocations — pinned by FetchedOnce
+}
+
+func (m *vmSKUCatalogueMockPager) More() bool {
+	return m.index < len(m.pages)
+}
+
+func (m *vmSKUCatalogueMockPager) NextPage(_ context.Context) (armcompute.ResourceSKUsClientListResponse, error) {
+	m.pageHits++
+	if m.err != nil {
+		return armcompute.ResourceSKUsClientListResponse{}, m.err
+	}
+	if m.index >= len(m.pages) {
+		return armcompute.ResourceSKUsClientListResponse{}, errors.New("no more pages")
+	}
+	page := m.pages[m.index]
+	m.index++
+	return page, nil
+}
+
+// buildVMSKU constructs an armcompute.ResourceSKU for "virtualMachines"
+// in the given region with the standard vCPUs / MemoryGB capabilities
+// the converter parses out.
+func buildVMSKU(name, region string, vCPUs int, memoryGB string) *armcompute.ResourceSKU {
+	resourceType := "virtualMachines"
+	regionStr := region
+	nameStr := name
+	vcpuName := "vCPUs"
+	vcpuVal := strconv.Itoa(vCPUs)
+	memName := "MemoryGB"
+	memVal := memoryGB
+	return &armcompute.ResourceSKU{
+		Name:         &nameStr,
+		ResourceType: &resourceType,
+		Locations:    []*string{&regionStr},
+		Capabilities: []*armcompute.ResourceSKUCapabilities{
+			{Name: &vcpuName, Value: &vcpuVal},
+			{Name: &memName, Value: &memVal},
+		},
+	}
+}
+
+// TestComputeClient_ConvertAzureVMRecommendation_PopulatesVCPUAndMemoryFromSKUCache
+// asserts the cached SKU-catalogue lookup populates ComputeDetails.VCPU
+// and ComputeDetails.MemoryGB when the catalogue contains the SKU named
+// in the recommendation. Pin for issue #148.
+func TestComputeClient_ConvertAzureVMRecommendation_PopulatesVCPUAndMemoryFromSKUCache(t *testing.T) {
+	client := NewClient(nil, "test-subscription", "eastus")
+
+	mockPager := &vmSKUCatalogueMockPager{
+		pages: []armcompute.ResourceSKUsClientListResponse{
+			{
+				ResourceSKUsResult: armcompute.ResourceSKUsResult{
+					Value: []*armcompute.ResourceSKU{
+						buildVMSKU("Standard_D2s_v3", "eastus", 2, "8"),
+						buildVMSKU("Standard_D4s_v3", "eastus", 4, "16"),
+					},
+				},
+			},
+		},
+	}
+	client.SetResourceSKUsPager(mockPager)
+
+	rec := mocks.BuildLegacyReservationRecommendation(
+		mocks.WithRegion("eastus"),
+		mocks.WithNormalizedSize("Standard_D2s_v3"),
+	)
+	out := client.convertAzureVMRecommendation(context.Background(), rec)
+	require.NotNil(t, out)
+	details, ok := out.Details.(common.ComputeDetails)
+	require.True(t, ok)
+	assert.Equal(t, "Standard_D2s_v3", details.InstanceType)
+	assert.Equal(t, 2, details.VCPU, "VCPU must be enriched from the cached SKU catalogue")
+	assert.Equal(t, 8.0, details.MemoryGB, "MemoryGB must be enriched from the cached SKU catalogue")
+}
+
+// TestComputeClient_ConvertAzureVMRecommendation_PagerErrorFallsBack
+// asserts that a SKU-catalogue fetch failure does NOT fail the
+// conversion — VCPU/MemoryGB stay at 0 and the rest of Details is
+// populated from the recommendation payload. Graceful-degradation
+// contract from PR #81, now extended to compute.
+func TestComputeClient_ConvertAzureVMRecommendation_PagerErrorFallsBack(t *testing.T) {
+	client := NewClient(nil, "test-subscription", "eastus")
+	mockPager := &vmSKUCatalogueMockPager{
+		pages: []armcompute.ResourceSKUsClientListResponse{{}},
+		err:   errors.New("transient Azure API error"),
+	}
+	client.SetResourceSKUsPager(mockPager)
+
+	rec := mocks.BuildLegacyReservationRecommendation(
+		mocks.WithRegion("eastus"),
+		mocks.WithNormalizedSize("Standard_D2s_v3"),
+	)
+	out := client.convertAzureVMRecommendation(context.Background(), rec)
+	require.NotNil(t, out, "conversion must NOT fail on catalogue-fetch error")
+	details, ok := out.Details.(common.ComputeDetails)
+	require.True(t, ok)
+	assert.Equal(t, "Standard_D2s_v3", details.InstanceType)
+	assert.Equal(t, 0, details.VCPU, "VCPU left at 0 when catalogue fetch fails")
+	assert.Equal(t, 0.0, details.MemoryGB, "MemoryGB left at 0 when catalogue fetch fails")
+}
+
+// TestComputeClient_ConvertAzureVMRecommendation_NoMatchLeavesFieldsZero
+// asserts that when the recommendation's SKU isn't in the catalogue
+// (e.g. SKU listed for another region only), VCPU/MemoryGB stay at 0
+// and the conversion still produces a usable recommendation.
+func TestComputeClient_ConvertAzureVMRecommendation_NoMatchLeavesFieldsZero(t *testing.T) {
+	client := NewClient(nil, "test-subscription", "eastus")
+	mockPager := &vmSKUCatalogueMockPager{
+		pages: []armcompute.ResourceSKUsClientListResponse{
+			{
+				ResourceSKUsResult: armcompute.ResourceSKUsResult{
+					Value: []*armcompute.ResourceSKU{
+						buildVMSKU("Standard_D2s_v3", "eastus", 2, "8"),
+					},
+				},
+			},
+		},
+	}
+	client.SetResourceSKUsPager(mockPager)
+
+	rec := mocks.BuildLegacyReservationRecommendation(
+		mocks.WithRegion("eastus"),
+		mocks.WithNormalizedSize("Standard_NC6s_v3"), // not in catalogue
+	)
+	out := client.convertAzureVMRecommendation(context.Background(), rec)
+	require.NotNil(t, out)
+	details, ok := out.Details.(common.ComputeDetails)
+	require.True(t, ok)
+	assert.Equal(t, "Standard_NC6s_v3", details.InstanceType)
+	assert.Equal(t, 0, details.VCPU)
+	assert.Equal(t, 0.0, details.MemoryGB)
+}
+
+// TestComputeClient_CachedSKULookup_FetchedOnce pins the perf
+// invariant from PR #81 (now also enforced for compute, per #148):
+// many converter calls in the same GetRecommendations run trigger
+// exactly ONE catalogue fetch.
+func TestComputeClient_CachedSKULookup_FetchedOnce(t *testing.T) {
+	client := NewClient(nil, "test-subscription", "eastus")
+	mockPager := &vmSKUCatalogueMockPager{
+		pages: []armcompute.ResourceSKUsClientListResponse{
+			{
+				ResourceSKUsResult: armcompute.ResourceSKUsResult{
+					Value: []*armcompute.ResourceSKU{
+						buildVMSKU("Standard_D2s_v3", "eastus", 2, "8"),
+					},
+				},
+			},
+		},
+	}
+	client.SetResourceSKUsPager(mockPager)
+
+	for i := 0; i < 10; i++ {
+		_, _ = client.cachedSKULookup(context.Background(), "Standard_D2s_v3")
+	}
+	assert.Equal(t, 1, mockPager.pageHits, "catalogue must be fetched ONCE regardless of lookup count")
 }


### PR DESCRIPTION
## Summary

Wires Azure compute to the lazy SKU-catalogue lookup pattern from PR #81, so `convertAzureVMRecommendation` now populates `common.ComputeDetails.VCPU` and `common.ComputeDetails.MemoryGB` from `armcompute.ResourceSKUsClient.NewListPager` capabilities. Both prerequisites are now in place: PR #97 added the destination fields (with `omitempty` JSON tags), and PR #81 landed the cache pattern for the other three Azure services.

Closes #148.

## Why

`common.ComputeDetails.GetDetailDescription()` already reads `VCPU` and `MemoryGB` and appends `" (<vcpu> vCPU / <memory> GB)"` when both are >0. Pre-PR, Azure VM recommendations always had both at 0, so the size string was suppressed and the UI rendered SKU names alone (e.g. `Standard_D2s_v3`). Post-PR they render as `Standard_D2s_v3 (2 vCPU / 8 GB)`.

## What changed

- **`providers/azure/services/compute/client.go`**:
  - New unexported `vmSKUEntry{vCPUs, memoryGB}`.
  - New `skuCacheOnce sync.Once` + `skuCacheMap map[string]vmSKUEntry` on `ComputeClient`.
  - `cachedSKULookup(ctx, skuName)` — lazy single-fetch, O(1) lookup thereafter.
  - `fetchSKUCatalogue(ctx)` — reuses the existing `createResourceSKUsPager` and `isAvailableInRegion` helpers (already used by `GetValidResourceTypes`); returns nil on error.
  - `populateVMSKUMapFromPage` extracted out of `fetchSKUCatalogue` to stay under the project's `gocyclo=10` threshold (matches the cache/database extraction pattern from PR #81).
  - `extractVMSKUCapabilities` parses `vCPUs` (Atoi) and `MemoryGB` (ParseFloat) from the SKU's name/value capability list.
  - `convertAzureVMRecommendation` takes `ctx` (was `_`) and populates `Details.VCPU`/`MemoryGB` from the cache when both >0. Single caller `GetRecommendations` already passes `ctx`.

- **`providers/azure/services/compute/client_test.go`**: 4 new tests
  - `_PopulatesVCPUAndMemoryFromSKUCache` — catalogue hit → fields enriched.
  - `_PagerErrorFallsBack` — fetch error → fields stay 0; conversion succeeds.
  - `_NoMatchLeavesFieldsZero` — catalogue miss → fields stay 0.
  - `_CachedSKULookup_FetchedOnce` — 10 lookups → 1 NextPage call (pins the N+1 invariant).

The shared `mocks.MockResourceSKUsPager` doesn't expose its page counter and can't simulate a `NextPage` error, so the tests use a small file-scoped `vmSKUCatalogueMockPager` (matches the cosmosdb/cache test convention where each service defines its own catalogue mock). No change to the shared mocks surface.

## Graceful-degradation contract

A transient `ResourceSKUsClient` failure no longer breaks Azure VM recommendation conversion: `VCPU`/`MemoryGB` stay at 0 (the `omitempty` JSON tags hide them from API payloads), the rest of `Details` is populated from the recommendation payload as before, and a `WARN` is logged once per client lifetime. Matches the contract from cache/cosmosdb/database in PR #81.

## Out of scope

- AWS / GCP compute converter wiring (separate follow-ups, per the issue body).
- `Platform` / `Tenancy` / `Scope` enrichment — those need additional Azure data sources beyond `armcompute.ResourceSKU.Capabilities`.
- No schema change to `common.ComputeDetails` (fields already added in PR #97).

## Test plan

- [x] `go build ./...`
- [x] `go test github.com/LeanerCloud/CUDly/providers/azure/services/compute` — 42 passed (4 new + all existing)
- [x] `go test github.com/LeanerCloud/CUDly/providers/azure/...` — 309 passed across 10 packages (the pre-existing `providers/azure/services/search` build failure is unrelated — `go.sum` drift)
- [x] `go test ./...` from `pkg/` — 319 passed
- [x] `go vet ./...` — clean
- [x] `gofmt -l .` — empty
- [x] `gocyclo -over 10` on the modified file — no offenders


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Azure VM recommendations now include detailed vCPU and memory capacity information.
  * Improved performance through intelligent caching of Azure VM specification data.
  * Enhanced reliability with graceful fallback handling when specification data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->