### PR TITLE
fix(api): correct async self-invoke payload shape so collection actually runs

### DIFF
--- a/internal/api/handler_recommendations_refresh.go
+++ b/internal/api/handler_recommendations_refresh.go
@@ -139,10 +139,27 @@ func (h *Handler) asyncInvokeSelf(ctx context.Context, functionARN string) error
 		return fmt.Errorf("failed to build Lambda client: %w", err)
 	}
 
-	// This payload matches the detectLambdaEventType "scheduled" branch in
-	// internal/server/lambda.go: `scheduledEvent.Action != ""` → "scheduled".
-	// HandleScheduledTask then dispatches to TaskCollectRecommendations.
-	payload, _ := json.Marshal(map[string]string{"event": "scheduled_recommendations"})
+	// Payload shape matches internal/server/handler.go::ScheduledEvent + its
+	// ParseScheduledEvent dispatch table: the Action field selects the
+	// scheduled-task type. "collect_recommendations" maps to
+	// TaskCollectRecommendations, which is what we want to fire.
+	//
+	// The previous payload `{"event":"scheduled_recommendations"}` had no
+	// matching field in ScheduledEvent at all — Action unmarshalled as ""
+	// and ParseScheduledEvent rejected the event with "unknown scheduled
+	// task action: \"\"". Verified in the deployed Lambda log
+	// `/aws/lambda/cudly-dev-426fc8af-api` request 3befb380-6d46-... — the
+	// async self-invoke was firing successfully but the receiving Lambda
+	// was rejecting every invocation, so collection never actually ran.
+	//
+	// Source = "aws.events" so detectLambdaEventType in
+	// internal/server/lambda.go (which checks Source == "aws.events" ||
+	// Action != "") classifies this consistently with EventBridge cron
+	// deliveries that already exercise this code path.
+	payload, _ := json.Marshal(map[string]string{
+		"source": "aws.events",
+		"action": "collect_recommendations",
+	})
 
 	_, err = invoker.Invoke(ctx, &lambda.InvokeInput{
 		FunctionName:   aws.String(functionARN),


### PR DESCRIPTION
## Summary

The async refresh path landed in #260 but the Lambda self-invoke payload doesn't match what the receiving Lambda's `ParseScheduledEvent` accepts. Every async invoke is being rejected, so the user clicks Refresh, the frontend polls indefinitely, and collection never actually runs — exact same UX as the original 60s timeout.

## Evidence (deployed log group `/aws/lambda/cudly-dev-426fc8af-api`)

```
16:49:40 Received unknown event (size: 37 bytes)
16:49:40 Unknown event type, treating as scheduled event
16:49:40 {"errorMessage":"failed to parse scheduled event:
              unknown scheduled task action: \"\""}
```

37 bytes = the `{"event":"scheduled_recommendations"}` string exactly. The handler's `ScheduledEvent` struct has no `event` field — it has `Action`, `Source`, `DetailType`, `Detail` — so `Action` unmarshals as `""` and the dispatch switch hits `default → unknown scheduled task action`.

## Fix

Send the payload the dispatcher accepts:

```json
{"source": "aws.events", "action": "collect_recommendations"}
```

`action="collect_recommendations"` maps to `TaskCollectRecommendations` in `internal/server/handler.go::ParseScheduledEvent`. `source="aws.events"` makes `detectLambdaEventType` in `internal/server/lambda.go` (which checks `Source == "aws.events" || Action != ""`) classify it consistently with EventBridge cron deliveries.

## Test plan

- [x] `go build ./...` succeeds
- [x] `go test ./internal/api/...` — 1,055 tests pass
- [x] Pre-commit hooks all pass
- [ ] CI green on push
- [ ] After merge + redeploy, click Refresh on `/recommendations` and confirm:
  - Lambda log shows `collect_recommendations` task running (not the rejection error)
  - Frontend banner clears once `last_collection_started_at` clears
  - Recommendations list shows monthly_cost values populated for newly-collected rows

## Why this didn't surface during PR #260's CI

CI runs Go unit tests with mocked Lambda invokers, so the payload shape was never end-to-end exercised against the receiving Lambda. The mismatch only manifests in the deployed environment when the real `lambda.Invoke` delivers the event back to the Lambda runtime.

Closes the user-visible symptom that re-opened the parent investigation under #257.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal scheduler event handling to improve system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->