### PR TITLE
ci: pre-merge frontend build gate (closes #191)

### DIFF
--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -1,0 +1,64 @@
+name: Frontend build (PR)
+
+# Pre-merge gate: catches TypeScript errors and webpack build failures
+# BEFORE a PR is merged, not after. Motivated by the post-mortem in #191:
+# a TS6133 error rode through to the protected branch and caused all three
+# post-merge deploy jobs to fail after spending minutes on infrastructure
+# only to hit the same tsc error inside the Dockerfile frontend-builder stage.
+#
+# Companion to frontend-build-sentinel.yml, which guards the protected
+# branch post-merge against rebases and GitHub-UI merge commits.
+# This job guards the PR gate itself — the earlier the catch, the cheaper.
+#
+# Uses pull_request (not pull_request_target) so this job runs in the
+# PR-head context with no access to repository secrets. pull_request_target
+# executes in the base-branch context WITH secrets, which is a known
+# fork-exfiltration vector and must not be used for untrusted code builds.
+#
+# See also: #177 (sentinel), #191 (this PR gate).
+
+on:
+  pull_request:
+    branches:
+      - feat/multicloud-web-frontend
+      - main
+    paths:
+      - "frontend/**"
+      - ".github/workflows/frontend-build.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  # Cancel redundant runs when new commits are pushed to the same PR.
+  group: frontend-build-pr-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build frontend
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: TypeScript typecheck
+        run: npm run typecheck
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/frontend-build.yml` — a `pull_request`-triggered job that runs `npm run typecheck` (tsc --noEmit) and `npm run build` (webpack) for any PR targeting `feat/multicloud-web-frontend` or `main` that touches `frontend/**`.
- Catches TypeScript errors once, before merge, in <1 min — instead of three times after merge across AWS/GCP/Azure deploy jobs that each spend ~5 min before hitting the same tsc failure (see #191 post-mortem).
- Companion to `frontend-build-sentinel.yml` (#177, post-merge defence-in-depth); not a replacement.

## Security note: `pull_request` vs `pull_request_target`

Uses `pull_request` (not `pull_request_target`). `pull_request_target` runs with base-branch secrets and is a known fork-exfiltration vector. `pull_request` runs in the PR-head context with no secrets — safe for untrusted-code builds.

## Paths filter

Restricts execution to PRs that touch `frontend/**` or the workflow file itself. Avoids wasting ~60s of runner time on Go/Terraform-only PRs.

## Test plan

- [ ] Open a PR against `feat/multicloud-web-frontend` that changes a file in `frontend/` — confirm "Frontend build (PR)" check appears and passes.
- [ ] Introduce a deliberate TypeScript error in `frontend/src/*.ts` in a PR — confirm the check fails and blocks merge.
- [ ] Open a PR that only touches Go or Terraform files — confirm the check is skipped (no run triggered).
- [ ] Add `Frontend build (PR)` to branch protection required status checks for `feat/multicloud-web-frontend` and `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated build and type-checking validation for pull requests to ensure code quality before merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->