### PR TITLE
fix(dashboard): defensive guards prevent 'is not iterable' on partial backend responses (closes #304)

### DIFF
--- a/frontend/src/__tests__/dashboard.test.ts
+++ b/frontend/src/__tests__/dashboard.test.ts
@@ -551,6 +551,90 @@ describe('Dashboard Module', () => {
       expect(savingsCard?.textContent).toContain('$300');
       expect(savingsCard?.textContent).toContain('$400');
     });
+
+    // #304: getRecommendations returns null (apiRequest catch-block fallback
+    // when response.json() fails on a 2xx with empty/non-JSON body). The
+    // Array.isArray guard in loadDashboard must coerce null → [] so
+    // groupRecsByCell never receives a non-iterable value.
+    test('#304: getRecommendations returning null does not throw "is not iterable"', async () => {
+      (api.getRecommendations as jest.Mock).mockResolvedValue(null);
+      (api.getDashboardSummary as jest.Mock).mockResolvedValue({
+        potential_monthly_savings: 500,
+        total_recommendations: 2,
+        active_commitments: 1,
+        committed_monthly: 100,
+        current_coverage: 50,
+        target_coverage: 80,
+        ytd_savings: 200,
+        by_service: {}
+      });
+      (api.getUpcomingPurchases as jest.Mock).mockResolvedValue({ purchases: [] });
+
+      // Must not throw.
+      await expect(loadDashboard()).resolves.toBeUndefined();
+
+      // The rest of the dashboard must still render.
+      const summary = document.getElementById('summary');
+      expect(summary?.innerHTML).toContain('Active Commitments');
+      expect(summary?.innerHTML).toContain('Current Coverage');
+      expect(summary?.innerHTML).toContain('YTD Savings');
+
+      // Savings card falls back to $0 when recs are absent.
+      const savingsCard = summary?.querySelector('.card');
+      expect(savingsCard?.textContent).toContain('Potential Monthly Savings');
+      expect(savingsCard?.innerHTML).toContain('$0');
+    });
+
+    // #304: getRecommendations returns a non-array object (e.g. a wrapped
+    // envelope or unexpected backend shape). Same coercion requirement.
+    test('#304: getRecommendations returning a non-array object does not throw "is not iterable"', async () => {
+      // Simulate an unexpected envelope shape from the backend.
+      (api.getRecommendations as jest.Mock).mockResolvedValue({ recommendations: [], total: 0 } as unknown);
+      (api.getDashboardSummary as jest.Mock).mockResolvedValue({
+        potential_monthly_savings: 400,
+        total_recommendations: 0,
+        active_commitments: 0,
+        committed_monthly: 0,
+        current_coverage: 0,
+        target_coverage: 80,
+        ytd_savings: 0,
+        by_service: {}
+      });
+      (api.getUpcomingPurchases as jest.Mock).mockResolvedValue({ purchases: [] });
+
+      await expect(loadDashboard()).resolves.toBeUndefined();
+
+      const summary = document.getElementById('summary');
+      expect(summary?.innerHTML).toContain('Active Commitments');
+
+      // Savings card falls back to $0.
+      const savingsCard = summary?.querySelector('.card');
+      expect(savingsCard?.innerHTML).toContain('$0');
+    });
+
+    // #304: summaryData.by_service missing entirely (null/undefined from
+    // backend). renderSavingsChart receives `undefined || {}` = {} which
+    // is safe; verify no throw and the error banner does not appear.
+    test('#304: summaryData missing by_service field does not throw', async () => {
+      (api.getDashboardSummary as jest.Mock).mockResolvedValue({
+        potential_monthly_savings: 0,
+        total_recommendations: 0,
+        active_commitments: 0,
+        committed_monthly: 0,
+        current_coverage: 0,
+        target_coverage: 80,
+        ytd_savings: 0,
+        // by_service intentionally omitted
+      });
+      (api.getUpcomingPurchases as jest.Mock).mockResolvedValue({ purchases: [] });
+
+      await expect(loadDashboard()).resolves.toBeUndefined();
+
+      const summary = document.getElementById('summary');
+      // The error banner must NOT appear.
+      expect(summary?.querySelector('.error')).toBeNull();
+      expect(summary?.innerHTML).toContain('Active Commitments');
+    });
   });
 
   describe('savings-trend chart', () => {

--- a/frontend/src/dashboard.ts
+++ b/frontend/src/dashboard.ts
@@ -110,9 +110,15 @@ export async function loadDashboard(): Promise<void> {
     // api.Recommendation and LocalRecommendation are structurally identical
     // except for provider: string vs provider: Provider. The provider values
     // from the API are always the union members at runtime, so this cast is safe.
-    const recs = recsResult.status === 'fulfilled'
-      ? (recsResult.value as unknown as LocalRecommendation[])
-      : ([] as LocalRecommendation[]);
+    // Defensive Array.isArray guard: apiRequest's catch block returns `null` when
+    // response.json() fails (HTTP 2xx with empty/non-JSON body), so the settled
+    // value may be null or a non-array shape even when status === 'fulfilled'.
+    // #304: that non-array value reaches groupRecsByCell which iterates via
+    // `for...of`, throwing "X is not iterable" and blanking the dashboard.
+    const rawRecs = recsResult.status === 'fulfilled' ? recsResult.value : null;
+    const recs: readonly LocalRecommendation[] = Array.isArray(rawRecs)
+      ? (rawRecs as unknown as LocalRecommendation[])
+      : [];
 
     if (summaryResult.status === 'rejected') {
       throw summaryResult.reason as Error;
@@ -147,11 +153,21 @@ function renderDashboardSummary(data: DashboardSummary, recs: readonly LocalReco
   // avoiding the ~6x inflation of summing every variant of every cell that
   // the flat summary.potential_monthly_savings carries.
   // Falls back to formatCurrency(0) when recs is empty or fetch failed.
-  const groups = groupRecsByCell(recs);
-  const range = pageLevelRange(groups);
-  const savingsDisplay = range.cellCount > 0
-    ? formatSavingsRange(range.savingsMin, range.savingsMax)
-    : formatCurrency(0);
+  // Soft-fail (#304): wrap in try/catch so an unexpected non-iterable shape
+  // that slips past the Array.isArray guard in loadDashboard (e.g. if
+  // groupRecsByCell is called from a path that bypasses the guard) cannot
+  // blank the entire dashboard — the savings card degrades to $0 instead.
+  let savingsDisplay: string;
+  try {
+    const groups = groupRecsByCell(recs);
+    const range = pageLevelRange(groups);
+    savingsDisplay = range.cellCount > 0
+      ? formatSavingsRange(range.savingsMin, range.savingsMax)
+      : formatCurrency(0);
+  } catch (recErr) {
+    console.warn('Dashboard: failed to compute savings range from recommendations:', recErr);
+    savingsDisplay = formatCurrency(0);
+  }
 
   // When no recommendations and no commitments exist, "100% coverage" is
   // misleading — nothing is being tracked. Show a dash instead.


### PR DESCRIPTION
## Summary

- `getRecommendations()` can resolve to `null` (when `apiRequest`'s JSON-parse catch fires on a 2xx with empty/non-JSON body) or an unexpected object shape — both reach `groupRecsByCell()` which uses `for...of`, throwing `"X is not iterable"` and replacing the entire dashboard with an error banner.
- Added `Array.isArray()` guard in `loadDashboard()` to coerce any non-array fulfilled value to `[]` before it reaches `groupRecsByCell()`.
- Added try/catch soft-fail in `renderDashboardSummary()` around the savings-range computation so the Potential Monthly Savings card degrades to `$0` rather than blanking the dashboard if the guard is ever bypassed.

## Fault site (PR #295 — commit e4a52f918)

```ts
// Before: no guard — null/object from apiRequest lands directly in groupRecsByCell
const recs = recsResult.status === 'fulfilled'
  ? (recsResult.value as unknown as LocalRecommendation[])
  : [];
```

## Regression tests added

- `#304: getRecommendations returning null does not throw "is not iterable"`
- `#304: getRecommendations returning a non-array object does not throw "is not iterable"`
- `#304: summaryData missing by_service field does not throw`

All 24 dashboard tests pass.

## Test plan

- [ ] Run `cd frontend && npm test -- --testPathPattern=dashboard` — all 24 tests pass
- [ ] Verify the three new `#304` tests are green
- [ ] Manually test with a backend returning 5xx for `/recommendations` — other cards still render, savings card shows `$0`

Closes #304

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Dashboard now gracefully handles unexpected recommendation data formats, preventing application crashes when the API returns null or other malformed response data
* The savings calculation automatically falls back to displaying $0 when encountering unexpected data structures, instead of causing the interface to crash
* Dashboard rendering continues to work correctly even when summary data is missing optional fields

<!-- end of auto-generated comment: release notes by coderabbit.ai -->