### PR TITLE
fix(api): backend save-side guard for account service override saves (#107 criterion 3)

### DIFF
--- a/internal/api/handler_accounts.go
+++ b/internal/api/handler_accounts.go
@@ -942,6 +942,19 @@ func (h *Handler) saveAccountServiceOverride(ctx context.Context, httpReq *event
 
 	override := buildServiceOverride(accountID, provider, service, req, existing, now)
 
+	// Defence-in-depth: reject invalid (term, payment) combos before persisting.
+	// checkCommitmentOptionCombo is permissive when commitmentOpts is nil or
+	// probe data is absent (ErrNoData) — the frontend's hardcoded rules are the
+	// primary gate in those cases.
+	if err := h.checkCommitmentOptionCombo(ctx, config.ServiceConfig{
+		Provider: override.Provider,
+		Service:  override.Service,
+		Term:     derefInt(override.Term),
+		Payment:  derefString(override.Payment),
+	}); err != nil {
+		return nil, err
+	}
+
 	if err := h.config.SaveAccountServiceOverride(ctx, override); err != nil {
 		return nil, fmt.Errorf("accounts: %w", err)
 	}
@@ -1014,6 +1027,22 @@ func applyOverrideSlices(o *config.AccountServiceOverride, req AccountServiceOve
 	if req.ExcludeTypes != nil {
 		o.ExcludeTypes = req.ExcludeTypes
 	}
+}
+
+// derefInt dereferences an *int pointer, returning 0 for nil.
+func derefInt(p *int) int {
+	if p == nil {
+		return 0
+	}
+	return *p
+}
+
+// derefString dereferences a *string pointer, returning "" for nil.
+func derefString(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
 }
 
 // deleteAccountServiceOverride handles DELETE /api/accounts/:id/service-overrides/:provider/:service.

--- a/internal/api/handler_accounts_test.go
+++ b/internal/api/handler_accounts_test.go
@@ -421,6 +421,11 @@ func TestSaveAccountServiceOverride_InvalidCombo_Returns400(t *testing.T) {
 	setupAdminAuth(ctx, mockAuth)
 
 	store := setupAdminMock(ctx)
+	saveCalled := false
+	store.SaveAccountServiceOverrideFn = func(_ context.Context, _ *config.AccountServiceOverride) error {
+		saveCalled = true
+		return nil
+	}
 	handler := &Handler{
 		auth:   mockAuth,
 		config: store,
@@ -445,6 +450,7 @@ func TestSaveAccountServiceOverride_InvalidCombo_Returns400(t *testing.T) {
 	require.True(t, ok, "expected ClientError, got %T: %v", err, err)
 	assert.Equal(t, 400, ce.code)
 	assert.Contains(t, ce.message, "3yr no-upfront")
+	assert.False(t, saveCalled, "override must not be persisted when combo is invalid")
 }
 
 func TestSaveAccountServiceOverride_ValidCombo_Saves(t *testing.T) {

--- a/internal/api/handler_accounts_test.go
+++ b/internal/api/handler_accounts_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/LeanerCloud/CUDly/internal/accounts"
+	"github.com/LeanerCloud/CUDly/internal/commitmentopts"
 	"github.com/LeanerCloud/CUDly/internal/config"
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -412,6 +413,104 @@ func TestSaveAccountServiceOverride_Success(t *testing.T) {
 	assert.Equal(t, "ec2", got.Service)
 	assert.Equal(t, "11111111-1111-1111-1111-111111111111", got.AccountID)
 	assert.NotEmpty(t, got.ID)
+}
+
+func TestSaveAccountServiceOverride_InvalidCombo_Returns400(t *testing.T) {
+	ctx := context.Background()
+	mockAuth := new(MockAuthService)
+	setupAdminAuth(ctx, mockAuth)
+
+	store := setupAdminMock(ctx)
+	handler := &Handler{
+		auth:   mockAuth,
+		config: store,
+		commitmentOpts: &stubCommitmentOpts{
+			validateFn: func(_ context.Context, provider, service string, term int, payment string) (bool, error) {
+				assert.Equal(t, "aws", provider)
+				assert.Equal(t, "rds", service)
+				assert.Equal(t, 3, term)
+				assert.Equal(t, "no-upfront", payment)
+				return false, nil
+			},
+		},
+	}
+
+	body := `{"term":3,"payment":"no-upfront"}`
+	path := "11111111-1111-1111-1111-111111111111/service-overrides/aws/rds"
+
+	result, err := handler.saveAccountServiceOverride(ctx, adminRequest(body), path)
+	assert.Nil(t, result)
+	require.Error(t, err)
+	ce, ok := IsClientError(err)
+	require.True(t, ok, "expected ClientError, got %T: %v", err, err)
+	assert.Equal(t, 400, ce.code)
+	assert.Contains(t, ce.message, "3yr no-upfront")
+}
+
+func TestSaveAccountServiceOverride_ValidCombo_Saves(t *testing.T) {
+	ctx := context.Background()
+	mockAuth := new(MockAuthService)
+	setupAdminAuth(ctx, mockAuth)
+
+	store := setupAdminMock(ctx)
+	handler := &Handler{
+		auth:   mockAuth,
+		config: store,
+		commitmentOpts: &stubCommitmentOpts{
+			validateFn: func(context.Context, string, string, int, string) (bool, error) {
+				return true, nil
+			},
+		},
+	}
+
+	body := `{"term":1,"payment":"all-upfront"}`
+	path := "11111111-1111-1111-1111-111111111111/service-overrides/aws/rds"
+
+	result, err := handler.saveAccountServiceOverride(ctx, adminRequest(body), path)
+	require.NoError(t, err)
+
+	got := result.(*config.AccountServiceOverride)
+	assert.Equal(t, "aws", got.Provider)
+	assert.Equal(t, "rds", got.Service)
+	assert.NotEmpty(t, got.ID)
+}
+
+func TestSaveAccountServiceOverride_NoProbeData_Permissive(t *testing.T) {
+	ctx := context.Background()
+	body := `{"term":3,"payment":"no-upfront"}`
+	path := "11111111-1111-1111-1111-111111111111/service-overrides/aws/rds"
+
+	t.Run("nil commitmentOpts", func(t *testing.T) {
+		mockAuth := new(MockAuthService)
+		setupAdminAuth(ctx, mockAuth)
+
+		store := setupAdminMock(ctx)
+		handler := &Handler{auth: mockAuth, config: store} // commitmentOpts is nil
+
+		result, err := handler.saveAccountServiceOverride(ctx, adminRequest(body), path)
+		require.NoError(t, err, "nil commitmentOpts must be permissive")
+		assert.NotNil(t, result)
+	})
+
+	t.Run("ErrNoData falls through permissive", func(t *testing.T) {
+		mockAuth := new(MockAuthService)
+		setupAdminAuth(ctx, mockAuth)
+
+		store := setupAdminMock(ctx)
+		handler := &Handler{
+			auth:   mockAuth,
+			config: store,
+			commitmentOpts: &stubCommitmentOpts{
+				validateFn: func(context.Context, string, string, int, string) (bool, error) {
+					return false, commitmentopts.ErrNoData
+				},
+			},
+		}
+
+		result, err := handler.saveAccountServiceOverride(ctx, adminRequest(body), path)
+		require.NoError(t, err, "ErrNoData must be permissive")
+		assert.NotNil(t, result)
+	})
 }
 
 // --- parseServiceOverridePath ---

--- a/internal/api/mocks_test.go
+++ b/internal/api/mocks_test.go
@@ -37,6 +37,11 @@ type MockConfigStore struct {
 	// provider-validation tests use it to assert whether the underlying
 	// store write was invoked (mismatched assignments must NOT call it).
 	SetPlanAccountsFn func(ctx context.Context, planID string, accountIDs []string) error
+	// SaveAccountServiceOverrideFn overrides SaveAccountServiceOverride when
+	// non-nil. Tests use it to assert whether the persist path was (or was
+	// not) reached — e.g. confirming invalid-combo rejections short-circuit
+	// before the store write.
+	SaveAccountServiceOverrideFn func(ctx context.Context, override *config.AccountServiceOverride) error
 }
 
 func (m *MockConfigStore) GetGlobalConfig(ctx context.Context) (*config.GlobalConfig, error) {
@@ -308,6 +313,9 @@ func (m *MockConfigStore) GetAccountServiceOverride(ctx context.Context, account
 	return nil, nil
 }
 func (m *MockConfigStore) SaveAccountServiceOverride(ctx context.Context, override *config.AccountServiceOverride) error {
+	if m.SaveAccountServiceOverrideFn != nil {
+		return m.SaveAccountServiceOverrideFn(ctx, override)
+	}
 	return nil
 }
 func (m *MockConfigStore) DeleteAccountServiceOverride(ctx context.Context, accountID, provider, service string) error {


### PR DESCRIPTION
## Summary

- Wires `checkCommitmentOptionCombo` into `saveAccountServiceOverride` so that a direct `PUT /api/accounts/:id/service-overrides/aws/rds` with an invalid `(term, payment)` tuple (e.g. `3yr no-upfront` for RDS) returns HTTP 400 instead of persisting silently.
- Adds `derefInt` / `derefString` helpers to bridge the sparse `*int`/`*string` override fields to the value-typed `config.ServiceConfig` shim expected by `checkCommitmentOptionCombo`.
- When `commitmentOpts` is nil or probe data is unavailable (`ErrNoData`), the guard is permissive — the frontend's hardcoded rules remain the primary gate (same contract as the global-config path).

Completes criterion 3 of #107. See also the tracking issue filed for this criterion (backend save-side guard).

## Test plan

- [ ] `go test ./internal/api/... -count=1 -run TestSaveAccountServiceOverride` — 6 tests pass (existing success + 4 new cases: invalid-combo-400, valid-combo-saves, nil-commitmentOpts-permissive, ErrNoData-permissive)
- [ ] `go test ./internal/api/... -count=1` — full api package (1054 tests) passes
- [ ] `go vet ./internal/api/...` — no issues
- [ ] `gofmt -l internal/api/handler_accounts.go internal/api/handler_accounts_test.go` — no output (clean)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent saving invalid provider/service/term/payment combinations; returns clear error and avoids persisting invalid overrides.

* **Tests**
  * Added handler tests covering invalid and valid combinations and permissive behavior for missing or no-data validation configs.

* **Chores**
  * Enhanced test mocks to support simulating save behavior for account service overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->