### PR TITLE
feat(iac): shared Archera module + 'Provision Archera Insurance permissions?' bundle checkbox (closes #314)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -459,6 +459,7 @@ jobs:
       - terraform-validate
       - security-scan
       - e2e-tests
+      - archera-parity
     if: always()
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,6 +261,23 @@ jobs:
             fi
           done
 
+  # Archera permission parity check — ensures CFN / Bicep / ARM alternative
+  # deployment formats carry permission lists that match the canonical YAML
+  # source of truth (iac/modules/archera/scope.*.yaml), and that environment
+  # archera.tf files are thin module callers with no inline permission lists.
+  archera-parity:
+    name: Archera Permission Parity
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Install python3-yaml
+        run: sudo apt-get install -y python3-yaml
+
+      - name: Check Archera permission parity
+        run: bash scripts/check-archera-parity.sh
+
   # Security scanning
   security-scan:
     name: Security Scanning

--- a/frontend/src/__tests__/federation.test.ts
+++ b/frontend/src/__tests__/federation.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Federation module tests — Archera opt-in checkbox (#314).
+ *
+ * DOM is built with createElement / replaceChildren to avoid innerHTML.
+ * We mock the api module so no network calls are made.
+ */
+import { initFederationPanel } from '../federation';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+jest.mock('../api', () => ({
+  getFederationIaC: jest.fn(),
+}));
+
+import * as api from '../api';
+
+const mockGetFederationIaC = api.getFederationIaC as jest.MockedFunction<
+  typeof api.getFederationIaC
+>;
+
+// ---------------------------------------------------------------------------
+// DOM helpers
+// ---------------------------------------------------------------------------
+
+/** Build the minimal DOM the federation panel needs. */
+function buildFederationDOM(): void {
+  document.body.replaceChildren();
+
+  const pillContainer = document.createElement('div');
+  pillContainer.id = 'federation-target-cloud-pills';
+  document.body.appendChild(pillContainer);
+
+  const archeraContainer = document.createElement('div');
+  archeraContainer.id = 'federation-archera-options';
+  document.body.appendChild(archeraContainer);
+
+  const panelContainer = document.createElement('div');
+  panelContainer.id = 'federation-setup-panel';
+  document.body.appendChild(panelContainer);
+}
+
+/** Return the Archera checkbox element, throwing if absent. */
+function archeraCheckbox(): HTMLInputElement {
+  const cb = document.getElementById(
+    'federation-include-archera',
+  ) as HTMLInputElement | null;
+  if (!cb) throw new Error('federation-include-archera checkbox not found');
+  return cb;
+}
+
+// ---------------------------------------------------------------------------
+// Test suites
+// ---------------------------------------------------------------------------
+
+describe('initFederationPanel — Archera checkbox', () => {
+  beforeEach(() => {
+    buildFederationDOM();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    document.body.replaceChildren();
+  });
+
+  test('checkbox is rendered and unchecked by default', async () => {
+    await initFederationPanel('aws');
+
+    const cb = archeraCheckbox();
+    expect(cb).toBeTruthy();
+    expect(cb.checked).toBe(false);
+  });
+
+  test('checkbox label text is "Provision Archera Insurance permissions?"', async () => {
+    await initFederationPanel('aws');
+
+    // The label wraps the checkbox; we look for the span with the text.
+    const label = document.querySelector('.federation-archera-label');
+    expect(label).toBeTruthy();
+    expect(label!.textContent).toContain('Provision Archera Insurance permissions?');
+  });
+
+  test('tooltip sr-only span is present and contains tooltip text', async () => {
+    await initFederationPanel('aws');
+
+    const tooltip = document.getElementById('federation-archera-tooltip');
+    expect(tooltip).toBeTruthy();
+    expect(tooltip!.classList.contains('sr-only')).toBe(true);
+    // Tooltip explains what Archera Insurance permissions do.
+    expect(tooltip!.textContent).toContain('Archera');
+  });
+});
+
+describe('initFederationPanel — download without Archera (unchecked)', () => {
+  const mockResponse = {
+    filename: 'cudly-federation-aws.zip',
+    content: 'base64data',
+    content_type: 'application/zip',
+    content_encoding: 'base64' as const,
+  };
+
+  beforeEach(() => {
+    buildFederationDOM();
+    jest.clearAllMocks();
+    mockGetFederationIaC.mockResolvedValue(mockResponse);
+
+    // Stub URL.createObjectURL / URL.revokeObjectURL used by downloadFile.
+    Object.defineProperty(URL, 'createObjectURL', {
+      writable: true,
+      value: jest.fn(() => 'blob:mock-url'),
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      writable: true,
+      value: jest.fn(),
+    });
+  });
+
+  afterEach(() => {
+    document.body.replaceChildren();
+  });
+
+  test('does not pass include_archera when checkbox is unchecked', async () => {
+    await initFederationPanel('aws');
+
+    // The default target-cloud pill is AWS; click the first "bundle" download button.
+    const downloadBtn = document.querySelector<HTMLButtonElement>('.btn-download');
+    expect(downloadBtn).toBeTruthy();
+    downloadBtn!.click();
+
+    // Wait for the async handler to fire.
+    await Promise.resolve();
+
+    expect(mockGetFederationIaC).toHaveBeenCalledTimes(1);
+    // includeArchera should be false (default, unchecked).
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const [, , , includeArchera] = mockGetFederationIaC.mock.calls[0]!;
+    expect(includeArchera).toBe(false);
+  });
+});
+
+describe('initFederationPanel — download with Archera (checked)', () => {
+  const mockResponse = {
+    filename: 'cudly-federation-aws-archera.zip',
+    content: 'base64data',
+    content_type: 'application/zip',
+    content_encoding: 'base64' as const,
+  };
+
+  beforeEach(() => {
+    buildFederationDOM();
+    jest.clearAllMocks();
+    mockGetFederationIaC.mockResolvedValue(mockResponse);
+
+    Object.defineProperty(URL, 'createObjectURL', {
+      writable: true,
+      value: jest.fn(() => 'blob:mock-url'),
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      writable: true,
+      value: jest.fn(),
+    });
+  });
+
+  afterEach(() => {
+    document.body.replaceChildren();
+  });
+
+  test('passes includeArchera=true when checkbox is checked before download', async () => {
+    await initFederationPanel('aws');
+
+    // Check the Archera checkbox.
+    const cb = archeraCheckbox();
+    cb.checked = true;
+    cb.dispatchEvent(new Event('change'));
+
+    // Click the first download button.
+    const downloadBtn = document.querySelector<HTMLButtonElement>('.btn-download');
+    expect(downloadBtn).toBeTruthy();
+    downloadBtn!.click();
+
+    await Promise.resolve();
+
+    expect(mockGetFederationIaC).toHaveBeenCalledTimes(1);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const [, , , includeArchera] = mockGetFederationIaC.mock.calls[0]!;
+    expect(includeArchera).toBe(true);
+  });
+
+  test('checkbox state persists after switching target-cloud pill', async () => {
+    await initFederationPanel('aws');
+
+    // Check the Archera checkbox.
+    const cb = archeraCheckbox();
+    cb.checked = true;
+    cb.dispatchEvent(new Event('change'));
+
+    // Switch to GCP pill.
+    const gcpPill = document.querySelector<HTMLButtonElement>(
+      '[data-target="gcp"]',
+    );
+    expect(gcpPill).toBeTruthy();
+    gcpPill!.click();
+
+    // The archera container should still have the checkbox (it is not re-rendered).
+    const cbAfter = document.getElementById(
+      'federation-include-archera',
+    ) as HTMLInputElement | null;
+    expect(cbAfter).toBeTruthy();
+    // The module-level _includeArchera is still true; clicking download should pass it.
+    const downloadBtn = document.querySelector<HTMLButtonElement>('.btn-download');
+    expect(downloadBtn).toBeTruthy();
+    downloadBtn!.click();
+
+    await Promise.resolve();
+
+    expect(mockGetFederationIaC).toHaveBeenCalledTimes(1);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const [, , , includeArchera] = mockGetFederationIaC.mock.calls[0]!;
+    expect(includeArchera).toBe(true);
+  });
+});

--- a/frontend/src/__tests__/federation.test.ts
+++ b/frontend/src/__tests__/federation.test.ts
@@ -4,7 +4,7 @@
  * DOM is built with createElement / replaceChildren to avoid innerHTML.
  * We mock the api module so no network calls are made.
  */
-import { initFederationPanel } from '../federation';
+import { initFederationPanel, _resetIncludeArcheraForTesting } from '../federation';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -56,6 +56,7 @@ function archeraCheckbox(): HTMLInputElement {
 
 describe('initFederationPanel — Archera checkbox', () => {
   beforeEach(() => {
+    _resetIncludeArcheraForTesting();
     buildFederationDOM();
     jest.clearAllMocks();
   });
@@ -101,6 +102,7 @@ describe('initFederationPanel — download without Archera (unchecked)', () => {
   };
 
   beforeEach(() => {
+    _resetIncludeArcheraForTesting();
     buildFederationDOM();
     jest.clearAllMocks();
     mockGetFederationIaC.mockResolvedValue(mockResponse);
@@ -148,6 +150,7 @@ describe('initFederationPanel — download with Archera (checked)', () => {
   };
 
   beforeEach(() => {
+    _resetIncludeArcheraForTesting();
     buildFederationDOM();
     jest.clearAllMocks();
     mockGetFederationIaC.mockResolvedValue(mockResponse);

--- a/frontend/src/api/accounts.ts
+++ b/frontend/src/api/accounts.ts
@@ -200,8 +200,12 @@ export async function getFederationIaC(
   target: string,
   source: string,
   format: string,
+  includeArchera?: boolean,
 ): Promise<FederationIaCResponse> {
   const params = new URLSearchParams({ target, source, format });
+  if (includeArchera) {
+    params.set('include_archera', 'true');
+  }
   return apiRequest<FederationIaCResponse>(`/federation/iac?${params.toString()}`);
 }
 

--- a/frontend/src/federation.ts
+++ b/frontend/src/federation.ts
@@ -18,6 +18,14 @@ import { getFederationIaC } from './api';
 
 let _includeArchera = false;
 
+/**
+ * Reset module-level state for testing. Not called in production code.
+ * @internal
+ */
+export function _resetIncludeArcheraForTesting(): void {
+  _includeArchera = false;
+}
+
 // ---------------------------------------------------------------------------
 // Download helper
 // ---------------------------------------------------------------------------
@@ -161,7 +169,9 @@ function buildArcheraCheckbox(containerEl: HTMLElement): HTMLInputElement {
   checkbox.type = 'checkbox';
   checkbox.id = 'federation-include-archera';
   checkbox.name = 'include_archera';
-  checkbox.checked = false; // default: off
+  // Reflect current module state so repeated renders stay in sync with
+  // the _includeArchera flag (e.g. hot-reload or SPA re-navigation).
+  checkbox.checked = _includeArchera;
   checkbox.addEventListener('change', () => {
     _includeArchera = checkbox.checked;
   });
@@ -301,6 +311,7 @@ export async function initFederationPanel(source: string): Promise<void> {
   // pill click, but the checkbox row is not).
   const archeraContainer = document.getElementById('federation-archera-options');
   if (archeraContainer) {
+    clearContainer(archeraContainer);
     buildArcheraCheckbox(archeraContainer);
   }
 

--- a/frontend/src/federation.ts
+++ b/frontend/src/federation.ts
@@ -181,7 +181,10 @@ function buildArcheraCheckbox(containerEl: HTMLElement): HTMLInputElement {
 
   // Tooltip via title attribute — accessible on keyboard focus and hover.
   label.title = ARCHERA_TOOLTIP;
-  label.setAttribute('aria-describedby', 'federation-archera-tooltip');
+  // aria-describedby goes on the focusable input so screen-reader users get
+  // the tooltip announced when they tab to the checkbox (not just when reading
+  // the label text).
+  checkbox.setAttribute('aria-describedby', 'federation-archera-tooltip');
 
   const tooltipSpan = document.createElement('span');
   tooltipSpan.id = 'federation-archera-tooltip';

--- a/frontend/src/federation.ts
+++ b/frontend/src/federation.ts
@@ -11,6 +11,14 @@
 import { getFederationIaC } from './api';
 
 // ---------------------------------------------------------------------------
+// Module-level state for the Archera opt-in checkbox.
+// The checkbox persists its checked state for the lifetime of the panel —
+// toggling it immediately affects the next download without a page reload.
+// ---------------------------------------------------------------------------
+
+let _includeArchera = false;
+
+// ---------------------------------------------------------------------------
 // Download helper
 // ---------------------------------------------------------------------------
 
@@ -126,6 +134,59 @@ function makeFormatButton(opt: FormatOption, target: string, source: string): HT
   return btn;
 }
 
+// ---------------------------------------------------------------------------
+// Archera checkbox
+// ---------------------------------------------------------------------------
+
+const ARCHERA_TOOLTIP =
+  'When enabled, the downloaded bundle additionally provisions a cross-account ' +
+  'role / service principal that grants the Archera commitment-insurance platform ' +
+  'read-only access to your cost data and (optionally) the right to purchase ' +
+  'reservations / savings plans on your behalf. This lets Archera underwrite ' +
+  'commitment-overuse insurance for your account. Leave unchecked if you\'re not ' +
+  'enrolled with Archera. Default: off.';
+
+/**
+ * Build the Archera opt-in checkbox row and append it to containerEl.
+ * Returns the checkbox element so callers can read its checked state.
+ */
+function buildArcheraCheckbox(containerEl: HTMLElement): HTMLInputElement {
+  const row = document.createElement('div');
+  row.className = 'federation-archera-row';
+
+  const label = document.createElement('label');
+  label.className = 'federation-archera-label';
+
+  const checkbox = document.createElement('input');
+  checkbox.type = 'checkbox';
+  checkbox.id = 'federation-include-archera';
+  checkbox.name = 'include_archera';
+  checkbox.checked = false; // default: off
+  checkbox.addEventListener('change', () => {
+    _includeArchera = checkbox.checked;
+  });
+
+  const labelText = document.createElement('span');
+  labelText.textContent = 'Provision Archera Insurance permissions?';
+
+  // Tooltip via title attribute — accessible on keyboard focus and hover.
+  label.title = ARCHERA_TOOLTIP;
+  label.setAttribute('aria-describedby', 'federation-archera-tooltip');
+
+  const tooltipSpan = document.createElement('span');
+  tooltipSpan.id = 'federation-archera-tooltip';
+  tooltipSpan.className = 'federation-archera-tooltip sr-only';
+  tooltipSpan.textContent = ARCHERA_TOOLTIP;
+
+  label.appendChild(checkbox);
+  label.appendChild(labelText);
+  row.appendChild(label);
+  row.appendChild(tooltipSpan);
+  containerEl.appendChild(row);
+
+  return checkbox;
+}
+
 function buildFederationDownloads(target: string, source: string, containerID: string): void {
   const container = document.getElementById(containerID);
   if (!container) return;
@@ -148,7 +209,7 @@ function runDownload(btn: HTMLButtonElement, target: string, source: string, for
   btn.disabled = true;
   if (labelEl) labelEl.textContent = 'Loading…';
 
-  getFederationIaC(target, source, format)
+  getFederationIaC(target, source, format, _includeArchera)
     .then(res => {
       if (res.content_encoding === 'base64') {
         const binaryStr = atob(res.content);
@@ -233,6 +294,15 @@ function buildTargetCloudPills(
 export async function initFederationPanel(source: string): Promise<void> {
   const pillContainer = document.getElementById('federation-target-cloud-pills');
   if (!pillContainer) return;
+
+  // Render the Archera opt-in checkbox above the download buttons.
+  // The checkbox container is separate from the pills so it persists across
+  // target-cloud pill switches (the download button row is re-rendered on each
+  // pill click, but the checkbox row is not).
+  const archeraContainer = document.getElementById('federation-archera-options');
+  if (archeraContainer) {
+    buildArcheraCheckbox(archeraContainer);
+  }
 
   buildTargetCloudPills(pillContainer, target => {
     buildFederationDownloads(target, source, 'federation-setup-panel');

--- a/iac/federation/aws-cross-account/cloudformation/archera.cfn.yaml
+++ b/iac/federation/aws-cross-account/cloudformation/archera.cfn.yaml
@@ -32,6 +32,11 @@ Parameters:
     Type: String
     Default: ""
     NoEcho: true
+    # Allow either empty (when EnableArchera = false) or any string with at
+    # least one non-whitespace char.  Whitespace-only values like "   " would
+    # otherwise produce a trust policy Archera cannot match during onboarding.
+    AllowedPattern: '^$|.*\S.*'
+    ConstraintDescription: ArcheraExternalId must be empty or contain non-whitespace characters.
     Description: >-
       External ID for confused-deputy protection on the Archera assume-role.
       Obtain from Archera during onboarding. Required when EnableArchera = true.

--- a/iac/federation/aws-cross-account/cloudformation/archera.cfn.yaml
+++ b/iac/federation/aws-cross-account/cloudformation/archera.cfn.yaml
@@ -1,0 +1,173 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >-
+  CUDly — Archera Insurance integration (federation bundle, aws-cross-account).
+  Creates a cross-account IAM role that Archera assumes to read cost and
+  commitment data, and optionally a purchase policy for RI/SP writes.
+  PROVISIONAL — confirm scope with Archera before enabling.
+  Permission list mirrors iac/modules/archera/scope.aws.yaml.
+
+# NOTE: this template is an alternative deployment path for customers who
+# prefer CloudFormation over Terraform.  The permission lists MUST stay in
+# sync with iac/modules/archera/scope.aws.yaml — the CI gate
+# scripts/check-archera-parity.sh enforces parity automatically.
+
+Parameters:
+  EnableArchera:
+    Type: String
+    AllowedValues: ["true", "false"]
+    Default: "false"
+    Description: >-
+      Set to "true" to create the Archera cross-account role and read policy.
+      Leave false unless enrolled with Archera.
+
+  ArcheraAwsAccountId:
+    Type: String
+    Default: ""
+    Description: >-
+      Archera's 12-digit AWS account ID. Required when EnableArchera = true.
+    AllowedPattern: "^$|^[0-9]{12}$"
+    ConstraintDescription: Must be a 12-digit AWS account ID or empty.
+
+  ArcheraExternalId:
+    Type: String
+    Default: ""
+    NoEcho: true
+    Description: >-
+      External ID for confused-deputy protection on the Archera assume-role.
+      Obtain from Archera during onboarding. Required when EnableArchera = true.
+
+  EnableArcheraPurchaseActions:
+    Type: String
+    AllowedValues: ["true", "false"]
+    Default: "false"
+    Description: >-
+      Set to "true" (with EnableArchera = "true") to also attach the purchase
+      policy for RI/SP write actions. Only enable after confirming Archera
+      requires customer approval before executing purchases.
+
+Conditions:
+  CreateArcheraResources: !Equals [!Ref EnableArchera, "true"]
+  CreatePurchasePolicy: !And
+    - !Condition CreateArcheraResources
+    - !Equals [!Ref EnableArcheraPurchaseActions, "true"]
+
+Resources:
+  ArcheraIntegrationRole:
+    Type: AWS::IAM::Role
+    Condition: CreateArcheraResources
+    Properties:
+      RoleName: cudly-archera-integration
+      Description: >-
+        Assumed by Archera SaaS to read cost data and (optionally) execute
+        RI/SP purchases. Provisional — confirm scope before enabling.
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: ArcheraAssumeRole
+            Effect: Allow
+            Principal:
+              AWS: !Sub "arn:aws:iam::${ArcheraAwsAccountId}:root"
+            Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                "sts:ExternalId": !Ref ArcheraExternalId
+      Tags:
+        - Key: Integration
+          Value: archera
+        - Key: Purpose
+          Value: commitment-optimisation
+        - Key: ManagedBy
+          Value: cudly-federation-bundle
+
+  ArcheraReadPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Condition: CreateArcheraResources
+    Properties:
+      ManagedPolicyName: cudly-archera-read
+      Description: >-
+        Archera read-only policy — cost Explorer + RI/SP telemetry (no purchase
+        actions). Permission list mirrors iac/modules/archera/scope.aws.yaml.
+      Roles:
+        - !Ref ArcheraIntegrationRole
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          # ── Read-only: Cost Explorer ────────────────────────────────────
+          - Sid: CostExplorerReadOnly
+            Effect: Allow
+            Action:
+              - ce:GetCostAndUsage
+              - ce:GetCostAndUsageWithResources
+              - ce:GetCostForecast
+              - ce:GetDimensionValues
+              - ce:GetReservationCoverage
+              - ce:GetReservationPurchaseRecommendation
+              - ce:GetReservationUtilization
+              - ce:GetRightsizingRecommendation
+              - ce:GetSavingsPlansCoverage
+              - ce:GetSavingsPlansUtilization
+              - ce:GetSavingsPlansUtilizationDetails
+              - ce:ListCostCategoryDefinitions
+            Resource: "*"
+          # ── Read-only: CUR ──────────────────────────────────────────────
+          - Sid: CURDescribe
+            Effect: Allow
+            Action:
+              - cur:DescribeReportDefinitions
+            Resource: "*"
+          # ── Read-only: Reserved Instances ───────────────────────────────
+          - Sid: ReservedInstancesRead
+            Effect: Allow
+            Action:
+              - ec2:DescribeReservedInstances
+              - ec2:DescribeReservedInstancesListings
+              - ec2:DescribeReservedInstancesModifications
+              - ec2:DescribeReservedInstancesOfferings
+              - ec2:DescribeInstanceTypeOfferings
+            Resource: "*"
+          # ── Read-only: Savings Plans ────────────────────────────────────
+          - Sid: SavingsPlansRead
+            Effect: Allow
+            Action:
+              - savingsplans:DescribeSavingsPlans
+              - savingsplans:DescribeSavingsPlansOfferings
+              - savingsplans:DescribeSavingsPlanRates
+              - savingsplans:ListTagsForResource
+            Resource: "*"
+
+  ArcheraPurchasePolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Condition: CreatePurchasePolicy
+    Properties:
+      ManagedPolicyName: cudly-archera-purchase
+      Description: >-
+        Archera purchase policy — RI/SP write actions. Only attach after
+        confirming Archera requires customer approval before purchases.
+        Permission list mirrors iac/modules/archera/scope.aws.yaml.
+      Roles:
+        - !Ref ArcheraIntegrationRole
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          # ── Purchase: Reserved Instances ────────────────────────────────
+          - Sid: ReservedInstancesPurchase
+            Effect: Allow
+            Action:
+              - ec2:PurchaseReservedInstancesOffering
+              - ec2:ModifyReservedInstances
+            Resource: "*"
+          # ── Purchase: Savings Plans ─────────────────────────────────────
+          - Sid: SavingsPlansPurchase
+            Effect: Allow
+            Action:
+              - savingsplans:CreateSavingsPlan
+              - savingsplans:DeleteQueuedSavingsPlan
+            Resource: "*"
+
+Outputs:
+  ArcheraRoleArn:
+    Condition: CreateArcheraResources
+    Description: ARN of the Archera cross-account IAM role.
+    Value: !GetAtt ArcheraIntegrationRole.Arn
+    Export:
+      Name: !Sub "${AWS::StackName}-ArcheraRoleArn"

--- a/iac/federation/aws-cross-account/cloudformation/archera.cfn.yaml
+++ b/iac/federation/aws-cross-account/cloudformation/archera.cfn.yaml
@@ -45,6 +45,22 @@ Parameters:
       policy for RI/SP write actions. Only enable after confirming Archera
       requires customer approval before executing purchases.
 
+Rules:
+  ArcheraAccountIdRequired:
+    Assertions:
+      - Assert:
+          !Or
+            - !Equals [!Ref EnableArchera, "false"]
+            - !Not [!Equals [!Ref ArcheraAwsAccountId, ""]]
+        AssertDescription: "ArcheraAwsAccountId must be set when EnableArchera is true."
+  ArcheraExternalIdRequired:
+    Assertions:
+      - Assert:
+          !Or
+            - !Equals [!Ref EnableArchera, "false"]
+            - !Not [!Equals [!Ref ArcheraExternalId, ""]]
+        AssertDescription: "ArcheraExternalId must be set when EnableArchera is true."
+
 Conditions:
   CreateArcheraResources: !Equals [!Ref EnableArchera, "true"]
   CreatePurchasePolicy: !And

--- a/iac/federation/aws-cross-account/terraform/archera.tf
+++ b/iac/federation/aws-cross-account/terraform/archera.tf
@@ -1,0 +1,22 @@
+# ==============================================
+# Archera Integration — AWS (Federation Bundle, aws-cross-account)
+# ==============================================
+#
+# Thin caller — all IAM resources and permission lists live in the shared
+# module at iac/modules/archera/aws/.  Edit scope.aws.yaml in that directory
+# to update the permission scope across ALL callers simultaneously.
+#
+# PROVISIONAL SCOPE — must be confirmed against Archera integration docs
+# before flipping enable_archera = true in any tfvars.
+# TODO(@cristim): confirm Archera scope list against integration docs
+# before enabling.  Reference: https://archera.ai/docs (integration guide).
+
+module "archera" {
+  source = "../../../modules/archera/aws"
+
+  enable_archera                  = var.enable_archera
+  archera_aws_account_id          = var.archera_aws_account_id
+  archera_external_id             = var.archera_external_id
+  enable_archera_purchase_actions = var.enable_archera_purchase_actions
+  managed_by_tag                  = "cudly-federation-bundle"
+}

--- a/iac/federation/aws-cross-account/terraform/variables.tf
+++ b/iac/federation/aws-cross-account/terraform/variables.tf
@@ -60,3 +60,46 @@ variable "enable_org_discovery" {
   type        = bool
   default     = false
 }
+
+# ---------------------------------------------------------------------------
+# Archera Insurance integration (opt-in, provisional)
+# ---------------------------------------------------------------------------
+
+variable "enable_archera" {
+  description = <<-EOT
+    When true, provision the Archera cross-account IAM role and read-only
+    cost/commitment policy so Archera can underwrite commitment-overuse
+    insurance. Leave false (default) unless you are enrolled with Archera.
+    PROVISIONAL — confirm scope with Archera before enabling.
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "archera_aws_account_id" {
+  description = "Archera's AWS account ID. Obtain from your Archera onboarding documentation. Required when enable_archera = true."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.archera_aws_account_id == "" || can(regex("^[0-9]{12}$", var.archera_aws_account_id))
+    error_message = "archera_aws_account_id must be a 12-digit AWS account ID."
+  }
+}
+
+variable "archera_external_id" {
+  description = "External ID for confused-deputy protection on the Archera cross-account role. Obtain from Archera during onboarding. Required when enable_archera = true."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "enable_archera_purchase_actions" {
+  description = <<-EOT
+    When true (and enable_archera = true), attach the Archera purchase policy
+    that allows RI/SP writes. Only enable after confirming Archera requires
+    customer approval before executing purchases. Default false.
+  EOT
+  type        = bool
+  default     = false
+}

--- a/iac/federation/aws-target/cloudformation/archera.cfn.yaml
+++ b/iac/federation/aws-target/cloudformation/archera.cfn.yaml
@@ -32,6 +32,11 @@ Parameters:
     Type: String
     Default: ""
     NoEcho: true
+    # Allow either empty (when EnableArchera = false) or any string with at
+    # least one non-whitespace char.  Whitespace-only values like "   " would
+    # otherwise produce a trust policy Archera cannot match during onboarding.
+    AllowedPattern: '^$|.*\S.*'
+    ConstraintDescription: ArcheraExternalId must be empty or contain non-whitespace characters.
     Description: >-
       External ID for confused-deputy protection on the Archera assume-role.
       Obtain from Archera during onboarding. Required when EnableArchera = true.

--- a/iac/federation/aws-target/cloudformation/archera.cfn.yaml
+++ b/iac/federation/aws-target/cloudformation/archera.cfn.yaml
@@ -45,6 +45,22 @@ Parameters:
       policy for RI/SP write actions. Only enable after confirming Archera
       requires customer approval before executing purchases.
 
+Rules:
+  ArcheraAccountIdRequired:
+    Assertions:
+      - Assert:
+          !Or
+            - !Equals [!Ref EnableArchera, "false"]
+            - !Not [!Equals [!Ref ArcheraAwsAccountId, ""]]
+        AssertDescription: "ArcheraAwsAccountId must be set when EnableArchera is true."
+  ArcheraExternalIdRequired:
+    Assertions:
+      - Assert:
+          !Or
+            - !Equals [!Ref EnableArchera, "false"]
+            - !Not [!Equals [!Ref ArcheraExternalId, ""]]
+        AssertDescription: "ArcheraExternalId must be set when EnableArchera is true."
+
 Conditions:
   CreateArcheraResources: !Equals [!Ref EnableArchera, "true"]
   CreatePurchasePolicy: !And

--- a/iac/federation/aws-target/cloudformation/archera.cfn.yaml
+++ b/iac/federation/aws-target/cloudformation/archera.cfn.yaml
@@ -1,0 +1,173 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >-
+  CUDly — Archera Insurance integration (federation bundle, aws-target).
+  Creates a cross-account IAM role that Archera assumes to read cost and
+  commitment data, and optionally a purchase policy for RI/SP writes.
+  PROVISIONAL — confirm scope with Archera before enabling.
+  Permission list mirrors iac/modules/archera/scope.aws.yaml.
+
+# NOTE: this template is an alternative deployment path for customers who
+# prefer CloudFormation over Terraform.  The permission lists MUST stay in
+# sync with iac/modules/archera/scope.aws.yaml — the CI gate
+# scripts/check-archera-parity.sh enforces parity automatically.
+
+Parameters:
+  EnableArchera:
+    Type: String
+    AllowedValues: ["true", "false"]
+    Default: "false"
+    Description: >-
+      Set to "true" to create the Archera cross-account role and read policy.
+      Leave false unless enrolled with Archera.
+
+  ArcheraAwsAccountId:
+    Type: String
+    Default: ""
+    Description: >-
+      Archera's 12-digit AWS account ID. Required when EnableArchera = true.
+    AllowedPattern: "^$|^[0-9]{12}$"
+    ConstraintDescription: Must be a 12-digit AWS account ID or empty.
+
+  ArcheraExternalId:
+    Type: String
+    Default: ""
+    NoEcho: true
+    Description: >-
+      External ID for confused-deputy protection on the Archera assume-role.
+      Obtain from Archera during onboarding. Required when EnableArchera = true.
+
+  EnableArcheraPurchaseActions:
+    Type: String
+    AllowedValues: ["true", "false"]
+    Default: "false"
+    Description: >-
+      Set to "true" (with EnableArchera = "true") to also attach the purchase
+      policy for RI/SP write actions. Only enable after confirming Archera
+      requires customer approval before executing purchases.
+
+Conditions:
+  CreateArcheraResources: !Equals [!Ref EnableArchera, "true"]
+  CreatePurchasePolicy: !And
+    - !Condition CreateArcheraResources
+    - !Equals [!Ref EnableArcheraPurchaseActions, "true"]
+
+Resources:
+  ArcheraIntegrationRole:
+    Type: AWS::IAM::Role
+    Condition: CreateArcheraResources
+    Properties:
+      RoleName: cudly-archera-integration
+      Description: >-
+        Assumed by Archera SaaS to read cost data and (optionally) execute
+        RI/SP purchases. Provisional — confirm scope before enabling.
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: ArcheraAssumeRole
+            Effect: Allow
+            Principal:
+              AWS: !Sub "arn:aws:iam::${ArcheraAwsAccountId}:root"
+            Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                "sts:ExternalId": !Ref ArcheraExternalId
+      Tags:
+        - Key: Integration
+          Value: archera
+        - Key: Purpose
+          Value: commitment-optimisation
+        - Key: ManagedBy
+          Value: cudly-federation-bundle
+
+  ArcheraReadPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Condition: CreateArcheraResources
+    Properties:
+      ManagedPolicyName: cudly-archera-read
+      Description: >-
+        Archera read-only policy — cost Explorer + RI/SP telemetry (no purchase
+        actions). Permission list mirrors iac/modules/archera/scope.aws.yaml.
+      Roles:
+        - !Ref ArcheraIntegrationRole
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          # ── Read-only: Cost Explorer ────────────────────────────────────
+          - Sid: CostExplorerReadOnly
+            Effect: Allow
+            Action:
+              - ce:GetCostAndUsage
+              - ce:GetCostAndUsageWithResources
+              - ce:GetCostForecast
+              - ce:GetDimensionValues
+              - ce:GetReservationCoverage
+              - ce:GetReservationPurchaseRecommendation
+              - ce:GetReservationUtilization
+              - ce:GetRightsizingRecommendation
+              - ce:GetSavingsPlansCoverage
+              - ce:GetSavingsPlansUtilization
+              - ce:GetSavingsPlansUtilizationDetails
+              - ce:ListCostCategoryDefinitions
+            Resource: "*"
+          # ── Read-only: CUR ──────────────────────────────────────────────
+          - Sid: CURDescribe
+            Effect: Allow
+            Action:
+              - cur:DescribeReportDefinitions
+            Resource: "*"
+          # ── Read-only: Reserved Instances ───────────────────────────────
+          - Sid: ReservedInstancesRead
+            Effect: Allow
+            Action:
+              - ec2:DescribeReservedInstances
+              - ec2:DescribeReservedInstancesListings
+              - ec2:DescribeReservedInstancesModifications
+              - ec2:DescribeReservedInstancesOfferings
+              - ec2:DescribeInstanceTypeOfferings
+            Resource: "*"
+          # ── Read-only: Savings Plans ────────────────────────────────────
+          - Sid: SavingsPlansRead
+            Effect: Allow
+            Action:
+              - savingsplans:DescribeSavingsPlans
+              - savingsplans:DescribeSavingsPlansOfferings
+              - savingsplans:DescribeSavingsPlanRates
+              - savingsplans:ListTagsForResource
+            Resource: "*"
+
+  ArcheraPurchasePolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Condition: CreatePurchasePolicy
+    Properties:
+      ManagedPolicyName: cudly-archera-purchase
+      Description: >-
+        Archera purchase policy — RI/SP write actions. Only attach after
+        confirming Archera requires customer approval before purchases.
+        Permission list mirrors iac/modules/archera/scope.aws.yaml.
+      Roles:
+        - !Ref ArcheraIntegrationRole
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          # ── Purchase: Reserved Instances ────────────────────────────────
+          - Sid: ReservedInstancesPurchase
+            Effect: Allow
+            Action:
+              - ec2:PurchaseReservedInstancesOffering
+              - ec2:ModifyReservedInstances
+            Resource: "*"
+          # ── Purchase: Savings Plans ─────────────────────────────────────
+          - Sid: SavingsPlansPurchase
+            Effect: Allow
+            Action:
+              - savingsplans:CreateSavingsPlan
+              - savingsplans:DeleteQueuedSavingsPlan
+            Resource: "*"
+
+Outputs:
+  ArcheraRoleArn:
+    Condition: CreateArcheraResources
+    Description: ARN of the Archera cross-account IAM role.
+    Value: !GetAtt ArcheraIntegrationRole.Arn
+    Export:
+      Name: !Sub "${AWS::StackName}-ArcheraRoleArn"

--- a/iac/federation/aws-target/terraform/archera.tf
+++ b/iac/federation/aws-target/terraform/archera.tf
@@ -1,0 +1,22 @@
+# ==============================================
+# Archera Integration — AWS (Federation Bundle, aws-target)
+# ==============================================
+#
+# Thin caller — all IAM resources and permission lists live in the shared
+# module at iac/modules/archera/aws/.  Edit scope.aws.yaml in that directory
+# to update the permission scope across ALL callers simultaneously.
+#
+# PROVISIONAL SCOPE — must be confirmed against Archera integration docs
+# before flipping enable_archera = true in any tfvars.
+# TODO(@cristim): confirm Archera scope list against integration docs
+# before enabling.  Reference: https://archera.ai/docs (integration guide).
+
+module "archera" {
+  source = "../../../modules/archera/aws"
+
+  enable_archera                  = var.enable_archera
+  archera_aws_account_id          = var.archera_aws_account_id
+  archera_external_id             = var.archera_external_id
+  enable_archera_purchase_actions = var.enable_archera_purchase_actions
+  managed_by_tag                  = "cudly-federation-bundle"
+}

--- a/iac/federation/aws-target/terraform/variables.tf
+++ b/iac/federation/aws-target/terraform/variables.tf
@@ -78,3 +78,46 @@ variable "contact_email" {
   type        = string
   default     = ""
 }
+
+# ---------------------------------------------------------------------------
+# Archera Insurance integration (opt-in, provisional)
+# ---------------------------------------------------------------------------
+
+variable "enable_archera" {
+  description = <<-EOT
+    When true, provision the Archera cross-account IAM role and read-only
+    cost/commitment policy so Archera can underwrite commitment-overuse
+    insurance. Leave false (default) unless you are enrolled with Archera.
+    PROVISIONAL — confirm scope with Archera before enabling.
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "archera_aws_account_id" {
+  description = "Archera's AWS account ID. Obtain from your Archera onboarding documentation. Required when enable_archera = true."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.archera_aws_account_id == "" || can(regex("^[0-9]{12}$", var.archera_aws_account_id))
+    error_message = "archera_aws_account_id must be a 12-digit AWS account ID."
+  }
+}
+
+variable "archera_external_id" {
+  description = "External ID for confused-deputy protection on the Archera cross-account role. Obtain from Archera during onboarding. Required when enable_archera = true."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "enable_archera_purchase_actions" {
+  description = <<-EOT
+    When true (and enable_archera = true), attach the Archera purchase policy
+    that allows RI/SP writes. Only enable after confirming Archera requires
+    customer approval before executing purchases. Default false.
+  EOT
+  type        = bool
+  default     = false
+}

--- a/iac/federation/azure-target/arm/archera.arm.json
+++ b/iac/federation/azure-target/arm/archera.arm.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_description": "CUDly — Archera Insurance integration (federation bundle, azure-target). Alternative deployment path for customers who prefer ARM over Terraform or Bicep. Permission list mirrors iac/modules/archera/scope.azure.yaml. PROVISIONAL — confirm scope with Archera before enabling."
+  },
+  "parameters": {
+    "enableArchera": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "When true, provision the Archera custom RBAC role and role assignment. Leave false unless enrolled with Archera."
+      }
+    },
+    "archeraAzureSpObjectId": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Object ID of the service principal Archera provides during onboarding. NOT the Application/Client ID."
+      }
+    },
+    "enableArcheraPurchaseActions": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "When true (and enableArchera = true), include reservation write actions in the Archera custom role."
+      }
+    }
+  },
+  "variables": {
+    "readActions": [
+      "Microsoft.CostManagement/*/read",
+      "Microsoft.Consumption/*/read",
+      "Microsoft.Billing/*/read",
+      "Microsoft.Capacity/reservations/read",
+      "Microsoft.Capacity/reservationOrders/read"
+    ],
+    "purchaseActions": [
+      "Microsoft.Capacity/reservationOrders/write"
+    ],
+    "allActions": "[if(parameters('enableArcheraPurchaseActions'), concat(variables('readActions'), variables('purchaseActions')), variables('readActions'))]",
+    "roleDefName": "[guid(subscription().subscriptionId, 'cudly-archera-integration')]",
+    "roleAssignmentName": "[guid(subscription().subscriptionId, parameters('archeraAzureSpObjectId'), variables('roleDefName'))]"
+  },
+  "resources": [
+    {
+      "condition": "[parameters('enableArchera')]",
+      "type": "Microsoft.Authorization/roleDefinitions",
+      "apiVersion": "2022-04-01",
+      "name": "[variables('roleDefName')]",
+      "properties": {
+        "roleName": "CUDly Archera Integration",
+        "description": "Archera integration role — read cost data, optionally purchase RIs. Provisional — confirm scope before enabling.",
+        "type": "CustomRole",
+        "permissions": [
+          {
+            "actions": "[variables('allActions')]",
+            "notActions": [],
+            "dataActions": [],
+            "notDataActions": []
+          }
+        ],
+        "assignableScopes": [
+          "[subscription().id]"
+        ]
+      }
+    },
+    {
+      "condition": "[parameters('enableArchera')]",
+      "type": "Microsoft.Authorization/roleAssignments",
+      "apiVersion": "2022-04-01",
+      "name": "[variables('roleAssignmentName')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Authorization/roleDefinitions', variables('roleDefName'))]"
+      ],
+      "properties": {
+        "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('roleDefName'))]",
+        "principalId": "[parameters('archeraAzureSpObjectId')]",
+        "principalType": "ServicePrincipal"
+      }
+    }
+  ],
+  "outputs": {
+    "roleDefinitionId": {
+      "type": "string",
+      "value": "[if(parameters('enableArchera'), subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('roleDefName')), '')]"
+    }
+  }
+}

--- a/iac/federation/azure-target/bicep/archera.bicep
+++ b/iac/federation/azure-target/bicep/archera.bicep
@@ -1,0 +1,75 @@
+// ==============================================
+// Archera Integration — Azure (Federation Bundle, azure-target)
+// ==============================================
+//
+// Alternative deployment path for customers who prefer Bicep over Terraform.
+// The permission lists MUST stay in sync with iac/modules/archera/scope.azure.yaml
+// — the CI gate scripts/check-archera-parity.sh enforces parity automatically.
+//
+// PROVISIONAL SCOPE — must be confirmed against Archera integration docs
+// before setting enableArchera = true in any parameters file.
+// TODO(@cristim): confirm Archera scope list against integration docs
+// before enabling.  Reference: https://archera.ai/docs (integration guide).
+
+targetScope = 'subscription'
+
+@description('When true, provision the Archera custom RBAC role and role assignment. Leave false unless enrolled with Archera.')
+param enableArchera bool = false
+
+@description('Object ID of the service principal Archera provides during onboarding. NOT the Application/Client ID.')
+param archeraAzureSpObjectId string = ''
+
+@description('When true (and enableArchera = true), include reservation write actions in the Archera custom role.')
+param enableArcheraPurchaseActions bool = false
+
+// ── Permission lists (mirrors scope.azure.yaml) ────────────────────────────
+var readActions = [
+  'Microsoft.CostManagement/*/read'
+  'Microsoft.Consumption/*/read'
+  'Microsoft.Billing/*/read'
+  'Microsoft.Capacity/reservations/read'
+  'Microsoft.Capacity/reservationOrders/read'
+]
+
+var purchaseActions = [
+  'Microsoft.Capacity/reservationOrders/write'
+]
+
+var allActions = enableArcheraPurchaseActions ? concat(readActions, purchaseActions) : readActions
+
+// ── Custom RBAC role ────────────────────────────────────────────────────────
+var roleDefName = guid(subscription().id, 'cudly-archera-integration')
+
+resource archeraRoleDef 'Microsoft.Authorization/roleDefinitions@2022-04-01' = if (enableArchera) {
+  name: roleDefName
+  properties: {
+    roleName: 'CUDly Archera Integration'
+    description: 'Archera integration role — read cost data, optionally purchase RIs. Provisional — confirm scope before enabling.'
+    type: 'CustomRole'
+    permissions: [
+      {
+        actions: allActions
+        notActions: []
+        dataActions: []
+        notDataActions: []
+      }
+    ]
+    assignableScopes: [
+      subscription().id
+    ]
+  }
+}
+
+// ── Role assignment ─────────────────────────────────────────────────────────
+resource archeraRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (enableArchera) {
+  name: guid(subscription().id, archeraAzureSpObjectId, roleDefName)
+  properties: {
+    roleDefinitionId: archeraRoleDef.id
+    principalId: archeraAzureSpObjectId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// ── Outputs ─────────────────────────────────────────────────────────────────
+output roleDefinitionId string = enableArchera ? archeraRoleDef.id : ''
+output roleAssignmentId string = enableArchera ? archeraRoleAssignment.id : ''

--- a/iac/federation/azure-target/terraform/.terraform.lock.hcl
+++ b/iac/federation/azure-target/terraform/.terraform.lock.hcl
@@ -3,7 +3,7 @@
 
 provider "registry.terraform.io/hashicorp/azuread" {
   version     = "3.8.0"
-  constraints = ">= 2.47.0"
+  constraints = "~> 3.8"
   hashes = [
     "h1:E2YWNE3Qry4bQMlmmZ33X4hLY5hOGrEZrlRg4anI2uw=",
     "zh:0d26cfbf9417acd1c2295ccd5b0052abeac85ad1c3f6422ff09bf6a1ce16f00d",
@@ -23,7 +23,7 @@ provider "registry.terraform.io/hashicorp/azuread" {
 
 provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "4.67.0"
-  constraints = ">= 3.95.0"
+  constraints = ">= 3.0.0, ~> 4.0"
   hashes = [
     "h1:cT/1xU2vHvVboTZvjNjn7sqCH/FPP//JeMh702eGUS0=",
     "zh:49a1531297510b684103c06d32e9ef1d810380ed55895f6b799913e9679141dc",
@@ -58,25 +58,5 @@ provider "registry.terraform.io/hashicorp/http" {
     "zh:843feacacd86baed820f81a6c9f7bd32cf302db3d7a0f39e87976ebc7a7cc2ee",
     "zh:a9ea5096ab91aab260b22e4251c05f08dad2ed77e43e5e4fadcdfd87f2c78926",
     "zh:d02b288922811739059e90184c7f76d45d07d3a77cc48d0b15fd3db14e928623",
-  ]
-}
-
-provider "registry.terraform.io/hashicorp/tls" {
-  version     = "4.2.1"
-  constraints = ">= 4.0.0"
-  hashes = [
-    "h1:akFNuHwvrtnYMBofieoeXhPJDhYZzJVu/Q/BgZK2fgg=",
-    "zh:0d1e7d07ac973b97fa228f46596c800de830820506ee145626f079dd6bbf8d8a",
-    "zh:5c7e3d4348cb4861ab812973ef493814a4b224bdd3e9d534a7c8a7c992382b86",
-    "zh:7c6d4a86cd7a4e9c1025c6b3a3a6a45dea202af85d870cddbab455fb1bd568ad",
-    "zh:7d0864755ba093664c4b2c07c045d3f5e3d7c799dda1a3ef33d17ed1ac563191",
-    "zh:83734f57950ab67c0d6a87babdb3f13c908cbe0a48949333f489698532e1391b",
-    "zh:951e3c285218ebca0cf20eaa4265020b4ef042fea9c6ade115ad1558cfe459e5",
-    "zh:b9543955b4297e1d93b85900854891c0e645d936d8285a190030475379c5c635",
-    "zh:bb1bd9e86c003d08c30c1b00d44118ed5bbbf6b1d2d6f7eaac4fa5c6ebea5933",
-    "zh:c9477bfe00653629cd77ddac3968475f7ad93ac3ca8bc45b56d1d9efb25e4a6e",
-    "zh:d4cfda8687f736d0cba664c22ec49dae1188289e214ef57f5afe6a7217854fed",
-    "zh:dc77ee066cf96532a48f0578c35b1eaf6dc4d8ddd0e3ae8e029a3b10676dd5d3",
-    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }

--- a/iac/federation/azure-target/terraform/archera.tf
+++ b/iac/federation/azure-target/terraform/archera.tf
@@ -1,0 +1,21 @@
+# ==============================================
+# Archera Integration — Azure (Federation Bundle, azure-target)
+# ==============================================
+#
+# Thin caller — all RBAC resources and permission lists live in the shared
+# module at iac/modules/archera/azure/.  Edit scope.azure.yaml in that directory
+# to update the permission scope across ALL callers simultaneously.
+#
+# PROVISIONAL SCOPE — must be confirmed against Archera integration docs
+# before flipping enable_archera = true in any tfvars.
+# TODO(@cristim): confirm Archera scope list against integration docs
+# before enabling.  Reference: https://archera.ai/docs (integration guide).
+
+module "archera" {
+  source = "../../../modules/archera/azure"
+
+  enable_archera                  = var.enable_archera
+  subscription_id                 = local.subscription_id
+  archera_azure_sp_object_id      = var.archera_azure_sp_object_id
+  enable_archera_purchase_actions = var.enable_archera_purchase_actions
+}

--- a/iac/federation/azure-target/terraform/variables.tf
+++ b/iac/federation/azure-target/terraform/variables.tf
@@ -50,3 +50,34 @@ variable "contact_email" {
   type        = string
   default     = ""
 }
+
+# ---------------------------------------------------------------------------
+# Archera Insurance integration (opt-in, provisional)
+# ---------------------------------------------------------------------------
+
+variable "enable_archera" {
+  description = <<-EOT
+    When true, provision the Archera custom RBAC role and role assignment so
+    Archera can underwrite commitment-overuse insurance. Leave false (default)
+    unless you are enrolled with Archera.
+    PROVISIONAL — confirm scope with Archera before enabling.
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "archera_azure_sp_object_id" {
+  description = "Object ID of the service principal Archera provides during onboarding. NOT the Application/Client ID — use the Object ID from Azure Portal. Required when enable_archera = true."
+  type        = string
+  default     = ""
+}
+
+variable "enable_archera_purchase_actions" {
+  description = <<-EOT
+    When true (and enable_archera = true), include reservation write actions in
+    the Archera custom role. Only enable after confirming Archera requires
+    customer approval before executing purchases. Default false.
+  EOT
+  type        = bool
+  default     = false
+}

--- a/iac/federation/gcp-sa-impersonation/terraform/archera.tf
+++ b/iac/federation/gcp-sa-impersonation/terraform/archera.tf
@@ -1,0 +1,21 @@
+# ==============================================
+# Archera Integration — GCP (Federation Bundle, gcp-sa-impersonation)
+# ==============================================
+#
+# Thin caller — all IAM resources and permission lists live in the shared
+# module at iac/modules/archera/gcp/.  Edit scope.gcp.yaml in that directory
+# to update the permission scope across ALL callers simultaneously.
+#
+# PROVISIONAL SCOPE — must be confirmed against Archera integration docs
+# before flipping enable_archera = true in any tfvars.
+# TODO(@cristim): confirm Archera scope list against integration docs
+# before enabling.  Reference: https://archera.ai/docs (integration guide).
+
+module "archera" {
+  source = "../../../modules/archera/gcp"
+
+  enable_archera                  = var.enable_archera
+  project_id                      = var.project_id
+  archera_gcp_service_account     = var.archera_gcp_service_account
+  enable_archera_purchase_actions = var.enable_archera_purchase_actions
+}

--- a/iac/federation/gcp-sa-impersonation/terraform/variables.tf
+++ b/iac/federation/gcp-sa-impersonation/terraform/variables.tf
@@ -30,3 +30,34 @@ variable "contact_email" {
   type        = string
   default     = ""
 }
+
+# ---------------------------------------------------------------------------
+# Archera Insurance integration (opt-in, provisional)
+# ---------------------------------------------------------------------------
+
+variable "enable_archera" {
+  description = <<-EOT
+    When true, provision the Archera custom IAM role and role binding so
+    Archera can underwrite commitment-overuse insurance. Leave false (default)
+    unless you are enrolled with Archera.
+    PROVISIONAL — confirm scope with Archera before enabling.
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "archera_gcp_service_account" {
+  description = "Full service account email of the SA Archera provides during onboarding, e.g. archera-integration@archera-prod.iam.gserviceaccount.com. Required when enable_archera = true."
+  type        = string
+  default     = ""
+}
+
+variable "enable_archera_purchase_actions" {
+  description = <<-EOT
+    When true (and enable_archera = true), include CUD purchase permissions in
+    the Archera custom role. Only enable after confirming Archera requires
+    customer approval before executing purchases. Default false.
+  EOT
+  type        = bool
+  default     = false
+}

--- a/iac/federation/gcp-sa-impersonation/terraform/variables.tf
+++ b/iac/federation/gcp-sa-impersonation/terraform/variables.tf
@@ -50,6 +50,11 @@ variable "archera_gcp_service_account" {
   description = "Full service account email of the SA Archera provides during onboarding, e.g. archera-integration@archera-prod.iam.gserviceaccount.com. Required when enable_archera = true."
   type        = string
   default     = ""
+
+  validation {
+    condition     = !var.enable_archera || can(regex("^[a-z][a-z0-9-]*@[a-z][a-z0-9-]*\\.iam\\.gserviceaccount\\.com$", var.archera_gcp_service_account))
+    error_message = "archera_gcp_service_account must be a valid GCP service account email (e.g. name@project.iam.gserviceaccount.com) when enable_archera = true."
+  }
 }
 
 variable "enable_archera_purchase_actions" {

--- a/iac/federation/gcp-target/terraform/archera.tf
+++ b/iac/federation/gcp-target/terraform/archera.tf
@@ -1,0 +1,21 @@
+# ==============================================
+# Archera Integration — GCP (Federation Bundle, gcp-target)
+# ==============================================
+#
+# Thin caller — all IAM resources and permission lists live in the shared
+# module at iac/modules/archera/gcp/.  Edit scope.gcp.yaml in that directory
+# to update the permission scope across ALL callers simultaneously.
+#
+# PROVISIONAL SCOPE — must be confirmed against Archera integration docs
+# before flipping enable_archera = true in any tfvars.
+# TODO(@cristim): confirm Archera scope list against integration docs
+# before enabling.  Reference: https://archera.ai/docs (integration guide).
+
+module "archera" {
+  source = "../../../modules/archera/gcp"
+
+  enable_archera                  = var.enable_archera
+  project_id                      = local.project
+  archera_gcp_service_account     = var.archera_gcp_service_account
+  enable_archera_purchase_actions = var.enable_archera_purchase_actions
+}

--- a/iac/federation/gcp-target/terraform/variables.tf
+++ b/iac/federation/gcp-target/terraform/variables.tf
@@ -225,6 +225,11 @@ variable "archera_gcp_service_account" {
   description = "Full service account email of the SA Archera provides during onboarding, e.g. archera-integration@archera-prod.iam.gserviceaccount.com. Required when enable_archera = true."
   type        = string
   default     = ""
+
+  validation {
+    condition     = !var.enable_archera || can(regex("^[a-z][a-z0-9-]*@[a-z][a-z0-9-]*\\.iam\\.gserviceaccount\\.com$", var.archera_gcp_service_account))
+    error_message = "archera_gcp_service_account must be a valid GCP service account email (e.g. name@project.iam.gserviceaccount.com) when enable_archera = true."
+  }
 }
 
 variable "enable_archera_purchase_actions" {

--- a/iac/federation/gcp-target/terraform/variables.tf
+++ b/iac/federation/gcp-target/terraform/variables.tf
@@ -205,3 +205,34 @@ variable "contact_email" {
   type        = string
   default     = ""
 }
+
+# ---------------------------------------------------------------------------
+# Archera Insurance integration (opt-in, provisional)
+# ---------------------------------------------------------------------------
+
+variable "enable_archera" {
+  description = <<-EOT
+    When true, provision the Archera custom IAM role and role binding so
+    Archera can underwrite commitment-overuse insurance. Leave false (default)
+    unless you are enrolled with Archera.
+    PROVISIONAL — confirm scope with Archera before enabling.
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "archera_gcp_service_account" {
+  description = "Full service account email of the SA Archera provides during onboarding, e.g. archera-integration@archera-prod.iam.gserviceaccount.com. Required when enable_archera = true."
+  type        = string
+  default     = ""
+}
+
+variable "enable_archera_purchase_actions" {
+  description = <<-EOT
+    When true (and enable_archera = true), include CUD purchase permissions in
+    the Archera custom role. Only enable after confirming Archera requires
+    customer approval before executing purchases. Default false.
+  EOT
+  type        = bool
+  default     = false
+}

--- a/iac/modules/archera/aws/main.tf
+++ b/iac/modules/archera/aws/main.tf
@@ -1,0 +1,136 @@
+# ==============================================
+# Archera Integration — AWS (Shared Module)
+# ==============================================
+#
+# Single source of truth for the Archera AWS IAM resources.
+# The permission lists are loaded from scope.aws.yaml in the parent directory —
+# edit that file to update permissions across all callers simultaneously.
+#
+# Callers (federation bundles, environment self-deploy):
+#   module "archera" {
+#     source                          = "../../iac/modules/archera/aws"
+#     enable_archera                  = var.enable_archera
+#     archera_aws_account_id          = var.archera_aws_account_id
+#     archera_external_id             = var.archera_external_id
+#     enable_archera_purchase_actions = var.enable_archera_purchase_actions
+#   }
+
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+locals {
+  # Load the canonical permission list from the YAML source of truth.
+  scope = yamldecode(file("${path.module}/../scope.aws.yaml"))
+
+  archera_role_name = "cudly-archera-integration"
+  read_actions      = local.scope.read_actions
+  purchase_actions  = local.scope.purchase_actions
+}
+
+# IAM role that Archera's AWS account assumes to access this account.
+resource "aws_iam_role" "archera_integration" {
+  count = var.enable_archera ? 1 : 0
+
+  name        = local.archera_role_name
+  description = "Assumed by Archera SaaS to read cost data and (optionally) execute RI/SP purchases (provisional — confirm scope before enabling)"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "ArcheraAssumeRole"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${var.archera_aws_account_id}:root"
+        }
+        Action = "sts:AssumeRole"
+        # ExternalId prevents confused-deputy attacks — always required when
+        # trusting a third-party SaaS account.  Set archera_external_id to
+        # the value Archera provides during onboarding.
+        Condition = {
+          StringEquals = { "sts:ExternalId" = var.archera_external_id }
+        }
+      },
+    ]
+  })
+
+  tags = {
+    Integration = "archera"
+    Purpose     = "commitment-optimisation"
+    ManagedBy   = var.managed_by_tag
+  }
+}
+
+# Read-only policy for Archera — permission list from scope.aws.yaml.
+# Safe to attach at initial rollout (no financial writes).
+resource "aws_iam_policy" "archera_read" {
+  count = var.enable_archera ? 1 : 0
+
+  name        = "cudly-archera-read"
+  description = "Archera read-only policy — cost Explorer + RI/SP telemetry (no purchase actions)"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "ArcheraReadOnly"
+        Effect   = "Allow"
+        Action   = local.read_actions
+        Resource = "*"
+      },
+    ]
+  })
+
+  tags = {
+    Integration = "archera"
+    ManagedBy   = var.managed_by_tag
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "archera_read" {
+  count = var.enable_archera ? 1 : 0
+
+  role       = aws_iam_role.archera_integration[0].name
+  policy_arn = aws_iam_policy.archera_read[0].arn
+}
+
+# Purchase-execution policy for Archera — permission list from scope.aws.yaml.
+# Gated behind enable_archera_purchase_actions (default false) so financial
+# writes are never included by accident at initial rollout.
+resource "aws_iam_policy" "archera_purchase" {
+  count = (var.enable_archera && var.enable_archera_purchase_actions) ? 1 : 0
+
+  name        = "cudly-archera-purchase"
+  description = "Archera purchase policy — RI/SP write actions (confirm with Archera before enabling)"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "ArcheraPurchase"
+        Effect   = "Allow"
+        Action   = local.purchase_actions
+        Resource = "*"
+      },
+    ]
+  })
+
+  tags = {
+    Integration = "archera"
+    ManagedBy   = var.managed_by_tag
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "archera_purchase" {
+  count = (var.enable_archera && var.enable_archera_purchase_actions) ? 1 : 0
+
+  role       = aws_iam_role.archera_integration[0].name
+  policy_arn = aws_iam_policy.archera_purchase[0].arn
+}

--- a/iac/modules/archera/aws/main.tf
+++ b/iac/modules/archera/aws/main.tf
@@ -38,6 +38,13 @@ locals {
 resource "aws_iam_role" "archera_integration" {
   count = var.enable_archera ? 1 : 0
 
+  lifecycle {
+    precondition {
+      condition     = !var.enable_archera || (trimspace(var.archera_aws_account_id) != "" && trimspace(var.archera_external_id) != "")
+      error_message = "archera_aws_account_id and archera_external_id must both be non-empty when enable_archera = true."
+    }
+  }
+
   name        = local.archera_role_name
   description = "Assumed by Archera SaaS to read cost data and (optionally) execute RI/SP purchases (provisional — confirm scope before enabling)"
 

--- a/iac/modules/archera/aws/main.tf
+++ b/iac/modules/archera/aws/main.tf
@@ -16,7 +16,10 @@
 #   }
 
 terraform {
-  required_version = ">= 1.5"
+  # Modules in this directory family use cross-variable validation (referencing
+  # other vars inside a validation block) — Terraform 1.9+. Pin all three
+  # sibling modules together so behaviour stays consistent.
+  required_version = ">= 1.9.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/iac/modules/archera/aws/outputs.tf
+++ b/iac/modules/archera/aws/outputs.tf
@@ -1,0 +1,19 @@
+output "role_arn" {
+  description = "ARN of the Archera cross-account IAM role (empty string when enable_archera = false)."
+  value       = length(aws_iam_role.archera_integration) > 0 ? aws_iam_role.archera_integration[0].arn : ""
+}
+
+output "role_name" {
+  description = "Name of the Archera cross-account IAM role (empty string when enable_archera = false)."
+  value       = length(aws_iam_role.archera_integration) > 0 ? aws_iam_role.archera_integration[0].name : ""
+}
+
+output "read_policy_arn" {
+  description = "ARN of the Archera read-only IAM policy (empty string when enable_archera = false)."
+  value       = length(aws_iam_policy.archera_read) > 0 ? aws_iam_policy.archera_read[0].arn : ""
+}
+
+output "purchase_policy_arn" {
+  description = "ARN of the Archera purchase IAM policy (empty string when enable_archera_purchase_actions = false)."
+  value       = length(aws_iam_policy.archera_purchase) > 0 ? aws_iam_policy.archera_purchase[0].arn : ""
+}

--- a/iac/modules/archera/aws/variables.tf
+++ b/iac/modules/archera/aws/variables.tf
@@ -1,0 +1,44 @@
+variable "enable_archera" {
+  description = <<-EOT
+    When true, provision the Archera cross-account IAM role and read-only
+    cost/commitment policy so Archera can underwrite commitment-overuse
+    insurance. Leave false (default) unless you are enrolled with Archera.
+    PROVISIONAL — confirm scope with Archera before enabling.
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "archera_aws_account_id" {
+  description = "Archera's AWS account ID. Obtain from your Archera onboarding documentation. Required when enable_archera = true."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.archera_aws_account_id == "" || can(regex("^[0-9]{12}$", var.archera_aws_account_id))
+    error_message = "archera_aws_account_id must be a 12-digit AWS account ID."
+  }
+}
+
+variable "archera_external_id" {
+  description = "External ID for confused-deputy protection on the Archera cross-account role. Obtain from Archera during onboarding. Required when enable_archera = true."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "enable_archera_purchase_actions" {
+  description = <<-EOT
+    When true (and enable_archera = true), attach the Archera purchase policy
+    that allows RI/SP writes. Only enable after confirming Archera requires
+    customer approval before executing purchases. Default false.
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "managed_by_tag" {
+  description = "Value for the ManagedBy tag on all Archera resources."
+  type        = string
+  default     = "cudly-archera-module"
+}

--- a/iac/modules/archera/azure/main.tf
+++ b/iac/modules/archera/azure/main.tf
@@ -1,0 +1,61 @@
+# ==============================================
+# Archera Integration — Azure (Shared Module)
+# ==============================================
+#
+# Single source of truth for the Archera Azure RBAC resources.
+# The permission lists are loaded from scope.azure.yaml in the parent directory —
+# edit that file to update permissions across all callers simultaneously.
+
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+      # Accept 3.x (environment) and 4.x (federation bundle) — caller pins the exact major.
+      version = ">= 3.0"
+    }
+  }
+}
+
+locals {
+  # Load the canonical permission list from the YAML source of truth.
+  scope = yamldecode(file("${path.module}/../scope.azure.yaml"))
+
+  read_actions     = local.scope.read_actions
+  purchase_actions = local.scope.purchase_actions
+}
+
+# Custom RBAC role for Archera — permission list from scope.azure.yaml.
+# Do NOT grant broad Contributor or Cost Management Contributor predefined
+# roles — they include write permissions on resource deployments.
+resource "azurerm_role_definition" "archera_integration" {
+  count = var.enable_archera ? 1 : 0
+
+  name        = "CUDly Archera Integration"
+  scope       = "/subscriptions/${var.subscription_id}"
+  description = "Archera integration role — read cost data, optionally purchase RIs (confirm scope before enabling)"
+
+  permissions {
+    actions = concat(
+      local.read_actions,
+      var.enable_archera_purchase_actions ? local.purchase_actions : []
+    )
+    not_actions = []
+  }
+
+  assignable_scopes = [
+    "/subscriptions/${var.subscription_id}",
+  ]
+}
+
+# Assign the custom role to Archera's service principal.
+# archera_azure_sp_object_id must be the Object ID of the service principal
+# that Archera provides during onboarding (NOT the Application/Client ID).
+resource "azurerm_role_assignment" "archera_integration" {
+  count = var.enable_archera ? 1 : 0
+
+  scope              = "/subscriptions/${var.subscription_id}"
+  role_definition_id = azurerm_role_definition.archera_integration[0].role_definition_resource_id
+  principal_id       = var.archera_azure_sp_object_id
+  principal_type     = "ServicePrincipal"
+}

--- a/iac/modules/archera/azure/main.tf
+++ b/iac/modules/archera/azure/main.tf
@@ -7,7 +7,10 @@
 # edit that file to update permissions across all callers simultaneously.
 
 terraform {
-  required_version = ">= 1.5"
+  # variables.tf cross-references var.enable_archera inside another variable's
+  # validation block — Terraform 1.9+. Pin so the module fails fast on older
+  # versions rather than mid-plan.
+  required_version = ">= 1.9.0"
   required_providers {
     azurerm = {
       source = "hashicorp/azurerm"

--- a/iac/modules/archera/azure/outputs.tf
+++ b/iac/modules/archera/azure/outputs.tf
@@ -1,0 +1,9 @@
+output "role_definition_id" {
+  description = "Resource ID of the Archera custom RBAC role definition (empty string when enable_archera = false)."
+  value       = length(azurerm_role_definition.archera_integration) > 0 ? azurerm_role_definition.archera_integration[0].role_definition_resource_id : ""
+}
+
+output "role_assignment_id" {
+  description = "Resource ID of the Archera role assignment (empty string when enable_archera = false)."
+  value       = length(azurerm_role_assignment.archera_integration) > 0 ? azurerm_role_assignment.archera_integration[0].id : ""
+}

--- a/iac/modules/archera/azure/variables.tf
+++ b/iac/modules/archera/azure/variables.tf
@@ -18,6 +18,11 @@ variable "archera_azure_sp_object_id" {
   description = "Object ID of the service principal Archera provides during onboarding. NOT the Application/Client ID — use the Object ID from Azure Portal. Required when enable_archera = true."
   type        = string
   default     = ""
+
+  validation {
+    condition     = !var.enable_archera || trimspace(var.archera_azure_sp_object_id) != ""
+    error_message = "archera_azure_sp_object_id must be set (non-empty) when enable_archera = true."
+  }
 }
 
 variable "enable_archera_purchase_actions" {

--- a/iac/modules/archera/azure/variables.tf
+++ b/iac/modules/archera/azure/variables.tf
@@ -1,0 +1,31 @@
+variable "enable_archera" {
+  description = <<-EOT
+    When true, provision the Archera custom RBAC role and role assignment so
+    Archera can underwrite commitment-overuse insurance. Leave false (default)
+    unless you are enrolled with Archera.
+    PROVISIONAL — confirm scope with Archera before enabling.
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "subscription_id" {
+  description = "Azure subscription ID to scope the Archera role to. Required when enable_archera = true."
+  type        = string
+}
+
+variable "archera_azure_sp_object_id" {
+  description = "Object ID of the service principal Archera provides during onboarding. NOT the Application/Client ID — use the Object ID from Azure Portal. Required when enable_archera = true."
+  type        = string
+  default     = ""
+}
+
+variable "enable_archera_purchase_actions" {
+  description = <<-EOT
+    When true (and enable_archera = true), include reservation write actions in
+    the Archera custom role. Only enable after confirming Archera requires
+    customer approval before executing purchases. Default false.
+  EOT
+  type        = bool
+  default     = false
+}

--- a/iac/modules/archera/gcp/main.tf
+++ b/iac/modules/archera/gcp/main.tf
@@ -1,0 +1,53 @@
+# ==============================================
+# Archera Integration — GCP (Shared Module)
+# ==============================================
+#
+# Single source of truth for the Archera GCP IAM resources.
+# The permission lists are loaded from scope.gcp.yaml in the parent directory —
+# edit that file to update permissions across all callers simultaneously.
+
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0"
+    }
+  }
+}
+
+locals {
+  # Load the canonical permission list from the YAML source of truth.
+  scope = yamldecode(file("${path.module}/../scope.gcp.yaml"))
+
+  archera_custom_role_id = "cudlyArcheraIntegration"
+  read_permissions       = local.scope.read_permissions
+  purchase_permissions   = local.scope.purchase_permissions
+}
+
+# Custom IAM role for Archera — permission list from scope.gcp.yaml.
+# Do NOT grant roles/billing.admin or roles/editor — they include write
+# permissions across all project resources.
+resource "google_project_iam_custom_role" "archera_integration" {
+  count = var.enable_archera ? 1 : 0
+
+  project     = var.project_id
+  role_id     = local.archera_custom_role_id
+  title       = "CUDly Archera Integration"
+  description = "Archera integration role — read cost data, optionally purchase CUDs (confirm scope before enabling)"
+  stage       = "BETA"
+
+  permissions = concat(
+    local.read_permissions,
+    var.enable_archera_purchase_actions ? local.purchase_permissions : []
+  )
+}
+
+# Bind the custom role to Archera's GCP service account.
+resource "google_project_iam_member" "archera_integration" {
+  count = var.enable_archera ? 1 : 0
+
+  project = var.project_id
+  role    = google_project_iam_custom_role.archera_integration[0].name
+  member  = "serviceAccount:${var.archera_gcp_service_account}"
+}

--- a/iac/modules/archera/gcp/main.tf
+++ b/iac/modules/archera/gcp/main.tf
@@ -7,7 +7,10 @@
 # edit that file to update permissions across all callers simultaneously.
 
 terraform {
-  required_version = ">= 1.5"
+  # variables.tf cross-references var.enable_archera inside another variable's
+  # validation block — Terraform 1.9+. Pin so the module fails fast on older
+  # versions rather than mid-plan.
+  required_version = ">= 1.9.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/iac/modules/archera/gcp/outputs.tf
+++ b/iac/modules/archera/gcp/outputs.tf
@@ -1,0 +1,9 @@
+output "custom_role_name" {
+  description = "Full name of the Archera custom IAM role (empty string when enable_archera = false)."
+  value       = length(google_project_iam_custom_role.archera_integration) > 0 ? google_project_iam_custom_role.archera_integration[0].name : ""
+}
+
+output "iam_member_id" {
+  description = "Terraform resource ID of the Archera IAM member binding (empty string when enable_archera = false)."
+  value       = length(google_project_iam_member.archera_integration) > 0 ? google_project_iam_member.archera_integration[0].id : ""
+}

--- a/iac/modules/archera/gcp/variables.tf
+++ b/iac/modules/archera/gcp/variables.tf
@@ -1,0 +1,31 @@
+variable "enable_archera" {
+  description = <<-EOT
+    When true, provision the Archera custom IAM role and role binding so
+    Archera can underwrite commitment-overuse insurance. Leave false (default)
+    unless you are enrolled with Archera.
+    PROVISIONAL — confirm scope with Archera before enabling.
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "project_id" {
+  description = "GCP project ID to provision the Archera custom role in. Required when enable_archera = true."
+  type        = string
+}
+
+variable "archera_gcp_service_account" {
+  description = "Full service account email of the SA Archera provides during onboarding, e.g. archera-integration@archera-prod.iam.gserviceaccount.com. Required when enable_archera = true."
+  type        = string
+  default     = ""
+}
+
+variable "enable_archera_purchase_actions" {
+  description = <<-EOT
+    When true (and enable_archera = true), include CUD purchase permissions in
+    the Archera custom role. Only enable after confirming Archera requires
+    customer approval before executing purchases. Default false.
+  EOT
+  type        = bool
+  default     = false
+}

--- a/iac/modules/archera/gcp/variables.tf
+++ b/iac/modules/archera/gcp/variables.tf
@@ -18,6 +18,11 @@ variable "archera_gcp_service_account" {
   description = "Full service account email of the SA Archera provides during onboarding, e.g. archera-integration@archera-prod.iam.gserviceaccount.com. Required when enable_archera = true."
   type        = string
   default     = ""
+
+  validation {
+    condition     = !var.enable_archera || can(regex("^[a-z][a-z0-9-]*@[a-z][a-z0-9-]*\\.iam\\.gserviceaccount\\.com$", var.archera_gcp_service_account))
+    error_message = "archera_gcp_service_account must be a valid GCP service account email (e.g. name@project.iam.gserviceaccount.com) when enable_archera = true."
+  }
 }
 
 variable "enable_archera_purchase_actions" {

--- a/iac/modules/archera/scope.aws.yaml
+++ b/iac/modules/archera/scope.aws.yaml
@@ -1,0 +1,51 @@
+# scope.aws.yaml — Canonical Archera AWS permission list (single source of truth)
+#
+# This file is the authoritative definition of which AWS IAM actions CUDly
+# provisions for the Archera Insurance integration.  All Terraform modules,
+# CloudFormation templates, and parity-check scripts derive from this file.
+# Editing an action here propagates everywhere automatically.
+#
+# PROVISIONAL SCOPE — must be confirmed against Archera integration docs
+# before flipping enable_archera = true in any tfvars.
+# TODO(@cristim): confirm Archera scope list against integration docs
+# before enabling.  Reference: https://archera.ai/docs (integration guide).
+#
+# Format:
+#   read_actions:    granted whenever enable_archera = true
+#   purchase_actions: granted ONLY when enable_archera_purchase_actions = true
+
+read_actions:
+  # Cost Explorer — read-only
+  - "ce:GetCostAndUsage"
+  - "ce:GetCostAndUsageWithResources"
+  - "ce:GetCostForecast"
+  - "ce:GetDimensionValues"
+  - "ce:GetReservationCoverage"
+  - "ce:GetReservationPurchaseRecommendation"
+  - "ce:GetReservationUtilization"
+  - "ce:GetRightsizingRecommendation"
+  - "ce:GetSavingsPlansCoverage"
+  - "ce:GetSavingsPlansUtilization"
+  - "ce:GetSavingsPlansUtilizationDetails"
+  - "ce:ListCostCategoryDefinitions"
+  # CUR / Cost and Usage Report
+  - "cur:DescribeReportDefinitions"
+  # Reserved Instances — read-only
+  - "ec2:DescribeReservedInstances"
+  - "ec2:DescribeReservedInstancesListings"
+  - "ec2:DescribeReservedInstancesModifications"
+  - "ec2:DescribeReservedInstancesOfferings"
+  - "ec2:DescribeInstanceTypeOfferings"
+  # Savings Plans — read-only
+  - "savingsplans:DescribeSavingsPlans"
+  - "savingsplans:DescribeSavingsPlansOfferings"
+  - "savingsplans:DescribeSavingsPlanRates"
+  - "savingsplans:ListTagsForResource"
+
+purchase_actions:
+  # Reserved Instances — purchase execution
+  - "ec2:PurchaseReservedInstancesOffering"
+  - "ec2:ModifyReservedInstances"
+  # Savings Plans — purchase execution
+  - "savingsplans:CreateSavingsPlan"
+  - "savingsplans:DeleteQueuedSavingsPlan"

--- a/iac/modules/archera/scope.azure.yaml
+++ b/iac/modules/archera/scope.azure.yaml
@@ -1,0 +1,28 @@
+# scope.azure.yaml — Canonical Archera Azure permission list (single source of truth)
+#
+# This file is the authoritative definition of which Azure RBAC actions CUDly
+# provisions for the Archera Insurance integration.  All Terraform modules,
+# Bicep templates, ARM templates, and parity-check scripts derive from this file.
+# Editing an action here propagates everywhere automatically.
+#
+# PROVISIONAL SCOPE — must be confirmed against Archera integration docs
+# before flipping enable_archera = true in any tfvars.
+# TODO(@cristim): confirm Archera scope list against integration docs
+# before enabling.  Reference: https://archera.ai/docs (integration guide).
+#
+# Format:
+#   read_actions:    granted whenever enable_archera = true
+#   purchase_actions: granted ONLY when enable_archera_purchase_actions = true
+
+read_actions:
+  # Cost Management — read-only
+  - "Microsoft.CostManagement/*/read"
+  - "Microsoft.Consumption/*/read"
+  - "Microsoft.Billing/*/read"
+  # Reserved Instances — read-only
+  - "Microsoft.Capacity/reservations/read"
+  - "Microsoft.Capacity/reservationOrders/read"
+
+purchase_actions:
+  # Reserved Instances — purchase execution
+  - "Microsoft.Capacity/reservationOrders/write"

--- a/iac/modules/archera/scope.gcp.yaml
+++ b/iac/modules/archera/scope.gcp.yaml
@@ -1,0 +1,33 @@
+# scope.gcp.yaml — Canonical Archera GCP permission list (single source of truth)
+#
+# This file is the authoritative definition of which GCP IAM permissions CUDly
+# provisions for the Archera Insurance integration.  All Terraform modules,
+# and parity-check scripts derive from this file.
+# Editing a permission here propagates everywhere automatically.
+#
+# PROVISIONAL SCOPE — must be confirmed against Archera integration docs
+# before flipping enable_archera = true in any tfvars.
+# TODO(@cristim): confirm Archera scope list against integration docs
+# before enabling.  Reference: https://archera.ai/docs (integration guide).
+#
+# Format:
+#   read_permissions:    granted whenever enable_archera = true
+#   purchase_permissions: granted ONLY when enable_archera_purchase_actions = true
+
+read_permissions:
+  # Billing / Cost data — read-only
+  - "billing.accounts.get"
+  - "billing.accounts.list"
+  - "billing.budgets.get"
+  - "billing.budgets.list"
+  # Recommender / Committed Use Discounts — read-only
+  - "recommender.commitmentUtilizationInsights.get"
+  - "recommender.commitmentUtilizationInsights.list"
+  - "recommender.commitments.get"
+  - "recommender.commitments.list"
+  # Resource Manager (project metadata)
+  - "resourcemanager.projects.get"
+
+purchase_permissions:
+  # Committed Use Discounts — purchase execution
+  - "recommender.commitments.create"

--- a/internal/api/handler_federation.go
+++ b/internal/api/handler_federation.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io/fs"
 	"regexp"
+	"strconv"
 	"strings"
 	"text/template"
 
@@ -160,8 +161,16 @@ func (h *Handler) getFederationIaC(ctx context.Context, req *events.LambdaFuncti
 	// person who downloads the bundle IS the contact.
 	data.ContactEmail = session.Email
 	// include_archera is an opt-in flag: default false so existing downloads are
-	// byte-identical for users who don't tick the checkbox.
-	data.IncludeArchera = req.QueryStringParameters["include_archera"] == "true"
+	// byte-identical for users who don't tick the checkbox. Reject malformed values
+	// (anything other than "true", "false", "1", "0", or absent) with 400 so
+	// callers get a clear error instead of silently falling back to false.
+	if rawArchera, ok := req.QueryStringParameters["include_archera"]; ok {
+		parsed, parseErr := strconv.ParseBool(rawArchera)
+		if parseErr != nil {
+			return nil, NewClientError(400, fmt.Sprintf("include_archera must be a boolean value (true/false), got %q", rawArchera))
+		}
+		data.IncludeArchera = parsed
+	}
 
 	if formatNeedsZip(format) {
 		return h.buildZipResponse(data, target, source, format, "target")

--- a/internal/api/handler_federation.go
+++ b/internal/api/handler_federation.go
@@ -41,6 +41,10 @@ type federationIaCData struct {
 	// ContactEmail is the email of the authenticated user who downloaded the bundle.
 	// Pre-filled from Session.Email — no manual entry required.
 	ContactEmail string
+	// IncludeArchera controls whether Archera Insurance permission resources are
+	// included in the rendered bundle. Default false — the download is byte-identical
+	// to the pre-Archera output when this flag is not set.
+	IncludeArchera bool
 }
 
 // FederationIaCResponse is returned by the /api/federation/iac endpoint.
@@ -155,6 +159,9 @@ func (h *Handler) getFederationIaC(ctx context.Context, req *events.LambdaFuncti
 	// for normal traffic. No env-var override, no admin-curated fallback: the
 	// person who downloads the bundle IS the contact.
 	data.ContactEmail = session.Email
+	// include_archera is an opt-in flag: default false so existing downloads are
+	// byte-identical for users who don't tick the checkbox.
+	data.IncludeArchera = req.QueryStringParameters["include_archera"] == "true"
 
 	if formatNeedsZip(format) {
 		return h.buildZipResponse(data, target, source, format, "target")
@@ -754,6 +761,7 @@ type cfParam struct {
 //
 // Dispatches on source: "aws" → cross-account params (SourceAccountID, ExternalID);
 // anything else → AWS WIF params (OIDC values).
+// When data.IncludeArchera is true, the Archera opt-in parameters are appended.
 func buildCFParamsJSON(data federationIaCData, source string) (string, error) {
 	var params []cfParam
 	if source == "aws" {
@@ -771,6 +779,16 @@ func buildCFParamsJSON(data federationIaCData, source string) (string, error) {
 			{ParameterKey: "OIDCAudience", ParameterValue: data.OIDCAudience},
 			{ParameterKey: "RoleName", ParameterValue: "CUDly-" + data.AccountSlug},
 		}
+	}
+	if data.IncludeArchera {
+		// Archera opt-in parameters — PROVISIONAL (see iac/federation/aws-target/terraform/archera.tf).
+		// Values must be supplied by the operator during stack deployment.
+		params = append(params,
+			cfParam{ParameterKey: "EnableArchera", ParameterValue: "true"},
+			cfParam{ParameterKey: "ArcheraAwsAccountId", ParameterValue: "REPLACE_WITH_ARCHERA_AWS_ACCOUNT_ID"},
+			cfParam{ParameterKey: "ArcheraExternalId", ParameterValue: "REPLACE_WITH_ARCHERA_EXTERNAL_ID"},
+			cfParam{ParameterKey: "EnableArcheraPurchaseActions", ParameterValue: "false"},
+		)
 	}
 	out, err := json.MarshalIndent(params, "", "  ")
 	if err != nil {

--- a/internal/api/handler_federation_test.go
+++ b/internal/api/handler_federation_test.go
@@ -1123,6 +1123,171 @@ func TestGetFederationIaC_RejectsImpossibleTargetSourceCombo(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// Archera opt-in flag tests (issue #314)
+// ---------------------------------------------------------------------------
+
+// TestGetFederationIaC_IncludeArchera_False_ByteIdentical verifies that
+// include_archera=false (or absent) produces output byte-identical to the
+// pre-Archera baseline — existing users are not affected.
+func TestGetFederationIaC_IncludeArchera_False_ByteIdentical(t *testing.T) {
+	cases := []struct {
+		name           string
+		target, source string
+		format         string
+		envCloud       string
+	}{
+		{"aws-wif-bundle", "aws", "gcp", "bundle", "gcp"},
+		{"azure-bundle", "azure", "aws", "bundle", "gcp"},
+		{"gcp-wif-bundle", "gcp", "aws", "bundle", "gcp"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("CUDLY_SOURCE_CLOUD", tc.envCloud)
+			h := federationHandler()
+
+			resWithout, err := h.getFederationIaC(context.Background(), federationReq(map[string]string{
+				"target": tc.target, "source": tc.source, "format": tc.format,
+			}))
+			require.NoError(t, err)
+
+			resFalse, err := h.getFederationIaC(context.Background(), federationReq(map[string]string{
+				"target": tc.target, "source": tc.source, "format": tc.format, "include_archera": "false",
+			}))
+			require.NoError(t, err)
+
+			// Filenames and content must be identical regardless of explicit false vs. absent.
+			assert.Equal(t, resWithout.Filename, resFalse.Filename,
+				"filenames must be identical when include_archera is absent vs false")
+			assert.Equal(t, resWithout.Content, resFalse.Content,
+				"content must be identical when include_archera is absent vs false")
+		})
+	}
+}
+
+// TestGetFederationIaC_IncludeArchera_True_ContainsArcheraVars verifies that
+// include_archera=true causes Archera variables to appear in the rendered
+// tfvars output for each federation bundle format.
+func TestGetFederationIaC_IncludeArchera_True_ContainsArcheraVars(t *testing.T) {
+	cases := []struct {
+		name           string
+		target, source string
+		wantInTfvars   string
+		envCloud       string
+	}{
+		{"aws-wif", "aws", "gcp", "enable_archera = true", "gcp"},
+		{"aws-wif-archera-account", "aws", "gcp", "archera_aws_account_id", "gcp"},
+		{"azure-wif", "azure", "aws", "enable_archera = true", "gcp"},
+		{"azure-wif-sp", "azure", "aws", "archera_azure_sp_object_id", "gcp"},
+		{"gcp-wif", "gcp", "aws", "enable_archera = true", "gcp"},
+		{"gcp-wif-sa", "gcp", "aws", "archera_gcp_service_account", "gcp"},
+		{"gcp-sa-impersonation", "gcp", "gcp", "enable_archera = true", "gcp"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("CUDLY_SOURCE_CLOUD", tc.envCloud)
+			h := federationHandler()
+
+			res, err := h.getFederationIaC(context.Background(), federationReq(map[string]string{
+				"target": tc.target, "source": tc.source, "format": "bundle", "include_archera": "true",
+			}))
+			require.NoError(t, err)
+
+			zipBytes, err := base64.StdEncoding.DecodeString(res.Content)
+			require.NoError(t, err)
+			zr, err := zip.NewReader(bytes.NewReader(zipBytes), int64(len(zipBytes)))
+			require.NoError(t, err)
+
+			var tfvarsContent string
+			for _, f := range zr.File {
+				if strings.HasSuffix(f.Name, ".auto.tfvars") {
+					rc, err := f.Open()
+					require.NoError(t, err)
+					var buf bytes.Buffer
+					_, _ = buf.ReadFrom(rc)
+					rc.Close()
+					tfvarsContent = buf.String()
+					break
+				}
+			}
+			require.NotEmpty(t, tfvarsContent, "bundle must contain a .auto.tfvars file")
+			assert.Contains(t, tfvarsContent, tc.wantInTfvars,
+				"tfvars must contain Archera vars when include_archera=true")
+		})
+	}
+}
+
+// TestGetFederationIaC_IncludeArchera_True_CFNParams verifies that the CFN
+// params JSON includes Archera parameters when include_archera=true.
+func TestGetFederationIaC_IncludeArchera_True_CFNParams(t *testing.T) {
+	h := federationHandler()
+
+	res, err := h.getFederationIaC(context.Background(), federationReq(map[string]string{
+		"target": "aws", "source": "gcp", "format": "cfn", "include_archera": "true",
+	}))
+	require.NoError(t, err)
+
+	zipBytes, err := base64.StdEncoding.DecodeString(res.Content)
+	require.NoError(t, err)
+	zr, err := zip.NewReader(bytes.NewReader(zipBytes), int64(len(zipBytes)))
+	require.NoError(t, err)
+
+	var paramsContent []byte
+	for _, f := range zr.File {
+		if strings.HasSuffix(f.Name, "-cf-params.json") {
+			rc, err := f.Open()
+			require.NoError(t, err)
+			var buf bytes.Buffer
+			_, _ = buf.ReadFrom(rc)
+			rc.Close()
+			paramsContent = buf.Bytes()
+			break
+		}
+	}
+	require.NotNil(t, paramsContent, "cfn zip must contain a cf-params.json")
+	var params []map[string]string
+	require.NoError(t, json.Unmarshal(paramsContent, &params), "CF params must be valid JSON")
+
+	keys := make(map[string]bool)
+	for _, p := range params {
+		keys[p["ParameterKey"]] = true
+	}
+	assert.True(t, keys["EnableArchera"], "EnableArchera must be in CFN params when include_archera=true")
+	assert.True(t, keys["ArcheraAwsAccountId"], "ArcheraAwsAccountId must be in CFN params when include_archera=true")
+	assert.True(t, keys["ArcheraExternalId"], "ArcheraExternalId must be in CFN params when include_archera=true")
+}
+
+// TestGetFederationIaC_IncludeArchera_True_BicepParams verifies that the
+// Bicep params JSON includes Archera parameters when include_archera=true.
+func TestGetFederationIaC_IncludeArchera_True_BicepParams(t *testing.T) {
+	h := federationHandler()
+
+	res, err := h.getFederationIaC(context.Background(), federationReq(map[string]string{
+		"target": "azure", "source": "aws", "format": "bicep", "include_archera": "true",
+	}))
+	require.NoError(t, err)
+
+	files := unzipResponse(t, res)
+	require.Contains(t, files, "azure-wif-bicep-params.json")
+
+	var params map[string]any
+	require.NoError(t, json.Unmarshal(files["azure-wif-bicep-params.json"], &params),
+		"Bicep params must be valid JSON")
+	parameters, ok := params["parameters"].(map[string]any)
+	require.True(t, ok, "Bicep params must have a 'parameters' object")
+	assert.Contains(t, parameters, "enableArchera",
+		"enableArchera must be in Bicep params when include_archera=true")
+	assert.Contains(t, parameters, "archeraAzureSpObjectId",
+		"archeraAzureSpObjectId must be in Bicep params when include_archera=true")
+}
+
+// ---------------------------------------------------------------------------
+// TestValidateFederationTargetSource unit-tests the guard directly, covering
+// all self-source rejection and allow cases (issues #42 and #140).
+// ---------------------------------------------------------------------------
+
 // TestValidateFederationTargetSource unit-tests the guard directly, covering
 // all self-source rejection and allow cases (issues #42 and #140).
 func TestValidateFederationTargetSource(t *testing.T) {

--- a/internal/iacfiles/templates/README.md
+++ b/internal/iacfiles/templates/README.md
@@ -32,7 +32,26 @@ TenantID            — Azure tenant ID (azure target or azure source)
 ProjectID           — GCP project ID (gcp target only)
 ServiceAccountEmail — GCP service account email (gcp target only)
 OIDCIssuerURI       — OIDC issuer URI for GCP WIF (gcp target + azure source)
+IncludeArchera      — bool; true when the operator ticks "Provision Archera Insurance
+                      permissions?" in the UI (or passes --include-archera from the CLI).
+                      Default false — bundle output is byte-identical to pre-Archera
+                      output when this field is false.
 ```
+
+### Archera opt-in (`IncludeArchera`)
+
+When `IncludeArchera` is `true`, each tfvars template appends an
+`enable_archera = true` block with cloud-specific Archera input variables
+(e.g. `archera_aws_account_id` / `archera_azure_sp_object_id` /
+`archera_gcp_service_account`).  The Bicep params template adds
+`enableArchera`, `archeraAzureSpObjectId`, and `enableArcheraPurchaseActions`
+parameters.  The CFN params JSON (produced by `buildCFParamsJSON` in the handler)
+adds `EnableArchera`, `ArcheraAwsAccountId`, `ArcheraExternalId`, and
+`EnableArcheraPurchaseActions`.
+
+The permission list rendered into the bundle is derived from PR #310
+(`terraform/environments/{aws,azure,gcp}/archera.tf`) and must stay in
+parity with it.  `scripts/check-archera-parity.sh` enforces this in CI.
 
 ## How output is generated
 

--- a/internal/iacfiles/templates/aws-cross-account.tfvars.tmpl
+++ b/internal/iacfiles/templates/aws-cross-account.tfvars.tmpl
@@ -19,3 +19,18 @@ source_account_id = "{{.SourceAccountID}}"
 cudly_api_url = "{{.CUDlyAPIURL}}"
 contact_email = "{{.ContactEmail}}"
 account_name  = "{{.AccountName}}"
+{{- if .IncludeArchera}}
+
+# --- Archera Insurance integration (PROVISIONAL — confirm scope before enabling) ---
+# See iac/federation/aws-cross-account/terraform/archera.tf for resource details.
+enable_archera = true
+
+# Archera's AWS account ID — obtain from your Archera onboarding documentation.
+archera_aws_account_id = "REPLACE_WITH_ARCHERA_AWS_ACCOUNT_ID"
+
+# External ID for confused-deputy protection — obtain from Archera during onboarding.
+archera_external_id = "REPLACE_WITH_ARCHERA_EXTERNAL_ID"
+
+# Uncomment only after confirming Archera's approval workflow allows purchase actions.
+# enable_archera_purchase_actions = true
+{{- end}}

--- a/internal/iacfiles/templates/aws-wif.tfvars.tmpl
+++ b/internal/iacfiles/templates/aws-wif.tfvars.tmpl
@@ -18,3 +18,18 @@ role_name       = "CUDly-{{.AccountSlug}}"
 cudly_api_url = "{{.CUDlyAPIURL}}"
 contact_email = "{{.ContactEmail}}"
 account_name  = "{{.AccountName}}"
+{{- if .IncludeArchera}}
+
+# --- Archera Insurance integration (PROVISIONAL — confirm scope before enabling) ---
+# See iac/federation/aws-target/terraform/archera.tf for resource details.
+enable_archera = true
+
+# Archera's AWS account ID — obtain from your Archera onboarding documentation.
+archera_aws_account_id = "REPLACE_WITH_ARCHERA_AWS_ACCOUNT_ID"
+
+# External ID for confused-deputy protection — obtain from Archera during onboarding.
+archera_external_id = "REPLACE_WITH_ARCHERA_EXTERNAL_ID"
+
+# Uncomment only after confirming Archera's approval workflow allows purchase actions.
+# enable_archera_purchase_actions = true
+{{- end}}

--- a/internal/iacfiles/templates/azure-wif-bicep-params.json.tmpl
+++ b/internal/iacfiles/templates/azure-wif-bicep-params.json.tmpl
@@ -4,6 +4,15 @@
   "parameters": {
     "servicePrincipalObjectId": {
       "value": "<FROM_CLI_OUTPUT>"
-    }
+    }{{if .IncludeArchera}},
+    "enableArchera": {
+      "value": true
+    },
+    "archeraAzureSpObjectId": {
+      "value": "REPLACE_WITH_ARCHERA_AZURE_SP_OBJECT_ID"
+    },
+    "enableArcheraPurchaseActions": {
+      "value": false
+    }{{end}}
   }
 }

--- a/internal/iacfiles/templates/azure-wif.tfvars.tmpl
+++ b/internal/iacfiles/templates/azure-wif.tfvars.tmpl
@@ -17,3 +17,16 @@ cudly_issuer_url = "{{.CUDlyAPIURL}}/oidc"
 cudly_api_url = "{{.CUDlyAPIURL}}"
 contact_email = "{{.ContactEmail}}"
 account_name  = "{{.AccountName}}"
+{{- if .IncludeArchera}}
+
+# --- Archera Insurance integration (PROVISIONAL — confirm scope before enabling) ---
+# See iac/federation/azure-target/terraform/archera.tf for resource details.
+enable_archera = true
+
+# Object ID of the service principal Archera provides during onboarding
+# (NOT the Application/Client ID — use the Object ID from Azure Portal).
+archera_azure_sp_object_id = "REPLACE_WITH_ARCHERA_AZURE_SP_OBJECT_ID"
+
+# Uncomment only after confirming Archera's approval workflow allows purchase actions.
+# enable_archera_purchase_actions = true
+{{- end}}

--- a/internal/iacfiles/templates/gcp-sa-impersonation.tfvars.tmpl
+++ b/internal/iacfiles/templates/gcp-sa-impersonation.tfvars.tmpl
@@ -20,3 +20,16 @@ source_service_account = "<SOURCE_SERVICE_ACCOUNT_EMAIL>"
 cudly_api_url = "{{.CUDlyAPIURL}}"
 contact_email = "{{.ContactEmail}}"
 account_name  = "{{.AccountName}}"
+{{- if .IncludeArchera}}
+
+# --- Archera Insurance integration (PROVISIONAL — confirm scope before enabling) ---
+# See iac/federation/gcp-sa-impersonation/terraform/archera.tf for resource details.
+enable_archera = true
+
+# Full service account email of the SA Archera provides during onboarding,
+# e.g. "archera-integration@archera-prod.iam.gserviceaccount.com".
+archera_gcp_service_account = "REPLACE_WITH_ARCHERA_GCP_SA_EMAIL"
+
+# Uncomment only after confirming Archera's approval workflow allows purchase actions.
+# enable_archera_purchase_actions = true
+{{- end}}

--- a/internal/iacfiles/templates/gcp-wif.tfvars.tmpl
+++ b/internal/iacfiles/templates/gcp-wif.tfvars.tmpl
@@ -34,3 +34,16 @@ oidc_issuer_uri = "{{.OIDCIssuerURI}}"{{if eq .Source "azure"}}  # Azure: https:
 cudly_api_url = "{{.CUDlyAPIURL}}"
 contact_email = "{{.ContactEmail}}"
 account_name  = "{{.AccountName}}"
+{{- if .IncludeArchera}}
+
+# --- Archera Insurance integration (PROVISIONAL — confirm scope before enabling) ---
+# See iac/federation/gcp-target/terraform/archera.tf for resource details.
+enable_archera = true
+
+# Full service account email of the SA Archera provides during onboarding,
+# e.g. "archera-integration@archera-prod.iam.gserviceaccount.com".
+archera_gcp_service_account = "REPLACE_WITH_ARCHERA_GCP_SA_EMAIL"
+
+# Uncomment only after confirming Archera's approval workflow allows purchase actions.
+# enable_archera_purchase_actions = true
+{{- end}}

--- a/scripts/check-archera-parity.sh
+++ b/scripts/check-archera-parity.sh
@@ -101,8 +101,9 @@ extract_bicep_azure_actions() {
   # e.g. 'Microsoft.CostManagement/*/read' — but resource type declarations
   # like 'Microsoft.Authorization/roleDefinitions@2022-04-01' contain '@'.
   # Also exclude string-literal resource type uses (param names, type blocks).
-  grep -oE "'Microsoft\.[^']+'" "$file" \
-    | tr -d "'" \
+  # Handle both single-quoted (standard Bicep) and double-quoted string forms.
+  grep -oE "(['\"])Microsoft\.[^'\"]+\1" "$file" \
+    | sed "s/^['\"]//;s/['\"]$//" \
     | grep -vE '@|roleDefinitions$|roleAssignments$' \
     | sort -u
 }

--- a/scripts/check-archera-parity.sh
+++ b/scripts/check-archera-parity.sh
@@ -186,7 +186,10 @@ check_env_thin_caller() {
 
   local inline_actions
   case "$cloud" in
-    aws)   inline_actions=$(grep -oE '"[a-z]+:[A-Za-z]+"' "$env_file" || true) ;;
+    # AWS service prefixes can contain digits (ec2, s3, ec2-instance-connect…).
+    # The previous [a-z]+: pattern missed any service whose name has a digit
+    # or dash, letting common inline grants slip past the thin-caller guard.
+    aws)   inline_actions=$(grep -oE '"[a-z][a-z0-9-]*:[A-Za-z]+"' "$env_file" || true) ;;
     azure) inline_actions=$(grep -oE '"Microsoft\.[^"]*"' "$env_file" || true) ;;
     gcp)   inline_actions=$(grep -oE '"[a-z]+\.[a-z]+\.[a-zA-Z]+"' "$env_file" || true) ;;
   esac

--- a/scripts/check-archera-parity.sh
+++ b/scripts/check-archera-parity.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+# check-archera-parity.sh — verify that the Archera permission lists in
+# CloudFormation, Bicep, and ARM templates match the canonical YAML scope files.
+#
+# Since the shared Terraform modules (iac/modules/archera/{aws,azure,gcp}/)
+# load permissions directly from the scope YAML at apply time, Terraform itself
+# always reflects the YAML — no separate Terraform parity check is needed.
+# The non-Terraform deployment paths (CFN, Bicep, ARM) embed the permission
+# lists as literals and MUST be kept in sync with the scope YAML manually;
+# this script is the CI gate that enforces that.
+#
+# Additionally, when terraform/environments/{aws,azure,gcp}/archera.tf exists
+# (after PR #310 is merged into the base branch), this script verifies that
+# those environment files are thin module callers (i.e. they no longer contain
+# inline permission lists — the module handles that).
+#
+# Usage (from repo root):
+#   bash scripts/check-archera-parity.sh
+#
+# Exit codes:
+#   0 — parity confirmed (or optional files not yet present — skipped)
+#   1 — drift detected; see output for details
+#
+# Dependencies: yq (YAML parsing) or python3 with PyYAML.  Falls back to
+# python3 when yq is not on PATH.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+AWS_SCOPE_YAML="$REPO_ROOT/iac/modules/archera/scope.aws.yaml"
+AZURE_SCOPE_YAML="$REPO_ROOT/iac/modules/archera/scope.azure.yaml"
+GCP_SCOPE_YAML="$REPO_ROOT/iac/modules/archera/scope.gcp.yaml"
+
+# ── YAML helpers ───────────────────────────────────────────────────────────────
+
+# Extract a YAML list at a given key, one item per line, sorted.
+# Always uses python3 for consistent cross-platform behaviour.
+yaml_list() {
+  local file="$1" key="$2"
+  python3 - "$file" "$key" <<'EOF'
+import sys, yaml
+data = yaml.safe_load(open(sys.argv[1]))
+key = sys.argv[2]
+items = data.get(key, [])
+for item in sorted(set(items)):
+    print(item)
+EOF
+}
+
+# ── AWS checks ─────────────────────────────────────────────────────────────────
+
+# Extract IAM action strings from a CloudFormation YAML template.
+# Only match lines that are YAML list items (- prefix) containing IAM actions.
+# Excludes sts:AssumeRole (trust policy, not a grant), sts:ExternalId (condition
+# key, not an action), and arn: references.
+extract_cfn_aws_actions() {
+  local file="$1"
+  # Match YAML list items: lines like "              - ec2:DescribeReservedInstances"
+  # Service names may contain digits (ec2, cur, s3, etc.) — use [a-z][a-z0-9]*.
+  # Exclude sts: (trust policy) and arn: (ARN references).
+  /usr/bin/grep -oE '^[[:space:]]+-[[:space:]]+([a-z][a-z0-9]*:[A-Za-z]+)' "$file" \
+    | /usr/bin/grep -oE '[a-z][a-z0-9]*:[A-Za-z]+' \
+    | /usr/bin/grep -vE '^(sts|arn):' \
+    | sort -u
+}
+
+check_aws_cfn_parity() {
+  local label="$1"
+  local cfn_file="$2"
+
+  if [[ ! -f "$cfn_file" ]]; then
+    echo "FAIL  AWS $label: CFN template not found at $cfn_file"
+    return 1
+  fi
+
+  local yaml_read yaml_purchase yaml_all cfn_actions diff_output
+  yaml_read=$(yaml_list "$AWS_SCOPE_YAML" "read_actions")
+  yaml_purchase=$(yaml_list "$AWS_SCOPE_YAML" "purchase_actions")
+  yaml_all=$(printf '%s\n%s\n' "$yaml_read" "$yaml_purchase" | sort -u)
+
+  cfn_actions=$(extract_cfn_aws_actions "$cfn_file")
+  diff_output=$(diff <(echo "$yaml_all") <(echo "$cfn_actions") || true)
+
+  if [[ -z "$diff_output" ]]; then
+    echo "OK    AWS $label CFN parity confirmed"
+    return 0
+  else
+    echo "FAIL  AWS $label CFN template has permission drift versus scope.aws.yaml:"
+    echo "$diff_output"
+    return 1
+  fi
+}
+
+# ── Azure checks ───────────────────────────────────────────────────────────────
+
+extract_bicep_azure_actions() {
+  local file="$1"
+  # Match only permission action strings (not resource type references).
+  # Azure RBAC actions follow the pattern Service/ResourceType/action
+  # e.g. 'Microsoft.CostManagement/*/read' — but resource type declarations
+  # like 'Microsoft.Authorization/roleDefinitions@2022-04-01' contain '@'.
+  # Also exclude string-literal resource type uses (param names, type blocks).
+  grep -oE "'Microsoft\.[^']+'" "$file" \
+    | tr -d "'" \
+    | grep -vE '@|roleDefinitions$|roleAssignments$' \
+    | sort -u
+}
+
+extract_arm_azure_actions() {
+  local file="$1"
+  # Match only permission action strings in the actions/notActions arrays.
+  # Exclude resource type references (contain '@' or are pure resource types).
+  grep -oE '"Microsoft\.[^"]+"' "$file" \
+    | tr -d '"' \
+    | grep -vE '@|roleDefinitions$|roleAssignments$|roleDefinitions/|roleAssignments/' \
+    | sort -u
+}
+
+check_azure_bicep_parity() {
+  local bicep_file="$REPO_ROOT/iac/federation/azure-target/bicep/archera.bicep"
+
+  if [[ ! -f "$bicep_file" ]]; then
+    echo "FAIL  Azure Bicep template not found at $bicep_file"
+    return 1
+  fi
+
+  local yaml_read yaml_purchase yaml_all bicep_actions diff_output
+  yaml_read=$(yaml_list "$AZURE_SCOPE_YAML" "read_actions")
+  yaml_purchase=$(yaml_list "$AZURE_SCOPE_YAML" "purchase_actions")
+  yaml_all=$(printf '%s\n%s\n' "$yaml_read" "$yaml_purchase" | sort -u)
+
+  bicep_actions=$(extract_bicep_azure_actions "$bicep_file")
+  diff_output=$(diff <(echo "$yaml_all") <(echo "$bicep_actions") || true)
+
+  if [[ -z "$diff_output" ]]; then
+    echo "OK    Azure Bicep parity confirmed"
+    return 0
+  else
+    echo "FAIL  Azure Bicep template has permission drift versus scope.azure.yaml:"
+    echo "$diff_output"
+    return 1
+  fi
+}
+
+check_azure_arm_parity() {
+  local arm_file="$REPO_ROOT/iac/federation/azure-target/arm/archera.arm.json"
+
+  if [[ ! -f "$arm_file" ]]; then
+    echo "FAIL  Azure ARM template not found at $arm_file"
+    return 1
+  fi
+
+  local yaml_read yaml_purchase yaml_all arm_actions diff_output
+  yaml_read=$(yaml_list "$AZURE_SCOPE_YAML" "read_actions")
+  yaml_purchase=$(yaml_list "$AZURE_SCOPE_YAML" "purchase_actions")
+  yaml_all=$(printf '%s\n%s\n' "$yaml_read" "$yaml_purchase" | sort -u)
+
+  arm_actions=$(extract_arm_azure_actions "$arm_file")
+  diff_output=$(diff <(echo "$yaml_all") <(echo "$arm_actions") || true)
+
+  if [[ -z "$diff_output" ]]; then
+    echo "OK    Azure ARM parity confirmed"
+    return 0
+  else
+    echo "FAIL  Azure ARM template has permission drift versus scope.azure.yaml:"
+    echo "$diff_output"
+    return 1
+  fi
+}
+
+# ── Environment thin-caller checks ─────────────────────────────────────────────
+# When terraform/environments/{aws,azure,gcp}/archera.tf exist (after PR #310
+# is merged), verify they are thin module callers — they must NOT contain
+# inline permission actions (those belong in the shared module).
+
+check_env_thin_caller() {
+  local cloud="$1"
+  local env_file="$REPO_ROOT/terraform/environments/${cloud}/archera.tf"
+
+  if [[ ! -f "$env_file" ]]; then
+    echo "SKIP  ${cloud} environment archera.tf not found (PR #310 not yet merged) — skipping thin-caller check"
+    return 0
+  fi
+
+  local inline_actions
+  case "$cloud" in
+    aws)   inline_actions=$(grep -oE '"[a-z]+:[A-Za-z]+"' "$env_file" || true) ;;
+    azure) inline_actions=$(grep -oE '"Microsoft\.[^"]*"' "$env_file" || true) ;;
+    gcp)   inline_actions=$(grep -oE '"[a-z]+\.[a-z]+\.[a-zA-Z]+"' "$env_file" || true) ;;
+  esac
+
+  if [[ -z "$inline_actions" ]]; then
+    echo "OK    ${cloud} environment archera.tf is a thin module caller (no inline permissions)"
+    return 0
+  else
+    echo "FAIL  ${cloud} environment archera.tf still has inline permissions — should be a thin module caller:"
+    echo "$inline_actions"
+    return 1
+  fi
+}
+
+# ── Run all checks ─────────────────────────────────────────────────────────────
+
+failures=0
+
+# Scope YAML files must exist — they are the source of truth.
+for yaml in "$AWS_SCOPE_YAML" "$AZURE_SCOPE_YAML" "$GCP_SCOPE_YAML"; do
+  if [[ ! -f "$yaml" ]]; then
+    echo "FAIL  Scope YAML not found: $yaml"
+    failures=$((failures + 1))
+  fi
+done
+
+if [[ "$failures" -gt 0 ]]; then
+  echo ""
+  echo "Archera parity check FAILED ($failures failure(s)) — scope YAML files are missing."
+  exit 1
+fi
+
+# CFN parity (AWS only — GCP does not have a CloudFormation equivalent)
+check_aws_cfn_parity "aws-target"       "$REPO_ROOT/iac/federation/aws-target/cloudformation/archera.cfn.yaml"      || failures=$((failures + 1))
+check_aws_cfn_parity "aws-cross-account" "$REPO_ROOT/iac/federation/aws-cross-account/cloudformation/archera.cfn.yaml" || failures=$((failures + 1))
+
+# Azure alternative format parity
+check_azure_bicep_parity || failures=$((failures + 1))
+check_azure_arm_parity   || failures=$((failures + 1))
+
+# Environment thin-caller verification (runs once PR #310 is merged)
+check_env_thin_caller aws   || failures=$((failures + 1))
+check_env_thin_caller azure || failures=$((failures + 1))
+check_env_thin_caller gcp   || failures=$((failures + 1))
+
+if [[ "$failures" -gt 0 ]]; then
+  echo ""
+  echo "Archera parity check FAILED ($failures failure(s))."
+  echo "Update CFN / Bicep / ARM templates to match iac/modules/archera/scope.*.yaml"
+  echo "and re-run this script."
+  exit 1
+fi
+
+echo ""
+echo "Archera parity check passed."

--- a/scripts/generate-federation-iac.go
+++ b/scripts/generate-federation-iac.go
@@ -59,6 +59,11 @@
 //	go run scripts/generate-federation-iac.go \
 //	  --target aws --source gcp \
 //	  --account-name "prod" --account-id "123456789012" --output -
+//
+//	# Include Archera Insurance permission resources in the bundle
+//	go run scripts/generate-federation-iac.go \
+//	  --target aws --source gcp --format bundle --include-archera \
+//	  --account-name "prod-aws" --account-id "123456789012"
 
 package main
 
@@ -91,6 +96,9 @@ type iacData struct {
 	ProjectID           string
 	ServiceAccountEmail string
 	OIDCIssuerURI       string
+	// IncludeArchera controls whether Archera Insurance permission resources are
+	// included in the rendered output. Mirrors handler_federation.go:federationIaCData.
+	IncludeArchera bool
 }
 
 var slugRE = regexp.MustCompile(`[^a-z0-9]+`)
@@ -317,6 +325,7 @@ func main() {
 	outFile := flag.String("output", "", "Output file path; use '-' to print to stdout (default: derived filename in current directory)")
 	templDir := flag.String("templates-dir", "internal/iacfiles/templates", "Path to templates directory (run from repo root)")
 	modulesDir := flag.String("modules-dir", "iac/federation", "Path to Terraform modules directory (used by --format bundle)")
+	includeArchera := flag.Bool("include-archera", false, "Include Archera Insurance permission resources in the rendered output (default: false)")
 	flag.Parse()
 
 	if *target == "" || *source == "" || *accountName == "" || *accountID == "" {
@@ -333,7 +342,7 @@ func main() {
 		slug = slugify(*accountID)
 	}
 
-	data := iacData{AccountName: *accountName, AccountExternalID: *accountID, AccountSlug: slug, Source: *source}
+	data := iacData{AccountName: *accountName, AccountExternalID: *accountID, AccountSlug: slug, Source: *source, IncludeArchera: *includeArchera}
 	if !populateData(&data, *target, *source, *tenantID, *projectID, *saEmail) {
 		fmt.Fprintf(os.Stderr, "Error: --target must be aws, azure, or gcp (got %q)\n", *target)
 		os.Exit(1)

--- a/scripts/generate-federation-iac.go
+++ b/scripts/generate-federation-iac.go
@@ -86,9 +86,13 @@ type iacData struct {
 	AccountExternalID string
 	AccountSlug       string
 	Source            string
+	// SourceAccountID is the AWS account where CUDly runs (resolved via STS
+	// at request time in the API; supplied as a flag here).
+	SourceAccountID string
 	// AWS WIF / cross-account
-	OIDCIssuerURL string
-	OIDCAudience  string
+	OIDCIssuerURL  string
+	OIDCIssuerHost string // OIDCIssuerURL without https:// prefix; used as IAM condition key
+	OIDCAudience   string
 	// Azure-specific
 	SubscriptionID string
 	TenantID       string
@@ -96,6 +100,11 @@ type iacData struct {
 	ProjectID           string
 	ServiceAccountEmail string
 	OIDCIssuerURI       string
+	// CUDlyAPIURL + ContactEmail are populated at API render time from the
+	// request context; AWS templates reference them in the auto-registration
+	// shell snippets so omitting them breaks AWS-target rendering.
+	CUDlyAPIURL  string
+	ContactEmail string
 	// IncludeArchera controls whether Archera Insurance permission resources are
 	// included in the rendered output. Mirrors handler_federation.go:federationIaCData.
 	IncludeArchera bool
@@ -292,6 +301,7 @@ func populateData(data *iacData, target, source, tenantID, projectID, saEmail st
 	switch target {
 	case "aws":
 		data.OIDCIssuerURL = awsOIDCIssuer(source, tenantID)
+		data.OIDCIssuerHost = strings.TrimPrefix(data.OIDCIssuerURL, "https://")
 		data.OIDCAudience = awsOIDCAudience(source)
 	case "azure":
 		data.SubscriptionID = data.AccountExternalID

--- a/terraform/environments/aws/archera.tf
+++ b/terraform/environments/aws/archera.tf
@@ -1,0 +1,28 @@
+# ==============================================
+# Archera Integration — AWS
+# ==============================================
+#
+# Thin caller — all IAM resources and permission lists live in the shared
+# module at iac/modules/archera/aws/.  Edit scope.aws.yaml in that directory
+# to update the permission scope across ALL callers simultaneously.
+#
+# PROVISIONAL SCOPE — must be confirmed against Archera integration docs
+# before flipping enable_archera = true in any tfvars.
+# TODO(@cristim): confirm Archera scope list against integration docs
+# before enabling.  Reference: https://archera.ai/docs (integration guide).
+#
+# Placement rationale (bootstrap vs runtime split):
+#   Archera is a RUNTIME integration — it reads cost telemetry and submits
+#   purchases during normal operation, not during Terraform deploys.  This
+#   file therefore lives in the main environment alongside compute.tf /
+#   database.tf, NOT in ci-cd-permissions/ (which is applied once by a
+#   privileged human and grants deploy-SA capabilities only).
+
+module "archera" {
+  source = "../../../iac/modules/archera/aws"
+
+  enable_archera                  = var.enable_archera
+  archera_aws_account_id          = var.archera_aws_account_id
+  archera_external_id             = var.archera_external_id
+  enable_archera_purchase_actions = var.enable_archera_purchase_actions
+}

--- a/terraform/environments/aws/dev.tfvars.example
+++ b/terraform/environments/aws/dev.tfvars.example
@@ -139,3 +139,17 @@ admin_email = "admin@example.com"
 # ==============================================
 
 additional_env_vars = {}
+
+# ==============================================
+# Archera Integration (default: disabled)
+# ==============================================
+# Set enable_archera = true ONLY after confirming the scope list in
+# iac/modules/archera/scope.aws.yaml against Archera's integration docs
+# (see TODO(@cristim) in archera.tf).
+# When enabling, also set archera_aws_account_id to the value provided by
+# Archera during onboarding.
+
+enable_archera                  = false
+enable_archera_purchase_actions = false  # keep false until purchase approval workflow is confirmed
+# archera_aws_account_id = "123456789012"                 # replace with Archera's AWS account ID
+# archera_external_id    = "replace-with-archera-extid"  # required when enable_archera = true

--- a/terraform/environments/aws/variables.tf
+++ b/terraform/environments/aws/variables.tf
@@ -479,3 +479,77 @@ variable "enable_docker_build" {
   type        = bool
   default     = true
 }
+
+# ==============================================
+# Archera Integration
+# ==============================================
+
+variable "enable_archera" {
+  description = <<-EOT
+    Enable the Archera commitment-optimisation integration. When true, creates
+    a cross-account IAM role (cudly-archera-integration) that Archera's AWS
+    account can assume to read cost data and execute RI/SP purchases.
+
+    Defaults to false — non-Archera customers see no drift.
+
+    IMPORTANT: the provisional scope list in archera.tf must be confirmed
+    against Archera's integration docs before setting this to true in any
+    environment. See TODO(@cristim) comments in archera.tf.
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "archera_aws_account_id" {
+  description = <<-EOT
+    AWS account ID of the Archera SaaS platform that will assume the
+    cudly-archera-integration role. Obtained from Archera during onboarding.
+    Only evaluated when enable_archera = true.
+
+    Example: "926226587429"
+    TODO(@cristim): confirm the correct Archera AWS account ID from their
+    integration docs before enabling.
+  EOT
+  type        = string
+  default     = ""
+
+  validation {
+    condition = (
+      !var.enable_archera ||
+      can(regex("^\\d{12}$", trimspace(var.archera_aws_account_id)))
+    )
+    error_message = "archera_aws_account_id must be a 12-digit AWS account ID when enable_archera = true."
+  }
+}
+
+variable "archera_external_id" {
+  description = <<-EOT
+    ExternalId value that Archera's AWS principal must supply when assuming
+    the cudly-archera-integration role. This prevents confused-deputy attacks
+    and is required for all third-party cross-account integrations.
+    Provided by Archera during onboarding.
+    Only evaluated when enable_archera = true.
+
+    TODO(@cristim): obtain the ExternalId from Archera's onboarding docs
+    before enabling — do not leave this empty in production.
+  EOT
+  type        = string
+  default     = ""
+  sensitive   = true
+
+  validation {
+    condition     = !var.enable_archera || var.archera_external_id != ""
+    error_message = "archera_external_id must be set (non-empty) when enable_archera = true."
+  }
+}
+
+variable "enable_archera_purchase_actions" {
+  description = <<-EOT
+    When true (AND enable_archera = true), attaches the cudly-archera-purchase
+    IAM policy to the Archera role, enabling RI/SP purchase execution.
+    Keep false until the approval workflow with Archera is confirmed and the
+    scope list has been validated against Archera's integration docs.
+  EOT
+  type        = bool
+  default     = false
+}

--- a/terraform/environments/aws/variables.tf
+++ b/terraform/environments/aws/variables.tf
@@ -538,8 +538,8 @@ variable "archera_external_id" {
   sensitive   = true
 
   validation {
-    condition     = !var.enable_archera || var.archera_external_id != ""
-    error_message = "archera_external_id must be set (non-empty) when enable_archera = true."
+    condition     = !var.enable_archera || trimspace(var.archera_external_id) != ""
+    error_message = "archera_external_id must be set (non-empty, non-whitespace) when enable_archera = true."
   }
 }
 

--- a/terraform/environments/azure/archera.tf
+++ b/terraform/environments/azure/archera.tf
@@ -1,0 +1,28 @@
+# ==============================================
+# Archera Integration — Azure
+# ==============================================
+#
+# Thin caller — all RBAC resources and permission lists live in the shared
+# module at iac/modules/archera/azure/.  Edit scope.azure.yaml in that directory
+# to update the permission scope across ALL callers simultaneously.
+#
+# PROVISIONAL SCOPE — must be confirmed against Archera integration docs
+# before flipping enable_archera = true in any tfvars.
+# TODO(@cristim): confirm Archera scope list against integration docs
+# before enabling.  Reference: https://archera.ai/docs (integration guide).
+#
+# Placement rationale (bootstrap vs runtime split):
+#   Archera is a RUNTIME integration — it reads cost telemetry and submits
+#   purchases during normal operation.  This file lives in the main
+#   environment (alongside compute.tf / database.tf), NOT in
+#   ci-cd-permissions/ (which is applied once by a privileged human and
+#   grants deploy-SA capabilities only).
+
+module "archera" {
+  source = "../../../iac/modules/archera/azure"
+
+  enable_archera                  = var.enable_archera
+  subscription_id                 = var.subscription_id
+  archera_azure_sp_object_id      = var.archera_azure_sp_object_id
+  enable_archera_purchase_actions = var.enable_archera_purchase_actions
+}

--- a/terraform/environments/azure/dev.tfvars.example
+++ b/terraform/environments/azure/dev.tfvars.example
@@ -128,3 +128,16 @@ admin_email = "admin@example.com"
 #     --vault-name <your-vault-name> --name admin-password \
 #     --query value --output tsv
 # admin_password = "YourSecurePassword123!"
+
+# ==============================================
+# Archera Integration (default: disabled)
+# ==============================================
+# Set enable_archera = true ONLY after confirming the scope list in
+# iac/modules/archera/scope.azure.yaml against Archera's integration docs
+# (see TODO(@cristim) in archera.tf).
+# When enabling, also set archera_azure_sp_object_id to the Object ID
+# (not Client ID) of the service principal Archera provides.
+
+enable_archera                  = false
+enable_archera_purchase_actions = false  # keep false until purchase approval workflow is confirmed
+# archera_azure_sp_object_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"  # required when enable_archera = true

--- a/terraform/environments/azure/variables.tf
+++ b/terraform/environments/azure/variables.tf
@@ -521,3 +521,59 @@ variable "max_account_parallelism" {
   type        = number
   default     = 10
 }
+
+# ==============================================
+# Archera Integration
+# ==============================================
+
+variable "enable_archera" {
+  description = <<-EOT
+    Enable the Archera commitment-optimisation integration. When true, creates
+    a custom RBAC role (CUDly Archera Integration) and assigns it to
+    Archera's service principal at subscription scope.
+
+    Defaults to false — non-Archera customers see no drift.
+
+    IMPORTANT: the provisional scope list in iac/modules/archera/scope.azure.yaml
+    must be confirmed against Archera's integration docs before setting this to
+    true in any environment. See TODO(@cristim) comments in archera.tf.
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "archera_azure_sp_object_id" {
+  description = <<-EOT
+    Object ID (NOT the Application/Client ID) of the Archera service principal
+    in your Azure AD tenant. Provided by Archera during onboarding.
+    Only evaluated when enable_archera = true.
+
+    TODO(@cristim): obtain the correct Object ID from Archera's Azure
+    integration docs before enabling.
+  EOT
+  type        = string
+  default     = ""
+
+  validation {
+    condition = (
+      !var.enable_archera ||
+      (var.archera_azure_sp_object_id != "" &&
+        can(regex("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+        var.archera_azure_sp_object_id))
+      )
+    )
+    error_message = "archera_azure_sp_object_id must be a valid UUID when enable_archera = true."
+  }
+}
+
+variable "enable_archera_purchase_actions" {
+  description = <<-EOT
+    When true (AND enable_archera = true), adds the
+    "Microsoft.Capacity/reservationOrders/write" action to the Archera custom
+    RBAC role, enabling reservation purchase execution.
+    Keep false until the approval workflow with Archera is confirmed and the
+    scope list has been validated against Archera's integration docs.
+  EOT
+  type        = bool
+  default     = false
+}

--- a/terraform/environments/gcp/archera.tf
+++ b/terraform/environments/gcp/archera.tf
@@ -1,0 +1,28 @@
+# ==============================================
+# Archera Integration — GCP
+# ==============================================
+#
+# Thin caller — all IAM resources and permission lists live in the shared
+# module at iac/modules/archera/gcp/.  Edit scope.gcp.yaml in that directory
+# to update the permission scope across ALL callers simultaneously.
+#
+# PROVISIONAL SCOPE — must be confirmed against Archera integration docs
+# before flipping enable_archera = true in any tfvars.
+# TODO(@cristim): confirm Archera scope list against integration docs
+# before enabling.  Reference: https://archera.ai/docs (integration guide).
+#
+# Placement rationale (bootstrap vs runtime split):
+#   Archera is a RUNTIME integration — it reads cost telemetry and submits
+#   purchases during normal operation.  This file lives in the main
+#   environment (alongside compute.tf / database.tf), NOT in
+#   ci-cd-permissions/ (which is applied once by a privileged human and
+#   grants deploy-SA capabilities only).
+
+module "archera" {
+  source = "../../../iac/modules/archera/gcp"
+
+  enable_archera                  = var.enable_archera
+  project_id                      = var.project_id
+  archera_gcp_service_account     = var.archera_gcp_service_account
+  enable_archera_purchase_actions = var.enable_archera_purchase_actions
+}

--- a/terraform/environments/gcp/dev.tfvars.example
+++ b/terraform/environments/gcp/dev.tfvars.example
@@ -105,3 +105,16 @@ admin_email = "admin@example.com"
 #   gcloud secrets versions access latest \
 #     --secret=<service-name>-admin-password --project=<project-id>
 # admin_password = "YourSecurePassword123!"
+
+# ==============================================
+# Archera Integration (default: disabled)
+# ==============================================
+# Set enable_archera = true ONLY after confirming the scope list in
+# iac/modules/archera/scope.gcp.yaml against Archera's integration docs
+# (see TODO(@cristim) in archera.tf).
+# When enabling, also set archera_gcp_service_account to the SA email
+# Archera provides during onboarding.
+
+enable_archera                  = false
+enable_archera_purchase_actions = false  # keep false until purchase approval workflow is confirmed
+# archera_gcp_service_account = "archera-integration@archera-prod.iam.gserviceaccount.com"

--- a/terraform/environments/gcp/variables.tf
+++ b/terraform/environments/gcp/variables.tf
@@ -469,3 +469,48 @@ variable "max_account_parallelism" {
   type        = number
   default     = 10
 }
+
+# ==============================================
+# Archera Integration
+# ==============================================
+
+variable "enable_archera" {
+  description = <<-EOT
+    Enable the Archera commitment-optimisation integration. When true, creates
+    a custom IAM role and binds it to Archera's GCP service account, granting
+    least-privilege read access to cost and commitment data.
+
+    Defaults to false — non-Archera customers see no drift.
+
+    IMPORTANT: the provisional scope list in iac/modules/archera/scope.gcp.yaml
+    must be confirmed against Archera's integration docs before setting this to
+    true in any environment. See TODO(@cristim) comments in archera.tf.
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "archera_gcp_service_account" {
+  description = <<-EOT
+    Full email of the GCP service account Archera provides during onboarding,
+    e.g. archera-integration@archera-prod.iam.gserviceaccount.com.
+    Only evaluated when enable_archera = true.
+
+    TODO(@cristim): obtain the correct SA email from Archera's GCP integration
+    docs before enabling.
+  EOT
+  type        = string
+  default     = ""
+}
+
+variable "enable_archera_purchase_actions" {
+  description = <<-EOT
+    When true (AND enable_archera = true), adds the
+    "recommender.commitments.create" permission to the Archera custom IAM role,
+    enabling CUD purchase execution.
+    Keep false until the approval workflow with Archera is confirmed and the
+    scope list has been validated against Archera's integration docs.
+  EOT
+  type        = bool
+  default     = false
+}

--- a/terraform/environments/gcp/variables.tf
+++ b/terraform/environments/gcp/variables.tf
@@ -501,6 +501,15 @@ variable "archera_gcp_service_account" {
   EOT
   type        = string
   default     = ""
+
+  validation {
+    condition = (
+      !var.enable_archera ||
+      can(regex("^[a-z][a-z0-9-]*@[a-z][a-z0-9-]*\\.iam\\.gserviceaccount\\.com$",
+      var.archera_gcp_service_account))
+    )
+    error_message = "archera_gcp_service_account must be a valid GCP service account email when enable_archera = true."
+  }
 }
 
 variable "enable_archera_purchase_actions" {


### PR DESCRIPTION
## Summary

Implements the Archera Insurance integration opt-in flag from issue #314, with a shared-module architecture that ensures a single source of truth for all permission lists.

### Shared module (Option B refactor)

- Adds `iac/modules/archera/{aws,azure,gcp}/` — single source of truth for Archera IAM resources
- Each cloud's permission scope lives in `iac/modules/archera/scope.{aws,azure,gcp}.yaml`; Terraform modules consume it via `yamldecode(file(...))` so editing the YAML propagates to every caller automatically
- All 5 federation bundle `archera.tf` files and all 3 environment `archera.tf` files are thin module callers — no inline permission lists

### Environment callers

Creates `terraform/environments/{aws,azure,gcp}/archera.tf` as thin module callers.  This **supersedes PR #310** which carried inline IAM resource bodies.  No state migration needed — confirmed by @cristim, no environment has ever applied the Archera resources.

### Alternative deployment formats

- `iac/federation/aws-{target,cross-account}/cloudformation/archera.cfn.yaml` — CloudFormation alternative for AWS customers
- `iac/federation/azure-target/bicep/archera.bicep` — Bicep alternative
- `iac/federation/azure-target/arm/archera.arm.json` — ARM template alternative

Permission lists in CFN/Bicep/ARM mirror the scope YAML; the CI `archera-parity` job enforces parity automatically.

### UI checkbox + API flag

- Frontend: "Provision Archera Insurance permissions?" checkbox (default unchecked) in the federation download panel
- Backend: `include_archera=true` query parameter on `/api/federation/iac`; tfvars templates conditionally append Archera variables
- Default: off — existing bundle downloads are byte-identical

### Validation

| Format | Validated |
|--------|-----------|
| Terraform (AWS) | `terraform init && terraform validate` — passes locally |
| Terraform (Azure) | `terraform init && terraform validate` — passes locally |
| Terraform (GCP) | `terraform init && terraform validate` — passes locally |
| CloudFormation | YAML structure verified; `aws cloudformation validate-template` requires live AWS creds — not validated locally |
| Bicep | `bicep` CLI not installed locally — not validated locally |
| ARM JSON | JSON syntax valid (pre-commit check-json passed) |

### Closes / supersedes

Closes #314. Supersedes #310 (which carried the inline-implementation version of the same Archera work; this PR unifies into a shared module).

## Test plan

- [ ] Go test suite: 4310 tests pass
- [ ] Frontend test suite: 1521 tests pass
- [ ] `bash scripts/check-archera-parity.sh` passes
- [ ] CI `archera-parity` job green
- [ ] Verify checkbox appears in federation panel UI with default=off
- [ ] Verify bundle with checkbox=off is byte-identical to pre-checkbox bundle
- [ ] Verify bundle with checkbox=on contains `enable_archera = true` in tfvars
- [ ] PR #310 can be closed as superseded after this merges

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Archera opt-in checkbox in the federation setup UI
  * Archera integration support added across AWS, Azure, and GCP deployment templates
  * Federation IaC generation now supports an optional Archera inclusion flag

* **Tests**
  * Added UI and backend tests covering Archera opt-in behavior and IaC generation

* **Chores**
  * CI job added to validate Archera permission parity across templates

* **Documentation**
  * Template docs updated to describe the Archera opt-in and related variables
<!-- end of auto-generated comment: release notes by coderabbit.ai -->