### PR TITLE
fix(recommendations): plumb provider on_demand_cost through to frontend (closes #274)

### DIFF
--- a/frontend/src/__tests__/recommendations.test.ts
+++ b/frontend/src/__tests__/recommendations.test.ts
@@ -2454,6 +2454,80 @@ describe('effectiveSavingsPct', () => {
     expect(pct).not.toBeNull();
     expect(pct!).toBeCloseTo(100, 1);
   });
+
+  // #274: on_demand_cost (when populated by the provider) is used directly
+  // as the denominator instead of reconstructing it from
+  // monthly_cost + savings + amortized. The reconstruction collapses for
+  // Azure all-upfront recs where monthly_cost = $0 and inflates the % well
+  // past realistic ceilings.
+  describe('on_demand_cost preference (#274)', () => {
+    test('repro of the live Azure D11_v2 row with provider-supplied on_demand_cost', () => {
+      // Reconstructed (no on_demand_cost): savings=$29, upfront=$26,
+      // monthly=$0, term=1 → onDemand = 0 + 29 + 2.17 = $31.17 →
+      // pct ≈ 86% (the inflated value the user complained about).
+      // With provider-supplied on_demand_cost = $122.64 (the real Azure
+      // CostWithNoReservedInstances for 2 × Standard_D11_v2 in eastus),
+      // pct ≈ (29 - 2.17) / 122.64 = ~21.9% — within realistic 1-year
+      // RI savings.
+      const pctReconstructed = effectiveSavingsPct(
+        mk({ savings: 29, upfront_cost: 26, monthly_cost: 0, term: 1 }),
+      );
+      expect(pctReconstructed!).toBeGreaterThan(80);
+
+      const pctWithBaseline = effectiveSavingsPct(
+        mk({ savings: 29, upfront_cost: 26, monthly_cost: 0, term: 1, on_demand_cost: 122.64 }),
+      );
+      expect(pctWithBaseline).not.toBeNull();
+      expect(pctWithBaseline!).toBeCloseTo(21.88, 1);
+    });
+
+    test('on_demand_cost overrides reconstruction even when monthly_cost is non-zero', () => {
+      // Demonstrates the preference order: when both are present, the
+      // provider's on_demand_cost wins over the reconstructed value.
+      // Otherwise a stale/cached monthly_cost could override the canonical
+      // baseline silently.
+      const pct = effectiveSavingsPct(
+        mk({ savings: 100, upfront_cost: 0, monthly_cost: 50, term: 1, on_demand_cost: 500 }),
+      );
+      // With baseline: pct = (100 - 0) / 500 * 100 = 20%
+      // Reconstruction would have given: pct = 100 / (50 + 100 + 0) * 100 = 66.7%
+      expect(pct).not.toBeNull();
+      expect(pct!).toBeCloseTo(20, 1);
+    });
+
+    test('on_demand_cost null/undefined falls back to reconstruction (back-compat)', () => {
+      // Pre-#274 cached recs have no on_demand_cost. The frontend
+      // reconstructs as before so older data still renders meaningful
+      // percentages while it gets refreshed.
+      const r = mk({ savings: 100, upfront_cost: 0, monthly_cost: 50, term: 1 });
+      delete (r as { on_demand_cost?: unknown }).on_demand_cost;
+      const pct = effectiveSavingsPct(r);
+      expect(pct).not.toBeNull();
+      expect(pct!).toBeCloseTo(66.67, 1);
+    });
+
+    test('on_demand_cost = 0 from the provider is treated as not-populated (falls back)', () => {
+      // The backend's convertRecommendations writes 0 → nil so this case
+      // is unlikely on a fresh refresh, but defence-in-depth: a literal 0
+      // baseline is impossible (the resource would be free), so the
+      // formula treats it the same as null.
+      const pct = effectiveSavingsPct(
+        mk({ savings: 100, upfront_cost: 0, monthly_cost: 50, term: 1, on_demand_cost: 0 }),
+      );
+      expect(pct).not.toBeNull();
+      expect(pct!).toBeCloseTo(66.67, 1);
+    });
+
+    test('on_demand_cost populated rescues the missing-monthly_cost case', () => {
+      // Without on_demand_cost: monthly_cost === null returns null
+      // (denominator can't be reconstructed). With the provider baseline,
+      // the formula has everything it needs and returns a real value.
+      const r = mk({ savings: 100, upfront_cost: 0, monthly_cost: null, term: 1, on_demand_cost: 250 });
+      const pct = effectiveSavingsPct(r);
+      expect(pct).not.toBeNull();
+      expect(pct!).toBeCloseTo(40, 1);
+    });
+  });
 });
 
 describe('Monthly Cost + Effective % column rendering', () => {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -58,6 +58,12 @@ export interface Recommendation {
   // null when the provider API did not return a monthly recurring breakdown.
   monthly_cost: number | null;
   savings: number;
+  // Canonical on-demand monthly baseline straight from the cloud provider
+  // (Azure CostWithNoReservedInstances, AWS EstimatedMonthlyOnDemandCost).
+  // Optional/null when the provider didn't return a baseline; in that case
+  // the frontend reconstructs on-demand from monthly_cost + savings +
+  // amortized_upfront. When populated it's preferred — see #274.
+  on_demand_cost?: number | null;
   selected: boolean;
   purchased: boolean;
   purchase_id?: string;

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -389,11 +389,23 @@ export function effectiveMonthlySavings(r: LocalRecommendation): number {
  * monthly cost, amortizing the upfront cost over the term. Returns null when
  * the result would require division by zero (on_demand_monthly === 0).
  *
- * Formula (assumes rec.savings excludes upfront amortization — see
- * effectiveMonthlySavings for the semantics note):
+ * Denominator source (closes #274):
+ *   1. If `r.on_demand_cost` is populated (non-null, > 0), use it directly
+ *      — it's the canonical baseline straight from the cloud provider
+ *      (Azure CostWithNoReservedInstances, AWS
+ *      EstimatedMonthlyOnDemandCost).
+ *   2. Otherwise fall back to reconstructing from
+ *      `monthly_cost + savings + amortized_upfront`. This is what the
+ *      frontend always did before #274 plumbed `on_demand_cost` through;
+ *      it stays correct for cleanly-shaped data, but for Azure all-upfront
+ *      recs where `monthly_cost = $0` the reconstructed denominator
+ *      collapses to `savings + amortized` and inflates the percentage well
+ *      past realistic ceilings (~30% real → 86% shown).
+ *
+ * Formula (numerator unchanged — assumes rec.savings excludes upfront
+ * amortization, see effectiveMonthlySavings):
  *   amortized_upfront_per_month = upfront_cost / (term * 12)
  *   effective_monthly_savings   = savings - amortized_upfront_per_month
- *   on_demand_monthly           = monthly_cost + savings + amortized_upfront_per_month
  *   effective_savings_pct       = (effective_monthly_savings / on_demand_monthly) * 100
  *
  * A negative result is valid data — it flags a rec where the upfront cost
@@ -403,14 +415,18 @@ export function effectiveSavingsPct(r: LocalRecommendation): number | null {
   // Per acceptance criteria: term=0 is a data anomaly — render as em-dash.
   if (!r.term) return null;
   // monthly_cost === null means the provider API did not return a recurring
-  // monthly breakdown. We cannot reconstruct on_demand_monthly without it,
-  // so the formula is underdetermined — render as em-dash rather than
-  // collapsing the denominator to savings alone (which produces 100% / neg%).
-  if (r.monthly_cost == null) return null;
+  // monthly breakdown. Without it we can only compute the formula when the
+  // provider also gave us an explicit on_demand_cost; otherwise render as
+  // em-dash rather than collapsing the denominator to savings alone (which
+  // produces 100% / neg%).
+  const hasOnDemand = r.on_demand_cost != null && r.on_demand_cost > 0;
+  if (r.monthly_cost == null && !hasOnDemand) return null;
   const monthsInTerm = r.term * 12;
   const amortized = r.upfront_cost / monthsInTerm;
   const effectiveSavings = r.savings - amortized;
-  const onDemand = r.monthly_cost + r.savings + amortized;
+  const onDemand = hasOnDemand
+    ? (r.on_demand_cost as number)
+    : (r.monthly_cost as number) + r.savings + amortized;
   if (onDemand === 0) return null;
   return (effectiveSavings / onDemand) * 100;
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -75,6 +75,13 @@ export interface LocalRecommendation {
   upfront_cost: number;
   // null = provider API did not return a monthly breakdown (renders as "—").
   monthly_cost?: number | null;
+  // Canonical on-demand monthly baseline straight from the cloud provider
+  // (Azure CostWithNoReservedInstances, AWS EstimatedMonthlyOnDemandCost).
+  // Optional/null when the provider didn't return a baseline; in that case
+  // effectiveSavingsPct reconstructs on-demand from
+  // `monthly_cost + savings + amortized_upfront`. When populated it's
+  // preferred — see #274.
+  on_demand_cost?: number | null;
   cloud_account_id?: string;
   // Populated by the scheduler when any active purchase_suppression
   // matches this rec's 6-tuple. The three fields drive the "recently

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -241,8 +241,22 @@ type RecommendationRecord struct {
 	// Backward-compatible with DynamoDB: existing items with a numeric 0
 	// attribute unmarshal as a pointer to 0.0; absent attributes unmarshal
 	// as nil. No migration needed.
-	MonthlyCost    *float64 `json:"monthly_cost" dynamodbav:"monthly_cost"`
-	Savings        float64  `json:"savings" dynamodbav:"savings"`
+	MonthlyCost *float64 `json:"monthly_cost" dynamodbav:"monthly_cost"`
+	Savings     float64  `json:"savings" dynamodbav:"savings"`
+	// OnDemandCost is the canonical on-demand monthly baseline for the
+	// recommended commitment, sourced directly from the cloud provider
+	// (Azure `CostWithNoReservedInstances`, AWS Cost Explorer
+	// `EstimatedMonthlyOnDemandCost`). Persisted via the recommendations
+	// row's JSONB `payload` column — no DDL needed.
+	//
+	// nil means the provider API did not return a baseline; the frontend
+	// falls back to reconstructing on-demand from `monthly_cost + savings
+	// + amortized_upfront`. When non-nil, the frontend prefers the raw
+	// value over reconstruction so anomalies in the reconstructed
+	// denominator (e.g. Azure all-upfront recs where monthly_cost=$0
+	// collapses the denominator) don't inflate the displayed effective
+	// savings %. See #274.
+	OnDemandCost   *float64 `json:"on_demand_cost,omitempty" dynamodbav:"on_demand_cost,omitempty"`
 	Selected       bool     `json:"selected" dynamodbav:"selected"`
 	Purchased      bool     `json:"purchased" dynamodbav:"purchased"`
 	PurchaseID     string   `json:"purchase_id,omitempty" dynamodbav:"purchase_id,omitempty"`

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -927,6 +927,21 @@ func (s *Scheduler) maybeKickBackgroundRefresh(freshness *config.Recommendations
 	}()
 }
 
+// nonZeroPtr returns &v when v > 0, else nil. Used by convertRecommendations
+// to pass the provider's on-demand baseline (rec.OnDemandCost) through as a
+// nullable pointer — a literal 0 from the provider means "not populated"
+// because every real on-demand baseline is non-zero. Always returning a
+// pointer would poison the frontend's "is this populated?" branch
+// (recommendations.ts::effectiveSavingsPct, see #274). Extracted to keep
+// convertRecommendations under the gocyclo gate (.golangci.yml
+// min-complexity: 15; pre-commit hook flags > 10).
+func nonZeroPtr(v float64) *float64 {
+	if v > 0 {
+		return &v
+	}
+	return nil
+}
+
 // convertRecommendations converts common.Recommendation slice to config.RecommendationRecord slice
 func (s *Scheduler) convertRecommendations(recs []common.Recommendation, providerName string) []config.RecommendationRecord {
 	records := make([]config.RecommendationRecord, 0, len(recs))
@@ -1007,7 +1022,8 @@ func (s *Scheduler) convertRecommendations(recs []common.Recommendation, provide
 			UpfrontCost:  rec.CommitmentCost,
 			MonthlyCost:  rec.RecurringMonthlyCost, // nil when provider API didn't return a monthly breakdown
 			Savings:      rec.EstimatedSavings,
-			Selected:     true, // Default to selected
+			OnDemandCost: nonZeroPtr(rec.OnDemandCost), // nil when provider API didn't return a baseline; frontend falls back to reconstruction (#274)
+			Selected:     true,                         // Default to selected
 			Purchased:    false,
 		})
 	}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1432,6 +1432,45 @@ func TestScheduler_ConvertRecommendations_Empty(t *testing.T) {
 	assert.Len(t, records, 0)
 }
 
+// TestScheduler_ConvertRecommendations_OnDemandCost pins #274: the
+// canonical on-demand baseline must round-trip from common.Recommendation
+// through to the persisted RecommendationRecord so the frontend can use
+// it directly instead of reconstructing from monthly_cost + savings +
+// amortized (which collapses for Azure all-upfront recs where
+// monthly_cost = $0).
+func TestScheduler_ConvertRecommendations_OnDemandCost(t *testing.T) {
+	scheduler := &Scheduler{}
+
+	recommendations := []common.Recommendation{
+		// Provider populated OnDemandCost — must propagate as a non-nil pointer.
+		{
+			Provider: common.ProviderAzure, Service: common.ServiceCompute,
+			Region: "eastus", ResourceType: "Standard_D11_v2",
+			Count: 2, Term: "1yr", PaymentOption: "all-upfront",
+			OnDemandCost: 122.64, CommitmentCost: 1050.0, EstimatedSavings: 35.0,
+		},
+		// Provider returned 0 (not populated) — must round-trip as nil so the
+		// frontend's "is this populated?" branch stays accurate. A literal $0
+		// on-demand baseline is impossible (it would mean the resource is
+		// free, in which case there's nothing to recommend reserving).
+		{
+			Provider: common.ProviderAWS, Service: common.ServiceEC2,
+			Region: "us-east-1", ResourceType: "m5.large",
+			Count: 1, Term: "3yr", PaymentOption: "all-upfront",
+			OnDemandCost: 0, CommitmentCost: 1000.0, EstimatedSavings: 500.0,
+		},
+	}
+
+	records := scheduler.convertRecommendations(recommendations, "azure")
+	require.Len(t, records, 2)
+
+	require.NotNil(t, records[0].OnDemandCost)
+	assert.InDelta(t, 122.64, *records[0].OnDemandCost, 0.001)
+
+	assert.Nil(t, records[1].OnDemandCost,
+		"OnDemandCost=0 from the provider must round-trip as nil, not as a pointer to 0.0")
+}
+
 // TestScheduler_ConvertRecommendations_IDUniqueness pins issue #187 +
 // #188: the rec ID must include term, account, and engine — not just
 // (provider, service, region, resource_type, payment) — otherwise


### PR DESCRIPTION
## Summary

Closes #274. Fixes the implausibly-high "Effective %" values by
plumbing the cloud providers' canonical on-demand baseline through to
the frontend.

**Before**: the frontend reconstructed the on-demand denominator from
`monthly_cost + savings + amortized_upfront`. For Azure all-upfront
recs `monthly_cost = $0`, so the reconstruction collapses to
`savings + amortized` — much smaller than the real on-demand cost.
Result: the `Standard_D11_v2 1y all-upfront` row from the screenshot
read **85.9%**.

**After**: when the provider populates `on_demand_cost` (Azure
`CostWithNoReservedInstances`, AWS `EstimatedMonthlyOnDemandCost`),
the frontend uses it directly. With the real on-demand of $122.64 for
the same row, the percentage drops to **21.9%** — within realistic
1-year RI ceilings.

## Plumbing path

```
provider SDK
  → pkg/common/types.go::Recommendation.OnDemandCost  (already populated)
  → internal/config/types.go::RecommendationRecord.OnDemandCost  ← NEW
  → JSONB `payload` column in recommendations table  (no DDL migration —
                                                      record persisted as
                                                      JSON via existing
                                                      payload column)
  → internal/api/types.go (uses config.RecommendationRecord directly — no API change)
  → frontend/src/api/types.ts::Recommendation.on_demand_cost  ← NEW
  → frontend/src/types.ts::LocalRecommendation.on_demand_cost  ← NEW
  → effectiveSavingsPct prefers it; falls back to reconstruction if null/0
```

## Compatibility

- **Older cached recs** without `on_demand_cost` → fallback to the
  previous reconstruction formula (visually unchanged).
- **Provider returns 0** → `nonZeroPtr` writes nil so the frontend
  falls back. Defensive: a literal $0 baseline is impossible (the
  resource would be free).
- **`monthly_cost === null` + populated `on_demand_cost`** → previously
  returned `null` (em-dash); now returns a real value. New rescue path.

## Test plan

- [x] `TestScheduler_ConvertRecommendations_OnDemandCost` — pins
  populated values round-trip and 0 → nil.
- [x] 5 new frontend tests in `effectiveSavingsPct`'s
  "on_demand_cost preference (#274)" sub-describe:
  - live `D11_v2` repro (86% reconstructed → 22% with baseline)
  - override behaviour (baseline wins over reconstruction)
  - null fallback (back-compat with older cached recs)
  - 0 fallback (defensive — provider returned 0)
  - rescue of `monthly_cost === null` when baseline is populated
- [x] `npm test -- --testPathPattern=recommendations` — 145 / 145 pass.
- [x] `npm run typecheck` — clean.
- [x] `go test ./internal/scheduler/...` — pass.
- [x] `gocyclo -over 10` clean (helper extraction keeps
  `convertRecommendations` under the gate).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recommendations now utilize provider-supplied on-demand cost baselines for more accurate calculations.

* **Bug Fixes**
  * Fixed inflated effective savings percentage calculations for all-upfront pricing scenarios.
  * Improved fallback logic when on-demand cost baseline data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->