### PR TITLE
fix(frontend/recs): Potential Monthly Savings card mirrors page-level range (closes #272)

### DIFF
--- a/frontend/src/__tests__/recommendations.test.ts
+++ b/frontend/src/__tests__/recommendations.test.ts
@@ -131,6 +131,41 @@ describe('Recommendations Module', () => {
       expect(summary?.innerHTML).toContain('Payback Period');
     });
 
+    test('Potential Monthly Savings card mirrors page-level range, not the API sum (#272)', async () => {
+      // Two cells, two variants per cell. The cells share (provider, account,
+      // service, resource_type, region, term, engine) within each group; the
+      // variants differ by payment_option. The user can only buy one variant
+      // per cell, so the achievable monthly savings is bounded by:
+      //   min = sum of per-cell savingsMin = 100 + 200 = 300
+      //   max = sum of per-cell savingsMax = 150 + 250 = 400
+      // The API's total_monthly_savings sums all 4 variants (= 700), which
+      // overstates achievable savings by ~75% on this 2-cell page. The card
+      // must NOT render 700; it must render the range "$300 – $400".
+      const recs = [
+        { id: 'cell1-cheap',  provider: 'aws', cloud_account_id: 'a1', service: 'ec2', resource_type: 't3.medium', region: 'us-east-1', count: 1, term: 1, payment_option: 'no-upfront',     savings: 100, upfront_cost: 0 },
+        { id: 'cell1-pricey', provider: 'aws', cloud_account_id: 'a1', service: 'ec2', resource_type: 't3.medium', region: 'us-east-1', count: 1, term: 1, payment_option: 'all-upfront',    savings: 150, upfront_cost: 1000 },
+        { id: 'cell2-cheap',  provider: 'aws', cloud_account_id: 'a1', service: 'rds', resource_type: 'db.t3',     region: 'us-east-1', count: 1, term: 1, payment_option: 'no-upfront',     savings: 200, upfront_cost: 0 },
+        { id: 'cell2-pricey', provider: 'aws', cloud_account_id: 'a1', service: 'rds', resource_type: 'db.t3',     region: 'us-east-1', count: 1, term: 1, payment_option: 'all-upfront',    savings: 250, upfront_cost: 2000 },
+      ];
+      (api.getRecommendations as jest.Mock).mockResolvedValue({
+        summary: { total_count: 4, total_monthly_savings: 700, total_upfront_cost: 3000, avg_payback_months: 1 },
+        recommendations: recs,
+        regions: [],
+      });
+
+      await loadRecommendations();
+
+      const summary = document.getElementById('recommendations-summary');
+      const savingsCard = Array.from(summary?.querySelectorAll('.card') ?? [])
+        .find((c) => c.querySelector('h3')?.textContent === 'Potential Monthly Savings');
+      const value = savingsCard?.querySelector('.value.savings')?.textContent ?? '';
+      // The page-level range is $300 – $400/mo; the API's flat 700 must not
+      // appear on the card.
+      expect(value).toContain('$300');
+      expect(value).toContain('$400');
+      expect(value).not.toContain('$700');
+    });
+
     test('renders recommendations list', async () => {
       (api.getRecommendations as jest.Mock).mockResolvedValue({
         summary: {},

--- a/frontend/src/__tests__/recommendations.test.ts
+++ b/frontend/src/__tests__/recommendations.test.ts
@@ -152,6 +152,14 @@ describe('Recommendations Module', () => {
         recommendations: recs,
         regions: [],
       });
+      // The summary card now reads the visible set via
+      // state.getVisibleRecommendations() (so it stays in sync with
+      // the banner under filter changes — see the next test for the
+      // filter-divergence case). On an unfiltered initial render the
+      // visible set equals the loaded set; mock it explicitly because
+      // setVisibleRecommendations() inside renderRecommendationsList
+      // is a no-op when state is mocked.
+      (state.getVisibleRecommendations as jest.Mock).mockReturnValue(recs);
 
       await loadRecommendations();
 
@@ -164,6 +172,70 @@ describe('Recommendations Module', () => {
       expect(value).toContain('$300');
       expect(value).toContain('$400');
       expect(value).not.toContain('$700');
+    });
+
+    test('savings card recomputes from visible set on filter change (#272 CR follow-up)', async () => {
+      // Same 4-rec / 2-cell setup as above. Initial render: card shows
+      // $300 – $400 (range across both cells). Then we apply a real
+      // column filter (service = "ec2") via the state mock so the
+      // applyColumnFilters() call inside renderRecommendationsList
+      // narrows the visible set to cell1's two variants, and trigger
+      // a rerender via a sortable-header click. The card MUST recompute
+      // to cell1's range ($100 – $150) — otherwise it stays pinned at
+      // the unfiltered $300 – $400 and diverges from the banner under
+      // the table, which is exactly the CR finding on #276 we're
+      // closing.
+      const allRecs = [
+        { id: 'cell1-cheap',  provider: 'aws', cloud_account_id: 'a1', service: 'ec2', resource_type: 't3.medium', region: 'us-east-1', count: 1, term: 1, payment_option: 'no-upfront',  savings: 100, upfront_cost: 0 },
+        { id: 'cell1-pricey', provider: 'aws', cloud_account_id: 'a1', service: 'ec2', resource_type: 't3.medium', region: 'us-east-1', count: 1, term: 1, payment_option: 'all-upfront', savings: 150, upfront_cost: 1000 },
+        { id: 'cell2-cheap',  provider: 'aws', cloud_account_id: 'a1', service: 'rds', resource_type: 'db.t3',     region: 'us-east-1', count: 1, term: 1, payment_option: 'no-upfront',  savings: 200, upfront_cost: 0 },
+        { id: 'cell2-pricey', provider: 'aws', cloud_account_id: 'a1', service: 'rds', resource_type: 'db.t3',     region: 'us-east-1', count: 1, term: 1, payment_option: 'all-upfront', savings: 250, upfront_cost: 2000 },
+      ];
+
+      (api.getRecommendations as jest.Mock).mockResolvedValue({
+        summary: { total_count: 4, total_monthly_savings: 700, total_upfront_cost: 3000, avg_payback_months: 1 },
+        recommendations: allRecs,
+        regions: [],
+      });
+      (state.getRecommendations as jest.Mock).mockReturnValue(allRecs);
+      (state.getVisibleRecommendations as jest.Mock).mockReturnValue(allRecs);
+      // No column filters initially — applyColumnFilters returns the input
+      // clone so all 4 recs reach the summary recompute.
+      (state.getRecommendationsColumnFilters as jest.Mock).mockReturnValue({});
+
+      await loadRecommendations();
+
+      const cardValue = (): string => {
+        const summary = document.getElementById('recommendations-summary');
+        const card = Array.from(summary?.querySelectorAll('.card') ?? [])
+          .find((c) => c.querySelector('h3')?.textContent === 'Potential Monthly Savings');
+        return card?.querySelector('.value.savings')?.textContent ?? '';
+      };
+      expect(cardValue()).toContain('$300');
+      expect(cardValue()).toContain('$400');
+
+      // Apply a real column filter restricting to service=ec2 (cell1
+      // only). renderRecommendationsList re-runs applyColumnFilters
+      // against the loaded set on every entry, so a sort-header click
+      // triggers the narrowing pipeline end-to-end.
+      (state.getRecommendationsColumnFilters as jest.Mock).mockReturnValue({
+        service: { kind: 'set', values: ['ec2'] },
+      });
+      const sortableHeader = document.querySelector<HTMLTableCellElement>('th[data-sort="service"]');
+      sortableHeader?.click();
+
+      // Card must recompute to cell1's range ($100 – $150) — NOT stay
+      // pinned at the loaded-set range ($300 – $400).
+      expect(cardValue()).toContain('$100');
+      expect(cardValue()).toContain('$150');
+      expect(cardValue()).not.toContain('$300');
+      expect(cardValue()).not.toContain('$400');
+
+      // Restore the filter mock to empty so the leaked return value
+      // doesn't bleed into subsequent tests in this file. jest.clearAllMocks
+      // resets mock.calls but not .mockReturnValue, so we have to undo
+      // explicitly.
+      (state.getRecommendationsColumnFilters as jest.Mock).mockReturnValue({});
     });
 
     test('renders recommendations list', async () => {

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -34,6 +34,13 @@ const expandedCells = new Set<string>();
 // Expand-All button handler to populate expandedCells without re-computing.
 let lastVisibleGroupKeys: string[] = [];
 
+// #272 (CR follow-up): cache of the most-recent API-derived summary so
+// rerenders triggered by column-filter changes can keep total_count /
+// total_upfront_cost / avg_payback_months stable while the savings card
+// itself is recomputed client-side from the *visible* recs (so it stays
+// in sync with the per-cell banner range under the table).
+let lastRecommendationsSummary: RecommendationsSummary = {};
+
 // issue #223: resolved GlobalConfig defaults, seeded on page load by
 // loadRecommendations(). Initial values mirror the historical hardcoded
 // defaults so the module is usable before the first API round-trip.
@@ -138,7 +145,14 @@ export async function loadRecommendations(): Promise<void> {
     state.setRecommendations((data.recommendations || []) as unknown as api.Recommendation[]);
     state.clearSelectedRecommendations();
 
-    renderRecommendationsSummary(data.summary || {}, data.recommendations || []);
+    // Cache the API-derived summary so renderRecommendationsList can
+    // recompute the savings card from the visible (post-filter) set on
+    // every rerender — covers initial load, sort-header clicks, column-
+    // filter commits, and the Clear-filters badge. Otherwise an active
+    // filter would shrink the banner range under the table while leaving
+    // the card pinned to the unfiltered totals — the same divergence
+    // #272 was supposed to close.
+    lastRecommendationsSummary = data.summary || {};
     renderRecommendationsList(data.recommendations || []);
 
     // Freshness indicator reflects the last collection timestamp; refreshed
@@ -1127,6 +1141,11 @@ function rebindOpenPopoverAnchor(): void {
 // rerenderRecommendations triggers a full re-render from the latest loaded
 // state. Used by popover commits and the Clear-filters badge so the table
 // reflects new column-filter state immediately.
+//
+// #272 (CR follow-up): the summary card is recomputed inside
+// renderRecommendationsList itself (against the post-filter visible set),
+// so this helper doesn't need to call renderRecommendationsSummary
+// separately — every entry to renderRecommendationsList covers it.
 function rerenderRecommendations(): void {
   const loaded = state.getRecommendations() as unknown as LocalRecommendation[];
   renderRecommendationsList(loaded);
@@ -2354,6 +2373,15 @@ function renderRecommendationsList(loadedRecs: LocalRecommendation[]): void {
     state.getRecommendationsColumnFilters(),
   );
   state.setVisibleRecommendations(recommendations as unknown as readonly api.Recommendation[]);
+
+  // Keep the savings card in sync with the visible (post-filter) set on
+  // every list rerender so the card and the per-cell banner under the
+  // table never diverge (#272 CR follow-up). The cached
+  // lastRecommendationsSummary holds the API-derived counts (total_count,
+  // total_upfront_cost, avg_payback_months); the savings figure itself is
+  // recomputed from `recommendations` inside renderRecommendationsSummary
+  // via the same pageLevelRange the banner uses.
+  renderRecommendationsSummary(lastRecommendationsSummary, recommendations);
 
   // Mount once; update is per-render below.
   mountBottomActionBox();

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -138,7 +138,7 @@ export async function loadRecommendations(): Promise<void> {
     state.setRecommendations((data.recommendations || []) as unknown as api.Recommendation[]);
     state.clearSelectedRecommendations();
 
-    renderRecommendationsSummary(data.summary || {});
+    renderRecommendationsSummary(data.summary || {}, data.recommendations || []);
     renderRecommendationsList(data.recommendations || []);
 
     // Freshness indicator reflects the last collection timestamp; refreshed
@@ -155,9 +155,26 @@ export async function loadRecommendations(): Promise<void> {
   }
 }
 
-function renderRecommendationsSummary(summary: RecommendationsSummary): void {
+function renderRecommendationsSummary(
+  summary: RecommendationsSummary,
+  recommendations: readonly LocalRecommendation[],
+): void {
   const container = document.getElementById('recommendations-summary');
   if (!container) return;
+
+  // Potential Monthly Savings is computed from the same source as the
+  // "Recommended range" banner under the table (closes #272). The previous
+  // implementation rendered `summary.total_monthly_savings` from the API —
+  // a flat sum across every (term, payment) variant of every cell — so a
+  // typical 12-cell page with 2 terms × 3 payments per cell showed up to
+  // ~6× the achievable savings (the user can only buy one variant per
+  // cell). pageLevelRange sums per-cell min/max and stays consistent with
+  // the banner.
+  const groups = groupRecsByCell(recommendations);
+  const plr = pageLevelRange(groups);
+  const savingsText = plr.cellCount > 0 && plr.savingsMax > 0
+    ? formatSavingsRange(plr.savingsMin, plr.savingsMax)
+    : formatCurrency(0);
 
   container.innerHTML = `
     <div class="card">
@@ -166,7 +183,7 @@ function renderRecommendationsSummary(summary: RecommendationsSummary): void {
     </div>
     <div class="card">
       <h3>Potential Monthly Savings</h3>
-      <p class="value savings">${formatCurrency(summary.total_monthly_savings)}</p>
+      <p class="value savings">${savingsText}</p>
     </div>
     <div class="card">
       <h3>Total Upfront Cost</h3>


### PR DESCRIPTION
## Summary

Closes #272. Aligns the **Potential Monthly Savings** stats card with
the **Recommended range** banner under the table.

**Before**: card showed `summary.total_monthly_savings` from the API
— a flat sum across every (term, payment) variant of every cell. On
the 33-rec dev cache the card read **$576** while the banner correctly
read **$235 – $344/mo across 12 cells**. The user can only buy one
variant per cell, so the card overstated achievable savings by ~75-500%
depending on the variant fan-out per cell.

**After**: the card is computed client-side from
`pageLevelRange(groupRecsByCell(recommendations))` — exactly the same
source the banner uses. Renders as a range via the existing
`formatSavingsRange` helper, which collapses "$X – $X" to "$X" for
single-variant cells (so single-cell pages still show one value).

## Changes

- `frontend/src/recommendations.ts:158::renderRecommendationsSummary`
  now takes `recommendations` and recomputes the savings figure from
  the same per-cell min/max sum the banner uses.
- `summary.total_monthly_savings` is no longer read by this view; the
  backend field is left in place for callers outside this view.

## Test plan

- [x] New test `Potential Monthly Savings card mirrors page-level
  range, not the API sum (#272)` — builds 2 cells × 2 variants where
  the API sum is $700 but achievable is $300 – $400, asserts the card
  shows the range and never the inflated total.
- [x] `npm test -- --testPathPattern=recommendations` — 141 / 141
  pass.
- [x] `npm run typecheck` — clean.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed "Potential Monthly Savings" display in the summary card to show page-level savings range computed from per-cell variants instead of API total.

* **Tests**
  * Added test coverage for savings range calculation in recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->