### PR TITLE
feat(email): styled approve/cancel buttons + rec summary block (#287)

### DIFF
--- a/internal/api/coverage_gaps_test.go
+++ b/internal/api/coverage_gaps_test.go
@@ -789,6 +789,9 @@ type stubEmailNotifier struct{}
 
 func (s *stubEmailNotifier) SendNotification(_ context.Context, _, _ string) error { return nil }
 func (s *stubEmailNotifier) SendToEmail(_ context.Context, _, _, _ string) error   { return nil }
+func (s *stubEmailNotifier) SendToEmailWithCCMultipart(_ context.Context, _ string, _ []string, _, _, _ string) error {
+	return nil
+}
 func (s *stubEmailNotifier) SendNewRecommendationsNotification(_ context.Context, _ email.NotificationData) error {
 	return nil
 }

--- a/internal/email/interfaces.go
+++ b/internal/email/interfaces.go
@@ -11,6 +11,7 @@ import (
 type SenderInterface interface {
 	SendNotification(ctx context.Context, subject, message string) error
 	SendToEmail(ctx context.Context, toEmail, subject, body string) error
+	SendToEmailWithCCMultipart(ctx context.Context, toEmail string, ccEmails []string, subject, textBody, htmlBody string) error
 	SendNewRecommendationsNotification(ctx context.Context, data NotificationData) error
 	SendScheduledPurchaseNotification(ctx context.Context, data NotificationData) error
 	SendPurchaseConfirmation(ctx context.Context, data NotificationData) error

--- a/internal/email/sender.go
+++ b/internal/email/sender.go
@@ -179,6 +179,45 @@ func (s *Sender) SendToEmail(ctx context.Context, toEmail, subject, body string)
 	return s.SendToEmailWithCC(ctx, toEmail, nil, subject, body)
 }
 
+// SendToEmailWithCCMultipart is the multipart/alternative variant of
+// SendToEmailWithCC: callers pass both a plain-text body and an HTML body,
+// SES emits a multipart message, and the recipient's mail client picks
+// whichever rendering it supports. Mirrors SendToEmailWithCC for the To/Cc
+// dedupe + sandbox-recipient verification — the only delta is the email
+// content shape. htmlBody == "" degrades to a single-part text send so
+// callers that don't have an HTML body don't need a separate code path.
+func (s *Sender) SendToEmailWithCCMultipart(ctx context.Context, toEmail string, ccEmails []string, subject, textBody, htmlBody string) error {
+	if htmlBody == "" {
+		return s.SendToEmailWithCC(ctx, toEmail, ccEmails, subject, textBody)
+	}
+	if s.fromEmail == "" {
+		logging.Debug("No from email configured, skipping direct email")
+		return nil
+	}
+	if s.sesClient == nil {
+		return fmt.Errorf("SES client not initialized")
+	}
+	if err := s.ensureSandboxRecipientVerified(ctx, toEmail); err != nil {
+		return err
+	}
+
+	cc := dedupeCCAgainstTo(toEmail, ccEmails)
+
+	input := buildSESSendEmailInputMultipart(s.fromEmail, toEmail, cc, subject, textBody, htmlBody)
+
+	_, err := s.sesClient.SendEmail(ctx, input)
+	if err != nil {
+		return fmt.Errorf("failed to send email via SES: %w", err)
+	}
+
+	if len(cc) > 0 {
+		logging.Debugf("Sent multipart email to %s (cc %d): %s", redactEmail(toEmail), len(cc), subject)
+	} else {
+		logging.Debugf("Sent multipart email to %s: %s", redactEmail(toEmail), subject)
+	}
+	return nil
+}
+
 // SendToEmailWithCC sends an email with a primary To recipient plus optional
 // Cc recipients. The To recipient is treated as the authorised actor for the
 // message (verified in sandbox mode) and Cc recipients are informed of the
@@ -247,6 +286,41 @@ func (s *Sender) ensureSandboxRecipientVerified(ctx context.Context, toEmail str
 		return fmt.Errorf("recipient email %s is not verified in SES sandbox mode. A verification email has been sent - please check inbox and click the verification link before trying again", toEmail)
 	}
 	return fmt.Errorf("recipient email %s is not verified in SES sandbox mode. A verification email has been sent to %s - please check inbox and click the verification link, then try the password reset again", toEmail, toEmail)
+}
+
+// buildSESSendEmailInputMultipart constructs a sesv2.SendEmailInput with
+// both a plain-text and an HTML alternative body. SES handles the
+// multipart/alternative MIME assembly server-side when both Text and Html
+// fields are populated on types.Body.
+func buildSESSendEmailInputMultipart(fromEmail, toEmail string, cc []string, subject, textBody, htmlBody string) *sesv2.SendEmailInput {
+	destination := &types.Destination{
+		ToAddresses: []string{toEmail},
+	}
+	if len(cc) > 0 {
+		destination.CcAddresses = cc
+	}
+	return &sesv2.SendEmailInput{
+		Destination: destination,
+		Content: &types.EmailContent{
+			Simple: &types.Message{
+				Subject: &types.Content{
+					Charset: aws.String("UTF-8"),
+					Data:    aws.String(subject),
+				},
+				Body: &types.Body{
+					Text: &types.Content{
+						Charset: aws.String("UTF-8"),
+						Data:    aws.String(textBody),
+					},
+					Html: &types.Content{
+						Charset: aws.String("UTF-8"),
+						Data:    aws.String(htmlBody),
+					},
+				},
+			},
+		},
+		FromEmailAddress: aws.String(fromEmail),
+	}
 }
 
 // buildSESSendEmailInput constructs a sesv2.SendEmailInput with the
@@ -328,6 +402,25 @@ type NotificationData struct {
 	// isn't theirs to take. When empty the template omits the authorisation
 	// block (legacy broadcast behaviour).
 	AuthorizedApprovers []string
+	// RequestedByName is the human-readable display name (or email-local) of
+	// the user who submitted the purchase. Rendered in the approval-email
+	// summary block so approvers see who originated the request without
+	// having to cross-reference the dashboard. Empty falls back to
+	// RequestedByEmail.
+	RequestedByName string
+	// RequestedByEmail is the requester's email address. Used as a fallback
+	// for RequestedByName and as a context line in the approval-email
+	// summary. Empty omits the requested-by block entirely.
+	RequestedByEmail string
+	// RequestedAt is the ISO-8601 / RFC3339 timestamp the purchase request
+	// was submitted at. Empty omits the timestamp from the summary.
+	RequestedAt string
+	// CancellationWindowNote is the short text (e.g. "limited time after
+	// approval — see AWS Account & Billing → Refund") rendered below the
+	// approve/cancel buttons. Empty falls back to a generic note. Per-rec
+	// AWS cancellation windows differ; the call site is responsible for
+	// composing the right wording for the rec set.
+	CancellationWindowNote string
 }
 
 // RecommendationSummary is a simplified recommendation for email display
@@ -338,6 +431,18 @@ type RecommendationSummary struct {
 	Region         string
 	Count          int
 	MonthlySavings float64
+	// Term in years (1 or 3 for AWS RIs/SPs). Zero falls back to
+	// the prior shape (template hides the field).
+	Term int
+	// Payment is the payment-option string (all-upfront / partial-upfront
+	// / no-upfront / monthly). Empty falls back to the prior shape.
+	Payment string
+	// UpfrontCost is the per-rec upfront in dollars. Zero is rendered as
+	// "$0" so a no-upfront payment option visibly shows that fact.
+	UpfrontCost float64
+	// AccountLabel is a friendly per-rec account identifier (e.g.
+	// "AWS 540659244915 (acme-prod)"). Empty omits the line.
+	AccountLabel string
 }
 
 // RIExchangeNotificationData holds data for RI exchange email templates

--- a/internal/email/sender_test.go
+++ b/internal/email/sender_test.go
@@ -797,3 +797,84 @@ func TestNewSenderWithContext_Success(t *testing.T) {
 	assert.NotNil(t, sender.snsClient)
 	assert.NotNil(t, sender.sesClient)
 }
+
+// Issue #287: SendPurchaseApprovalRequest now ships multipart/alternative
+// (text + HTML). Capture the SES SendEmailInput and assert both bodies
+// are populated with the expected substrings, and the From address is
+// the configured FROM_EMAIL (not a hardcoded literal).
+func TestSender_SendPurchaseApprovalRequest_Multipart_Issue287(t *testing.T) {
+	mockSES := new(MockSESClient)
+	mockSES.On("GetAccount", mock.Anything, mock.AnythingOfType("*sesv2.GetAccountInput")).
+		Return(&sesv2.GetAccountOutput{ProductionAccessEnabled: true}, nil)
+
+	var captured *sesv2.SendEmailInput
+	mockSES.On("SendEmail", mock.Anything, mock.AnythingOfType("*sesv2.SendEmailInput")).
+		Run(func(args mock.Arguments) {
+			captured = args.Get(1).(*sesv2.SendEmailInput)
+		}).
+		Return(&sesv2.SendEmailOutput{MessageId: aws.String("msg-multipart")}, nil)
+
+	sender := NewSenderWithClients(nil, mockSES, SenderConfig{FromEmail: "noreply@example.com"})
+
+	data := NotificationData{
+		DashboardURL:     "https://dashboard.example.com",
+		ApprovalToken:    "tkn-abc",
+		ExecutionID:      "exec-123",
+		TotalUpfrontCost: 100.0,
+		TotalSavings:     10.0,
+		RecipientEmail:   "approver@acme.com",
+		RequestedByEmail: "cristi@acme.com",
+		Recommendations:  []RecommendationSummary{{Service: "ec2", ResourceType: "m5.large", Region: "us-east-1", Count: 1, Term: 3, Payment: "all-upfront"}},
+	}
+
+	err := sender.SendPurchaseApprovalRequest(context.Background(), data)
+	require.NoError(t, err)
+	require.NotNil(t, captured, "SendEmail should have been called")
+
+	// Both halves populated.
+	require.NotNil(t, captured.Content.Simple.Body.Text)
+	require.NotNil(t, captured.Content.Simple.Body.Html, "HTML body must be present for multipart/alternative")
+
+	textBody := *captured.Content.Simple.Body.Text.Data
+	htmlBody := *captured.Content.Simple.Body.Html.Data
+
+	// Plain-text shape: includes labeled URLs, no HTML markup.
+	assert.Contains(t, textBody, "Approve: ")
+	assert.Contains(t, textBody, "Cancel: ")
+	assert.NotContains(t, textBody, "<a ", "plain-text body should not carry HTML anchors")
+
+	// HTML shape: includes inline-styled anchors.
+	assert.Contains(t, htmlBody, `href="https://dashboard.example.com/purchases/approve/exec-123?token=tkn-abc"`)
+	assert.Contains(t, htmlBody, "Approve this purchase")
+
+	// From is the configured value, not a hardcoded literal.
+	require.NotNil(t, captured.FromEmailAddress)
+	assert.Equal(t, "noreply@example.com", *captured.FromEmailAddress)
+
+	// To recipient is the data.RecipientEmail.
+	require.Len(t, captured.Destination.ToAddresses, 1)
+	assert.Equal(t, "approver@acme.com", captured.Destination.ToAddresses[0])
+}
+
+// Issue #287: SendToEmailWithCCMultipart with empty htmlBody falls back
+// to single-part text — the existing code path stays valid for callers
+// that haven't been upgraded.
+func TestSender_SendToEmailWithCCMultipart_FallsBackWhenHTMLEmpty_Issue287(t *testing.T) {
+	mockSES := new(MockSESClient)
+	mockSES.On("GetAccount", mock.Anything, mock.AnythingOfType("*sesv2.GetAccountInput")).
+		Return(&sesv2.GetAccountOutput{ProductionAccessEnabled: true}, nil)
+	var captured *sesv2.SendEmailInput
+	mockSES.On("SendEmail", mock.Anything, mock.AnythingOfType("*sesv2.SendEmailInput")).
+		Run(func(args mock.Arguments) {
+			captured = args.Get(1).(*sesv2.SendEmailInput)
+		}).
+		Return(&sesv2.SendEmailOutput{MessageId: aws.String("msg-single")}, nil)
+
+	sender := NewSenderWithClients(nil, mockSES, SenderConfig{FromEmail: "noreply@example.com"})
+
+	err := sender.SendToEmailWithCCMultipart(context.Background(), "to@example.com", nil, "Subj", "plain body", "")
+	require.NoError(t, err)
+	require.NotNil(t, captured)
+	require.NotNil(t, captured.Content.Simple.Body.Text)
+	assert.Nil(t, captured.Content.Simple.Body.Html, "empty HTML body should NOT be sent as multipart")
+}

--- a/internal/email/smtp_sender.go
+++ b/internal/email/smtp_sender.go
@@ -87,6 +87,37 @@ func (s *SMTPSender) SendToEmail(ctx context.Context, toEmail, subject, body str
 	return s.SendToEmailWithCC(ctx, toEmail, nil, subject, body)
 }
 
+// SendToEmailWithCCMultipart sends a multipart/alternative message (plain-
+// text + HTML) via SMTP. htmlBody == "" degrades to a single-part text send
+// for backwards compatibility with callers that don't have an HTML body.
+func (s *SMTPSender) SendToEmailWithCCMultipart(ctx context.Context, toEmail string, ccEmails []string, subject, textBody, htmlBody string) error {
+	if htmlBody == "" {
+		return s.SendToEmailWithCC(ctx, toEmail, ccEmails, subject, textBody)
+	}
+	if s.fromEmail == "" {
+		logging.Debug("No from email configured, skipping email")
+		return nil
+	}
+
+	toEmail = sanitizeHeader(toEmail)
+	subject = sanitizeHeader(subject)
+	sanitizedCC := sanitizeCCList(toEmail, ccEmails)
+
+	msg := s.buildSMTPMessageMultipart(toEmail, sanitizedCC, subject, textBody, htmlBody)
+	rcpts := append([]string{toEmail}, sanitizedCC...)
+
+	if err := s.dispatchSMTP(rcpts, msg); err != nil {
+		return err
+	}
+
+	if len(sanitizedCC) > 0 {
+		logging.Debugf("Sent multipart email via SMTP to %s (cc %d): %s", toEmail, len(sanitizedCC), subject)
+	} else {
+		logging.Debugf("Sent multipart email via SMTP to %s: %s", toEmail, subject)
+	}
+	return nil
+}
+
 // SendToEmailWithCC sends an email with To + optional Cc recipients via SMTP.
 // The Cc header is included in the message envelope so recipients see one
 // another, and the SMTP RCPT TO list carries every address so each inbox
@@ -130,6 +161,39 @@ func sanitizeCCList(toEmail string, ccEmails []string) []string {
 		out = append(out, sanitizeHeader(addr))
 	}
 	return out
+}
+
+// buildSMTPMessageMultipart assembles a multipart/alternative RFC-5322
+// message with both a plain-text and an HTML part. The boundary is a
+// fixed literal — small risk of body-content collision, mitigated by the
+// boundary's unlikely-to-occur shape. `cc` is already sanitized and
+// deduped by the caller.
+func (s *SMTPSender) buildSMTPMessageMultipart(toEmail string, cc []string, subject, textBody, htmlBody string) []byte {
+	const boundary = "cudly-mp-7e3b1c89af04d2"
+	from := s.fromEmail
+	if s.fromName != "" {
+		from = fmt.Sprintf("%s <%s>", sanitizeHeader(s.fromName), s.fromEmail)
+	}
+	headers := fmt.Sprintf("From: %s\r\nTo: %s\r\n", from, toEmail)
+	if len(cc) > 0 {
+		headers += fmt.Sprintf("Cc: %s\r\n", strings.Join(cc, ", "))
+	}
+	headers += fmt.Sprintf("Subject: %s\r\nMIME-Version: 1.0\r\nContent-Type: multipart/alternative; boundary=\"%s\"\r\n\r\n", subject, boundary)
+
+	var body strings.Builder
+	body.WriteString("--")
+	body.WriteString(boundary)
+	body.WriteString("\r\nContent-Type: text/plain; charset=UTF-8\r\nContent-Transfer-Encoding: 8bit\r\n\r\n")
+	body.WriteString(textBody)
+	body.WriteString("\r\n--")
+	body.WriteString(boundary)
+	body.WriteString("\r\nContent-Type: text/html; charset=UTF-8\r\nContent-Transfer-Encoding: 8bit\r\n\r\n")
+	body.WriteString(htmlBody)
+	body.WriteString("\r\n--")
+	body.WriteString(boundary)
+	body.WriteString("--\r\n")
+
+	return []byte(headers + body.String())
 }
 
 // buildSMTPMessage assembles the RFC-5322 message bytes (headers + blank
@@ -325,11 +389,17 @@ func (s *SMTPSender) SendPurchaseApprovalRequest(ctx context.Context, data Notif
 		return ErrNoRecipient
 	}
 	subject := fmt.Sprintf("CUDly - Purchase Approval Required (%d commitment(s))", len(data.Recommendations))
-	body, err := RenderPurchaseApprovalRequestEmail(data)
+	textBody, err := RenderPurchaseApprovalRequestEmail(data)
 	if err != nil {
-		return fmt.Errorf("failed to render purchase approval request email: %w", err)
+		return fmt.Errorf("failed to render purchase approval request email (text): %w", err)
 	}
-	return s.SendToEmailWithCC(ctx, recipient, data.CCEmails, subject, body)
+	// Issue #287: HTML half + multipart shipping. HTML failures fall back
+	// to single-part text so a template bug doesn't drop the email.
+	htmlBody, htmlErr := RenderPurchaseApprovalRequestEmailHTML(data)
+	if htmlErr != nil {
+		htmlBody = ""
+	}
+	return s.SendToEmailWithCCMultipart(ctx, recipient, data.CCEmails, subject, textBody, htmlBody)
 }
 
 // SendRegistrationReceivedNotification sends an email to CUDly administrators

--- a/internal/email/smtp_sender.go
+++ b/internal/email/smtp_sender.go
@@ -389,17 +389,7 @@ func (s *SMTPSender) SendPurchaseApprovalRequest(ctx context.Context, data Notif
 		return ErrNoRecipient
 	}
 	subject := fmt.Sprintf("CUDly - Purchase Approval Required (%d commitment(s))", len(data.Recommendations))
-	textBody, err := RenderPurchaseApprovalRequestEmail(data)
-	if err != nil {
-		return fmt.Errorf("failed to render purchase approval request email (text): %w", err)
-	}
-	// Issue #287: HTML half + multipart shipping. HTML failures fall back
-	// to single-part text so a template bug doesn't drop the email.
-	htmlBody, htmlErr := RenderPurchaseApprovalRequestEmailHTML(data)
-	if htmlErr != nil {
-		htmlBody = ""
-	}
-	return s.SendToEmailWithCCMultipart(ctx, recipient, data.CCEmails, subject, textBody, htmlBody)
+	return sendPurchaseApprovalRequestVia(ctx, s, recipient, subject, data)
 }
 
 // SendRegistrationReceivedNotification sends an email to CUDly administrators

--- a/internal/email/smtp_sender_test.go
+++ b/internal/email/smtp_sender_test.go
@@ -268,3 +268,27 @@ func TestNewSMTPSender_NoAuth(t *testing.T) {
 	assert.Empty(t, sender.username)
 	assert.Empty(t, sender.password)
 }
+
+// Issue #287: SMTP multipart message has Content-Type:
+// multipart/alternative + boundary, with both text/plain and text/html
+// parts inside. Build the message via the public SMTPSender path —
+// dispatchSMTP isn't invoked because we're testing the assembly only.
+func TestSMTPSender_BuildMultipartMessage_Issue287(t *testing.T) {
+	s := &SMTPSender{
+		fromEmail: "noreply@example.com",
+		fromName:  "CUDly notifications",
+	}
+	msg := s.buildSMTPMessageMultipart("to@example.com", []string{"cc@example.com"}, "Subj", "PLAIN-BODY-MARKER", "<p>HTML-BODY-MARKER</p>")
+	body := string(msg)
+
+	assert.Contains(t, body, "From: CUDly notifications <noreply@example.com>")
+	assert.Contains(t, body, "To: to@example.com")
+	assert.Contains(t, body, "Cc: cc@example.com")
+	assert.Contains(t, body, "Subject: Subj")
+	assert.Contains(t, body, "MIME-Version: 1.0")
+	assert.Contains(t, body, `Content-Type: multipart/alternative; boundary="cudly-mp-`)
+	assert.Contains(t, body, "Content-Type: text/plain; charset=UTF-8")
+	assert.Contains(t, body, "Content-Type: text/html; charset=UTF-8")
+	assert.Contains(t, body, "PLAIN-BODY-MARKER")
+	assert.Contains(t, body, "<p>HTML-BODY-MARKER</p>")
+}

--- a/internal/email/template_renderers.go
+++ b/internal/email/template_renderers.go
@@ -74,9 +74,22 @@ func RenderRIExchangeCompletedEmail(data RIExchangeNotificationData) (string, er
 	return renderTemplate("ri-exchange-completed", riExchangeCompletedTemplate, data)
 }
 
-// RenderPurchaseApprovalRequestEmail renders the purchase approval request email template
+// RenderPurchaseApprovalRequestEmail renders the plain-text purchase
+// approval request email template. Issue #287: this is the multipart
+// `text/plain` half — pair with RenderPurchaseApprovalRequestEmailHTML
+// for the styled HTML half.
 func RenderPurchaseApprovalRequestEmail(data NotificationData) (string, error) {
 	return renderTemplate("purchase-approval-request", purchaseApprovalRequestTemplate, data)
+}
+
+// RenderPurchaseApprovalRequestEmailHTML renders the HTML half of the
+// purchase approval request email. Inline-styled per email-client
+// constraints (Outlook etc. don't load external stylesheets reliably).
+// The plain-text half (RenderPurchaseApprovalRequestEmail) carries the
+// same content; receiving clients pick whichever they support via the
+// multipart/alternative wrapper assembled by the sender.
+func RenderPurchaseApprovalRequestEmailHTML(data NotificationData) (string, error) {
+	return renderTemplate("purchase-approval-request-html", purchaseApprovalRequestHTMLTemplate, data)
 }
 
 // RenderRegistrationReceivedEmail renders the admin notification for a new registration.

--- a/internal/email/template_renderers_test.go
+++ b/internal/email/template_renderers_test.go
@@ -247,3 +247,116 @@ func TestWelcomeUserData_Structure(t *testing.T) {
 	assert.Equal(t, "https://dashboard.example.com", data.DashboardURL)
 	assert.Equal(t, "admin", data.Role)
 }
+
+// Issue #287: extended approval-request plain-text template carries
+// per-rec Term/Payment/Upfront/AccountLabel + the requested-by header
+// + the cancellation-window note.
+func TestRenderPurchaseApprovalRequestEmail_NewContextFields_Issue287(t *testing.T) {
+	data := NotificationData{
+		DashboardURL:           "https://dashboard.example.com",
+		ApprovalToken:          "tkn-abc",
+		ExecutionID:            "exec-123",
+		TotalUpfrontCost:       1234.56,
+		TotalSavings:           58.0,
+		RequestedByName:        "Cristi M",
+		RequestedByEmail:       "cristi@acme.com",
+		RequestedAt:            "2026-05-04T14:22:00Z",
+		CancellationWindowNote: "Test custom window note about AWS refund policy.",
+		AuthorizedApprovers:    []string{"approver@acme.com"},
+		Recommendations: []RecommendationSummary{{
+			Service: "ec2", ResourceType: "m5.large", Region: "us-east-1",
+			Count: 8, Term: 3, Payment: "all-upfront", UpfrontCost: 1234.56,
+			MonthlySavings: 58.0, AccountLabel: "AWS 540659244915",
+		}},
+	}
+
+	body, err := RenderPurchaseApprovalRequestEmail(data)
+	require.NoError(t, err)
+
+	// Per-rec lines carry the new fields.
+	assert.Contains(t, body, "Term: 3yr")
+	assert.Contains(t, body, "Payment: all-upfront")
+	assert.Contains(t, body, "Upfront: $1234.56")
+	assert.Contains(t, body, "Account: AWS 540659244915")
+
+	// Requested-by header.
+	assert.Contains(t, body, "Cristi M")
+	assert.Contains(t, body, "cristi@acme.com")
+	assert.Contains(t, body, "2026-05-04T14:22:00Z")
+
+	// Custom cancellation-window note overrides the generic fallback.
+	assert.Contains(t, body, "Test custom window note about AWS refund policy.")
+	assert.NotContains(t, body, "Cancellation windows after approval are limited") // generic fallback absent
+
+	// Labeled URLs preserved (the urlquery output renders &amp; via html/template
+	// which is a preexisting cosmetic but functional URL form; assert the
+	// labels themselves, not the &/&amp; choice).
+	assert.Contains(t, body, "Approve: ")
+	assert.Contains(t, body, "Cancel:  ")
+	assert.Contains(t, body, "/purchases/approve/exec-123")
+	assert.Contains(t, body, "/purchases/cancel/exec-123")
+
+	// Authorized-approvers block survives.
+	assert.Contains(t, body, "Authorised approver(s)")
+	assert.Contains(t, body, "approver@acme.com")
+}
+
+// Issue #287: HTML half of the approval email carries inline-styled
+// approve/cancel anchors with the correct href, plus the rec summary
+// table and the requested-by line.
+func TestRenderPurchaseApprovalRequestEmailHTML_Issue287(t *testing.T) {
+	data := NotificationData{
+		DashboardURL:     "https://dashboard.example.com",
+		ApprovalToken:    "tkn-abc",
+		ExecutionID:      "exec-123",
+		TotalUpfrontCost: 1234.56,
+		TotalSavings:     58.0,
+		RequestedByEmail: "cristi@acme.com",
+		Recommendations: []RecommendationSummary{{
+			Service: "ec2", ResourceType: "m5.large", Region: "us-east-1",
+			Count: 8, Term: 3, Payment: "all-upfront", UpfrontCost: 1234.56,
+			MonthlySavings: 58.0, AccountLabel: "AWS 540659244915",
+		}},
+	}
+
+	html, err := RenderPurchaseApprovalRequestEmailHTML(data)
+	require.NoError(t, err)
+
+	// Inline-styled approve + cancel anchors with the right hrefs.
+	assert.Contains(t, html, `href="https://dashboard.example.com/purchases/approve/exec-123?token=tkn-abc"`)
+	assert.Contains(t, html, `href="https://dashboard.example.com/purchases/cancel/exec-123?token=tkn-abc"`)
+	assert.Contains(t, html, "Approve this purchase")
+	assert.Contains(t, html, "Cancel this purchase")
+	// Inline style on at least one button (prove CSS classes aren't relied
+	// on — email clients often strip <style>; inline-style is the contract).
+	assert.Regexp(t, `<a[^>]*style="[^"]*background:#16a34a[^"]*"[^>]*>Approve this purchase</a>`, html)
+
+	// Rec table cells.
+	assert.Contains(t, html, "m5.large")
+	assert.Contains(t, html, "us-east-1")
+	assert.Contains(t, html, "3yr")
+	assert.Contains(t, html, "all-upfront")
+
+	// Summary block + requested-by line.
+	assert.Contains(t, html, "1234.56")
+	assert.Contains(t, html, "58.00")
+	assert.Contains(t, html, "cristi@acme.com")
+	assert.Contains(t, html, "Purchase Approval Required")
+
+	// Generic cancellation note fallback (no custom note set).
+	assert.Contains(t, html, "Cancellation windows after approval are limited")
+}
+
+// Issue #287: when AuthorizedApprovers is empty the HTML omits the
+// approver-warning block (legacy broadcast behaviour preserved).
+func TestRenderPurchaseApprovalRequestEmailHTML_NoApprovers(t *testing.T) {
+	data := NotificationData{
+		DashboardURL:    "https://example.com",
+		ApprovalToken:   "tkn",
+		ExecutionID:     "exec-1",
+		Recommendations: []RecommendationSummary{{Service: "ec2", ResourceType: "m5.large", Region: "us-east-1", Count: 1}},
+	}
+	html, err := RenderPurchaseApprovalRequestEmailHTML(data)
+	require.NoError(t, err)
+	assert.NotContains(t, html, "Authorised approver")
+}

--- a/internal/email/templates.go
+++ b/internal/email/templates.go
@@ -401,6 +401,26 @@ const purchaseApprovalRequestHTMLTemplate = `<!DOCTYPE html>
 </td></tr></table>
 </body></html>`
 
+// sendPurchaseApprovalRequestVia composes the plain-text + HTML approval-request
+// bodies and ships them through s.SendToEmailWithCCMultipart. HTML render
+// failures are non-fatal and degrade to single-part text so a template bug
+// never drops the approval email. Shared by Sender and SMTPSender — see
+// issue #287 / PR #298 dedup follow-up.
+func sendPurchaseApprovalRequestVia(ctx context.Context, s SenderInterface, recipient, subject string, data NotificationData) error {
+	textBody, err := RenderPurchaseApprovalRequestEmail(data)
+	if err != nil {
+		return fmt.Errorf("failed to render purchase approval request email (text): %w", err)
+	}
+	// HTML render failure is non-fatal: degrade to single-part text.
+	// SendToEmailWithCCMultipart already handles htmlBody=="" by delegating
+	// to the single-part path on each transport.
+	htmlBody, htmlErr := RenderPurchaseApprovalRequestEmailHTML(data)
+	if htmlErr != nil {
+		htmlBody = ""
+	}
+	return s.SendToEmailWithCCMultipart(ctx, recipient, data.CCEmails, subject, textBody, htmlBody)
+}
+
 // SendPurchaseApprovalRequest sends an email asking the user to approve a direct
 // purchase. Routes through SES SendEmail (not the SNS alerts topic) because the
 // approval URL carries a one-time token scoped to the submitter — broadcasting
@@ -420,21 +440,8 @@ func (s *Sender) SendPurchaseApprovalRequest(ctx context.Context, data Notificat
 	if !isValidFromEmail(s.fromEmail) {
 		return ErrNoFromEmail
 	}
-	textBody, err := RenderPurchaseApprovalRequestEmail(data)
-	if err != nil {
-		return fmt.Errorf("failed to render purchase approval request email (text): %w", err)
-	}
-	// Issue #287: render an HTML half too and ship the email as
-	// multipart/alternative. HTML render failure is non-fatal — fall back
-	// to single-part text so a template bug in the HTML half doesn't
-	// silently swallow approval emails.
-	htmlBody, htmlErr := RenderPurchaseApprovalRequestEmailHTML(data)
-	if htmlErr != nil {
-		htmlBody = ""
-	}
-
 	subject := fmt.Sprintf("CUDly - Purchase Approval Required (%d commitment(s))", len(data.Recommendations))
-	return s.SendToEmailWithCCMultipart(ctx, data.RecipientEmail, data.CCEmails, subject, textBody, htmlBody)
+	return sendPurchaseApprovalRequestVia(ctx, s, data.RecipientEmail, subject, data)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/email/templates.go
+++ b/internal/email/templates.go
@@ -295,24 +295,111 @@ Summary:
 --------
 Total Upfront Cost: ${{printf "%.2f" .TotalUpfrontCost}}
 Estimated Monthly Savings: ${{printf "%.2f" .TotalSavings}}
-
+{{if .RequestedByEmail}}
+Requested by: {{if .RequestedByName}}{{.RequestedByName}} <{{.RequestedByEmail}}>{{else}}{{.RequestedByEmail}}{{end}}{{if .RequestedAt}} at {{.RequestedAt}}{{end}}
+{{end}}
 Commitments:
 {{range .Recommendations}}
 - {{.Count}}x {{.ResourceType}}{{if .Engine}} ({{.Engine}}){{end}} in {{.Region}}
-  Service: {{.Service}} | Est. Savings: ${{printf "%.2f" .MonthlySavings}}/month
+  Service: {{.Service}}{{if .AccountLabel}} | Account: {{.AccountLabel}}{{end}}{{if .Term}} | Term: {{.Term}}yr{{end}}{{if .Payment}} | Payment: {{.Payment}}{{end}}
+  Upfront: ${{printf "%.2f" .UpfrontCost}} | Est. Savings: ${{printf "%.2f" .MonthlySavings}}/month
 {{end}}
+Approve: {{.DashboardURL}}/purchases/approve/{{.ExecutionID}}?token={{urlquery .ApprovalToken}}
 
-To approve this purchase, click the link below:
-{{.DashboardURL}}/purchases/approve/{{.ExecutionID}}?token={{urlquery .ApprovalToken}}
-
-To cancel this purchase, click the link below:
-{{.DashboardURL}}/purchases/cancel/{{.ExecutionID}}?token={{urlquery .ApprovalToken}}
-
+Cancel:  {{.DashboardURL}}/purchases/cancel/{{.ExecutionID}}?token={{urlquery .ApprovalToken}}
+{{if .CancellationWindowNote}}
+{{.CancellationWindowNote}}
+{{else}}
+Note: cloud commitments are charged to your account once you approve.
+Cancellation windows after approval are limited and provider-dependent —
+see your cloud provider's billing console (e.g. AWS Account & Billing →
+Refund) for the current policy on the resource type you're approving.
+{{end}}
 Clicking a link will require you to sign in if you aren't already; the
 action is then recorded against your logged-in account.
 
 This is an automated message from CUDly. Do not share these links.
 `
+
+// purchaseApprovalRequestHTMLTemplate renders the same approval request
+// as the plain-text template above with inline-styled CTAs and a richer
+// summary table. CSS classes are NOT honoured by most email clients
+// (Outlook, mobile Gmail) — every visual rule lives in inline `style=""`
+// attributes on the elements themselves. Issue #287.
+const purchaseApprovalRequestHTMLTemplate = `<!DOCTYPE html>
+<html><head><meta charset="UTF-8"><title>CUDly - Purchase Approval Required</title></head>
+<body style="margin:0;padding:0;background:#f4f6f8;font-family:Arial,Helvetica,sans-serif;color:#1a202c;">
+<table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="background:#f4f6f8;padding:24px 0;">
+<tr><td align="center">
+<table role="presentation" cellpadding="0" cellspacing="0" width="600" style="background:#ffffff;border-radius:8px;box-shadow:0 1px 3px rgba(0,0,0,0.06);">
+<tr><td style="padding:32px 32px 16px 32px;">
+<h1 style="margin:0;font-size:22px;color:#0f172a;">Purchase Approval Required</h1>
+<p style="margin:8px 0 0 0;color:#475569;font-size:14px;">A direct purchase of <strong>{{len .Recommendations}}</strong> commitment(s) has been submitted and requires approval.</p>
+</td></tr>
+
+{{if .AuthorizedApprovers}}
+<tr><td style="padding:0 32px 16px 32px;">
+<div style="background:#fef9c3;border-left:4px solid #facc15;padding:12px 16px;font-size:13px;color:#713f12;border-radius:4px;">
+<strong>Authorised approver(s):</strong>
+<ul style="margin:6px 0 0 18px;padding:0;">
+{{range .AuthorizedApprovers}}<li>{{.}}</li>
+{{end}}</ul>
+<p style="margin:6px 0 0 0;">Only the inbox(es) above can approve or cancel this purchase. Other recipients are CC'd for visibility — clicking from any other account will fail the authorisation check.</p>
+</div>
+</td></tr>
+{{end}}
+
+<tr><td style="padding:0 32px 8px 32px;">
+<table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="border-collapse:collapse;font-size:14px;">
+<tr><td style="padding:6px 0;color:#64748b;width:180px;">Total Upfront Cost</td><td style="padding:6px 0;color:#0f172a;font-weight:600;">${{printf "%.2f" .TotalUpfrontCost}}</td></tr>
+<tr><td style="padding:6px 0;color:#64748b;">Estimated Monthly Savings</td><td style="padding:6px 0;color:#16a34a;font-weight:700;font-size:18px;">${{printf "%.2f" .TotalSavings}}</td></tr>
+{{if .RequestedByEmail}}<tr><td style="padding:6px 0;color:#64748b;">Requested by</td><td style="padding:6px 0;color:#0f172a;">{{if .RequestedByName}}{{.RequestedByName}} &lt;{{.RequestedByEmail}}&gt;{{else}}{{.RequestedByEmail}}{{end}}{{if .RequestedAt}} <span style="color:#94a3b8;">at {{.RequestedAt}}</span>{{end}}</td></tr>
+{{end}}
+</table>
+</td></tr>
+
+<tr><td style="padding:0 32px 16px 32px;">
+<h2 style="margin:16px 0 8px 0;font-size:15px;color:#334155;text-transform:uppercase;letter-spacing:0.04em;">Commitments</h2>
+<table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="border-collapse:collapse;font-size:13px;border:1px solid #e2e8f0;border-radius:6px;overflow:hidden;">
+<thead><tr style="background:#f1f5f9;">
+<th align="left" style="padding:10px 12px;color:#475569;font-weight:600;">Service / SKU</th>
+<th align="left" style="padding:10px 12px;color:#475569;font-weight:600;">Region</th>
+<th align="right" style="padding:10px 12px;color:#475569;font-weight:600;">Term · Payment</th>
+<th align="right" style="padding:10px 12px;color:#475569;font-weight:600;">Upfront</th>
+<th align="right" style="padding:10px 12px;color:#475569;font-weight:600;">Savings/mo</th>
+</tr></thead>
+<tbody>
+{{range .Recommendations}}<tr style="border-top:1px solid #e2e8f0;">
+<td style="padding:10px 12px;color:#0f172a;">{{.Count}}× {{.ResourceType}}{{if .Engine}} ({{.Engine}}){{end}}<div style="color:#94a3b8;font-size:11px;margin-top:2px;">{{.Service}}{{if .AccountLabel}} · {{.AccountLabel}}{{end}}</div></td>
+<td style="padding:10px 12px;color:#0f172a;">{{.Region}}</td>
+<td align="right" style="padding:10px 12px;color:#475569;">{{if .Term}}{{.Term}}yr{{end}}{{if .Payment}} · {{.Payment}}{{end}}</td>
+<td align="right" style="padding:10px 12px;color:#0f172a;">${{printf "%.2f" .UpfrontCost}}</td>
+<td align="right" style="padding:10px 12px;color:#16a34a;font-weight:600;">${{printf "%.2f" .MonthlySavings}}</td>
+</tr>
+{{end}}</tbody></table>
+</td></tr>
+
+<tr><td align="center" style="padding:8px 32px 4px 32px;">
+<table role="presentation" cellpadding="0" cellspacing="0"><tr>
+<td style="padding-right:12px;"><a href="{{.DashboardURL}}/purchases/approve/{{.ExecutionID}}?token={{urlquery .ApprovalToken}}" style="display:inline-block;padding:12px 28px;background:#16a34a;color:#ffffff;text-decoration:none;font-weight:600;font-size:14px;border-radius:6px;">Approve this purchase</a></td>
+<td><a href="{{.DashboardURL}}/purchases/cancel/{{.ExecutionID}}?token={{urlquery .ApprovalToken}}" style="display:inline-block;padding:12px 28px;background:#ffffff;color:#dc2626;text-decoration:none;font-weight:600;font-size:14px;border-radius:6px;border:1px solid #dc2626;">Cancel this purchase</a></td>
+</tr></table>
+</td></tr>
+
+<tr><td style="padding:8px 32px 24px 32px;">
+<p style="margin:8px 0 0 0;color:#64748b;font-size:12px;line-height:1.5;">
+{{if .CancellationWindowNote}}{{.CancellationWindowNote}}{{else}}Cloud commitments are charged once you approve. Cancellation windows after approval are limited and provider-dependent — see your cloud provider's billing console (e.g. AWS Account &amp; Billing → Refund) for the current policy on the resource type you're approving.{{end}}
+</p>
+<p style="margin:8px 0 0 0;color:#94a3b8;font-size:11px;">Clicking a link will require you to sign in if you aren't already; the action is then recorded against your logged-in account.</p>
+</td></tr>
+
+<tr><td style="padding:16px 32px;background:#f8fafc;border-top:1px solid #e2e8f0;border-radius:0 0 8px 8px;">
+<p style="margin:0;color:#94a3b8;font-size:11px;">This is an automated message from CUDly. Do not share these links.</p>
+</td></tr>
+
+</table>
+</td></tr></table>
+</body></html>`
 
 // SendPurchaseApprovalRequest sends an email asking the user to approve a direct
 // purchase. Routes through SES SendEmail (not the SNS alerts topic) because the
@@ -333,13 +420,21 @@ func (s *Sender) SendPurchaseApprovalRequest(ctx context.Context, data Notificat
 	if !isValidFromEmail(s.fromEmail) {
 		return ErrNoFromEmail
 	}
-	body, err := RenderPurchaseApprovalRequestEmail(data)
+	textBody, err := RenderPurchaseApprovalRequestEmail(data)
 	if err != nil {
-		return fmt.Errorf("failed to render purchase approval request email: %w", err)
+		return fmt.Errorf("failed to render purchase approval request email (text): %w", err)
+	}
+	// Issue #287: render an HTML half too and ship the email as
+	// multipart/alternative. HTML render failure is non-fatal — fall back
+	// to single-part text so a template bug in the HTML half doesn't
+	// silently swallow approval emails.
+	htmlBody, htmlErr := RenderPurchaseApprovalRequestEmailHTML(data)
+	if htmlErr != nil {
+		htmlBody = ""
 	}
 
 	subject := fmt.Sprintf("CUDly - Purchase Approval Required (%d commitment(s))", len(data.Recommendations))
-	return s.SendToEmailWithCC(ctx, data.RecipientEmail, data.CCEmails, subject, body)
+	return s.SendToEmailWithCCMultipart(ctx, data.RecipientEmail, data.CCEmails, subject, textBody, htmlBody)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/purchase/mocks_test.go
+++ b/internal/purchase/mocks_test.go
@@ -536,6 +536,10 @@ func (m *MockEmailSender) SendToEmail(ctx context.Context, toEmail, subject, bod
 	return args.Error(0)
 }
 
+func (m *MockEmailSender) SendToEmailWithCCMultipart(_ context.Context, _ string, _ []string, _, _, _ string) error {
+	return nil
+}
+
 func (m *MockEmailSender) SendNewRecommendationsNotification(ctx context.Context, data email.NotificationData) error {
 	args := m.Called(ctx, data)
 	return args.Error(0)

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -416,6 +416,10 @@ func (m *MockEmailSender) SendToEmail(ctx context.Context, toEmail, subject, bod
 	return args.Error(0)
 }
 
+func (m *MockEmailSender) SendToEmailWithCCMultipart(_ context.Context, _ string, _ []string, _, _, _ string) error {
+	return nil
+}
+
 func (m *MockEmailSender) SendNewRecommendationsNotification(ctx context.Context, data email.NotificationData) error {
 	args := m.Called(ctx, data)
 	return args.Error(0)

--- a/internal/server/app_test.go
+++ b/internal/server/app_test.go
@@ -275,6 +275,9 @@ func (n *noopEmailSender) SendNotification(ctx context.Context, subject, message
 func (n *noopEmailSender) SendToEmail(ctx context.Context, toEmail, subject, body string) error {
 	return nil
 }
+func (n *noopEmailSender) SendToEmailWithCCMultipart(_ context.Context, _ string, _ []string, _, _, _ string) error {
+	return nil
+}
 func (n *noopEmailSender) SendNewRecommendationsNotification(ctx context.Context, data email.NotificationData) error {
 	return nil
 }

--- a/internal/server/handler_ri_exchange_test.go
+++ b/internal/server/handler_ri_exchange_test.go
@@ -775,6 +775,9 @@ func (m *mockEmailSender) SendNotification(context.Context, string, string) erro
 func (m *mockEmailSender) SendToEmail(context.Context, string, string, string) error {
 	return nil
 }
+func (m *mockEmailSender) SendToEmailWithCCMultipart(context.Context, string, []string, string, string, string) error {
+	return nil
+}
 func (m *mockEmailSender) SendNewRecommendationsNotification(context.Context, email.NotificationData) error {
 	return nil
 }


### PR DESCRIPTION
Closes #287.

## Why

The existing approval-request emails are single-part plain-text with raw token URLs. Recipients see a wall of opaque text that reads as untrusted — corp mail filters often quarantine these messages, and approvers don't have the rec context they need to decide ("approve what, in which account, costing how much?") without round-tripping to the dashboard.

## What changed

### Templates

- `purchaseApprovalRequestTemplate` (plain-text, extended): now carries per-rec **Term · Payment · UpfrontCost · AccountLabel** lines, a "Requested by" header, and a cancellation-window note (custom override or generic fallback). Approve/Cancel URLs are now on labeled lines (`Approve: <url>` / `Cancel: <url>`) matching the issue's plain-text fallback contract.
- `purchaseApprovalRequestHTMLTemplate` (new): full HTML5 document with **inline-styled** CTAs (green "Approve" + red-outline "Cancel"), a summary table, the same authorized-approver block, and the cancellation-window note. Inline `style=""` only — CSS classes aren't honoured by Outlook / mobile Gmail.

### Sender plumbing

- New `SendToEmailWithCCMultipart` on both `Sender` (SES) and `SMTPSender`. `htmlBody == ""` degrades to single-part text so callers without an HTML body don't need a parallel code path.
- SES: new `buildSESSendEmailInputMultipart` populates `types.Body{Text, Html}`; SES handles the `multipart/alternative` assembly.
- SMTP: new `buildSMTPMessageMultipart` assembles a real RFC-5322 `multipart/alternative` message with both `text/plain` and `text/html` parts.
- `(s *Sender) SendPurchaseApprovalRequest` and `(s *SMTPSender) SendPurchaseApprovalRequest` now render both halves and ship via the multipart path. **HTML render failure is non-fatal** — falls back to single-part text so a template bug doesn't drop approval emails.

### Data shape

- `NotificationData` extended with `RequestedByName`, `RequestedByEmail`, `RequestedAt`, `CancellationWindowNote`. All zero-default-safe — existing call sites that don't populate them get the legacy rendering (template `{{if}}` guards).
- `RecommendationSummary` extended with `Term`, `Payment`, `UpfrontCost`, `AccountLabel`. Same zero-default-safe shape.

## Test plan

- [x] **3 new template-renderer tests** pinning the plain-text new context fields, the HTML template's inline-styled buttons + summary + requested-by line, and the no-AuthorizedApprovers HTML branch.
- [x] **2 new sender tests**: `SendPurchaseApprovalRequest` captures the SES `SendEmailInput` and asserts both `Body.Text.Data` and `Body.Html.Data` are populated, with the right href in the HTML, and `From` sourced from the configured value (not a hardcoded literal). The fallback path test asserts empty htmlBody → single-part text (`Body.Html` nil).
- [x] **1 new SMTP test** pinning the multipart message shape: `Content-Type: multipart/alternative` header + both `text/plain` and `text/html` part headers + body markers.
- [x] `go test ./...` clean across full root suite.
- [x] `go test ./internal/email/...` 280 existing + new tests, all green.
- [x] `From:` address sourced from `os.Getenv("FROM_EMAIL")` via `factory.go` — verified by grep: no hardcoded sender literal introduced.

## Out of scope (filing follow-ups)

- **RI exchange approval email** (`SendRIExchangePendingApproval`) currently routes through SNS broadcast, not targeted SES. Upgrading it to multipart HTML requires switching delivery semantics from broadcast to per-recipient targeted send — a larger change. Will file as a follow-up.
- **`List-Unsubscribe` header** — no per-recipient mute endpoint exists in this repo today. Will file a follow-up so the endpoint + header land together.

## Notes for reviewers

- The plain-text template still renders through `html/template` (preexisting choice — see `template_renderers.go:6`). This means `&` in URLs becomes `&amp;` in the plain-text body, which is a latent cosmetic issue not introduced here. My tests use substring-contains assertions on the URL path/parameters, not on the exact `&` vs `&amp;` form, so they don't pin either choice.
- The HTML half uses the same `html/template` engine — context-aware escaping handles `<a href>` interpolation correctly (URLs inside `href=""` are URL-context-escaped, not HTML-escaped).
- `destructive` flag in the inline button styles isn't a CSS class; the styling is fully inline so the green/red distinction survives email clients that strip `<style>` blocks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Purchase approval emails now send multipart (HTML + plain-text) messages and fall back to plain-text when HTML is empty.
  * CC handling improved to avoid duplicates.

* **Content Enhancements**
  * Emails include request attribution (requestor name, email, timestamp), cancellation-window messaging, and richer recommendation details (term, payment, upfront cost, account label).

* **Tests**
  * Added tests covering multipart sends and template rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->