### PR TITLE
fix(dashboard): coverage=0 falls through to default instead of silent zero

### DIFF
--- a/internal/api/handler_dashboard.go
+++ b/internal/api/handler_dashboard.go
@@ -119,10 +119,11 @@ func (h *Handler) filterDashboardRecommendations(ctx context.Context, session *S
 // coverageByKey via config.AccountConfigKey(account, provider, service).
 // Pass coverageByKey=nil to disable scaling (every rec counts fully).
 //
-// Recs without a CloudAccountID, recs whose triple has no entry in the
-// map, and recs with a recorded coverage of zero (treated as "no
-// scaling configured") all count at full weight — this matches the
-// pre-#196 behaviour for un-configured accounts.
+// Recs without a CloudAccountID and recs whose triple has no entry in the
+// map all count at full weight — this matches the pre-#196 behaviour for
+// un-configured accounts. Zero-coverage configs are excluded from the map
+// by resolveCoverageByAccountKey (issue #201) so they also fall through to
+// full weight rather than silently zeroing the headline.
 //
 // Coverage > 100 is capped at 100 so a misconfigured override cannot
 // inflate the headline "potential savings" beyond the raw rec total.
@@ -170,6 +171,13 @@ func scaledSavings(rec config.RecommendationRecord, coverageByKey map[string]flo
 // coverage% for every (account, provider, service) triple represented in
 // recs. Lookup errors degrade gracefully to a nil map (no scaling applied
 // → un-overridden behaviour).
+//
+// Entries with a resolved coverage of zero are omitted from the map.
+// ServiceConfig.Coverage is a float64 whose zero-value means "not configured",
+// so including a zero entry would silently scale that account's savings to $0
+// even though the operator never set an explicit coverage cap (issue #201).
+// When an entry is absent, scaledSavings falls through to full savings,
+// matching the pre-#196 behaviour for un-configured accounts.
 func (h *Handler) resolveCoverageByAccountKey(ctx context.Context, recs []config.RecommendationRecord) map[string]float64 {
 	if len(recs) == 0 {
 		return nil
@@ -184,7 +192,16 @@ func (h *Handler) resolveCoverageByAccountKey(ctx context.Context, recs []config
 	}
 	out := make(map[string]float64, len(resolved))
 	for k, cfg := range resolved {
+		if cfg.Coverage == 0 {
+			// Zero is the float64 zero-value, meaning "not configured".
+			// Omit the entry so scaledSavings returns full savings
+			// rather than silently zeroing the dashboard headline.
+			continue
+		}
 		out[k] = cfg.Coverage
+	}
+	if len(out) == 0 {
+		return nil
 	}
 	return out
 }

--- a/internal/api/handler_dashboard_test.go
+++ b/internal/api/handler_dashboard_test.go
@@ -139,6 +139,51 @@ func TestHandler_getDashboardSummary_PerAccountCoverageScalesSavings(t *testing.
 
 func float64Ptr(f float64) *float64 { return &f }
 
+// Issue #201 — a global ServiceConfig with Coverage=0 (the float64 zero-value,
+// meaning "not configured") must NOT silence the dashboard headline. The fix is
+// in resolveCoverageByAccountKey: zero-coverage entries are omitted from the map
+// so scaledSavings falls through to full savings.
+func TestHandler_getDashboardSummary_ZeroCoverageInServiceConfigFallsThroughToFull(t *testing.T) {
+	ctx := context.Background()
+	mockScheduler := new(MockScheduler)
+	mockStore := new(MockConfigStore)
+	// No AccountServiceOverride — only a global ServiceConfig with Coverage=0.
+	store := &dashboardOverrideStore{
+		MockConfigStore: mockStore,
+		overrides:       map[string]*config.AccountServiceOverride{}, // no overrides
+	}
+
+	acctA := "acct-A"
+	recommendations := []config.RecommendationRecord{
+		{Provider: "aws", Service: "rds", Savings: 200.0, CloudAccountID: &acctA},
+	}
+
+	mockScheduler.On("ListRecommendations", ctx, mock.Anything).Return(recommendations, nil)
+	mockStore.On("GetGlobalConfig", ctx).Return(&config.GlobalConfig{DefaultCoverage: 80.0}, nil)
+	mockStore.On("GetPurchaseHistory", ctx, mock.Anything, mock.Anything).Return([]config.PurchaseHistoryRecord{}, nil)
+	// Global ServiceConfig has Coverage=0 (zero-value — operator never set it).
+	mockStore.On("GetServiceConfig", ctx, "aws", "rds").Return(&config.ServiceConfig{
+		Provider: "aws", Service: "rds", Enabled: true, Coverage: 0,
+	}, nil)
+
+	mockAuth, req := adminDashboardReq(ctx)
+	handler := &Handler{
+		auth:      mockAuth,
+		scheduler: mockScheduler,
+		config:    store,
+	}
+
+	result, err := handler.getDashboardSummary(ctx, req, map[string]string{"provider": "aws"})
+	require.NoError(t, err)
+
+	// Before the fix, Coverage=0 was inserted into the map and scaledSavings
+	// returned $0. After the fix, the zero entry is omitted and the full $200
+	// is returned.
+	assert.InDelta(t, 200.0, result.PotentialMonthlySavings, 0.001,
+		"Coverage=0 (unset zero-value) must not silence savings (issue #201)")
+	assert.InDelta(t, 200.0, result.ByService["rds"].PotentialSavings, 0.001)
+}
+
 // summarizeRecommendationsWithCoverage table-driven unit tests cover the
 // scaling math in isolation from the handler / store / auth dependencies.
 func TestSummarizeRecommendationsWithCoverage(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Root cause**: `ServiceConfig.Coverage` is `float64` with zero-value `0`. When a user creates a global `ServiceConfig` for (e.g.) `aws/rds` to set Term/Payment defaults without explicitly setting `Coverage`, the field resolves to `0`. `resolveCoverageByAccountKey` was inserting that zero entry into the coverage map, causing `scaledSavings` to return `$0` for every matching account — silently zeroing the dashboard headline.

- **Fix**: Skip zero-coverage entries in `resolveCoverageByAccountKey` (8-line change in `handler_dashboard.go`). When an entry is absent from the map, `scaledSavings` falls through to full savings, matching the pre-#196 behaviour for un-configured accounts.

- **Tests**: Added `TestHandler_getDashboardSummary_ZeroCoverageInServiceConfigFallsThroughToFull` — an end-to-end handler test that seeds `ServiceConfig{Coverage: 0}` and asserts the full `$200` is returned. The existing `"zero coverage scales savings to zero"` unit test is unchanged (it seeds the coverage map directly, not via the resolver, and correctly pins the `scaledSavings` function's behavior for an explicitly-set zero).

## Test plan

- [ ] All 1010 `internal/api` tests pass (`go test ./internal/api/... -count=1`)
- [ ] `go vet ./internal/api/...` clean
- [ ] `gofmt -l` empty on changed files
- [ ] New regression test `TestHandler_getDashboardSummary_ZeroCoverageInServiceConfigFallsThroughToFull` passes
- [ ] Existing `TestSummarizeRecommendationsWithCoverage/"zero coverage scales savings to zero"` still passes (explicit 0 in map still scales to zero — correct behavior)

Closes #201