### PR TITLE
fix(frontend/recs): require explicit selection for Purchase/Plan actions (closes #273)

### DIFF
--- a/frontend/src/__tests__/plans.test.ts
+++ b/frontend/src/__tests__/plans.test.ts
@@ -882,15 +882,20 @@ describe('Plans Module', () => {
       }));
     });
 
-    test('includes selected ∩ visible recommendations (Bundle B)', async () => {
-      // Bundle B: savePlan reads getVisibleRecommendations (post-filter set)
-      // so plans never include filtered-out rows. Selection is intersected
-      // with that visible list.
-      (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set(['rec-1', 'rec-2']));
-      (state.getVisibleRecommendations as jest.Mock).mockReturnValue([
+    test('includes the snapshot stamped by openCreatePlanModal (#273 CR)', async () => {
+      // #273 CR follow-up: savePlan now reads the snapshot stamped at
+      // Plan-button click time via openCreatePlanModal(snapshot), instead
+      // of re-deriving from getVisibleRecommendations() / getSelectedRec
+      // ommendationIDs() at Save time. State mutations between modal-open
+      // and modal-Save (Refresh, filter changes, deselections) can no
+      // longer change which recs are planned. The Purchase flow already
+      // captures the target at click time; the Plan flow now mirrors it.
+      const snapshot = [
         { id: 'rec-1', service: 'ec2' },
-        { id: 'rec-2', service: 'rds' }
-      ]);
+        { id: 'rec-2', service: 'rds' },
+      ] as unknown as readonly api.Recommendation[];
+      openCreatePlanModal(snapshot);
+
       (api.createPlan as jest.Mock).mockResolvedValue({});
       (api.getPlans as jest.Mock).mockResolvedValue({ plans: [] });
       (api.getPlannedPurchases as jest.Mock).mockResolvedValue({ purchases: [] });
@@ -899,6 +904,39 @@ describe('Plans Module', () => {
       await savePlan(event);
 
       const sentRecs = (api.createPlan as jest.Mock).mock.calls[0][0].recommendations;
+      expect(sentRecs.map((r: { id: string }) => r.id).sort()).toEqual(['rec-1', 'rec-2']);
+    });
+
+    test('snapshot is immune to state mutations between modal-open and Save (#273 CR)', async () => {
+      // The race the snapshot closes: user clicks "Plan from N selected"
+      // → openCreatePlanModal stamps the snapshot → user toggles a
+      // checkbox / Refresh fires / a column filter is applied while the
+      // modal is open → user clicks Save. The Plan must reflect the
+      // user's intent at click time, NOT the (potentially narrower /
+      // wider / different) state at Save time.
+      const snapshotAtClickTime = [
+        { id: 'rec-1', service: 'ec2' },
+        { id: 'rec-2', service: 'rds' },
+      ] as unknown as readonly api.Recommendation[];
+      openCreatePlanModal(snapshotAtClickTime);
+
+      // Now simulate post-modal-open state mutations: deselection,
+      // refresh-replaced visible set, etc. None of these should affect
+      // the saved plan.
+      (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set());
+      (state.getVisibleRecommendations as jest.Mock).mockReturnValue([
+        { id: 'completely-different-rec', service: 'cache' },
+      ]);
+
+      (api.createPlan as jest.Mock).mockResolvedValue({});
+      (api.getPlans as jest.Mock).mockResolvedValue({ plans: [] });
+      (api.getPlannedPurchases as jest.Mock).mockResolvedValue({ purchases: [] });
+
+      const event = { preventDefault: jest.fn() } as unknown as Event;
+      await savePlan(event);
+
+      const sentRecs = (api.createPlan as jest.Mock).mock.calls[0][0].recommendations;
+      // Must be the snapshot, NOT the post-mutation state.
       expect(sentRecs.map((r: { id: string }) => r.id).sort()).toEqual(['rec-1', 'rec-2']);
     });
 
@@ -911,11 +949,11 @@ describe('Plans Module', () => {
       // state; this assertion is the defence-in-depth at the savePlan
       // layer for any path that bypasses the disabled UI (programmatic
       // calls, future code paths, regressions on the gating).
-      (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set());
-      (state.getVisibleRecommendations as jest.Mock).mockReturnValue([
-        { id: 'rec-1', service: 'ec2' },
-        { id: 'rec-2', service: 'rds' }
-      ]);
+      // Clear the snapshot cache that earlier tests in this describe stamped
+      // via openCreatePlanModal(snapshot). openNewPlanModal() resets it
+      // (the New-Plan-from-scratch path explicitly clears the cache so a
+      // subsequent New-Plan submit doesn't inherit a previous flow's recs).
+      openNewPlanModal();
       (api.createPlan as jest.Mock).mockResolvedValue({});
       (api.getPlans as jest.Mock).mockResolvedValue({ plans: [] });
       (api.getPlannedPurchases as jest.Mock).mockResolvedValue({ purchases: [] });
@@ -927,13 +965,12 @@ describe('Plans Module', () => {
       expect(sentRecs == null || sentRecs.length === 0).toBe(true);
     });
 
-    test('plan does not include filtered-out recs (Bundle B)', async () => {
-      // Selection points at IDs that aren't in the visible set — they're
-      // filtered out, so the plan should silently ignore them.
-      (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set(['stale-1']));
-      (state.getVisibleRecommendations as jest.Mock).mockReturnValue([
-        { id: 'rec-1', service: 'ec2' }
-      ]);
+    test('empty snapshot from openCreatePlanModal also produces no recs', async () => {
+      // Defence-in-depth: if a future caller passes an empty array as the
+      // snapshot (e.g. the resolvePurchaseTarget result captured at click
+      // time was empty for some reason), savePlan must still submit without
+      // a recommendations field, not blow up.
+      openCreatePlanModal([] as unknown as readonly api.Recommendation[]);
       (api.createPlan as jest.Mock).mockResolvedValue({});
       (api.getPlans as jest.Mock).mockResolvedValue({ plans: [] });
       (api.getPlannedPurchases as jest.Mock).mockResolvedValue({ purchases: [] });
@@ -942,7 +979,6 @@ describe('Plans Module', () => {
       await savePlan(event);
 
       const sentRecs = (api.createPlan as jest.Mock).mock.calls[0][0].recommendations;
-      // selection had no intersection with visible → recommendations field empty/undefined.
       expect(sentRecs == null || sentRecs.length === 0).toBe(true);
     });
 
@@ -1045,10 +1081,15 @@ describe('Plans Module', () => {
       expect(modal?.classList.contains('hidden')).toBe(false);
     });
 
-    test('sets "Create Purchase Plan" title when a selection exists', () => {
-      (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set([0]));
-
-      openCreatePlanModal();
+    test('sets "Create Purchase Plan" title when a snapshot is passed', () => {
+      // #273 CR follow-up: title now keys off the snapshot the caller
+      // passes (the resolved-target captured at button-click time)
+      // rather than the live selection state, which would otherwise be
+      // racy between modal-open and modal-render.
+      const snapshot = [
+        { id: 'rec-x', service: 'ec2' },
+      ] as unknown as readonly api.Recommendation[];
+      openCreatePlanModal(snapshot);
 
       const title = document.getElementById('plan-modal-title');
       expect(title?.textContent).toBe('Create Purchase Plan');

--- a/frontend/src/__tests__/plans.test.ts
+++ b/frontend/src/__tests__/plans.test.ts
@@ -902,7 +902,15 @@ describe('Plans Module', () => {
       expect(sentRecs.map((r: { id: string }) => r.id).sort()).toEqual(['rec-1', 'rec-2']);
     });
 
-    test('falls back to all visible when no selection (Bundle B)', async () => {
+    test('does NOT include any recs when no selection (#273 CR follow-up)', async () => {
+      // The Bundle B fallback to "all visible recs" was removed as part of
+      // the #273 CR loop: Refresh / filter changes silently mutate the
+      // visible set between the user clicking the Create-Plan-button and
+      // clicking Save in the modal, so a no-selection path is structurally
+      // unsafe. The bottom action box already disables the button in that
+      // state; this assertion is the defence-in-depth at the savePlan
+      // layer for any path that bypasses the disabled UI (programmatic
+      // calls, future code paths, regressions on the gating).
       (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set());
       (state.getVisibleRecommendations as jest.Mock).mockReturnValue([
         { id: 'rec-1', service: 'ec2' },
@@ -916,7 +924,7 @@ describe('Plans Module', () => {
       await savePlan(event);
 
       const sentRecs = (api.createPlan as jest.Mock).mock.calls[0][0].recommendations;
-      expect(sentRecs.map((r: { id: string }) => r.id).sort()).toEqual(['rec-1', 'rec-2']);
+      expect(sentRecs == null || sentRecs.length === 0).toBe(true);
     });
 
     test('plan does not include filtered-out recs (Bundle B)', async () => {

--- a/frontend/src/__tests__/recommendations.test.ts
+++ b/frontend/src/__tests__/recommendations.test.ts
@@ -1477,30 +1477,43 @@ describe('Bundle B: sticky bottom action box', () => {
   });
 
   test('button labels reflect the selection (#273)', async () => {
-    // No selection → buttons disabled, label is the static form, tooltip
-    // prompts the user. The previous "Purchase N visible" fallback was
-    // removed because Refresh / filter changes silently mutate the
-    // visible set, making misclick irreversible.
+    // No selection → buttons disabled, label is the static form. The
+    // disabled-state explanation lives on a sibling hint span linked via
+    // aria-describedby (CR follow-up): disabled <button> elements are
+    // non-focusable per HTML spec and don't reliably show title tooltips
+    // across browsers, so the sibling-element pattern is the
+    // discoverable channel for both mouse and keyboard users.
     await loadRecommendations();
     let purchaseBtn = document.getElementById('bulk-purchase-btn') as HTMLButtonElement;
     let planBtn = document.getElementById('create-plan-btn') as HTMLButtonElement;
+    let hint = document.getElementById('recommendations-action-disabled-hint') as HTMLSpanElement;
     expect(purchaseBtn.disabled).toBe(true);
     expect(purchaseBtn.textContent).toBe('Purchase');
-    expect(purchaseBtn.title).toContain('Select at least one cell to enable');
+    expect(purchaseBtn.hasAttribute('title')).toBe(false);
+    expect(purchaseBtn.getAttribute('aria-describedby')).toBe('recommendations-action-disabled-hint');
     expect(planBtn.disabled).toBe(true);
     expect(planBtn.textContent).toBe('Create Plan');
-    expect(planBtn.title).toContain('Select at least one cell to enable');
+    expect(planBtn.hasAttribute('title')).toBe(false);
+    expect(planBtn.getAttribute('aria-describedby')).toBe('recommendations-action-disabled-hint');
+    expect(hint.hidden).toBe(false);
+    expect(hint.textContent).toContain('Select at least one cell to enable');
+    expect(hint.getAttribute('aria-live')).toBe('polite');
 
     // Selection populated → buttons enabled, label shows the selection
-    // count.
+    // count, hint hidden, aria-describedby cleared, title restored.
     (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set(['r1']));
     await loadRecommendations();
     purchaseBtn = document.getElementById('bulk-purchase-btn') as HTMLButtonElement;
     planBtn = document.getElementById('create-plan-btn') as HTMLButtonElement;
+    hint = document.getElementById('recommendations-action-disabled-hint') as HTMLSpanElement;
     expect(purchaseBtn.disabled).toBe(false);
     expect(purchaseBtn.textContent).toBe('Purchase 1 selected');
+    expect(purchaseBtn.hasAttribute('aria-describedby')).toBe(false);
+    expect(purchaseBtn.title).toContain('Buy these reservations now');
     expect(planBtn.disabled).toBe(false);
     expect(planBtn.textContent).toBe('Plan from 1 selected');
+    expect(planBtn.hasAttribute('aria-describedby')).toBe(false);
+    expect(hint.hidden).toBe(true);
   });
 
   test('buttons disabled when no rows visible at all', async () => {

--- a/frontend/src/__tests__/recommendations.test.ts
+++ b/frontend/src/__tests__/recommendations.test.ts
@@ -428,12 +428,16 @@ describe('Recommendations Module', () => {
       await loadRecommendations();
 
       // Bundle B: per-row Purchase buttons gone; the Purchase action lives
-      // in the sticky bottom action box at #bulk-purchase-btn. The button
-      // resolves its target via state.getVisibleRecommendations(), so the
-      // mock needs to return the loaded recs for the click to fire.
+      // in the sticky bottom action box at #bulk-purchase-btn. #273: the
+      // button is disabled until the user explicitly selects rows, so seed
+      // the selection mock with the rec's id before clicking — the test is
+      // asserting the modal-open flow, not the selection-gating UI.
       (state.getVisibleRecommendations as jest.Mock).mockReturnValue(mockRecs);
+      (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set(['rec-11']));
+      await loadRecommendations(); // re-render so the button picks up the selection
       const purchaseBtn = document.querySelector('#bulk-purchase-btn') as HTMLButtonElement;
       expect(purchaseBtn).not.toBeNull();
+      expect(purchaseBtn.disabled).toBe(false);
       purchaseBtn.click();
       // Issue #111 (iii): openPurchaseModal is async; flush microtasks
       // so the modal-open call lands before we assert visibility.
@@ -529,19 +533,22 @@ describe('Recommendations Module', () => {
       await loadRecommendations();
 
       const summary = document.getElementById('recommendations-action-summary');
-      // issues #225/#226: summary text now uses "cells visible" (cell-grouped count).
-      expect(summary?.textContent).toContain('1 selected of 1 cells visible');
+      // #273: summary text shows just the selection count (drops the
+      // "of N cells visible" suffix — the visible fallback is gone).
+      expect(summary?.textContent).toContain('1 selected');
       // Old bulk-toolbar surface is gone.
       expect(document.querySelector('.recommendations-bulk-toolbar')).toBeNull();
     });
 
-    test('bottom action box shows "All N visible" when no row is selected (Bundle B)', async () => {
+    test('bottom action box prompts for selection when no row is selected (#273)', async () => {
       (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set());
       (state.getVisibleRecommendations as jest.Mock).mockReturnValue(twoRecs);
       await loadRecommendations();
       const summary = document.getElementById('recommendations-action-summary');
-      // issues #225/#226: summary text now uses "cells visible" (cell-grouped count).
-      expect(summary?.textContent).toMatch(/All \d+ cells visible/);
+      // #273: action buttons require an explicit selection. Summary
+      // prompts the user instead of advertising a default-target count
+      // that would fire on misclick.
+      expect(summary?.textContent).toContain('Select cells to act on');
       expect(document.querySelector('.recommendations-bulk-toolbar')).toBeNull();
     });
 
@@ -1469,18 +1476,34 @@ describe('Bundle B: sticky bottom action box', () => {
     expect(document.getElementById('bulk-purchase-term')).toBeNull();
   });
 
-  test('button labels reflect the action target', async () => {
+  test('button labels reflect the selection (#273)', async () => {
+    // No selection → buttons disabled, label is the static form, tooltip
+    // prompts the user. The previous "Purchase N visible" fallback was
+    // removed because Refresh / filter changes silently mutate the
+    // visible set, making misclick irreversible.
     await loadRecommendations();
     let purchaseBtn = document.getElementById('bulk-purchase-btn') as HTMLButtonElement;
-    expect(purchaseBtn.textContent).toBe('Purchase 2 visible');
+    let planBtn = document.getElementById('create-plan-btn') as HTMLButtonElement;
+    expect(purchaseBtn.disabled).toBe(true);
+    expect(purchaseBtn.textContent).toBe('Purchase');
+    expect(purchaseBtn.title).toContain('Select at least one cell to enable');
+    expect(planBtn.disabled).toBe(true);
+    expect(planBtn.textContent).toBe('Create Plan');
+    expect(planBtn.title).toContain('Select at least one cell to enable');
 
+    // Selection populated → buttons enabled, label shows the selection
+    // count.
     (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set(['r1']));
     await loadRecommendations();
     purchaseBtn = document.getElementById('bulk-purchase-btn') as HTMLButtonElement;
+    planBtn = document.getElementById('create-plan-btn') as HTMLButtonElement;
+    expect(purchaseBtn.disabled).toBe(false);
     expect(purchaseBtn.textContent).toBe('Purchase 1 selected');
+    expect(planBtn.disabled).toBe(false);
+    expect(planBtn.textContent).toBe('Plan from 1 selected');
   });
 
-  test('buttons disabled when target is empty', async () => {
+  test('buttons disabled when no rows visible at all', async () => {
     (state.getVisibleRecommendations as jest.Mock).mockReturnValue([]);
     (api.getRecommendations as jest.Mock).mockResolvedValue({ summary: {}, recommendations: [], regions: [] });
     await loadRecommendations();
@@ -1529,10 +1552,10 @@ describe('Bundle B: term-aware bucketing in the Purchase flow', () => {
 
   test('multi-term selection produces multiple fan-out buckets', async () => {
     // Two different resource types (different cells) with different terms.
-    // issues #225/#226: resolvePurchaseTarget now uses pickBestVariantPerCell
-    // for the default (no-selection) target — each cell contributes one rec.
-    // Use different resource_type so each rec is its own cell (no grouping),
-    // ensuring both are selected as the default target and trigger fan-out.
+    // #273: resolvePurchaseTarget no longer falls back to "all visible" when
+    // nothing is selected — the buttons are disabled in that state. Tests
+    // that exercise the post-Purchase fan-out must explicitly select the
+    // recs they want included in the target.
     const mixed = [
       { id: 'a', provider: 'aws', cloud_account_id: 'a1', service: 'ec2', resource_type: 't3.medium', region: 'us-east-1', count: 1, term: 1, savings: 100, upfront_cost: 500 },
       { id: 'b', provider: 'aws', cloud_account_id: 'a1', service: 'ec2', resource_type: 'm5.large', region: 'us-east-1', count: 1, term: 3, savings: 200, upfront_cost: 800 },
@@ -1541,7 +1564,7 @@ describe('Bundle B: term-aware bucketing in the Purchase flow', () => {
     (state.getRecommendations as jest.Mock).mockReturnValue(mixed);
     (state.getVisibleRecommendations as jest.Mock).mockReturnValue(mixed);
     (state.getRecommendationsColumnFilters as jest.Mock).mockReturnValue({});
-    (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set());
+    (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set(['a', 'b']));
 
     await loadRecommendations();
     const purchaseBtn = document.getElementById('bulk-purchase-btn') as HTMLButtonElement;
@@ -1607,7 +1630,14 @@ describe('Issue #111: per-bucket Payment seed from per-account service override'
     (state.getRecommendations as jest.Mock).mockReturnValue(recs);
     (state.getVisibleRecommendations as jest.Mock).mockReturnValue(recs);
     (state.getRecommendationsColumnFilters as jest.Mock).mockReturnValue({});
-    (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set());
+    // #273: action buttons now require an explicit selection. Each fan-out
+    // test in this suite is asserting bucket assembly, not the selection-
+    // gating UI, so seed the selection with every rec id to keep Purchase
+    // enabled and the click effective. The earlier
+    // "no-selection → default to visible" fallback path is gone.
+    (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(
+      new Set(recs.map((r) => r.id as string)),
+    );
   };
 
   test('(a) single-account bucket with matching override → bucket payment seeded from override', async () => {
@@ -1978,7 +2008,7 @@ describe('Issue #132: bulk-buy collapses SP plan types into one bucket', () => {
     (state.getRecommendations as jest.Mock).mockReturnValue(recs);
     (state.getVisibleRecommendations as jest.Mock).mockReturnValue(recs);
     (state.getRecommendationsColumnFilters as jest.Mock).mockReturnValue({});
-    (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set());
+    (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set(recs.map((r) => r.id as string)));
 
     await loadRecommendations();
     (document.getElementById('bulk-purchase-btn') as HTMLButtonElement).click();
@@ -2006,7 +2036,7 @@ describe('Issue #132: bulk-buy collapses SP plan types into one bucket', () => {
     (state.getRecommendations as jest.Mock).mockReturnValue(recs);
     (state.getVisibleRecommendations as jest.Mock).mockReturnValue(recs);
     (state.getRecommendationsColumnFilters as jest.Mock).mockReturnValue({});
-    (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set());
+    (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set(recs.map((r) => r.id as string)));
 
     await loadRecommendations();
     (document.getElementById('bulk-purchase-btn') as HTMLButtonElement).click();
@@ -2044,7 +2074,7 @@ describe('Issue #132: bulk-buy collapses SP plan types into one bucket', () => {
     (state.getRecommendations as jest.Mock).mockReturnValue(recs);
     (state.getVisibleRecommendations as jest.Mock).mockReturnValue(recs);
     (state.getRecommendationsColumnFilters as jest.Mock).mockReturnValue({});
-    (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set());
+    (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set(recs.map((r) => r.id as string)));
 
     await loadRecommendations();
     (document.getElementById('bulk-purchase-btn') as HTMLButtonElement).click();
@@ -2070,7 +2100,7 @@ describe('Issue #132: bulk-buy collapses SP plan types into one bucket', () => {
     (state.getRecommendations as jest.Mock).mockReturnValue(recs);
     (state.getVisibleRecommendations as jest.Mock).mockReturnValue(recs);
     (state.getRecommendationsColumnFilters as jest.Mock).mockReturnValue({});
-    (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set());
+    (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set(recs.map((r) => r.id as string)));
 
     await loadRecommendations();
     (document.getElementById('bulk-purchase-btn') as HTMLButtonElement).click();

--- a/frontend/src/plans.ts
+++ b/frontend/src/plans.ts
@@ -549,19 +549,20 @@ export async function savePlan(e: Event): Promise<void> {
     plan.custom_interval_days = parseInt((document.getElementById('ramp-interval-days') as HTMLInputElement).value, 10);
   }
 
-  // Bundle B (column-filter UX overhaul): read from getVisibleRecommendations
-  // — the post-filter, post-sort set tracked by recommendations.ts on every
-  // render — instead of getRecommendations() (raw API-loaded list). This
-  // ensures plans never include recs the user filtered out of view.
-  // When no row is explicitly selected, fall back to the full visible set so
-  // "Create Plan" with filters but no selection plans against everything the
-  // user can see.
+  // Read from getVisibleRecommendations — the post-filter, post-sort set
+  // tracked by recommendations.ts on every render — and intersect with the
+  // explicit selection. Plans only include rows the user explicitly ticked
+  // (#273): the prior fallback to "all visible recs when nothing is
+  // selected" was structurally unsafe because Refresh / filter changes
+  // silently mutate the visible set between Create-Plan-button click and
+  // Save-modal click. The button itself is gated on selection in
+  // updateBottomActionBox, but we mirror the gating here as defence-in-
+  // depth so a programmatic / future-code-path caller bypassing the
+  // disabled UI still produces an empty plan rather than a runaway one.
   const selectedIDs = state.getSelectedRecommendationIDs();
   const visibleRecs = state.getVisibleRecommendations();
   if (selectedIDs.size > 0) {
     plan.recommendations = visibleRecs.filter((r) => selectedIDs.has(r.id)) as api.Recommendation[];
-  } else if (visibleRecs.length > 0) {
-    plan.recommendations = [...visibleRecs] as api.Recommendation[];
   }
 
   try {

--- a/frontend/src/plans.ts
+++ b/frontend/src/plans.ts
@@ -3,7 +3,6 @@
  */
 
 import * as api from './api';
-import * as state from './state';
 import { formatDate, formatTerm, getStatusBadge, escapeHtml, formatCurrency, populateAccountFilter } from './utils';
 import { showToast } from './toast';
 import { confirmDialog } from './confirmDialog';
@@ -12,6 +11,17 @@ import { viewPlanHistory } from './history';
 import type { PlannedPurchase } from './api';
 import { populateTermSelect, populatePaymentSelect, isValidCombination, normalizePaymentValue } from './commitmentOptions';
 import { openModal, closeModal } from './modal';
+
+// pendingPlanRecommendations holds the resolved plan target captured at
+// "Plan from N selected" button-click time. The Plan flow used to re-derive
+// its target from state.getVisibleRecommendations() + getSelectedRecommendation
+// IDs() at savePlan time, but state mutations between modal-open and
+// modal-Save (Refresh, filter changes, deselections) could silently shrink
+// or replace the planned set. This snapshot is stamped by openCreatePlan-
+// Modal(snapshot) and consumed by savePlan; openNewPlanModal() clears it
+// (the New-Plan-from-scratch path has no pre-resolved target). See #273
+// CR follow-up.
+let pendingPlanRecommendations: api.Recommendation[] = [];
 
 /**
  * Load plans and planned purchases
@@ -549,20 +559,16 @@ export async function savePlan(e: Event): Promise<void> {
     plan.custom_interval_days = parseInt((document.getElementById('ramp-interval-days') as HTMLInputElement).value, 10);
   }
 
-  // Read from getVisibleRecommendations — the post-filter, post-sort set
-  // tracked by recommendations.ts on every render — and intersect with the
-  // explicit selection. Plans only include rows the user explicitly ticked
-  // (#273): the prior fallback to "all visible recs when nothing is
-  // selected" was structurally unsafe because Refresh / filter changes
-  // silently mutate the visible set between Create-Plan-button click and
-  // Save-modal click. The button itself is gated on selection in
-  // updateBottomActionBox, but we mirror the gating here as defence-in-
-  // depth so a programmatic / future-code-path caller bypassing the
-  // disabled UI still produces an empty plan rather than a runaway one.
-  const selectedIDs = state.getSelectedRecommendationIDs();
-  const visibleRecs = state.getVisibleRecommendations();
-  if (selectedIDs.size > 0) {
-    plan.recommendations = visibleRecs.filter((r) => selectedIDs.has(r.id)) as api.Recommendation[];
+  // Use the snapshot stamped at Plan-button click time (#273 CR follow-up).
+  // Reading state.getVisibleRecommendations() / getSelectedRecommendation
+  // IDs() here would re-derive the target at Save time — racing Refresh,
+  // filter changes, and deselections that happen while the modal is open.
+  // openCreatePlanModal(snapshot) freezes the Plan target the moment the
+  // user clicked "Plan from N selected"; we read it back here.
+  // openNewPlanModal() clears the snapshot for the New-Plan-from-scratch
+  // path (no pre-resolved target — plan submits without `recommendations`).
+  if (pendingPlanRecommendations.length > 0) {
+    plan.recommendations = [...pendingPlanRecommendations];
   }
 
   try {
@@ -596,6 +602,11 @@ export async function savePlan(e: Event): Promise<void> {
 export function closePlanModal(): void {
   const planModal = document.getElementById('plan-modal');
   if (planModal) closeModal(planModal);
+  // Invalidate the resolved-target snapshot stamped by openCreatePlanModal
+  // so a subsequent flow doesn't accidentally inherit it. The snapshot
+  // ties the plan to a specific button-click moment; once the modal
+  // closes — by Save, Cancel, or any other path — that moment is over.
+  pendingPlanRecommendations = [];
 }
 
 // Selected accounts for the plan modal
@@ -716,9 +727,16 @@ async function setupPlanAccountsSection(planId?: string): Promise<void> {
  * miss. Same UX as the dedicated "New Plan" button — the modal
  * always opens, and the user fills in provider/service from scratch.
  */
-export function openCreatePlanModal(): void {
+export function openCreatePlanModal(snapshot?: readonly api.Recommendation[]): void {
+  // Stamp the resolved-target snapshot from the caller so savePlan can
+  // consume it without re-deriving from global state at Save time. The
+  // Bottom Action Box passes the result of resolvePurchaseTarget(); a
+  // missing arg falls back to the legacy behaviour (no captured target,
+  // savePlan submits a plan without `recommendations`). See #273 CR.
+  pendingPlanRecommendations = snapshot ? [...snapshot] : [];
+
   const titleEl = document.getElementById('plan-modal-title');
-  const hasSelection = state.getSelectedRecommendationIDs().size > 0;
+  const hasSelection = pendingPlanRecommendations.length > 0;
   if (titleEl) {
     titleEl.textContent = hasSelection ? 'Create Purchase Plan' : 'New Purchase Plan';
   }
@@ -741,6 +759,12 @@ export function openCreatePlanModal(): void {
  * Open new plan modal (without pre-selected recommendations)
  */
 export function openNewPlanModal(): void {
+  // No pre-resolved target — this is the "New Plan from scratch" path.
+  // Clear any stale snapshot from a prior openCreatePlanModal call so a
+  // subsequent savePlan doesn't accidentally inherit a previous flow's
+  // recs. See #273 CR.
+  pendingPlanRecommendations = [];
+
   const titleEl = document.getElementById('plan-modal-title');
   if (titleEl) titleEl.textContent = 'New Purchase Plan';
   (document.getElementById('plan-id') as HTMLInputElement).value = '';

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -1785,6 +1785,21 @@ function mountBottomActionBox(): HTMLElement | null {
   planBtn.title = 'Schedule a recurring plan that will purchase these recommendations on a defined cadence';
   box.appendChild(planBtn);
 
+  // a11y hint for the disabled-button state (#273 CR follow-up).
+  // Disabled <button> elements are non-focusable per HTML spec and
+  // browsers don't reliably show their `title` tooltips, so a sibling
+  // hint with aria-describedby is the discoverable channel for both
+  // mouse and keyboard users. The element starts hidden; updateBottom-
+  // ActionBox toggles its visibility and links the buttons via
+  // aria-describedby when they're disabled.
+  const disabledHint = document.createElement('span');
+  disabledHint.id = 'recommendations-action-disabled-hint';
+  disabledHint.className = 'recommendations-action-disabled-hint';
+  disabledHint.setAttribute('role', 'status');
+  disabledHint.setAttribute('aria-live', 'polite');
+  disabledHint.hidden = true;
+  box.appendChild(disabledHint);
+
   const persist = (): void => {
     saveBulkPurchaseState({
       payment: paymentSelect.value as BulkPurchaseToolbarState['payment'],
@@ -1866,30 +1881,57 @@ function updateBottomActionBox(visibleCount: number, loadedCount: number): void 
 
   const purchaseBtn = document.getElementById('bulk-purchase-btn') as HTMLButtonElement | null;
   const planBtn = document.getElementById('create-plan-btn') as HTMLButtonElement | null;
+  const disabledHint = document.getElementById('recommendations-action-disabled-hint');
   const hasSelection = selectedVisibleCount > 0;
-  const disabledTooltip = loadedCount === 0
+  const disabledMessage = loadedCount === 0
     ? 'No recommendations loaded'
     : visibleCount === 0
       ? 'No rows visible — adjust filters'
       : 'Select at least one cell to enable';
+
+  // a11y: the disabled-state explanation lives on a sibling hint span,
+  // not on the buttons' `title` attribute. Disabled <button> elements are
+  // non-focusable per HTML spec and don't reliably surface `title`
+  // tooltips across browsers, so keyboard users would never see the
+  // hint and mouse users only sometimes would. The sibling element +
+  // aria-describedby pattern works for both. See #273 CR follow-up.
+  if (disabledHint) {
+    if (hasSelection) {
+      disabledHint.hidden = true;
+      disabledHint.textContent = '';
+    } else {
+      disabledHint.hidden = false;
+      disabledHint.textContent = disabledMessage;
+    }
+  }
 
   if (purchaseBtn) {
     purchaseBtn.disabled = !hasSelection;
     purchaseBtn.textContent = hasSelection
       ? `Purchase ${selectedVisibleCount} selected`
       : 'Purchase';
-    purchaseBtn.title = hasSelection
-      ? 'Buy these reservations now (one-off, processed immediately)'
-      : disabledTooltip;
+    if (hasSelection) {
+      purchaseBtn.title = 'Buy these reservations now (one-off, processed immediately)';
+      purchaseBtn.removeAttribute('aria-describedby');
+    } else {
+      // Drop the title — title on disabled buttons is unreliable; the
+      // sibling hint carries the message.
+      purchaseBtn.removeAttribute('title');
+      purchaseBtn.setAttribute('aria-describedby', 'recommendations-action-disabled-hint');
+    }
   }
   if (planBtn) {
     planBtn.disabled = !hasSelection;
     planBtn.textContent = hasSelection
       ? `Plan from ${selectedVisibleCount} selected`
       : 'Create Plan';
-    planBtn.title = hasSelection
-      ? 'Schedule a recurring plan that will purchase these recommendations on a defined cadence'
-      : disabledTooltip;
+    if (hasSelection) {
+      planBtn.title = 'Schedule a recurring plan that will purchase these recommendations on a defined cadence';
+      planBtn.removeAttribute('aria-describedby');
+    } else {
+      planBtn.removeAttribute('title');
+      planBtn.setAttribute('aria-describedby', 'recommendations-action-disabled-hint');
+    }
   }
 }
 

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -1818,10 +1818,14 @@ function mountBottomActionBox(): HTMLElement | null {
   planBtn.addEventListener('click', () => {
     const target = resolvePurchaseTarget();
     if (target.length === 0) return;
-    // Plans-side savePlan reads state.getVisibleRecommendations() and
-    // intersects with state.getSelectedRecommendationIDs() — it'll see
-    // the same target as the Purchase button uses.
-    void openCreatePlanFromBottomBox();
+    // Pass the resolved target through to the plan modal as a snapshot
+    // (#273 CR follow-up). Without this, savePlan would re-derive the
+    // target from state.getVisibleRecommendations() / getSelectedRecommendation
+    // IDs() at Save time — racing Refresh, filter changes, and
+    // deselections that happen while the modal is open. The Purchase
+    // path already captures the target at click time via handleBulkPurchase
+    // Click(target); the Plan path now mirrors that.
+    void openCreatePlanFromBottomBox(target);
   });
 
   recsTab.appendChild(box);
@@ -1939,9 +1943,14 @@ function updateBottomActionBox(visibleCount: number, loadedCount: number): void 
 // savePlan reads state.getVisibleRecommendations() (Bundle B's plumbing
 // addition in Step 8c) so the plan only includes selected ∩ visible (or
 // all visible if no selection).
-async function openCreatePlanFromBottomBox(): Promise<void> {
+async function openCreatePlanFromBottomBox(snapshot: LocalRecommendation[]): Promise<void> {
   const { openCreatePlanModal } = await import('./plans');
-  openCreatePlanModal();
+  // Cast: api.Recommendation and LocalRecommendation share the persisted
+  // wire shape; the modal stores a copy and savePlan submits it as
+  // api.Recommendation[]. The snapshot was already passed through
+  // resolvePurchaseTarget() / Set membership, both of which treat the
+  // shape as opaque.
+  openCreatePlanModal(snapshot as unknown as readonly api.Recommendation[]);
 }
 
 function handleBulkPurchaseClick(recommendations: LocalRecommendation[]): void {

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -1813,27 +1813,22 @@ function mountBottomActionBox(): HTMLElement | null {
   return box;
 }
 
-// Resolve the action target: selected ∩ visible if a selection exists,
-// else all visible. "Visible" is the post-filter set tracked in module
-// state via setVisibleRecommendations.
+// Resolve the action target: selected ∩ visible. Returns an empty slice when
+// no rows are selected — the action buttons are disabled in that state by
+// updateBottomActionBox (closes #273), so callers should never reach this
+// helper without a selection. The empty-return is defence-in-depth: if a
+// caller bypasses the disabled UI (programmatic invocation, future code path,
+// regression on the gating), no purchase happens.
 //
-// CR #253: when no rows are manually selected, fall back to one variant per
-// cell (pickBestVariantPerCell) rather than all visible variants. With the
-// grouped table, a collapsed 2-variant cell counts as "1 visible cell" to
-// the user but "2 visible recs" to the flat visible list — submitting both
-// would create 2 conflicting reservations for the same resource, violating
-// the one-variant-per-cell contract from #224.
+// Historical context: prior to #273 this fell back to
+// pickBestVariantPerCell(visible) when no rows were selected, so misclicking
+// a "Purchase visible" button could trigger an irreversible bulk purchase.
+// The fallback was removed because Refresh and filter changes silently
+// mutate the visible set, making the no-selection path structurally unsafe.
 function resolvePurchaseTarget(): LocalRecommendation[] {
   const visible = state.getVisibleRecommendations() as unknown as LocalRecommendation[];
   const selected = state.getSelectedRecommendationIDs();
-  const intersection = visible.filter((r) => selected.has(r.id));
-  // Selection path: use the explicit user selection (radio enforcement from
-  // #224 already caps at one per cell).
-  if (intersection.length > 0) return intersection;
-  // Default (no selection): pick the best variant per cell so the purchase
-  // target is exactly one rec per physical resource, matching what the user
-  // sees in the grouped collapsed table.
-  return pickBestVariantPerCell(visible);
+  return visible.filter((r) => selected.has(r.id));
 }
 
 // updateBottomActionBox refreshes labels and disabled state on every
@@ -1851,14 +1846,11 @@ function updateBottomActionBox(visibleCount: number, loadedCount: number): void 
     0,
   );
 
-  // CR #253: for the default (no-selection) target count, use the number of
-  // cells (distinct physical resources) rather than the flat variant count,
-  // since resolvePurchaseTarget() now applies pickBestVariantPerCell when no
-  // rows are selected. The user sees one row per cell in the collapsed table.
-  const visibleCellCount = selectedVisibleCount > 0
-    ? selectedVisibleCount
-    : pickBestVariantPerCell(visible).length;
-
+  // Action buttons require an explicit selection (closes #273): a misclick
+  // on "Purchase visible" / "Plan from visible" with no checkboxes ticked
+  // could trigger an irreversible bulk purchase across every visible row,
+  // and the visible set silently changes when the user clicks Refresh or
+  // adjusts filters. Only the "selected" form of the action buttons remains.
   const summary = document.getElementById('recommendations-action-summary');
   if (summary) {
     if (loadedCount === 0) {
@@ -1866,43 +1858,38 @@ function updateBottomActionBox(visibleCount: number, loadedCount: number): void 
     } else if (visibleCount === 0) {
       summary.textContent = '(0 visible — adjust filters)';
     } else if (selectedVisibleCount > 0) {
-      summary.textContent = `(${selectedVisibleCount} selected of ${visibleCellCount} cells visible)`;
+      summary.textContent = `(${selectedVisibleCount} selected)`;
     } else {
-      summary.textContent = `(All ${visibleCellCount} cells visible — no selection)`;
+      summary.textContent = '(Select cells to act on)';
     }
   }
 
   const purchaseBtn = document.getElementById('bulk-purchase-btn') as HTMLButtonElement | null;
   const planBtn = document.getElementById('create-plan-btn') as HTMLButtonElement | null;
-  const targetCount = visibleCellCount;
-  const empty = targetCount === 0;
-  const targetIsSelection = selectedVisibleCount > 0;
+  const hasSelection = selectedVisibleCount > 0;
+  const disabledTooltip = loadedCount === 0
+    ? 'No recommendations loaded'
+    : visibleCount === 0
+      ? 'No rows visible — adjust filters'
+      : 'Select at least one cell to enable';
 
   if (purchaseBtn) {
-    purchaseBtn.disabled = empty;
-    purchaseBtn.textContent = empty
-      ? 'Purchase'
-      : targetIsSelection
-        ? `Purchase ${targetCount} selected`
-        : `Purchase ${targetCount} visible`;
-    purchaseBtn.title = empty
-      ? (loadedCount === 0
-          ? 'No recommendations loaded'
-          : 'No rows visible — adjust filters')
-      : 'Buy these reservations now (one-off, processed immediately)';
+    purchaseBtn.disabled = !hasSelection;
+    purchaseBtn.textContent = hasSelection
+      ? `Purchase ${selectedVisibleCount} selected`
+      : 'Purchase';
+    purchaseBtn.title = hasSelection
+      ? 'Buy these reservations now (one-off, processed immediately)'
+      : disabledTooltip;
   }
   if (planBtn) {
-    planBtn.disabled = empty;
-    planBtn.textContent = empty
-      ? 'Create Plan'
-      : targetIsSelection
-        ? `Plan from ${targetCount} selected`
-        : `Plan from ${targetCount} visible`;
-    planBtn.title = empty
-      ? (loadedCount === 0
-          ? 'No recommendations loaded'
-          : 'No rows visible — adjust filters')
-      : 'Schedule a recurring plan that will purchase these recommendations on a defined cadence';
+    planBtn.disabled = !hasSelection;
+    planBtn.textContent = hasSelection
+      ? `Plan from ${selectedVisibleCount} selected`
+      : 'Create Plan';
+    planBtn.title = hasSelection
+      ? 'Schedule a recurring plan that will purchase these recommendations on a defined cadence'
+      : disabledTooltip;
   }
 }
 


### PR DESCRIPTION
## Summary

Closes #273. Drops the unsafe "Purchase / Plan from N visible" fallback
on the Recommendations page bottom action box.

**Before**: with no checkboxes ticked, both buttons defaulted to "all
visible cells" and remained enabled. A single misclick triggered an
irreversible bulk Purchase / Plan across every visible row, and the
visible set silently changes when Refresh runs or filters mutate.

**After**: with 0 selected → buttons disabled, label is the static form
("Purchase" / "Create Plan"), tooltip prompts "Select at least one cell
to enable", and `resolvePurchaseTarget()` returns an empty slice as
defence-in-depth (so a programmatic caller bypassing the disabled UI
also can't fire). With ≥1 selected → buttons enabled, label shows the
selection count.

## Changes

- `frontend/src/recommendations.ts:1842::updateBottomActionBox` —
  drops `pickBestVariantPerCell(visible)` fallback; gates labels +
  tooltips + disabled state on `selectedVisibleCount > 0`.
- `frontend/src/recommendations.ts:1826::resolvePurchaseTarget` —
  returns `selected ∩ visible` only.
- Summary line replaces `(All N cells visible — no selection)` with
  `(Select cells to act on)` so the prompt is unambiguous.

## Test plan

- [x] New `button labels reflect the selection (#273)` pins both
  branches (disabled + tooltip when no selection; enabled + count
  when selected).
- [x] Existing `bottom action box shows "All N visible"` test renamed
  to `prompts for selection when no row is selected (#273)` with the
  new copy.
- [x] 5 fan-out / SP-flow tests that previously relied on the
  no-selection default-target fallback now seed the selection mock
  explicitly so they assert the post-click flow, not the gating UI.
- [x] `npm test -- --testPathPattern=recommendations` — 140 / 140
  pass.
- [x] `npm run typecheck` — clean.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recommendations now require explicit selection before taking actions (purchase, create plans). UI messaging updated to "Select cells to act on" to guide users.
  
* **Tests**
  * Test suite updated to reflect explicit selection requirements and verify button states with appropriate tooltips when no items are selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->