### PR TITLE
fix(recommendations/aws): plumb on_demand_cost for canonical Effective Savings % (closes #303)

### DIFF
--- a/frontend/src/__tests__/recommendations.test.ts
+++ b/frontend/src/__tests__/recommendations.test.ts
@@ -3248,6 +3248,55 @@ describe('effectiveSavingsPct', () => {
       expect(pct).not.toBeNull();
       expect(pct!).toBeCloseTo(40, 1);
     });
+
+    // #303: AWS RI and SP fixtures — the same on_demand_cost preference
+    // applies to AWS recommendations (previously only verified for Azure).
+    describe('AWS provider fixtures (#303)', () => {
+      test('AWS EC2 RI: on_demand_cost from EstimatedMonthlyOnDemandCost is used as denominator', () => {
+        // Real-world shape: 2 × m5.large 1yr partial-upfront.
+        // EstimatedMonthlyOnDemandCost = $150 (AWS CE field plumbed via
+        // parseAWSCostDetails → common.Recommendation.OnDemandCost).
+        // savings = $45, upfront = $120 → amortized = $10/mo.
+        // effectiveSavings = 45 - 10 = $35.
+        // pct = 35 / 150 × 100 ≈ 23.3%.
+        // Without on_demand_cost the reconstruction would give:
+        //   onDemand = 60 + 45 + 10 = $115 → pct ≈ 30.4% (wrong).
+        const pct = effectiveSavingsPct(
+          mk({ savings: 45, upfront_cost: 120, monthly_cost: 60, term: 1, on_demand_cost: 150 }),
+        );
+        expect(pct).not.toBeNull();
+        // pct = (45 - 10) / 150 × 100 = 23.33…
+        expect(pct!).toBeCloseTo(23.33, 1);
+      });
+
+      test('AWS Compute SP: on_demand_cost from CurrentAverageHourlyOnDemandSpend×730 is used as denominator', () => {
+        // SP rows carry monthly_cost = the recurring commitment charge, not
+        // the full on-demand baseline. Without on_demand_cost the
+        // reconstruction would over- or under-count the denominator.
+        // Here: savings=$200, monthly_cost=$800 (commitment), on_demand_cost=$1000.
+        // Reconstruction would give: onDemand = 800 + 200 + 0 = $1000 — same
+        // in this clean case, but diverges for partial-upfront SP where
+        // monthly_cost ≠ hourlyCommitment × 730.
+        // effectiveSavings = 200 - 0 = $200; pct = 200 / 1000 × 100 = 20%.
+        const pct = effectiveSavingsPct(
+          mk({ savings: 200, upfront_cost: 0, monthly_cost: 800, term: 1, on_demand_cost: 1000 }),
+        );
+        expect(pct).not.toBeNull();
+        expect(pct!).toBeCloseTo(20, 1);
+      });
+
+      test('AWS SP no-upfront with null monthly_cost: on_demand_cost alone is sufficient', () => {
+        // SP recommendation where the backend did not populate monthly_cost
+        // (e.g. all-upfront SP with recurring = $0 stored as nil).
+        // With on_demand_cost the formula is fully determined.
+        const pct = effectiveSavingsPct(
+          mk({ savings: 300, upfront_cost: 0, monthly_cost: null, term: 1, on_demand_cost: 1500 }),
+        );
+        expect(pct).not.toBeNull();
+        // effectiveSavings = 300 - 0 = 300; pct = 300 / 1500 × 100 = 20%
+        expect(pct!).toBeCloseTo(20, 1);
+      });
+    });
   });
 });
 

--- a/providers/aws/recommendations/parser_sp.go
+++ b/providers/aws/recommendations/parser_sp.go
@@ -136,6 +136,17 @@ func (c *Client) parseSavingsPlanDetail(
 	monthlySavings := parseOptionalFloat("EstimatedMonthlySavingsAmount", detail.EstimatedMonthlySavingsAmount)
 	savingsPercent := parseOptionalFloat("EstimatedSavingsPercentage", detail.EstimatedSavingsPercentage)
 	upfrontCost := parseOptionalFloat("UpfrontCost", detail.UpfrontCost)
+	// onDemandCost is the canonical monthly on-demand baseline for this SP
+	// recommendation. AWS Cost Explorer returns the average hourly on-demand
+	// spend over the lookback period in CurrentAverageHourlyOnDemandSpend;
+	// multiplying by hoursPerMonth gives the monthly equivalent, which is the
+	// denominator AWS uses internally when computing EstimatedSavingsPercentage.
+	// We surface it as OnDemandCost so the frontend can use the provider-
+	// supplied value directly instead of reconstructing from
+	// monthly_cost + savings + amortized (which is less accurate for SP rows
+	// where monthly_cost reflects only the no-upfront recurring charge, not
+	// the full on-demand baseline). See #303.
+	onDemandCost := parseOptionalFloat("CurrentAverageHourlyOnDemandSpend", detail.CurrentAverageHourlyOnDemandSpend) * hoursPerMonth
 
 	planTypeStr := string(planType)
 	switch planType {
@@ -187,6 +198,7 @@ func (c *Client) parseSavingsPlanDetail(
 		EstimatedSavings:     monthlySavings,
 		SavingsPercentage:    savingsPercent,
 		CommitmentCost:       upfrontCost,
+		OnDemandCost:         onDemandCost,
 		RecurringMonthlyCost: recurringMonthlyCost,
 		Timestamp:            time.Now(),
 		Account:              accountID,

--- a/providers/aws/recommendations/parser_sp_additional_test.go
+++ b/providers/aws/recommendations/parser_sp_additional_test.go
@@ -302,3 +302,58 @@ func TestGetSavingsPlansRecommendations_EmptyFilters(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, recs)
 }
+
+// TestParseSavingsPlanDetail_OnDemandCost pins #303: the canonical monthly
+// on-demand baseline must be computed from CurrentAverageHourlyOnDemandSpend
+// × 730 and surfaced as OnDemandCost so the frontend can use the provider-
+// supplied value instead of reconstructing from monthly_cost + savings +
+// amortized (which is inaccurate for SP rows where monthly_cost only reflects
+// the recurring charge, not the full on-demand baseline).
+func TestParseSavingsPlanDetail_OnDemandCost(t *testing.T) {
+	client := &Client{}
+
+	params := common.RecommendationParams{
+		PaymentOption:  "no-upfront",
+		Term:           "1yr",
+		LookbackPeriod: "30d",
+	}
+
+	tests := []struct {
+		name         string
+		detail       *types.SavingsPlansPurchaseRecommendationDetail
+		wantOnDemand float64
+	}{
+		{
+			name: "on_demand_cost populated from CurrentAverageHourlyOnDemandSpend",
+			// CurrentAverageHourlyOnDemandSpend = $1.37/hr × 730 hr/mo = $1000.10/mo
+			detail: &types.SavingsPlansPurchaseRecommendationDetail{
+				HourlyCommitmentToPurchase:        aws.String("1.00"),
+				EstimatedMonthlySavingsAmount:     aws.String("200.00"),
+				EstimatedSavingsPercentage:        aws.String("20.0"),
+				CurrentAverageHourlyOnDemandSpend: aws.String("1.3699"),
+			},
+			wantOnDemand: 1.3699 * hoursPerMonth,
+		},
+		{
+			name: "on_demand_cost is zero when CurrentAverageHourlyOnDemandSpend is absent",
+			// nil field → parseOptionalFloat returns 0 → 0 × 730 = 0.
+			// nonZeroPtr in convertRecommendations will turn 0 → nil so the
+			// frontend falls back to reconstruction as before #303.
+			detail: &types.SavingsPlansPurchaseRecommendationDetail{
+				HourlyCommitmentToPurchase:    aws.String("1.00"),
+				EstimatedMonthlySavingsAmount: aws.String("200.00"),
+				EstimatedSavingsPercentage:    aws.String("20.0"),
+			},
+			wantOnDemand: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := client.parseSavingsPlanDetail(tt.detail, params, types.SupportedSavingsPlansTypeComputeSp)
+			require.NotNil(t, rec)
+			assert.InDelta(t, tt.wantOnDemand, rec.OnDemandCost, 0.001,
+				"OnDemandCost should equal CurrentAverageHourlyOnDemandSpend × 730")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Plumbs `OnDemandCost` for AWS Savings Plans recommendations by computing it from `CurrentAverageHourlyOnDemandSpend × 730` in `parseSavingsPlanDetail` — the same field AWS Cost Explorer uses internally for `EstimatedSavingsPercentage`.
- AWS RI was already plumbed (via `parseAWSCostDetails → EstimatedMonthlyOnDemandCost`) and the scheduler already forwarded it (both landed in #277); this PR closes the SP gap.
- Adds `TestParseSavingsPlanDetail_OnDemandCost` in `parser_sp_additional_test.go` (SP provider regression test, AC #4).
- Adds AWS RI + SP frontend fixtures inside the existing `on_demand_cost preference (#274)` describe block (AC #3).

## Acceptance criteria check

- [x] AWS recommendations carry a non-null `on_demand_cost` from the provider all the way to `RecommendationRecord` and the API payload — RI: existing `parseAWSCostDetails`; SP: this PR.
- [x] `effectiveSavingsPct()` resolves to the same value as the underlying provider report for AWS RIs and Savings Plans — formula unchanged from #274; this PR ensures the provider-supplied denominator reaches the frontend for SP.
- [x] Unit test in `frontend/src/__tests__/recommendations.test.ts` pinning the expected effective % for at least one AWS RI fixture and one SP fixture — added in this PR.
- [x] Regression test in the AWS provider mapping asserting `OnDemandCost` is populated — `TestParseRecommendationDetail_WithAccountAndCosts` (RI, pre-existing) + `TestParseSavingsPlanDetail_OnDemandCost` (SP, this PR).

## Reference

Pattern mirrors PR #277 (commit `66a993fa5`) which fixed the same bug for Azure 1y RIs.

Closes #303


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of AWS Savings Plans recommendation calculations by properly computing on-demand cost baselines, ensuring effective savings percentages align with AWS Cost Explorer data for EC2 RI, Compute Savings Plans, and other plan types.

* **Tests**
  * Enhanced test coverage validating on-demand cost calculations across multiple AWS recommendation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->