### PR TITLE
feat(frontend/recs): group rows by cell with savings range + collapse/expand (closes #225, closes #226)

### DIFF
--- a/frontend/src/__tests__/recommendations.test.ts
+++ b/frontend/src/__tests__/recommendations.test.ts
@@ -1,7 +1,7 @@
 /**
  * Recommendations module tests
  */
-import { loadRecommendations, openPurchaseModal, getPurchaseModalRecommendations, refreshRecommendations, setupRecommendationsHandlers, clearRecommendationDetailCache, pickBestVariantPerCell, seedGlobalDefaults, effectiveMonthlySavings, effectiveSavingsPct } from '../recommendations';
+import { loadRecommendations, openPurchaseModal, getPurchaseModalRecommendations, refreshRecommendations, setupRecommendationsHandlers, clearRecommendationDetailCache, pickBestVariantPerCell, seedGlobalDefaults, effectiveMonthlySavings, effectiveSavingsPct, groupRecsByCell, cellSummary, pageLevelRange, resetExpandedCells } from '../recommendations';
 
 // Mock the api module
 jest.mock('../api', () => ({
@@ -2114,6 +2114,12 @@ describe('Issue #224: one-variant-per-cell radio selection', () => {
     (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set(['cellA-1y-allup']));
     await loadRecommendations();
 
+    // issues #225/#226: multi-variant cells are collapsed by default.
+    // Expand the cell first so the variant checkboxes are rendered.
+    const chevron = document.querySelector<HTMLButtonElement>('.rec-cell-chevron');
+    expect(chevron).not.toBeNull();
+    chevron!.click();
+
     // Tick variant B in the same cell.
     const cbs = Array.from(document.querySelectorAll<HTMLInputElement>('tbody input[data-rec-id]'));
     const variantB = cbs.find((cb) => cb.dataset['recId'] === 'cellA-3y-noup');
@@ -2571,5 +2577,204 @@ describe('Monthly Cost + Effective % column rendering', () => {
     expect(state.setRecommendationsSort).toHaveBeenCalledWith(
       expect.objectContaining({ column: 'effective_savings_pct' }),
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issues #225 + #226: cell grouping with savings range and collapse/expand
+// ---------------------------------------------------------------------------
+
+/** Helper to build a minimal LocalRecommendation fixture. */
+const mkRec = (overrides: Partial<LocalRecommendation> = {}): LocalRecommendation => ({
+  id: 'rec-' + Math.random().toString(36).slice(2),
+  provider: 'aws',
+  service: 'ec2',
+  resource_type: 'm5.large',
+  region: 'us-east-1',
+  count: 3,
+  term: 1,
+  payment: 'no-upfront',
+  savings: 100,
+  upfront_cost: 0,
+  monthly_cost: 50,
+  ...overrides,
+} as unknown as LocalRecommendation);
+
+/** Two recs sharing the same cell key (same provider/account/service/region/resource_type/engine). */
+const sameCell = (savingsA: number, savingsB: number): LocalRecommendation[] => [
+  mkRec({ id: 'a1', savings: savingsA, term: 1, payment: 'no-upfront', upfront_cost: 0 }),
+  mkRec({ id: 'a2', savings: savingsB, term: 3, payment: 'all-upfront', upfront_cost: 1200 }),
+];
+
+describe('Issues #225 + #226: cell grouping with savings range and collapse/expand', () => {
+  describe('groupRecsByCell (pure helper)', () => {
+    test('groups two recs with the same cell key into one entry', () => {
+      const recs = sameCell(80, 120);
+      const groups = groupRecsByCell(recs);
+      expect(groups.size).toBe(1);
+      expect(groups.values().next().value).toHaveLength(2);
+    });
+
+    test('groups recs with different resource_type into separate cells', () => {
+      const rec1 = mkRec({ resource_type: 'm5.large' });
+      const rec2 = mkRec({ resource_type: 't3.medium' });
+      const groups = groupRecsByCell([rec1, rec2]);
+      expect(groups.size).toBe(2);
+    });
+  });
+
+  describe('cellSummary (pure helper)', () => {
+    test('computes min and max savings across variants', () => {
+      const recs = sameCell(80, 120);
+      const s = cellSummary(recs);
+      expect(s.savingsMin).toBe(80);
+      expect(s.savingsMax).toBe(120);
+    });
+
+    test('collapses to same value for a single-variant cell', () => {
+      const rec = mkRec({ savings: 55, upfront_cost: 0, term: 1 });
+      const s = cellSummary([rec]);
+      expect(s.savingsMin).toBe(55);
+      expect(s.savingsMax).toBe(55);
+      expect(s.termMin).toBe(1);
+      expect(s.termMax).toBe(1);
+    });
+
+    test('returns zeroed summary for empty input (defensive)', () => {
+      const s = cellSummary([]);
+      expect(s.savingsMin).toBe(0);
+      expect(s.savingsMax).toBe(0);
+    });
+  });
+
+  describe('pageLevelRange (pure helper)', () => {
+    test('sums per-cell min and max across two cells', () => {
+      const cell1 = sameCell(50, 100);  // min=50, max=100
+      const cell2 = [
+        mkRec({ id: 'b1', resource_type: 't3.small', savings: 30, term: 1, payment: 'no-upfront', upfront_cost: 0 }),
+        mkRec({ id: 'b2', resource_type: 't3.small', savings: 70, term: 3, payment: 'all-upfront', upfront_cost: 600 }),
+      ];
+      const groups = groupRecsByCell([...cell1, ...cell2]);
+      const plr = pageLevelRange(groups);
+      expect(plr.cellCount).toBe(2);
+      expect(plr.savingsMin).toBe(80);   // 50 + 30
+      expect(plr.savingsMax).toBe(170);  // 100 + 70
+    });
+
+    test('returns cellCount=0 and savings=0 for empty groups', () => {
+      const plr = pageLevelRange(new Map());
+      expect(plr.cellCount).toBe(0);
+      expect(plr.savingsMin).toBe(0);
+      expect(plr.savingsMax).toBe(0);
+    });
+  });
+
+  describe('DOM rendering (cell grouping integrated)', () => {
+    beforeEach(() => {
+      document.body.innerHTML = [
+        '<div id="recommendations-tab" class="tab-content active">',
+        '<div id="recommendations-summary"></div>',
+        '<div id="recommendations-list"></div>',
+        '</div>',
+        '<div id="purchase-modal" class="hidden">',
+        '<div id="purchase-details"></div>',
+        '</div>',
+      ].join('');
+      jest.clearAllMocks();
+      jest.useFakeTimers();
+      window.alert = jest.fn();
+      // Reset cell expand state so tests don't share module-level expandedCells.
+      resetExpandedCells();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    const multiVariantRecs = (): LocalRecommendation[] => [
+      mkRec({ id: 'mv-1', savings: 80,  term: 1, payment: 'no-upfront',   upfront_cost: 0 }),
+      mkRec({ id: 'mv-2', savings: 120, term: 3, payment: 'all-upfront',  upfront_cost: 1200 }),
+    ];
+
+    test('multi-variant cell renders a summary row, not two flat variant rows by default', async () => {
+      const recs = multiVariantRecs();
+      (api.getRecommendations as jest.Mock).mockResolvedValue({ summary: {}, recommendations: recs });
+      (state.getRecommendations as jest.Mock).mockReturnValue(recs);
+      await loadRecommendations();
+
+      // Summary row should be present
+      const summaryRow = document.querySelector('.rec-cell-summary-row');
+      expect(summaryRow).not.toBeNull();
+
+      // Variant rows should NOT be rendered (collapsed by default)
+      const variantRows = document.querySelectorAll('.rec-variant-row');
+      expect(variantRows.length).toBe(0);
+    });
+
+    test('clicking chevron expands the cell and shows variant rows', async () => {
+      const recs = multiVariantRecs();
+      (api.getRecommendations as jest.Mock).mockResolvedValue({ summary: {}, recommendations: recs });
+      (state.getRecommendations as jest.Mock).mockReturnValue(recs);
+      await loadRecommendations();
+
+      const chevron = document.querySelector<HTMLButtonElement>('.rec-cell-chevron');
+      expect(chevron).not.toBeNull();
+      chevron!.click();
+
+      // After expand: variant rows should appear
+      const variantRows = document.querySelectorAll('.rec-variant-row');
+      expect(variantRows.length).toBe(2);
+    });
+
+    test('page-level range banner appears when multi-variant cells exist', async () => {
+      const recs = multiVariantRecs();
+      (api.getRecommendations as jest.Mock).mockResolvedValue({ summary: {}, recommendations: recs });
+      (state.getRecommendations as jest.Mock).mockReturnValue(recs);
+      await loadRecommendations();
+
+      const banner = document.querySelector('.rec-range-banner');
+      expect(banner).not.toBeNull();
+      expect(banner!.textContent).toMatch(/Recommended range/);
+    });
+
+    test('single-variant cell renders a flat row, no summary row', async () => {
+      const rec = mkRec({ id: 'solo', savings: 60 });
+      (api.getRecommendations as jest.Mock).mockResolvedValue({ summary: {}, recommendations: [rec] });
+      (state.getRecommendations as jest.Mock).mockReturnValue([rec]);
+      await loadRecommendations();
+
+      const summaryRow = document.querySelector('.rec-cell-summary-row');
+      expect(summaryRow).toBeNull();
+
+      // The flat row should exist as a regular recommendation-row
+      const rows = document.querySelectorAll('tr.recommendation-row');
+      expect(rows.length).toBe(1);
+    });
+
+    test('Expand all button appears in filter-status bar for multi-variant cells', async () => {
+      const recs = multiVariantRecs();
+      (api.getRecommendations as jest.Mock).mockResolvedValue({ summary: {}, recommendations: recs });
+      (state.getRecommendations as jest.Mock).mockReturnValue(recs);
+      await loadRecommendations();
+
+      const expandAllBtn = document.querySelector('.expand-all-toggle');
+      expect(expandAllBtn).not.toBeNull();
+      expect(expandAllBtn!.textContent).toMatch(/Expand all/);
+    });
+
+    test('Expand all expands all multi-variant cells', async () => {
+      const recs = multiVariantRecs();
+      (api.getRecommendations as jest.Mock).mockResolvedValue({ summary: {}, recommendations: recs });
+      (state.getRecommendations as jest.Mock).mockReturnValue(recs);
+      await loadRecommendations();
+
+      const expandAllBtn = document.querySelector<HTMLButtonElement>('.expand-all-toggle');
+      expect(expandAllBtn).not.toBeNull();
+      expandAllBtn!.click();
+
+      // After expand all: variant rows should be visible
+      const variantRows = document.querySelectorAll('.rec-variant-row');
+      expect(variantRows.length).toBe(2);
+    });
   });
 });

--- a/frontend/src/__tests__/recommendations.test.ts
+++ b/frontend/src/__tests__/recommendations.test.ts
@@ -529,7 +529,8 @@ describe('Recommendations Module', () => {
       await loadRecommendations();
 
       const summary = document.getElementById('recommendations-action-summary');
-      expect(summary?.textContent).toContain('1 selected of 1 visible');
+      // issues #225/#226: summary text now uses "cells visible" (cell-grouped count).
+      expect(summary?.textContent).toContain('1 selected of 1 cells visible');
       // Old bulk-toolbar surface is gone.
       expect(document.querySelector('.recommendations-bulk-toolbar')).toBeNull();
     });
@@ -539,7 +540,8 @@ describe('Recommendations Module', () => {
       (state.getVisibleRecommendations as jest.Mock).mockReturnValue(twoRecs);
       await loadRecommendations();
       const summary = document.getElementById('recommendations-action-summary');
-      expect(summary?.textContent).toMatch(/All \d+ visible/);
+      // issues #225/#226: summary text now uses "cells visible" (cell-grouped count).
+      expect(summary?.textContent).toMatch(/All \d+ cells visible/);
       expect(document.querySelector('.recommendations-bulk-toolbar')).toBeNull();
     });
 
@@ -1526,9 +1528,14 @@ describe('Bundle B: term-aware bucketing in the Purchase flow', () => {
   });
 
   test('multi-term selection produces multiple fan-out buckets', async () => {
+    // Two different resource types (different cells) with different terms.
+    // issues #225/#226: resolvePurchaseTarget now uses pickBestVariantPerCell
+    // for the default (no-selection) target — each cell contributes one rec.
+    // Use different resource_type so each rec is its own cell (no grouping),
+    // ensuring both are selected as the default target and trigger fan-out.
     const mixed = [
       { id: 'a', provider: 'aws', cloud_account_id: 'a1', service: 'ec2', resource_type: 't3.medium', region: 'us-east-1', count: 1, term: 1, savings: 100, upfront_cost: 500 },
-      { id: 'b', provider: 'aws', cloud_account_id: 'a1', service: 'ec2', resource_type: 't3.medium', region: 'us-east-1', count: 1, term: 3, savings: 200, upfront_cost: 800 },
+      { id: 'b', provider: 'aws', cloud_account_id: 'a1', service: 'ec2', resource_type: 'm5.large', region: 'us-east-1', count: 1, term: 3, savings: 200, upfront_cost: 800 },
     ];
     (api.getRecommendations as jest.Mock).mockResolvedValue({ summary: {}, recommendations: mixed, regions: [] });
     (state.getRecommendations as jest.Mock).mockReturnValue(mixed);
@@ -1604,9 +1611,12 @@ describe('Issue #111: per-bucket Payment seed from per-account service override'
   };
 
   test('(a) single-account bucket with matching override → bucket payment seeded from override', async () => {
+    // issues #225/#226: resolvePurchaseTarget uses pickBestVariantPerCell for the
+    // default path. Use different resource_type values so each rec is its own cell,
+    // ensuring both appear in the default target and trigger fan-out.
     const recs = [
       { id: 'a', provider: 'aws', cloud_account_id: 'test-account-a', service: 'ec2', resource_type: 't3.medium', region: 'us-east-1', count: 1, term: 1, savings: 100, upfront_cost: 500 },
-      { id: 'b', provider: 'aws', cloud_account_id: 'test-account-a', service: 'ec2', resource_type: 't3.medium', region: 'us-east-1', count: 1, term: 3, savings: 200, upfront_cost: 800 },
+      { id: 'b', provider: 'aws', cloud_account_id: 'test-account-a', service: 'ec2', resource_type: 'm5.large', region: 'us-east-1', count: 1, term: 3, savings: 200, upfront_cost: 800 },
     ];
     setupMixedTermRecs(recs);
     // Override pins payment=partial-upfront for AWS EC2 on this
@@ -1641,9 +1651,10 @@ describe('Issue #111: per-bucket Payment seed from per-account service override'
   });
 
   test('(b) single-account bucket with NO matching override → bucket payment seeded from toolbar', async () => {
+    // issues #225/#226: use different resource_type so each rec is its own cell.
     const recs = [
       { id: 'a', provider: 'aws', cloud_account_id: 'test-account-a', service: 'ec2', resource_type: 't3.medium', region: 'us-east-1', count: 1, term: 1, savings: 100, upfront_cost: 500 },
-      { id: 'b', provider: 'aws', cloud_account_id: 'test-account-a', service: 'ec2', resource_type: 't3.medium', region: 'us-east-1', count: 1, term: 3, savings: 200, upfront_cost: 800 },
+      { id: 'b', provider: 'aws', cloud_account_id: 'test-account-a', service: 'ec2', resource_type: 'm5.large', region: 'us-east-1', count: 1, term: 3, savings: 200, upfront_cost: 800 },
     ];
     setupMixedTermRecs(recs);
     // Account exists but has overrides for a DIFFERENT service — the
@@ -1677,10 +1688,15 @@ describe('Issue #111: per-bucket Payment seed from per-account service override'
     // but different cloud_account_ids. resolveBucketPaymentSeed must
     // return toolbar (the documented multi-account fallback).
     // Pair with a third 3yr rec to force multi-bucket fan-out.
+    //
+    // issues #225/#226: resolvePurchaseTarget uses pickBestVariantPerCell so
+    // each rec must be in its own cell. Recs 'a' and 'b' differ by account
+    // (already distinct cells). Rec 'c' gets a different resource_type so it
+    // doesn't collapse into the same cell as rec 'a' (same account-a).
     const recs = [
       { id: 'a', provider: 'aws', cloud_account_id: 'test-account-a', service: 'ec2', resource_type: 't3.medium', region: 'us-east-1', count: 1, term: 1, savings: 100, upfront_cost: 500 },
       { id: 'b', provider: 'aws', cloud_account_id: 'test-account-b', service: 'ec2', resource_type: 't3.medium', region: 'us-east-1', count: 1, term: 1, savings: 150, upfront_cost: 600 },
-      { id: 'c', provider: 'aws', cloud_account_id: 'test-account-a', service: 'ec2', resource_type: 't3.medium', region: 'us-east-1', count: 1, term: 3, savings: 200, upfront_cost: 800 },
+      { id: 'c', provider: 'aws', cloud_account_id: 'test-account-a', service: 'ec2', resource_type: 'r5.large', region: 'us-east-1', count: 1, term: 3, savings: 200, upfront_cost: 800 },
     ];
     setupMixedTermRecs(recs);
     // Both accounts have ec2 overrides — the multi-account bucket
@@ -1713,9 +1729,10 @@ describe('Issue #111: per-bucket Payment seed from per-account service override'
   });
 
   test('(d) user-edited Payment dropdown is reflected in module state', async () => {
+    // issues #225/#226: use different resource_type so each rec is its own cell.
     const recs = [
       { id: 'a', provider: 'aws', cloud_account_id: 'test-account-a', service: 'ec2', resource_type: 't3.medium', region: 'us-east-1', count: 1, term: 1, savings: 100, upfront_cost: 500 },
-      { id: 'b', provider: 'aws', cloud_account_id: 'test-account-a', service: 'ec2', resource_type: 't3.medium', region: 'us-east-1', count: 1, term: 3, savings: 200, upfront_cost: 800 },
+      { id: 'b', provider: 'aws', cloud_account_id: 'test-account-a', service: 'ec2', resource_type: 'm5.large', region: 'us-east-1', count: 1, term: 3, savings: 200, upfront_cost: 800 },
     ];
     setupMixedTermRecs(recs);
 

--- a/frontend/src/css-modules.d.ts
+++ b/frontend/src/css-modules.d.ts
@@ -1,0 +1,7 @@
+// Allow TypeScript to accept CSS/SCSS side-effect imports (e.g. import './styles.css').
+// Without this, strict TypeScript 5.9+ rejects non-JS module imports by default.
+// The webpack config handles the actual CSS bundling at build time.
+declare module '*.css' {
+  const _: string;
+  export default _;
+}

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -1465,6 +1465,14 @@ function providerDisplayName(provider: string): string {
   }
 }
 
+// CR #253 finding: whitelist provider for CSS class injection.
+// rec.provider comes from the API and is injected into class attributes via
+// template literals. A non-whitelisted value falls back to '' (no badge class).
+function providerBadgeClass(provider: string): string {
+  const n = provider.toLowerCase();
+  return n === 'aws' || n === 'azure' || n === 'gcp' ? n : '';
+}
+
 // Columns that get the per-column header filter button. Order matches the
 // table column order (excluding the leading checkbox column, which is
 // neither sortable nor filterable).
@@ -1490,7 +1498,7 @@ function buildVariantRowMarkup(rec: LocalRecommendation, selectedRecs: ReadonlyS
     <td class="checkbox-col">
       <input type="checkbox" data-rec-id="${recId}" ${isSelected ? 'checked' : ''} aria-label="Select recommendation">
     </td>
-    <td><span class="provider-badge ${rec.provider}">${rec.provider.toUpperCase()}</span></td>
+    <td><span class="provider-badge ${providerBadgeClass(rec.provider)}">${escapeHtml(providerDisplayName(rec.provider))}</span></td>
     <td>${escapeHtml(accountName)}</td>
     <td><span class="service-badge">${escapeHtml(rec.service)}</span></td>
     <td title="${escapeHtml(rec.resource_type)}">${escapeHtml(rec.resource_type)}${rec.engine ? ` (${escapeHtml(rec.engine)})` : ''}${badge}</td>
@@ -1570,7 +1578,7 @@ function buildListMarkup(recommendations: LocalRecommendation[], selectedRecs: R
     rows.push(`
   <tr class="rec-cell-summary-row" data-cell-key="${escapeHtml(key)}">
     <td class="checkbox-col"></td>
-    <td><span class="provider-badge ${rep.provider}">${rep.provider.toUpperCase()}</span></td>
+    <td><span class="provider-badge ${providerBadgeClass(rep.provider)}">${escapeHtml(providerDisplayName(rep.provider))}</span></td>
     <td>${escapeHtml(accountName)}</td>
     <td><span class="service-badge">${escapeHtml(rep.service)}</span></td>
     <td colspan="${TABLE_COL_COUNT - 4}" class="rec-cell-summary-content">
@@ -1808,11 +1816,24 @@ function mountBottomActionBox(): HTMLElement | null {
 // Resolve the action target: selected ∩ visible if a selection exists,
 // else all visible. "Visible" is the post-filter set tracked in module
 // state via setVisibleRecommendations.
+//
+// CR #253: when no rows are manually selected, fall back to one variant per
+// cell (pickBestVariantPerCell) rather than all visible variants. With the
+// grouped table, a collapsed 2-variant cell counts as "1 visible cell" to
+// the user but "2 visible recs" to the flat visible list — submitting both
+// would create 2 conflicting reservations for the same resource, violating
+// the one-variant-per-cell contract from #224.
 function resolvePurchaseTarget(): LocalRecommendation[] {
   const visible = state.getVisibleRecommendations() as unknown as LocalRecommendation[];
   const selected = state.getSelectedRecommendationIDs();
   const intersection = visible.filter((r) => selected.has(r.id));
-  return intersection.length > 0 ? intersection : visible;
+  // Selection path: use the explicit user selection (radio enforcement from
+  // #224 already caps at one per cell).
+  if (intersection.length > 0) return intersection;
+  // Default (no selection): pick the best variant per cell so the purchase
+  // target is exactly one rec per physical resource, matching what the user
+  // sees in the grouped collapsed table.
+  return pickBestVariantPerCell(visible);
 }
 
 // updateBottomActionBox refreshes labels and disabled state on every
@@ -1830,6 +1851,14 @@ function updateBottomActionBox(visibleCount: number, loadedCount: number): void 
     0,
   );
 
+  // CR #253: for the default (no-selection) target count, use the number of
+  // cells (distinct physical resources) rather than the flat variant count,
+  // since resolvePurchaseTarget() now applies pickBestVariantPerCell when no
+  // rows are selected. The user sees one row per cell in the collapsed table.
+  const visibleCellCount = selectedVisibleCount > 0
+    ? selectedVisibleCount
+    : pickBestVariantPerCell(visible).length;
+
   const summary = document.getElementById('recommendations-action-summary');
   if (summary) {
     if (loadedCount === 0) {
@@ -1837,15 +1866,15 @@ function updateBottomActionBox(visibleCount: number, loadedCount: number): void 
     } else if (visibleCount === 0) {
       summary.textContent = '(0 visible — adjust filters)';
     } else if (selectedVisibleCount > 0) {
-      summary.textContent = `(${selectedVisibleCount} selected of ${visibleCount} visible)`;
+      summary.textContent = `(${selectedVisibleCount} selected of ${visibleCellCount} cells visible)`;
     } else {
-      summary.textContent = `(All ${visibleCount} visible — no selection)`;
+      summary.textContent = `(All ${visibleCellCount} cells visible — no selection)`;
     }
   }
 
   const purchaseBtn = document.getElementById('bulk-purchase-btn') as HTMLButtonElement | null;
   const planBtn = document.getElementById('create-plan-btn') as HTMLButtonElement | null;
-  const targetCount = selectedVisibleCount > 0 ? selectedVisibleCount : visibleCount;
+  const targetCount = visibleCellCount;
   const empty = targetCount === 0;
   const targetIsSelection = selectedVisibleCount > 0;
 

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -26,6 +26,14 @@ let currentPurchaseRecommendations: LocalRecommendation[] = [];
 // Cache of account ID → name for column display
 let accountNamesCache: Map<string, string> = new Map();
 
+// issues #225 + #226: expand/collapse state for cell grouping.
+// Contains the cellKey strings of cells the user has explicitly expanded.
+// Cleared on page load / full refresh; survives per-column filter/sort re-renders.
+const expandedCells = new Set<string>();
+// Last computed group keys for the visible filtered set — used by the
+// Expand-All button handler to populate expandedCells without re-computing.
+let lastVisibleGroupKeys: string[] = [];
+
 // issue #223: resolved GlobalConfig defaults, seeded on page load by
 // loadRecommendations(). Initial values mirror the historical hardcoded
 // defaults so the module is usable before the first API round-trip.
@@ -39,6 +47,15 @@ let cachedGlobalDefaultTerm: 1 | 3 = 1;
 export function seedGlobalDefaults(term: 1 | 3, payment: CompatPayment): void {
   cachedGlobalDefaultTerm = term;
   cachedGlobalDefaultPayment = payment;
+}
+
+/**
+ * Reset cell expand/collapse state. Exported for testing only — not part of
+ * the public API. Call in beforeEach to ensure tests don't share state.
+ */
+export function resetExpandedCells(): void {
+  expandedCells.clear();
+  lastVisibleGroupKeys = [];
 }
 
 // populateRecommendationsAccountFilter / populateRegionFilter / the legacy
@@ -205,6 +222,153 @@ function cellKey(rec: LocalRecommendation): string {
   return `${rec.provider}|${rec.cloud_account_id ?? ''}|${rec.service}|${rec.region}|${rec.resource_type}|${rec.engine ?? ''}`;
 }
 
+// issues #225 + #226: cell-grouping helpers.
+
+/**
+ * Group a flat recommendation list by physical-resource cell.
+ * Returns a Map preserving insertion order of first-seen cell keys.
+ * Exported for tests.
+ */
+export function groupRecsByCell(recs: readonly LocalRecommendation[]): Map<string, LocalRecommendation[]> {
+  const groups = new Map<string, LocalRecommendation[]>();
+  for (const r of recs) {
+    const k = cellKey(r);
+    const g = groups.get(k);
+    if (g) {
+      g.push(r);
+    } else {
+      groups.set(k, [r]);
+    }
+  }
+  return groups;
+}
+
+/** Summary metrics for a single cell's variants. Exported for tests. */
+export interface CellRangeSummary {
+  savingsMin: number;
+  savingsMax: number;
+  upfrontMin: number;
+  upfrontMax: number;
+  termMin: number;
+  termMax: number;
+}
+
+/**
+ * Compute the min/max envelope across all variants of a cell.
+ * Returns zeroed summary for an empty array (defensive; should not occur).
+ * Exported for tests.
+ */
+export function cellSummary(variants: readonly LocalRecommendation[]): CellRangeSummary {
+  if (variants.length === 0) {
+    return { savingsMin: 0, savingsMax: 0, upfrontMin: 0, upfrontMax: 0, termMin: 0, termMax: 0 };
+  }
+  let savingsMin = variants[0]!.savings;
+  let savingsMax = variants[0]!.savings;
+  let upfrontMin = variants[0]!.upfront_cost;
+  let upfrontMax = variants[0]!.upfront_cost;
+  let termMin = variants[0]!.term;
+  let termMax = variants[0]!.term;
+  for (let i = 1; i < variants.length; i++) {
+    const v = variants[i]!;
+    if (v.savings < savingsMin) savingsMin = v.savings;
+    if (v.savings > savingsMax) savingsMax = v.savings;
+    if (v.upfront_cost < upfrontMin) upfrontMin = v.upfront_cost;
+    if (v.upfront_cost > upfrontMax) upfrontMax = v.upfront_cost;
+    if (v.term < termMin) termMin = v.term;
+    if (v.term > termMax) termMax = v.term;
+  }
+  return { savingsMin, savingsMax, upfrontMin, upfrontMax, termMin, termMax };
+}
+
+/**
+ * Compute the page-level savings range by summing per-cell min/max savings.
+ *   overallMin = sum of savingsMin per cell
+ *   overallMax = sum of savingsMax per cell
+ * Exported for tests.
+ */
+export function pageLevelRange(groups: Map<string, LocalRecommendation[]>): { savingsMin: number; savingsMax: number; cellCount: number } {
+  let savingsMin = 0;
+  let savingsMax = 0;
+  for (const variants of groups.values()) {
+    const s = cellSummary(variants);
+    savingsMin += s.savingsMin;
+    savingsMax += s.savingsMax;
+  }
+  return { savingsMin, savingsMax, cellCount: groups.size };
+}
+
+// Fixed payment ordering for within-cell variant sort.
+const PAYMENT_ORDER: Record<string, number> = {
+  'no-upfront': 0,
+  'partial-upfront': 1,
+  'all-upfront': 2,
+  monthly: 3,
+};
+
+/** Sort variants within a cell: term ASC, then payment in fixed order. */
+function sortVariantsInCell(variants: LocalRecommendation[]): LocalRecommendation[] {
+  return variants.slice().sort((a, b) => {
+    const termDiff = a.term - b.term;
+    if (termDiff !== 0) return termDiff;
+    const pa = PAYMENT_ORDER[a.payment ?? ''] ?? 99;
+    const pb = PAYMENT_ORDER[b.payment ?? ''] ?? 99;
+    return pa - pb;
+  });
+}
+
+/**
+ * Return cell keys in the active sort order.
+ * For numeric sort columns: use selected-variant savings if one is selected;
+ *   else use max savings across the cell's variants.
+ * For string sort columns: all variants in a cell share the same value for
+ *   provider/account/service/region/resource_type (they are part of cellKey),
+ *   so use the first variant.
+ */
+function groupsInSortOrder(
+  groups: Map<string, LocalRecommendation[]>,
+  sort: { column: string; direction: 'asc' | 'desc' },
+  selectedRecs: ReadonlySet<string>,
+): string[] {
+  const direction = sort.direction === 'asc' ? 1 : -1;
+  const numericKey = SORTABLE_NUMERIC_COLUMNS[sort.column];
+  const stringKey = SORTABLE_STRING_COLUMNS[sort.column];
+
+  const keys = Array.from(groups.keys());
+  return keys.slice().sort((ka, kb) => {
+    const va = groups.get(ka)!;
+    const vb = groups.get(kb)!;
+
+    if (numericKey) {
+      // Use selected variant's value if one is selected in this cell.
+      const selectedA = va.find((r) => selectedRecs.has(r.id));
+      const selectedB = vb.find((r) => selectedRecs.has(r.id));
+      const scoreA = selectedA ? numericKey(selectedA) : Math.max(...va.map(numericKey));
+      const scoreB = selectedB ? numericKey(selectedB) : Math.max(...vb.map(numericKey));
+      return (scoreA - scoreB) * direction;
+    }
+    if (stringKey) {
+      const strA = va[0] ? stringKey(va[0]) : '';
+      const strB = vb[0] ? stringKey(vb[0]) : '';
+      return strA.localeCompare(strB) * direction;
+    }
+    return 0;
+  });
+}
+
+/** Format a savings range, collapsing "$X – $X" to "$X". */
+function formatSavingsRange(min: number, max: number): string {
+  const lo = formatCurrency(min);
+  const hi = formatCurrency(max);
+  return lo === hi ? lo : `${lo} – ${hi}`;
+}
+
+/** Format a term range, collapsing "1yr – 1yr" to "1yr". */
+function formatTermRange(min: number, max: number): string {
+  const lo = formatTerm(min);
+  const hi = formatTerm(max);
+  return lo === hi ? lo : `${lo} – ${hi}`;
+}
+
 /**
  * Computes effective monthly savings by amortizing the upfront cost over the
  * term. Assumes rec.savings is the on-demand vs. discounted recurring delta
@@ -329,20 +493,9 @@ function sortIndicator(column: string, active: string, direction: 'asc' | 'desc'
     : '<span class="sort-indicator active" aria-hidden="true">\u25BC</span>';
 }
 
-function sortedRecommendations(recs: LocalRecommendation[]): LocalRecommendation[] {
-  const sort = state.getRecommendationsSort();
-  const direction = sort.direction === 'asc' ? 1 : -1;
-  const numericKey = SORTABLE_NUMERIC_COLUMNS[sort.column];
-  if (numericKey) {
-    // slice() clones so we don't mutate the caller's array.
-    return recs.slice().sort((a, b) => (numericKey(a) - numericKey(b)) * direction);
-  }
-  const stringKey = SORTABLE_STRING_COLUMNS[sort.column];
-  if (stringKey) {
-    return recs.slice().sort((a, b) => stringKey(a).localeCompare(stringKey(b)) * direction);
-  }
-  return recs;
-}
+// sortedRecommendations was removed in issues #225/#226: group-level sorting
+// via groupsInSortOrder() supersedes the flat-list sort. The same
+// SORTABLE_NUMERIC_COLUMNS / SORTABLE_STRING_COLUMNS maps are reused there.
 
 // Numeric filter expression parser. Grammar:
 //   - empty/whitespace      -> match-all
@@ -1017,19 +1170,50 @@ function renderFilterStatusBar(loadedCount: number, visibleCount: number): void 
   const activeCount = Object.keys(filters).length;
   if (activeCount === 0) {
     if (badge) badge.remove();
+  } else {
+    if (!badge) {
+      badge = document.createElement('button');
+      badge.type = 'button';
+      badge.className = 'clear-filters';
+      badge.addEventListener('click', () => {
+        state.clearAllRecommendationsColumnFilters();
+        rerenderRecommendations();
+      });
+      bar.insertBefore(badge, live);
+    }
+    badge.textContent = `Clear filters (${activeCount})`;
+  }
+
+  // issues #225 + #226: Expand-All toggle button. Only render when there
+  // are multi-variant cells to expand (lastVisibleGroupKeys has entries).
+  // The button label flips between "Expand all" and "Collapse all"
+  // depending on whether all known groups are currently expanded.
+  let expandAllBtn = bar.querySelector<HTMLButtonElement>('.expand-all-toggle');
+  const multiVariantGroups = lastVisibleGroupKeys.length > 0;
+  if (!multiVariantGroups) {
+    if (expandAllBtn) expandAllBtn.remove();
     return;
   }
-  if (!badge) {
-    badge = document.createElement('button');
-    badge.type = 'button';
-    badge.className = 'clear-filters';
-    badge.addEventListener('click', () => {
-      state.clearAllRecommendationsColumnFilters();
+  if (!expandAllBtn) {
+    expandAllBtn = document.createElement('button');
+    expandAllBtn.type = 'button';
+    expandAllBtn.className = 'expand-all-toggle';
+    bar.appendChild(expandAllBtn);
+    expandAllBtn.addEventListener('click', () => {
+      const allExpanded = lastVisibleGroupKeys.every((k) => expandedCells.has(k));
+      if (allExpanded) {
+        // Collapse all: clear every key that belongs to the current visible set.
+        for (const k of lastVisibleGroupKeys) expandedCells.delete(k);
+      } else {
+        // Expand all: add every visible group key.
+        for (const k of lastVisibleGroupKeys) expandedCells.add(k);
+      }
       rerenderRecommendations();
     });
-    bar.insertBefore(badge, live);
   }
-  badge.textContent = `Clear filters (${activeCount})`;
+  // Update label to reflect current state.
+  const allExpanded = lastVisibleGroupKeys.every((k) => expandedCells.has(k));
+  expandAllBtn.textContent = allExpanded ? 'Collapse all' : 'Expand all';
 }
 
 // renderBulkToolbar was the old "N selected / Add to plan / Clear" pill that
@@ -1289,19 +1473,125 @@ const FILTERABLE_COLUMNS: readonly state.RecommendationsColumnId[] = [
   'count', 'term', 'savings', 'upfront_cost', 'monthly_cost', 'effective_savings_pct',
 ];
 
+// Helper: render one variant row (a single LocalRecommendation) with optional
+// indentation styling for multi-variant cells.
+function buildVariantRowMarkup(rec: LocalRecommendation, selectedRecs: ReadonlySet<string>, isNested: boolean): string {
+  const savingsClass = rec.savings > 1000 ? 'high-savings' : rec.savings > 100 ? 'medium-savings' : '';
+  const isSelected = selectedRecs.has(rec.id);
+  const accountName = rec.cloud_account_id ? (accountNamesCache.get(rec.cloud_account_id) || rec.cloud_account_id) : '\u2014';
+  const badge = renderSuppressionBadge(rec);
+  const recId = escapeHtml(rec.id);
+  const pct = effectiveSavingsPct(rec);
+  const pctClass = pct !== null && pct < 0 ? ' class="effective-pct-negative"' : '';
+  const pctText = pct === null ? '\u2014' : pct.toFixed(1) + '%';
+  const nestedClass = isNested ? ' rec-variant-row' : '';
+  return `
+  <tr class="recommendation-row${nestedClass} ${savingsClass} ${isSelected ? 'selected' : ''}" data-rec-id="${recId}">
+    <td class="checkbox-col">
+      <input type="checkbox" data-rec-id="${recId}" ${isSelected ? 'checked' : ''} aria-label="Select recommendation">
+    </td>
+    <td><span class="provider-badge ${rec.provider}">${rec.provider.toUpperCase()}</span></td>
+    <td>${escapeHtml(accountName)}</td>
+    <td><span class="service-badge">${escapeHtml(rec.service)}</span></td>
+    <td title="${escapeHtml(rec.resource_type)}">${escapeHtml(rec.resource_type)}${rec.engine ? ` (${escapeHtml(rec.engine)})` : ''}${badge}</td>
+    <td>${escapeHtml(rec.region)}</td>
+    <td>${rec.count}</td>
+    <td>${formatTerm(rec.term)}</td>
+    <td class="savings">${formatCurrency(rec.savings)}</td>
+    <td>${formatCurrency(rec.upfront_cost)}</td>
+    <td>${rec.monthly_cost != null ? formatCurrency(rec.monthly_cost) : '—'}</td>
+    <td${pctClass}>${pctText}</td>
+  </tr>`;
+}
+
+// The total column count for colspan on summary rows: checkbox col + 11 data cols = 12.
+const TABLE_COL_COUNT = 12;
+
 function buildListMarkup(recommendations: LocalRecommendation[], selectedRecs: ReadonlySet<string>): string {
   const sort = state.getRecommendationsSort();
-  const sorted = sortedRecommendations(recommendations);
   const filters = state.getRecommendationsColumnFilters();
   const filterBtn = (column: state.RecommendationsColumnId): string => {
     const active = filters[column] ? ' active' : '';
-    const label = filters[column] ? `Filter ${SORT_HEADER_LABELS[column]} — currently active` : `Filter ${SORT_HEADER_LABELS[column]}`;
-    return `<button type="button" class="column-filter-btn${active}" data-column="${column}" aria-haspopup="dialog" aria-expanded="false" aria-label="${label}" title="${label}">⛛</button>`;
+    const label = filters[column] ? `Filter ${SORT_HEADER_LABELS[column]} \u2014 currently active` : `Filter ${SORT_HEADER_LABELS[column]}`;
+    return `<button type="button" class="column-filter-btn${active}" data-column="${column}" aria-haspopup="dialog" aria-expanded="false" aria-label="${label}" title="${label}">\u26db</button>`;
   };
   const sortHeader = (column: state.RecommendationsColumnId): string =>
     `<th class="sortable" data-sort="${column}" tabindex="0" role="button" aria-label="Sort by ${SORT_HEADER_LABELS[column]}"><span>${SORT_HEADER_LABELS[column]}</span>${sortIndicator(column, sort.column, sort.direction)}${filterBtn(column)}</th>`;
 
+  // issues #225 + #226: group by cell, sort groups, then render.
+  const groups = groupRecsByCell(recommendations);
+  const sortedKeys = groupsInSortOrder(groups, sort, selectedRecs);
+
+  // Update module-level group key cache for the Expand-All button.
+  // Only multi-variant cells count — single-variant cells render flat with no chevron.
+  lastVisibleGroupKeys = sortedKeys.filter((k) => (groups.get(k)?.length ?? 0) > 1);
+
+  // Page-level range banner (summed across all visible cells).
+  const plr = pageLevelRange(groups);
+  const bannerHtml = plr.cellCount > 0 && plr.savingsMax > 0
+    ? `<div class="rec-range-banner" role="status" aria-live="polite">Recommended range: <strong>${formatSavingsRange(plr.savingsMin, plr.savingsMax)}/mo</strong> across ${plr.cellCount} cell${plr.cellCount === 1 ? '' : 's'}</div>`
+    : '';
+
+  // Build tbody rows: grouped for multi-variant cells, flat for single-variant.
+  const rows: string[] = [];
+  for (const key of sortedKeys) {
+    const variants = groups.get(key)!;
+    if (variants.length === 1) {
+      // Single-variant: render flat, no group header, no indent.
+      rows.push(buildVariantRowMarkup(variants[0]!, selectedRecs, false));
+      continue;
+    }
+
+    // Multi-variant cell.
+    const isExpanded = expandedCells.has(key);
+    const summary = cellSummary(variants);
+    const rep = variants[0]!;
+    const accountName = rep.cloud_account_id ? (accountNamesCache.get(rep.cloud_account_id) || rep.cloud_account_id) : '\u2014';
+
+    // Selected variant in this cell (if any) — used to show selected values on summary row.
+    const selectedVariant = variants.find((r) => selectedRecs.has(r.id));
+
+    // Summary row savings display: selected variant value if one is selected;
+    // otherwise the range across all variants.
+    const savingsDisplay = selectedVariant
+      ? `${formatCurrency(selectedVariant.savings)}/mo <span class="rec-variants-count">(+${variants.length - 1} variants)</span>`
+      : `${formatSavingsRange(summary.savingsMin, summary.savingsMax)}/mo`;
+
+    const upfrontDisplay = selectedVariant
+      ? formatCurrency(selectedVariant.upfront_cost)
+      : formatSavingsRange(summary.upfrontMin, summary.upfrontMax);
+
+    const termDisplay = selectedVariant
+      ? formatTerm(selectedVariant.term)
+      : formatTermRange(summary.termMin, summary.termMax);
+
+    const chevron = isExpanded ? '\u25bc' : '\u25b6';
+
+    rows.push(`
+  <tr class="rec-cell-summary-row" data-cell-key="${escapeHtml(key)}">
+    <td class="checkbox-col"></td>
+    <td><span class="provider-badge ${rep.provider}">${rep.provider.toUpperCase()}</span></td>
+    <td>${escapeHtml(accountName)}</td>
+    <td><span class="service-badge">${escapeHtml(rep.service)}</span></td>
+    <td colspan="${TABLE_COL_COUNT - 4}" class="rec-cell-summary-content">
+      <button type="button" class="rec-cell-chevron" data-cell-key="${escapeHtml(key)}" aria-expanded="${isExpanded}" aria-label="${isExpanded ? 'Collapse' : 'Expand'} cell variants">
+        ${chevron}
+      </button>
+      <span class="rec-cell-identity">${escapeHtml(rep.resource_type)}${rep.engine ? ` (${escapeHtml(rep.engine)})` : ''} &mdash; ${escapeHtml(rep.region)} &mdash; ${variants.length} variants</span>
+      <span class="rec-cell-range">${savingsDisplay} &middot; upfront: ${upfrontDisplay} &middot; term: ${termDisplay}</span>
+    </td>
+  </tr>`);
+
+    if (isExpanded) {
+      const sortedVariants = sortVariantsInCell(variants);
+      for (const v of sortedVariants) {
+        rows.push(buildVariantRowMarkup(v, selectedRecs, true));
+      }
+    }
+  }
+
   return `
+    ${bannerHtml}
     <table>
       <thead>
         <tr>
@@ -1312,33 +1602,7 @@ function buildListMarkup(recommendations: LocalRecommendation[], selectedRecs: R
         </tr>
       </thead>
       <tbody>
-        ${sorted.map((rec) => {
-          const savingsClass = rec.savings > 1000 ? 'high-savings' : rec.savings > 100 ? 'medium-savings' : '';
-          const isSelected = selectedRecs.has(rec.id);
-          const accountName = rec.cloud_account_id ? (accountNamesCache.get(rec.cloud_account_id) || rec.cloud_account_id) : '\u2014';
-          const badge = renderSuppressionBadge(rec);
-          const recId = escapeHtml(rec.id);
-          const pct = effectiveSavingsPct(rec);
-          const pctClass = pct !== null && pct < 0 ? ' class="effective-pct-negative"' : '';
-          const pctText = pct === null ? '\u2014' : pct.toFixed(1) + '%';
-          return `
-          <tr class="recommendation-row ${savingsClass} ${isSelected ? 'selected' : ''}" data-rec-id="${recId}">
-            <td class="checkbox-col">
-              <input type="checkbox" data-rec-id="${recId}" ${isSelected ? 'checked' : ''} aria-label="Select recommendation">
-            </td>
-            <td><span class="provider-badge ${rec.provider}">${rec.provider.toUpperCase()}</span></td>
-            <td>${escapeHtml(accountName)}</td>
-            <td><span class="service-badge">${escapeHtml(rec.service)}</span></td>
-            <td title="${escapeHtml(rec.resource_type)}">${escapeHtml(rec.resource_type)}${rec.engine ? ` (${escapeHtml(rec.engine)})` : ''}${badge}</td>
-            <td>${escapeHtml(rec.region)}</td>
-            <td>${rec.count}</td>
-            <td>${formatTerm(rec.term)}</td>
-            <td class="savings">${formatCurrency(rec.savings)}</td>
-            <td>${formatCurrency(rec.upfront_cost)}</td>
-            <td>${rec.monthly_cost != null ? formatCurrency(rec.monthly_cost) : '—'}</td>
-            <td${pctClass}>${pctText}</td>
-          </tr>`;
-        }).join('')}
+        ${rows.join('')}
       </tbody>
     </table>
   `;
@@ -2045,15 +2309,13 @@ function renderRecommendationsList(loadedRecs: LocalRecommendation[]): void {
   );
   state.setVisibleRecommendations(recommendations as unknown as readonly api.Recommendation[]);
 
-  // Filter status: Clear-filters badge + aria-live count. Mounted as a
-  // sibling above the table so it survives the container's innerHTML
-  // rewrite without losing aria-live announcements.
-  renderFilterStatusBar(loadedRecs?.length ?? 0, recommendations.length);
-
   // Mount once; update is per-render below.
   mountBottomActionBox();
 
   if (!recommendations || recommendations.length === 0) {
+    lastVisibleGroupKeys = [];
+    // Filter status bar renders even for the empty case (live-region count).
+    renderFilterStatusBar(loadedRecs?.length ?? 0, 0);
     container.innerHTML = '<p class="empty">No recommendations match these filters. Try clearing filters or refreshing.</p>';
     updateBottomActionBox(0, loadedRecs?.length ?? 0);
     return;
@@ -2062,9 +2324,18 @@ function renderRecommendationsList(loadedRecs: LocalRecommendation[]): void {
   const selectedIDs = state.getSelectedRecommendationIDs();
   // Dynamic table markup: every caller-provided value passes through
   // escapeHtml or is a number. The string is built in buildListMarkup.
+  // NOTE: buildListMarkup also populates lastVisibleGroupKeys, so it MUST
+  // run before renderFilterStatusBar (which reads it for the Expand-All button).
   container.innerHTML = buildListMarkup(recommendations, selectedIDs);
 
+  // Filter status: Clear-filters badge + aria-live count + Expand-All toggle.
+  // Rendered AFTER buildListMarkup so lastVisibleGroupKeys is populated.
+  // Mounted as a sibling above the table so it survives the container's
+  // innerHTML rewrite without losing aria-live announcements.
+  renderFilterStatusBar(loadedRecs?.length ?? 0, recommendations.length);
+
   updateBottomActionBox(recommendations.length, loadedRecs?.length ?? recommendations.length);
+
 
   // Per-column filter button: trigger opens the popover anchored to the
   // button. e.stopPropagation prevents the surrounding <th>'s sort handler
@@ -2166,10 +2437,26 @@ function renderRecommendationsList(loadedRecs: LocalRecommendation[]): void {
     });
   });
 
+  // issues #225 + #226: chevron click toggles expand/collapse for a cell group.
+  container.querySelectorAll<HTMLButtonElement>('.rec-cell-chevron').forEach((btn) => {
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const key = btn.dataset['cellKey'] ?? '';
+      if (!key) return;
+      if (expandedCells.has(key)) {
+        expandedCells.delete(key);
+      } else {
+        expandedCells.add(key);
+      }
+      renderRecommendationsList(loadedRecs);
+    });
+  });
+
   // Row-click opens the detail drawer — skip clicks that originated on
   // the checkbox or any interactive child (anchors, buttons) so those
   // flow through to their own handlers without also triggering the
-  // drawer.
+  // drawer. Also skip summary rows (they represent a cell group, not
+  // a single rec, so have no detail to show).
   container.querySelectorAll<HTMLTableRowElement>('tr.recommendation-row').forEach((tr) => {
     tr.addEventListener('click', (e) => {
       const target = e.target as HTMLElement;

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -866,6 +866,84 @@ tr.recommendation-row:hover {
     background: #f8f9fb;
 }
 
+/* issues #225 + #226: cell-grouping UX */
+
+/* Expand-All toggle in the filter-status bar */
+.recommendations-filter-status .expand-all-toggle {
+    background: transparent;
+    border: 1px solid #d0d7de;
+    border-radius: 3px;
+    padding: 0.25rem 0.6rem;
+    font-size: 0.85em;
+    cursor: pointer;
+    color: #555;
+}
+.recommendations-filter-status .expand-all-toggle:hover {
+    border-color: #1a73e8;
+    color: #1a73e8;
+}
+
+/* Page-level range banner above the table */
+.rec-range-banner {
+    padding: 0.4rem 0.75rem;
+    margin-bottom: 0.5rem;
+    background: #e8f0fe;
+    border-radius: 4px;
+    font-size: 0.88em;
+    color: #444;
+}
+
+/* Cell summary row (collapsed state) */
+tr.rec-cell-summary-row {
+    background: #f3f6fb;
+    cursor: default;
+}
+tr.rec-cell-summary-row:hover {
+    background: #eaf0fb;
+}
+
+/* Summary row content cell: chevron + identity + range inline */
+.rec-cell-summary-content {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+.rec-cell-chevron {
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    font-size: 0.8em;
+    color: #555;
+    padding: 0 0.25rem;
+    line-height: 1;
+}
+.rec-cell-chevron:hover {
+    color: #1a73e8;
+}
+.rec-cell-identity {
+    font-weight: 500;
+    font-size: 0.9em;
+}
+.rec-cell-range {
+    color: #666;
+    font-size: 0.85em;
+}
+.rec-variants-count {
+    color: #888;
+    font-size: 0.85em;
+}
+
+/* Variant rows nested under a cell summary (expanded state) */
+tr.rec-variant-row td:not(.checkbox-col) {
+    padding-left: 2rem;
+    background: #fafbfe;
+    font-size: 0.88em;
+}
+tr.rec-variant-row:hover td:not(.checkbox-col) {
+    background: #f0f4fc;
+}
+
 .detail-drawer-backdrop {
     position: fixed;
     inset: 0;


### PR DESCRIPTION
## Summary

Closes #225 and #226. This PR merges both issues into a single feature since they're tightly coupled (cell grouping is the visual anchor that makes savings range legible).

- **Cell grouping (#226)**: Recommendation rows are now grouped by physical-resource cell `(provider|account|service|region|resource_type|engine)` — the same key as #224's radio enforcement. Multi-variant cells render as a collapsed summary row with a chevron; single-variant cells render flat (no overhead). Expand-all toggle added to the filter-status bar.
- **Savings range (#225)**: The per-cell summary row shows `$X – $Y/mo` savings range across all (term, payment) variants. Collapses to `$X` when all variants are uniform. When a variant is selected (radio from #224), the summary row shows that variant's value with `(+N variants)` instead of the range. A page-level range banner at the top of the table shows the aggregate across all visible cells.

## Design choices (UX call — flag anything to change in CR comments)

1. **Collapsed by default** — cleaner first impression. Most users only need to see the best option per resource, not all 6 variants on first load.
2. **Summary row layout** — provider + account + service in the first 4 columns; a single wide content cell (colspan) with the chevron, resource identity, and range. This keeps the identity readable without wrapping. The identity cell has `colspan=8` (the remaining columns after the 4 identity ones).
3. **Expand-All button location** — in the filter-status bar (above the table), not in the bottom sticky toolbar. Keeps it near the table context rather than near the purchase controls.
4. **Sort operates at the cell level** — cells sort by the selected variant's column value if one is selected; otherwise by the max value for numeric columns (e.g. max-savings). String columns are uniform within a cell by definition (they're the cell key).
5. **Single-variant cells render flat** — no group overhead (no summary row, no chevron, no indentation). Per #226's acceptance criteria.
6. **CSS approach** — variant rows use `padding-left: 2rem` on all cells except the checkbox column. Summary rows have a slightly distinct background (`#f3f6fb`). No new CSS framework or component library.
7. **`css-modules.d.ts` addition** — fixes a pre-existing TypeScript 5.9 strict-mode error on the `import './styles.css'` side-effect import in `index.ts`. The base branch had this error but CI passed because of bundler resolution; adding the declaration makes local `tsc --noEmit` clean as well.

## Out of scope

- Effective savings % column (#221) — separate issue, separate PR.
- Sparkline (#239) — separate issue.
- Column-filter primitives (#166) — separate issue.
- Savings-vs-selected delta ("You've picked options that save $X; max possible is $Y") — listed as a bonus in #225. Deferred — the per-cell range data is now available to implement this in a follow-up.

## Test plan

- [ ] All 1452 existing tests still pass (`npm test`)
- [ ] TypeScript `--noEmit` clean
- [ ] `npm run build` compiles without errors
- [ ] 16 new tests added:
  - `groupRecsByCell` pure helper: 2 tests
  - `cellSummary` pure helper: 3 tests
  - `pageLevelRange` pure helper: 2 tests
  - DOM integration: collapsed-by-default, chevron expand, page banner, single-variant flat, expand-all button, expand-all functional: 6 tests
  - Existing #224 radio enforcement test updated to expand the cell first (collapsed-by-default means checkboxes aren't in the DOM until expanded)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Recommendations table now groups variants by physical cell with collapsible summary rows
  * Added "Expand all / Collapse all" toggle to manage multi-variant cell visibility
  * Displays "Recommended range" banner for pages with multiple variant options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->