### PR TITLE
feat(frontend/recs): add Monthly cost + Effective savings % columns

### DIFF
--- a/frontend/src/__tests__/recommendations.test.ts
+++ b/frontend/src/__tests__/recommendations.test.ts
@@ -2403,8 +2403,7 @@ describe('effectiveSavingsPct', () => {
 
   test('term=0 clamps to 12 months (no explosion)', () => {
     const pct = effectiveSavingsPct(mk({ savings: 60, upfront_cost: 120, monthly_cost: 40, term: 0 }));
-    expect(pct).not.toBeNull();
-    expect(pct!).toBeCloseTo(45.45, 1);
+    expect(pct).toBeNull();
   });
 
   test('negative effective savings returns a negative percentage', () => {

--- a/frontend/src/__tests__/recommendations.test.ts
+++ b/frontend/src/__tests__/recommendations.test.ts
@@ -1,7 +1,7 @@
 /**
  * Recommendations module tests
  */
-import { loadRecommendations, openPurchaseModal, getPurchaseModalRecommendations, refreshRecommendations, setupRecommendationsHandlers, clearRecommendationDetailCache, pickBestVariantPerCell, seedGlobalDefaults } from '../recommendations';
+import { loadRecommendations, openPurchaseModal, getPurchaseModalRecommendations, refreshRecommendations, setupRecommendationsHandlers, clearRecommendationDetailCache, pickBestVariantPerCell, seedGlobalDefaults, effectiveMonthlySavings, effectiveSavingsPct } from '../recommendations';
 
 // Mock the api module
 jest.mock('../api', () => ({
@@ -490,14 +490,15 @@ describe('Recommendations Module', () => {
       });
     });
 
-    test('renders sortable column headers with indicators (Bundle B: 9 columns)', async () => {
+    test('renders sortable column headers with indicators (Bundle B: 11 columns)', async () => {
       await loadRecommendations();
       const list = document.getElementById('recommendations-list');
-      // Bundle B: every data column is sortable. 9 sortable data columns:
+      // Bundle B: every data column is sortable. 11 sortable data columns:
       // provider, account, service, resource_type, region, count, term,
-      // savings, upfront_cost. The leading checkbox column is not sortable.
+      // savings, upfront_cost, monthly_cost, effective_savings_pct.
+      // The leading checkbox column is not sortable.
       const sortables = list?.querySelectorAll('th.sortable');
-      expect(sortables?.length).toBe(9);
+      expect(sortables?.length).toBe(11);
       // The default sort is savings desc → that header shows an active ▼.
       const savingsHeader = list?.querySelector('th[data-sort="savings"]');
       expect(savingsHeader?.innerHTML).toContain('active');
@@ -1131,7 +1132,7 @@ describe('Bundle B: column header filter triggers', () => {
     const buttons = document.querySelectorAll<HTMLButtonElement>('th .column-filter-btn[data-column]');
     const cols = Array.from(buttons).map((b) => b.dataset['column']);
     expect(cols.sort()).toEqual(
-      ['account', 'count', 'provider', 'region', 'resource_type', 'savings', 'service', 'term', 'upfront_cost'].sort(),
+      ['account', 'count', 'effective_savings_pct', 'monthly_cost', 'provider', 'region', 'resource_type', 'savings', 'service', 'term', 'upfront_cost'].sort(),
     );
   });
 
@@ -2273,8 +2274,8 @@ describe('issue #223: pickBestVariantPerCell config-match tiebreaker', () => {
     // Two variants in one cell: 1yr/all-upfront (configured default) vs
     // 3yr/no-upfront (higher effective savings).
     const recs = [
-      rec('want-this',  1, 'all-upfront',   300, 0),    // effective = $300/mo
-      rec('skip-this',  3, 'no-upfront',    400, 0),    // effective = $400/mo (higher)
+      rec('want-this', 1, 'all-upfront', 300, 0), // effective = $300/mo
+      rec('skip-this', 3, 'no-upfront', 400, 0), // effective = $400/mo (higher)
     ];
     seedGlobalDefaults(1, 'all-upfront');
     const result = pickBestVariantPerCell(recs);
@@ -2285,8 +2286,8 @@ describe('issue #223: pickBestVariantPerCell config-match tiebreaker', () => {
   test('falls back to highest-effective when no variant matches configured defaults', () => {
     // Neither variant matches term=1/all-upfront; fallback picks highest effective.
     const recs = [
-      rec('low-effective',  3, 'all-upfront',  1200, 36000),  // effective = 1200 - 1000 = $200
-      rec('high-effective', 3, 'no-upfront',    400, 0),      // effective = $400
+      rec('low-effective', 3, 'all-upfront', 1200, 36000), // effective = 1200 - 1000 = $200
+      rec('high-effective', 3, 'no-upfront', 400, 0), // effective = $400
     ];
     seedGlobalDefaults(1, 'all-upfront'); // neither matches
     const result = pickBestVariantPerCell(recs);
@@ -2297,8 +2298,8 @@ describe('issue #223: pickBestVariantPerCell config-match tiebreaker', () => {
   test('handles multiple independent cells and picks config-match in each', () => {
     // Two distinct cells; each has a variant matching configured defaults.
     const recs = [
-      rec('cell-a-match',  1, 'all-upfront', 100, 0),
-      rec('cell-a-other',  3, 'no-upfront',  400, 0),  // higher effective but different cell
+      rec('cell-a-match', 1, 'all-upfront', 100, 0),
+      rec('cell-a-other', 3, 'no-upfront', 400, 0), // higher effective but different cell
       { ...rec('cell-b-match', 1, 'all-upfront', 200, 0), region: 'eu-west-1', id: 'cell-b-match' },
       { ...rec('cell-b-other', 3, 'partial-upfront', 600, 0), region: 'eu-west-1', id: 'cell-b-other' },
     ];
@@ -2310,12 +2311,253 @@ describe('issue #223: pickBestVariantPerCell config-match tiebreaker', () => {
 
   test('config-match with 3yr/partial-upfront as configured defaults', () => {
     const recs = [
-      rec('wrong-1',   1, 'all-upfront',     100, 0),
-      rec('want-3yr',  3, 'partial-upfront', 100, 0),
+      rec('wrong-1', 1, 'all-upfront', 100, 0),
+      rec('want-3yr', 3, 'partial-upfront', 100, 0),
     ];
     seedGlobalDefaults(3, 'partial-upfront');
     const result = pickBestVariantPerCell(recs);
     expect(result).toHaveLength(1);
     expect(result[0]!.id).toBe('want-3yr');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #220 / #221: effectiveMonthlySavings + effectiveSavingsPct helpers
+// + Monthly Cost and Effective % column rendering
+// ---------------------------------------------------------------------------
+
+describe('effectiveMonthlySavings', () => {
+  const mk = (overrides: Partial<LocalRecommendation>): LocalRecommendation => ({
+    id: 'r',
+    provider: 'aws',
+    service: 'ec2',
+    resource_type: 't3.medium',
+    region: 'us-east-1',
+    count: 1,
+    term: 1,
+    savings: 100,
+    upfront_cost: 0,
+    monthly_cost: 50,
+    ...overrides,
+  } as unknown as LocalRecommendation);
+
+  test('no-upfront: effective equals raw savings when upfront=0', () => {
+    expect(effectiveMonthlySavings(mk({ savings: 100, upfront_cost: 0, term: 1 }))).toBeCloseTo(100);
+  });
+
+  test('all-upfront: effective = savings - upfront / (term * 12)', () => {
+    expect(effectiveMonthlySavings(mk({ savings: 50, upfront_cost: 600, term: 1 }))).toBeCloseTo(0);
+    expect(effectiveMonthlySavings(mk({ savings: 1200, upfront_cost: 36000, term: 3 }))).toBeCloseTo(200);
+  });
+
+  test('partial-upfront: intermediate amortization', () => {
+    expect(effectiveMonthlySavings(mk({ savings: 600, upfront_cost: 7200, term: 3 }))).toBeCloseTo(400);
+  });
+
+  test('term=0 clamps to 1yr (12 months) to avoid division by zero', () => {
+    expect(effectiveMonthlySavings(mk({ savings: 60, upfront_cost: 120, term: 0 }))).toBeCloseTo(50);
+  });
+
+  test('can return negative when upfront dominates (data anomaly signal)', () => {
+    expect(effectiveMonthlySavings(mk({ savings: 10, upfront_cost: 1200, term: 1 }))).toBeCloseTo(-90);
+  });
+});
+
+describe('effectiveSavingsPct', () => {
+  const mk = (overrides: Partial<LocalRecommendation>): LocalRecommendation => ({
+    id: 'r',
+    provider: 'aws',
+    service: 'ec2',
+    resource_type: 't3.medium',
+    region: 'us-east-1',
+    count: 1,
+    term: 1,
+    savings: 100,
+    upfront_cost: 0,
+    monthly_cost: 50,
+    ...overrides,
+  } as unknown as LocalRecommendation);
+
+  test('no-upfront: pct = savings / (monthly_cost + savings) * 100', () => {
+    const pct = effectiveSavingsPct(mk({ savings: 100, upfront_cost: 0, monthly_cost: 50, term: 1 }));
+    expect(pct).not.toBeNull();
+    expect(pct!).toBeCloseTo(66.67, 1);
+  });
+
+  test('all-upfront with monthly_cost=0: pct uses amortized upfront in onDemand', () => {
+    const pct = effectiveSavingsPct(mk({ savings: 50, upfront_cost: 600, monthly_cost: 0, term: 1 }));
+    expect(pct).not.toBeNull();
+    expect(pct!).toBeCloseTo(0, 1);
+  });
+
+  test('partial-upfront: standard case', () => {
+    const pct = effectiveSavingsPct(mk({ savings: 600, upfront_cost: 7200, monthly_cost: 200, term: 3 }));
+    expect(pct).not.toBeNull();
+    expect(pct!).toBeCloseTo(40, 1);
+  });
+
+  test('on_demand_monthly=0 returns null (no division by zero)', () => {
+    const pct = effectiveSavingsPct(mk({ savings: 0, upfront_cost: 0, monthly_cost: 0, term: 1 }));
+    expect(pct).toBeNull();
+  });
+
+  test('term=0 clamps to 12 months (no explosion)', () => {
+    const pct = effectiveSavingsPct(mk({ savings: 60, upfront_cost: 120, monthly_cost: 40, term: 0 }));
+    expect(pct).not.toBeNull();
+    expect(pct!).toBeCloseTo(45.45, 1);
+  });
+
+  test('negative effective savings returns a negative percentage', () => {
+    const pct = effectiveSavingsPct(mk({ savings: 10, upfront_cost: 1200, monthly_cost: 400, term: 1 }));
+    expect(pct).not.toBeNull();
+    expect(pct!).toBeLessThan(0);
+    expect(pct!).toBeCloseTo(-17.65, 1);
+  });
+
+  test('undefined monthly_cost treated as 0', () => {
+    const pct = effectiveSavingsPct(mk({ savings: 100, upfront_cost: 0, monthly_cost: undefined, term: 1 }));
+    expect(pct).not.toBeNull();
+    expect(pct!).toBeCloseTo(100, 1);
+  });
+});
+
+describe('Monthly Cost + Effective % column rendering', () => {
+  beforeEach(() => {
+    document.body.innerHTML = [
+      '<div id="recommendations-tab" class="tab-content active">',
+      '<div id="recommendations-summary"></div>',
+      '<div id="recommendations-list"></div>',
+      '</div>',
+      '<div id="purchase-modal" class="hidden">',
+      '<div id="purchase-details"></div>',
+      '</div>',
+    ].join('');
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    window.alert = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  const baseRec = (overrides: Partial<LocalRecommendation> = {}): LocalRecommendation => ({
+    id: 'test-rec',
+    provider: 'aws' as const,
+    service: 'ec2',
+    resource_type: 't3.medium',
+    region: 'us-east-1',
+    count: 1,
+    term: 1,
+    savings: 100,
+    upfront_cost: 0,
+    monthly_cost: 50,
+    ...overrides,
+  } as unknown as LocalRecommendation);
+
+  test('table header includes "Monthly Cost" and "Effective %" columns', async () => {
+    (api.getRecommendations as jest.Mock).mockResolvedValue({
+      summary: {},
+      recommendations: [baseRec()],
+      regions: [],
+    });
+    (state.getRecommendations as jest.Mock).mockReturnValue([baseRec()]);
+    await loadRecommendations();
+
+    const headers = Array.from(document.querySelectorAll('th')).map((th) => th.textContent ?? '');
+    expect(headers.some((h) => h.includes('Monthly Cost'))).toBe(true);
+    expect(headers.some((h) => h.includes('Effective %'))).toBe(true);
+  });
+
+  test('no-upfront row: Monthly Cost shows rec.monthly_cost, Effective % is positive', async () => {
+    const rec = baseRec({ savings: 100, upfront_cost: 0, monthly_cost: 50, term: 1 });
+    (api.getRecommendations as jest.Mock).mockResolvedValue({
+      summary: {},
+      recommendations: [rec],
+      regions: [],
+    });
+    (state.getRecommendations as jest.Mock).mockReturnValue([rec]);
+    await loadRecommendations();
+
+    const cells = Array.from(document.querySelectorAll('tbody td')).map((td) => td.textContent ?? '');
+    expect(cells.some((c) => c === '$50')).toBe(true);
+    expect(cells.some((c) => c.includes('%') && !c.includes('em'))).toBe(true);
+  });
+
+  test('all-upfront row: Monthly Cost shows $0, Effective % accounts for amortization', async () => {
+    const rec = baseRec({ savings: 50, upfront_cost: 600, monthly_cost: 0, term: 1 });
+    (api.getRecommendations as jest.Mock).mockResolvedValue({
+      summary: {},
+      recommendations: [rec],
+      regions: [],
+    });
+    (state.getRecommendations as jest.Mock).mockReturnValue([rec]);
+    await loadRecommendations();
+
+    const cells = Array.from(document.querySelectorAll('tbody td')).map((td) => td.textContent ?? '');
+    expect(cells.some((c) => c === '$0')).toBe(true);
+    expect(cells.some((c) => c === '0.0%')).toBe(true);
+  });
+
+  test('on_demand_monthly=0 row: Effective % renders as em-dash', async () => {
+    const rec = baseRec({ savings: 0, upfront_cost: 0, monthly_cost: 0, term: 1 });
+    (api.getRecommendations as jest.Mock).mockResolvedValue({
+      summary: {},
+      recommendations: [rec],
+      regions: [],
+    });
+    (state.getRecommendations as jest.Mock).mockReturnValue([rec]);
+    await loadRecommendations();
+
+    const cells = Array.from(document.querySelectorAll('tbody td')).map((td) => td.textContent ?? '');
+    expect(cells.some((c) => c === '—')).toBe(true);
+  });
+
+  test('negative-effective row: Effective % cell has effective-pct-negative class', async () => {
+    const rec = baseRec({ savings: 10, upfront_cost: 1200, monthly_cost: 400, term: 1 });
+    (api.getRecommendations as jest.Mock).mockResolvedValue({
+      summary: {},
+      recommendations: [rec],
+      regions: [],
+    });
+    (state.getRecommendations as jest.Mock).mockReturnValue([rec]);
+    await loadRecommendations();
+
+    const negativeCells = document.querySelectorAll('tbody td.effective-pct-negative');
+    expect(negativeCells.length).toBeGreaterThan(0);
+  });
+
+  test('sort header for monthly_cost is wired - clicking sets sort to monthly_cost', async () => {
+    (api.getRecommendations as jest.Mock).mockResolvedValue({
+      summary: {},
+      recommendations: [baseRec()],
+      regions: [],
+    });
+    (state.getRecommendations as jest.Mock).mockReturnValue([baseRec()]);
+    await loadRecommendations();
+
+    const header = document.querySelector<HTMLTableCellElement>('th[data-sort="monthly_cost"]');
+    expect(header).not.toBeNull();
+    header!.click();
+    expect(state.setRecommendationsSort).toHaveBeenCalledWith(
+      expect.objectContaining({ column: 'monthly_cost' }),
+    );
+  });
+
+  test('sort header for effective_savings_pct is wired - clicking sets sort', async () => {
+    (api.getRecommendations as jest.Mock).mockResolvedValue({
+      summary: {},
+      recommendations: [baseRec()],
+      regions: [],
+    });
+    (state.getRecommendations as jest.Mock).mockReturnValue([baseRec()]);
+    await loadRecommendations();
+
+    const header = document.querySelector<HTMLTableCellElement>('th[data-sort="effective_savings_pct"]');
+    expect(header).not.toBeNull();
+    header!.click();
+    expect(state.setRecommendationsSort).toHaveBeenCalledWith(
+      expect.objectContaining({ column: 'effective_savings_pct' }),
+    );
   });
 });

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -169,6 +169,10 @@ function renderRecommendationsSummary(summary: RecommendationsSummary): void {
 const SORTABLE_NUMERIC_COLUMNS: Record<string, (r: LocalRecommendation) => number> = {
   savings: (r) => r.savings,
   upfront_cost: (r) => r.upfront_cost,
+  monthly_cost: (r) => r.monthly_cost ?? 0,
+  // effectiveSavingsPct returns null on division-by-zero edge cases;
+  // sentinel NEGATIVE_INFINITY sorts those rows to the bottom in asc order.
+  effective_savings_pct: (r) => effectiveSavingsPct(r) ?? Number.NEGATIVE_INFINITY,
   count: (r) => r.count,
   term: (r) => r.term,
 };
@@ -195,7 +199,48 @@ function cellKey(rec: LocalRecommendation): string {
   return `${rec.provider}|${rec.cloud_account_id ?? ''}|${rec.service}|${rec.region}|${rec.resource_type}|${rec.engine ?? ''}`;
 }
 
-// pickBestVariantPerCell collapses a list of recs to one rec per cell.
+/**
+ * Computes effective monthly savings by amortizing the upfront cost over the
+ * term. Assumes rec.savings is the on-demand vs. discounted recurring delta
+ * EXCLUDING upfront amortization (matches AWS Cost Explorer's
+ * EstimatedMonthlySavingsAmount semantics; verify per-provider if adding
+ * non-AWS sources).
+ *
+ * Edge case: term=0 clamps to 1yr to avoid division by zero (defensive
+ * clamp consistent with the original pickBestVariantPerCell behaviour).
+ */
+export function effectiveMonthlySavings(r: LocalRecommendation): number {
+  const monthsInTerm = Math.max(12, (r.term || 1) * 12);
+  return r.savings - (r.upfront_cost / monthsInTerm);
+}
+
+/**
+ * Computes effective savings as a percentage of the equivalent on-demand
+ * monthly cost, amortizing the upfront cost over the term. Returns null when
+ * the result would require division by zero (on_demand_monthly === 0).
+ *
+ * Formula (assumes rec.savings excludes upfront amortization — see
+ * effectiveMonthlySavings for the semantics note):
+ *   amortized_upfront_per_month = upfront_cost / (term * 12)
+ *   effective_monthly_savings   = savings - amortized_upfront_per_month
+ *   on_demand_monthly           = monthly_cost + savings + amortized_upfront_per_month
+ *   effective_savings_pct       = (effective_monthly_savings / on_demand_monthly) * 100
+ *
+ * A negative result is valid data — it flags a rec where the upfront cost
+ * outweighs the recurring savings over the term (anomaly signal).
+ */
+export function effectiveSavingsPct(r: LocalRecommendation): number | null {
+  const monthsInTerm = Math.max(12, (r.term || 1) * 12);
+  const amortized = r.upfront_cost / monthsInTerm;
+  const effectiveSavings = r.savings - amortized;
+  const onDemand = (r.monthly_cost ?? 0) + r.savings + amortized;
+  if (onDemand === 0) return null;
+  return (effectiveSavings / onDemand) * 100;
+}
+
+// pickBestVariantPerCell collapses a list of recs to one rec per cell,
+// preferring the variant matching resolved GlobalConfig.DefaultTerm +
+// DefaultPayment, then falling back to the highest effective monthly savings.
 //
 // issue #223: tiebreaker is "matches resolved GlobalConfig.DefaultTerm +
 // DefaultPayment". If no variant in a cell matches the configured defaults,
@@ -206,9 +251,19 @@ function cellKey(rec: LocalRecommendation): string {
 // the term:
 //   effective = savings - (upfront_cost / (term * 12))
 //
+// Two `(savings, upfront_cost, term)` tuples that look identical on raw
+// `savings` can score very differently on the amortized number — e.g. a
+// 3yr all-upfront commitment with a large lump-sum upfront has a much
+// lower effective monthly savings than a no-upfront variant with the
+// same headline savings. Picking by amortization picks the variant
+// that's actually best for the operator's wallet over the term.
+//
+// Used by issue #224's `select-all` handler. Sibling issue #223 will
+// replace this tiebreaker with "matches resolved GlobalConfig.DefaultTerm
+// + DefaultPayment" once that lands; until then, amortized savings is
+// the right deterministic default.
 // Exported so unit tests can exercise it directly.
 export function pickBestVariantPerCell(recs: readonly LocalRecommendation[]): LocalRecommendation[] {
-  // Group recs by cell key.
   const groups = new Map<string, LocalRecommendation[]>();
   for (const r of recs) {
     const k = cellKey(r);
@@ -219,13 +274,6 @@ export function pickBestVariantPerCell(recs: readonly LocalRecommendation[]): Lo
       groups.set(k, [r]);
     }
   }
-
-  const effective = (r: LocalRecommendation): number => {
-    // Defensive clamp: if a rec arrives with term=0 from a malformed
-    // fixture, treat it as 1yr so the division doesn't blow up.
-    const monthsInTerm = Math.max(12, (r.term || 1) * 12);
-    return r.savings - (r.upfront_cost / monthsInTerm);
-  };
 
   const result: LocalRecommendation[] = [];
   for (const group of groups.values()) {
@@ -240,7 +288,7 @@ export function pickBestVariantPerCell(recs: readonly LocalRecommendation[]): Lo
     // No config-matching variant in this cell: fall back to highest effective savings.
     let best = group[0]!;
     for (let i = 1; i < group.length; i++) {
-      if (effective(group[i]!) > effective(best)) best = group[i]!;
+      if (effectiveMonthlySavings(group[i]!) > effectiveMonthlySavings(best)) best = group[i]!;
     }
     result.push(best);
   }
@@ -257,6 +305,8 @@ const SORT_HEADER_LABELS: Record<string, string> = {
   term: 'Term',
   savings: 'Monthly Savings',
   upfront_cost: 'Upfront Cost',
+  monthly_cost: 'Monthly Cost',
+  effective_savings_pct: 'Effective %',
 };
 
 function sortIndicator(column: string, active: string, direction: 'asc' | 'desc'): string {
@@ -384,15 +434,21 @@ function categoricalCellValue(r: LocalRecommendation, col: state.Recommendations
     // Numeric columns shouldn't reach this branch; return empty for type-safety.
     case 'count':
     case 'savings':
-    case 'upfront_cost':   return '';
+    case 'upfront_cost':
+    case 'monthly_cost':
+    case 'effective_savings_pct':   return '';
   }
 }
 
 function numericCellValue(r: LocalRecommendation, col: state.RecommendationsColumnId): number {
   switch (col) {
-    case 'count':         return r.count ?? 0;
-    case 'savings':       return r.savings ?? 0;
-    case 'upfront_cost':  return r.upfront_cost ?? 0;
+    case 'count':                return r.count ?? 0;
+    case 'savings':              return r.savings ?? 0;
+    case 'upfront_cost':         return r.upfront_cost ?? 0;
+    case 'monthly_cost':         return r.monthly_cost ?? 0;
+    // Return NaN for null effective_savings_pct so any numeric predicate
+    // returns false rather than coincidentally matching 0.
+    case 'effective_savings_pct': return effectiveSavingsPct(r) ?? Number.NaN;
     // Categorical columns shouldn't reach this branch; return NaN so any
     // numeric predicate returns false rather than coincidentally matching 0.
     case 'provider':
@@ -419,7 +475,7 @@ function numericCellValue(r: LocalRecommendation, col: state.RecommendationsColu
 // ---------------------------------------------------------------------------
 
 const NUMERIC_COLUMNS: ReadonlySet<state.RecommendationsColumnId> = new Set([
-  'count', 'savings', 'upfront_cost',
+  'count', 'savings', 'upfront_cost', 'monthly_cost', 'effective_savings_pct',
 ]);
 
 interface PopoverState {
@@ -1215,7 +1271,7 @@ function providerDisplayName(provider: string): string {
 // neither sortable nor filterable).
 const FILTERABLE_COLUMNS: readonly state.RecommendationsColumnId[] = [
   'provider', 'account', 'service', 'resource_type', 'region',
-  'count', 'term', 'savings', 'upfront_cost',
+  'count', 'term', 'savings', 'upfront_cost', 'monthly_cost', 'effective_savings_pct',
 ];
 
 function buildListMarkup(recommendations: LocalRecommendation[], selectedRecs: ReadonlySet<string>): string {
@@ -1247,6 +1303,9 @@ function buildListMarkup(recommendations: LocalRecommendation[], selectedRecs: R
           const accountName = rec.cloud_account_id ? (accountNamesCache.get(rec.cloud_account_id) || rec.cloud_account_id) : '\u2014';
           const badge = renderSuppressionBadge(rec);
           const recId = escapeHtml(rec.id);
+          const pct = effectiveSavingsPct(rec);
+          const pctClass = pct !== null && pct < 0 ? ' class="effective-pct-negative"' : '';
+          const pctText = pct === null ? '\u2014' : pct.toFixed(1) + '%';
           return `
           <tr class="recommendation-row ${savingsClass} ${isSelected ? 'selected' : ''}" data-rec-id="${recId}">
             <td class="checkbox-col">
@@ -1261,6 +1320,8 @@ function buildListMarkup(recommendations: LocalRecommendation[], selectedRecs: R
             <td>${formatTerm(rec.term)}</td>
             <td class="savings">${formatCurrency(rec.savings)}</td>
             <td>${formatCurrency(rec.upfront_cost)}</td>
+            <td>${formatCurrency(rec.monthly_cost ?? 0)}</td>
+            <td${pctClass}>${pctText}</td>
           </tr>`;
         }).join('')}
       </tbody>

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -170,9 +170,11 @@ const SORTABLE_NUMERIC_COLUMNS: Record<string, (r: LocalRecommendation) => numbe
   savings: (r) => r.savings,
   upfront_cost: (r) => r.upfront_cost,
   monthly_cost: (r) => r.monthly_cost ?? 0,
-  // effectiveSavingsPct returns null on division-by-zero edge cases;
-  // sentinel NEGATIVE_INFINITY sorts those rows to the bottom in asc order.
-  effective_savings_pct: (r) => effectiveSavingsPct(r) ?? Number.NEGATIVE_INFINITY,
+  // effectiveSavingsPct returns null for term=0 / on_demand=0 edge cases.
+  // POSITIVE_INFINITY places null rows at the bottom in ascending order and
+  // at the top in descending — the least surprising behaviour for a savings
+  // column where "no data" rows should be de-emphasised.
+  effective_savings_pct: (r) => effectiveSavingsPct(r) ?? Number.POSITIVE_INFINITY,
   count: (r) => r.count,
   term: (r) => r.term,
 };
@@ -230,7 +232,9 @@ export function effectiveMonthlySavings(r: LocalRecommendation): number {
  * outweighs the recurring savings over the term (anomaly signal).
  */
 export function effectiveSavingsPct(r: LocalRecommendation): number | null {
-  const monthsInTerm = Math.max(12, (r.term || 1) * 12);
+  // Per acceptance criteria: term=0 is a data anomaly — render as em-dash.
+  if (!r.term) return null;
+  const monthsInTerm = r.term * 12;
   const amortized = r.upfront_cost / monthsInTerm;
   const effectiveSavings = r.savings - amortized;
   const onDemand = (r.monthly_cost ?? 0) + r.savings + amortized;

--- a/frontend/src/state.ts
+++ b/frontend/src/state.ts
@@ -5,7 +5,7 @@
 import type { AppState } from './types';
 import type { Recommendation } from './api/types';
 
-export type RecommendationsSortColumn = 'savings' | 'upfront_cost' | 'count' | 'term' | 'payback';
+export type RecommendationsSortColumn = 'savings' | 'upfront_cost' | 'count' | 'term' | 'payback' | 'monthly_cost' | 'effective_savings_pct';
 export interface RecommendationsSort {
   column: RecommendationsSortColumn;
   direction: 'asc' | 'desc';

--- a/frontend/src/state.ts
+++ b/frontend/src/state.ts
@@ -15,7 +15,8 @@ export interface RecommendationsSort {
 // Typo-safety: misspellings at call sites become compile errors.
 export type RecommendationsColumnId =
   | 'provider' | 'account' | 'service' | 'resource_type' | 'region'
-  | 'count' | 'term' | 'savings' | 'upfront_cost';
+  | 'count' | 'term' | 'savings' | 'upfront_cost'
+  | 'monthly_cost' | 'effective_savings_pct';
 
 export type RecommendationsColumnFilter =
   | { kind: 'set'; values: string[] }   // categorical — values always string-form


### PR DESCRIPTION
## Summary

- Adds **Monthly Cost** column to the recommendations table so no-upfront / partial-upfront / all-upfront rows show the complete cost picture (`upfront_cost` + `monthly_cost` + `savings`) without requiring mental arithmetic (closes #220).
- Adds **Effective %** column showing amortized savings as a percentage of equivalent on-demand monthly cost. Negative values render in red to flag data anomalies. Division-by-zero is guarded: renders `—` when `on_demand_monthly == 0` (closes #221).
- Extracts `effectiveMonthlySavings()` from the inline arrow in `pickBestVariantPerCell` (added by #231/issue #224) into a named export used by both the sort extractor and the new Effective % helper — no divergent amortization formulas.
- Both columns are fully wired into sort, numeric filter, and popover infrastructure identically to existing numeric columns.

## Test plan

- [ ] `npm test` in `frontend/` passes (1435 tests, 0 failures).
- [ ] `npm run build` completes successfully.
- [ ] Table header shows "Monthly Cost" and "Effective %" columns after `upfront_cost`.
- [ ] No-upfront rec row: Upfront = $0, Monthly = $X, Savings = $Y, Effective % positive.
- [ ] All-upfront rec row: Upfront = $X, Monthly = $0, Savings = $Y, Effective % accounting for amortization.
- [ ] Partial-upfront rec row: all four cells populated with correct values.
- [ ] Clicking "Monthly Cost" or "Effective %" header sorts the table.
- [ ] Filter popover opens for both new columns with numeric expression input.
- [ ] Rec where effective savings < 0: Effective % cell has red styling (`effective-pct-negative` class).
- [ ] Rec where on_demand_monthly = 0: Effective % shows `—`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Monthly Cost" and "Effective %" columns to the recommendations table with sorting and filtering support.
  * "Effective %" renders an em-dash for no-data, uses negative styling for negative percentages.

* **Bug Fixes / Improvements**
  * Improved tie-breaking and numeric handling to prevent incorrect matches for undefined percentages.

* **Tests**
  * Expanded test coverage for new columns, sorting/filtering, edge cases, rendering, and UI interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->