### PR TITLE
fix(db/azure): flush stale monthly_cost cache + Azure recurring cost (closes #252)

### DIFF
--- a/internal/database/postgres/migrations/000046_invalidate_monthly_cost_cache.down.sql
+++ b/internal/database/postgres/migrations/000046_invalidate_monthly_cost_cache.down.sql
@@ -1,0 +1,9 @@
+-- No rollback: truncated recommendation rows cannot be restored. The
+-- scheduler will re-collect from cloud APIs on the next API read, which
+-- restores the cache regardless of the migration direction. Setting
+-- last_collected_at to NULL here would trigger another cold-start collect
+-- on the next read, which is the correct behaviour after a rollback that
+-- leaves the table empty.
+UPDATE recommendations_state
+   SET last_collected_at = NULL
+ WHERE id = 1;

--- a/internal/database/postgres/migrations/000046_invalidate_monthly_cost_cache.down.sql
+++ b/internal/database/postgres/migrations/000046_invalidate_monthly_cost_cache.down.sql
@@ -1,9 +1,4 @@
--- No rollback: truncated recommendation rows cannot be restored. The
--- scheduler will re-collect from cloud APIs on the next API read, which
--- restores the cache regardless of the migration direction. Setting
--- last_collected_at to NULL here would trigger another cold-start collect
--- on the next read, which is the correct behaviour after a rollback that
--- leaves the table empty.
-UPDATE recommendations_state
-   SET last_collected_at = NULL
- WHERE id = 1;
+-- No rollback for the payload rewrite: the original monthly_cost=0 values
+-- were themselves incorrect (stale pre-PR-#254 data). Reverting to 0
+-- would re-introduce the very bug this migration fixes. The correct
+-- monthly_cost values will be written on the next scheduled collection.

--- a/internal/database/postgres/migrations/000046_invalidate_monthly_cost_cache.up.sql
+++ b/internal/database/postgres/migrations/000046_invalidate_monthly_cost_cache.up.sql
@@ -1,0 +1,17 @@
+-- Invalidate the recommendations cache so pre-PR-#254 rows (which stored
+-- monthly_cost as a literal 0 from the old float64 struct field) are
+-- flushed. After this migration runs, the next call to
+-- ListRecommendations triggers a synchronous cold-start collect that
+-- re-populates the table with correct monthly_cost values:
+--   - nil  (JSON null)  for providers/services that don't expose it
+--   - 0    (JSON 0)     for all-upfront commitments (no recurring charge)
+--   - >0               for AWS RI/SP recs (actual recurring monthly cost)
+--
+-- TRUNCATE is safe because this table is a cache: the scheduler
+-- re-fetches all data from cloud APIs on the next collect. No user-
+-- created or non-reproducible data lives here.
+TRUNCATE TABLE recommendations;
+
+UPDATE recommendations_state
+   SET last_collected_at = NULL
+ WHERE id = 1;

--- a/internal/database/postgres/migrations/000046_invalidate_monthly_cost_cache.up.sql
+++ b/internal/database/postgres/migrations/000046_invalidate_monthly_cost_cache.up.sql
@@ -1,17 +1,21 @@
--- Invalidate the recommendations cache so pre-PR-#254 rows (which stored
--- monthly_cost as a literal 0 from the old float64 struct field) are
--- flushed. After this migration runs, the next call to
--- ListRecommendations triggers a synchronous cold-start collect that
--- re-populates the table with correct monthly_cost values:
---   - nil  (JSON null)  for providers/services that don't expose it
---   - 0    (JSON 0)     for all-upfront commitments (no recurring charge)
---   - >0               for AWS RI/SP recs (actual recurring monthly cost)
+-- Rewrite stale pre-PR-#254 recommendation payloads that store
+-- monthly_cost as a literal JSON 0 (from the old float64 struct field).
+-- After PR #254, monthly_cost is *float64 so a real zero means "no
+-- recurring charge" (e.g. all-upfront), while null means "provider API
+-- did not return a monthly breakdown".
 --
--- TRUNCATE is safe because this table is a cache: the scheduler
--- re-fetches all data from cloud APIs on the next collect. No user-
--- created or non-reproducible data lives here.
-TRUNCATE TABLE recommendations;
-
-UPDATE recommendations_state
-   SET last_collected_at = NULL
- WHERE id = 1;
+-- Pre-deploy rows have monthly_cost=0 from the old float64 zero — they
+-- are stale and would render as "$0" in the UI even after the code fix.
+-- Setting them to null here causes the frontend to render "—" instead,
+-- which is at least accurate ("data not yet collected") until the next
+-- scheduler tick re-collects with correct values.
+--
+-- NOTE: We do NOT truncate the table or reset last_collected_at because
+-- Azure recommendation collection alone exceeds the API Lambda's 60s
+-- timeout — a forced cold-start collect would cause a 502 on the next
+-- request. The daily scheduled collector will write correct values on
+-- its next run. See GitHub issue #256 companion issue for the Lambda
+-- timeout root cause.
+UPDATE recommendations
+   SET payload = jsonb_set(payload, '{monthly_cost}', 'null'::jsonb)
+ WHERE (payload->>'monthly_cost')::text = '0';

--- a/providers/azure/internal/recommendations/converter.go
+++ b/providers/azure/internal/recommendations/converter.go
@@ -40,6 +40,18 @@ type ExtractedFields struct {
 	EstimatedSavings float64
 	Term             string
 	Scope            string
+	// RecurringMonthlyCost is the monthly recurring charge for this
+	// commitment. Azure Reservation recommendations are all all-upfront
+	// (a single payment, no recurring monthly charge), so this is always
+	// a pointer to 0.0 — meaning "no recurring charge" rather than
+	// "data not available" (which would be nil).
+	RecurringMonthlyCost *float64
+}
+
+// float64Ptr returns a pointer to the given float64 value. Used to
+// distinguish "explicitly zero" from "not provided" (nil) on pointer fields.
+func float64Ptr(v float64) *float64 {
+	return &v
 }
 
 // Extract reads the Azure reservation recommendation payload into
@@ -101,6 +113,10 @@ func extractLegacy(rec *armconsumption.LegacyReservationRecommendation) *Extract
 		// treat EstimatedSavings as lookback-period ≈ monthly.
 		out.EstimatedSavings = *props.NetSavings
 	}
+	// Azure Reservation recommendations are always all-upfront (single payment,
+	// no monthly recurring charge). Set to 0 (not nil) so the frontend renders
+	// "$0" rather than "—" (which would imply "data not available").
+	out.RecurringMonthlyCost = float64Ptr(0)
 	return out
 }
 
@@ -133,6 +149,10 @@ func extractModern(rec *armconsumption.ModernReservationRecommendation) *Extract
 	out.OnDemandCost = amountValue(props.CostWithNoReservedInstances)
 	out.CommitmentCost = amountValue(props.TotalCostWithReservedInstances)
 	out.EstimatedSavings = amountValue(props.NetSavings)
+	// Azure Reservation recommendations are always all-upfront (single payment,
+	// no monthly recurring charge). Set to 0 (not nil) so the frontend renders
+	// "$0" rather than "—" (which would imply "data not available").
+	out.RecurringMonthlyCost = float64Ptr(0)
 
 	return out
 }

--- a/providers/azure/internal/recommendations/converter_test.go
+++ b/providers/azure/internal/recommendations/converter_test.go
@@ -138,6 +138,21 @@ func TestExtract_MissingCostsReadAsZero(t *testing.T) {
 	assert.InDelta(t, 0.0, f.EstimatedSavings, 1e-9)
 }
 
+func TestExtract_Legacy_RecurringMonthlyCostIsZeroPointer(t *testing.T) {
+	// Azure reservations are always all-upfront (single payment, no monthly
+	// recurring charge). RecurringMonthlyCost must be a non-nil pointer to 0
+	// so the frontend renders "$0" instead of "—" (which would mean unknown).
+	rec := mocks.BuildLegacyReservationRecommendation(
+		mocks.WithRegion("eastus"),
+		mocks.WithNormalizedSize("Standard_D2s_v3"),
+		mocks.WithCosts(100, 70, 30),
+	)
+	f := Extract(rec)
+	require.NotNil(t, f)
+	require.NotNil(t, f.RecurringMonthlyCost, "RecurringMonthlyCost must be non-nil for Azure reservations")
+	assert.InDelta(t, 0.0, *f.RecurringMonthlyCost, 1e-9)
+}
+
 // --- Modern (MCA billing account) ----------------------------------------
 
 func TestExtract_Modern_NilProperties(t *testing.T) {
@@ -208,4 +223,19 @@ func TestExtract_Modern_MissingCostAmountsReadAsZero(t *testing.T) {
 	assert.InDelta(t, 0.0, f.OnDemandCost, 1e-9)
 	assert.InDelta(t, 0.0, f.CommitmentCost, 1e-9)
 	assert.InDelta(t, 0.0, f.EstimatedSavings, 1e-9)
+}
+
+func TestExtract_Modern_RecurringMonthlyCostIsZeroPointer(t *testing.T) {
+	// Azure Reservation recommendations are always all-upfront regardless
+	// of billing account type. RecurringMonthlyCost must be a non-nil pointer
+	// to 0 for both Legacy and Modern response shapes.
+	rec := mocks.BuildModernReservationRecommendation(
+		mocks.WithModernRegion("westeurope"),
+		mocks.WithModernSKUName("Standard_D4s_v5"),
+		mocks.WithModernCosts(400, 260, 140),
+	)
+	f := Extract(rec)
+	require.NotNil(t, f)
+	require.NotNil(t, f.RecurringMonthlyCost, "RecurringMonthlyCost must be non-nil for Azure reservations")
+	assert.InDelta(t, 0.0, *f.RecurringMonthlyCost, 1e-9)
 }

--- a/providers/azure/services/cache/client.go
+++ b/providers/azure/services/cache/client.go
@@ -597,20 +597,21 @@ func (c *CacheClient) convertAzureRedisRecommendation(ctx context.Context, azure
 		details.Shards = entry.shardCount
 	}
 	return &common.Recommendation{
-		Provider:         common.ProviderAzure,
-		Service:          common.ServiceCache,
-		Account:          c.subscriptionID,
-		Region:           f.Region,
-		ResourceType:     f.ResourceType,
-		Count:            f.Count,
-		OnDemandCost:     f.OnDemandCost,
-		CommitmentCost:   f.CommitmentCost,
-		EstimatedSavings: f.EstimatedSavings,
-		CommitmentType:   common.CommitmentReservedInstance,
-		Term:             f.Term,
-		PaymentOption:    "upfront",
-		Timestamp:        time.Now(),
-		Details:          details,
+		Provider:             common.ProviderAzure,
+		Service:              common.ServiceCache,
+		Account:              c.subscriptionID,
+		Region:               f.Region,
+		ResourceType:         f.ResourceType,
+		Count:                f.Count,
+		OnDemandCost:         f.OnDemandCost,
+		CommitmentCost:       f.CommitmentCost,
+		EstimatedSavings:     f.EstimatedSavings,
+		RecurringMonthlyCost: f.RecurringMonthlyCost,
+		CommitmentType:       common.CommitmentReservedInstance,
+		Term:                 f.Term,
+		PaymentOption:        "upfront",
+		Timestamp:            time.Now(),
+		Details:              details,
 	}
 }
 

--- a/providers/azure/services/compute/client.go
+++ b/providers/azure/services/compute/client.go
@@ -729,20 +729,21 @@ func (c *ComputeClient) convertAzureVMRecommendation(ctx context.Context, azureR
 		}
 	}
 	return &common.Recommendation{
-		Provider:         common.ProviderAzure,
-		Service:          common.ServiceCompute,
-		Account:          c.subscriptionID,
-		Region:           f.Region,
-		ResourceType:     f.ResourceType,
-		Count:            f.Count,
-		OnDemandCost:     f.OnDemandCost,
-		CommitmentCost:   f.CommitmentCost,
-		EstimatedSavings: f.EstimatedSavings,
-		CommitmentType:   common.CommitmentReservedInstance,
-		Term:             f.Term,
-		PaymentOption:    "upfront",
-		Timestamp:        time.Now(),
-		Details:          details,
+		Provider:             common.ProviderAzure,
+		Service:              common.ServiceCompute,
+		Account:              c.subscriptionID,
+		Region:               f.Region,
+		ResourceType:         f.ResourceType,
+		Count:                f.Count,
+		OnDemandCost:         f.OnDemandCost,
+		CommitmentCost:       f.CommitmentCost,
+		EstimatedSavings:     f.EstimatedSavings,
+		RecurringMonthlyCost: f.RecurringMonthlyCost,
+		CommitmentType:       common.CommitmentReservedInstance,
+		Term:                 f.Term,
+		PaymentOption:        "upfront",
+		Timestamp:            time.Now(),
+		Details:              details,
 	}
 }
 

--- a/providers/azure/services/compute/client_test.go
+++ b/providers/azure/services/compute/client_test.go
@@ -605,6 +605,11 @@ func TestComputeClient_ConvertAzureVMRecommendation_PopulatesAllFields(t *testin
 	assert.Equal(t, "3yr", out.Term)
 	assert.Equal(t, "upfront", out.PaymentOption)
 
+	// Azure reservations are all-upfront: RecurringMonthlyCost must be a
+	// non-nil pointer to 0 so the frontend shows "$0" not "—" (unknown).
+	require.NotNil(t, out.RecurringMonthlyCost, "RecurringMonthlyCost must be non-nil for Azure compute recs")
+	assert.InDelta(t, 0.0, *out.RecurringMonthlyCost, 1e-9)
+
 	// Details is populated from the payload's ResourceType (InstanceType
 	// only — Platform/Tenancy/Scope are deferred to batched enrichment).
 	require.NotNil(t, out.Details)

--- a/providers/azure/services/cosmosdb/client.go
+++ b/providers/azure/services/cosmosdb/client.go
@@ -601,20 +601,21 @@ func (c *CosmosDBClient) convertAzureCosmosRecommendation(ctx context.Context, a
 		details.APIType = api
 	}
 	return &common.Recommendation{
-		Provider:         common.ProviderAzure,
-		Service:          common.ServiceNoSQL,
-		Account:          c.subscriptionID,
-		Region:           f.Region,
-		ResourceType:     f.ResourceType,
-		Count:            f.Count,
-		OnDemandCost:     f.OnDemandCost,
-		CommitmentCost:   f.CommitmentCost,
-		EstimatedSavings: f.EstimatedSavings,
-		CommitmentType:   common.CommitmentReservedInstance,
-		Term:             f.Term,
-		PaymentOption:    "upfront",
-		Timestamp:        time.Now(),
-		Details:          details,
+		Provider:             common.ProviderAzure,
+		Service:              common.ServiceNoSQL,
+		Account:              c.subscriptionID,
+		Region:               f.Region,
+		ResourceType:         f.ResourceType,
+		Count:                f.Count,
+		OnDemandCost:         f.OnDemandCost,
+		CommitmentCost:       f.CommitmentCost,
+		EstimatedSavings:     f.EstimatedSavings,
+		RecurringMonthlyCost: f.RecurringMonthlyCost,
+		CommitmentType:       common.CommitmentReservedInstance,
+		Term:                 f.Term,
+		PaymentOption:        "upfront",
+		Timestamp:            time.Now(),
+		Details:              details,
 	}
 }
 

--- a/providers/azure/services/database/client.go
+++ b/providers/azure/services/database/client.go
@@ -599,20 +599,21 @@ func (c *DatabaseClient) convertAzureSQLRecommendation(ctx context.Context, azur
 		details.EngineVersion = entry.engineVersion
 	}
 	return &common.Recommendation{
-		Provider:         common.ProviderAzure,
-		Service:          common.ServiceRelationalDB,
-		Account:          c.subscriptionID,
-		Region:           f.Region,
-		ResourceType:     f.ResourceType,
-		Count:            f.Count,
-		OnDemandCost:     f.OnDemandCost,
-		CommitmentCost:   f.CommitmentCost,
-		EstimatedSavings: f.EstimatedSavings,
-		CommitmentType:   common.CommitmentReservedInstance,
-		Term:             f.Term,
-		PaymentOption:    "upfront",
-		Timestamp:        time.Now(),
-		Details:          details,
+		Provider:             common.ProviderAzure,
+		Service:              common.ServiceRelationalDB,
+		Account:              c.subscriptionID,
+		Region:               f.Region,
+		ResourceType:         f.ResourceType,
+		Count:                f.Count,
+		OnDemandCost:         f.OnDemandCost,
+		CommitmentCost:       f.CommitmentCost,
+		EstimatedSavings:     f.EstimatedSavings,
+		RecurringMonthlyCost: f.RecurringMonthlyCost,
+		CommitmentType:       common.CommitmentReservedInstance,
+		Term:                 f.Term,
+		PaymentOption:        "upfront",
+		Timestamp:            time.Now(),
+		Details:              details,
 	}
 }
 


### PR DESCRIPTION
## Summary

Follow-up to PR #254 which fixed the Go struct types and AWS parsers but left two gaps that keep the deployed app returning \`monthly_cost: 0\` for all 33 recs (17 AWS, 16 Azure):

**Gap 1 — Stale cache (migration 000046)**: Pre-#254 rows in the \`recommendations\` table store \`monthly_cost\` as a literal JSON \`0\` (from the old \`float64\` field). Reading those rows post-deploy produces a pointer-to-zero, which the API re-emits as 0 — indistinguishable from a legitimate $0 recurring charge.

Fix: targeted in-place JSONB rewrite (not TRUNCATE) — sets \`monthly_cost = null\` for all rows where the current value is 0. This causes the frontend to render "—" (honest: data not yet collected) rather than "$0" (misleading). Existing rows stay intact; the daily scheduled collector will overwrite them with correct values on its next run.

**Why not TRUNCATE + cold-start?** Azure collection alone exceeds the API Lambda's 60s timeout (#257). A forced cold-start collect on the next request would cause a 502. Filed #257 as a separate perf issue.

**Gap 2 — Azure parsers (ExtractedFields + 4 converters)**: PR #254 never updated the Azure parsers. Azure Reservation recommendations are always all-upfront (single payment, no recurring monthly charge), so \`RecurringMonthlyCost\` should be a non-nil \`*float64\` pointing to 0.0 — meaning "no recurring charge" rather than nil ("data not available"). Added \`RecurringMonthlyCost *float64\` to \`ExtractedFields\`, set to \`float64Ptr(0)\` in both \`extractLegacy\` and \`extractModern\`, and wired it through all four active service converters (compute, cache, database, cosmosdb).

**GCP**: Left nil — the GCP Recommender API does not expose commitment cost per period. Frontend renders "—" which is accurate.

**Related**: #257 (Azure Lambda timeout — separate perf issue, not fixed here)

## Test plan

- [x] \`providers/azure/internal/recommendations\` tests: \`TestExtract_Legacy_RecurringMonthlyCostIsZeroPointer\` and \`TestExtract_Modern_RecurringMonthlyCostIsZeroPointer\` assert the field is a non-nil pointer-to-zero for both Legacy and Modern API response shapes
- [x] \`providers/azure/services/compute/client_test.go\`: \`TestComputeClient_ConvertAzureVMRecommendation_PopulatesAllFields\` now asserts \`RecurringMonthlyCost != nil && *RecurringMonthlyCost == 0\`
- [x] All 345 Azure tests pass, all 4261 root module tests pass, all 319 pkg tests pass
- After deploy: migration 000046 runs, stale \`monthly_cost: 0\` rows are rewritten to \`null\`, frontend shows "—" for existing rows. The daily scheduler tick will then write correct values: AWS RI/SP recs get actual recurring cost, Azure recs get $0 (all-upfront), GCP shows "—" (data not available)

Closes #252

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected stale monthly cost values in recommendations that were previously cached as zero.

* **New Features**
  * Added consistent recurring monthly cost handling for Azure reservation recommendations.
  * Enhanced Azure VM recommendations with SKU catalogue enrichment to automatically populate CPU and memory specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->