### PR TITLE
feat(frontend/recs): per-column show/hide with Columns toolbar dropdown

### DIFF
--- a/frontend/src/__tests__/recommendations.test.ts
+++ b/frontend/src/__tests__/recommendations.test.ts
@@ -3970,6 +3970,24 @@ describe('Issues #225 + #226: cell grouping with savings range and collapse/expa
       expect(variantRows.length).toBe(0);
     });
 
+    test('multi-variant summary row omits hidden column values', async () => {
+      const recs = multiVariantRecs();
+      (api.getRecommendations as jest.Mock).mockResolvedValue({ summary: {}, recommendations: recs });
+      (state.getRecommendations as jest.Mock).mockReturnValue(recs);
+      (state.getHiddenColumns as jest.Mock).mockReturnValue(new Set(['region', 'savings', 'upfront_cost', 'term']));
+      await loadRecommendations();
+
+      const summaryContent = document.querySelector('.rec-cell-summary-content');
+      expect(summaryContent).not.toBeNull();
+      expect(summaryContent!.textContent).toContain('2 variants');
+      expect(summaryContent!.textContent).not.toContain('us-east-1');
+      expect(summaryContent!.textContent).not.toContain('$80');
+      expect(summaryContent!.textContent).not.toContain('$120');
+      expect(summaryContent!.textContent).not.toContain('upfront:');
+      expect(summaryContent!.textContent).not.toContain('term:');
+      expect(summaryContent!.querySelector('.rec-cell-range')).toBeNull();
+    });
+
     test('chevron button lives inside td.checkbox-col of the summary row (closes #280)', async () => {
       const recs = multiVariantRecs();
       (api.getRecommendations as jest.Mock).mockResolvedValue({ summary: {}, recommendations: recs });

--- a/frontend/src/__tests__/recommendations.test.ts
+++ b/frontend/src/__tests__/recommendations.test.ts
@@ -4758,7 +4758,7 @@ describe('Column visibility (issue #318)', () => {
       expect(keys).not.toContain('account');
       expect(keys).not.toContain('service');
       expect(keys).not.toContain('resource_type');
-      // All other 8 (including payment) should be toggleable
+      // All other 9 columns should be toggleable
       expect(keys).toContain('region');
       expect(keys).toContain('count');
       expect(keys).toContain('term');
@@ -4766,7 +4766,9 @@ describe('Column visibility (issue #318)', () => {
       expect(keys).toContain('savings');
       expect(keys).toContain('upfront_cost');
       expect(keys).toContain('monthly_cost');
+      expect(keys).toContain('on_demand_monthly');
       expect(keys).toContain('effective_savings_pct');
+      expect(keys.length).toBe(9);
     });
   });
 });

--- a/frontend/src/__tests__/recommendations.test.ts
+++ b/frontend/src/__tests__/recommendations.test.ts
@@ -3940,6 +3940,8 @@ describe('Issues #225 + #226: cell grouping with savings range and collapse/expa
         '</div>',
       ].join('');
       jest.clearAllMocks();
+      // Reset getHiddenColumns to return empty Set so tests don't inherit sticky values
+      (state.getHiddenColumns as jest.Mock).mockReturnValue(new Set());
       jest.useFakeTimers();
       window.alert = jest.fn();
       // Reset cell expand state so tests don't share module-level expandedCells.

--- a/frontend/src/__tests__/recommendations.test.ts
+++ b/frontend/src/__tests__/recommendations.test.ts
@@ -1,7 +1,7 @@
 /**
  * Recommendations module tests
  */
-import { loadRecommendations, openPurchaseModal, getPurchaseModalRecommendations, clearPurchaseModalRecommendations, refreshRecommendations, setupRecommendationsHandlers, clearRecommendationDetailCache, pickBestVariantPerCell, seedGlobalDefaults, effectiveMonthlySavings, effectiveSavingsPct, onDemandMonthly, groupRecsByCell, cellSummary, pageLevelRange, resetExpandedCells, resetAutoRefreshInFlight, scaleCost, formatCostForPeriod, periodSuffix } from '../recommendations';
+import { loadRecommendations, openPurchaseModal, getPurchaseModalRecommendations, clearPurchaseModalRecommendations, refreshRecommendations, setupRecommendationsHandlers, clearRecommendationDetailCache, pickBestVariantPerCell, seedGlobalDefaults, effectiveMonthlySavings, effectiveSavingsPct, onDemandMonthly, groupRecsByCell, cellSummary, pageLevelRange, resetExpandedCells, resetAutoRefreshInFlight, scaleCost, formatCostForPeriod, periodSuffix, loadColumnVisibility, saveColumnVisibility, resetColumnVisibilityState, TOGGLEABLE_COLUMNS, COLUMN_DEFS } from '../recommendations';
 import type { CostPeriod } from '../state';
 
 // Mock the api module
@@ -80,6 +80,9 @@ jest.mock('../state', () => ({
   // see unchanged behaviour (monthly is the identity factor).
   getCostPeriod: jest.fn().mockReturnValue('monthly'),
   setCostPeriod: jest.fn(),
+  // issue #318: column visibility (default: all visible — empty hidden set)
+  getHiddenColumns: jest.fn().mockReturnValue(new Set()),
+  setHiddenColumns: jest.fn(),
 }));
 
 // Mock utils
@@ -4603,5 +4606,147 @@ describe('Issue #319: localStorage persistence (state.ts getCostPeriod / setCost
     expect(getCostPeriodFn()).toBe('hourly');
     localStorage.setItem('cudly.recs.costPeriod', 'invalid-value');
     expect(getCostPeriodFn()).toBe('monthly');
+  });
+});
+
+// ============================================================================
+// Issue #318: Column visibility — localStorage persistence + toggle layer
+// ============================================================================
+import { localStorageMock } from './setup';
+
+describe('Column visibility (issue #318)', () => {
+  beforeEach(() => {
+    resetColumnVisibilityState();
+    // localStorageMock is cleared by jest.clearAllMocks() in the global beforeEach
+    // (setup.ts). Each test below configures the mock as needed.
+  });
+
+  // --- loadColumnVisibility ---
+
+  describe('loadColumnVisibility', () => {
+    test('returns empty set when localStorage key is absent', () => {
+      // Default mock: getItem returns null
+      const result = loadColumnVisibility();
+      expect(result.size).toBe(0);
+    });
+
+    test('returns empty set on JSON parse error', () => {
+      localStorageMock.getItem.mockReturnValue('{not valid json}');
+      const result = loadColumnVisibility();
+      expect(result.size).toBe(0);
+    });
+
+    test('returns empty set when schemaVersion is wrong', () => {
+      localStorageMock.getItem.mockReturnValue(
+        JSON.stringify({ schemaVersion: 99, hidden: ['count'] }),
+      );
+      const result = loadColumnVisibility();
+      expect(result.size).toBe(0);
+    });
+
+    test('returns empty set when hidden is not an array', () => {
+      localStorageMock.getItem.mockReturnValue(
+        JSON.stringify({ schemaVersion: 1, hidden: 'count' }),
+      );
+      const result = loadColumnVisibility();
+      expect(result.size).toBe(0);
+    });
+
+    test('returns the correct hidden set for valid JSON', () => {
+      localStorageMock.getItem.mockReturnValue(
+        JSON.stringify({ schemaVersion: 1, hidden: ['count', 'term'] }),
+      );
+      const result = loadColumnVisibility();
+      expect(result.has('count')).toBe(true);
+      expect(result.has('term')).toBe(true);
+      expect(result.size).toBe(2);
+    });
+
+    test('silently drops unknown column keys (forward-compatibility)', () => {
+      localStorageMock.getItem.mockReturnValue(
+        JSON.stringify({ schemaVersion: 1, hidden: ['count', 'future_column_not_yet_added'] }),
+      );
+      const result = loadColumnVisibility();
+      // 'count' is a known toggleable column; 'future_column_not_yet_added' is not
+      expect(result.has('count')).toBe(true);
+      expect(result.size).toBe(1);
+    });
+
+    test('silently drops fixed (non-toggleable) column keys', () => {
+      // provider/account/service/resource_type are fixed; should be ignored even if stored
+      localStorageMock.getItem.mockReturnValue(
+        JSON.stringify({ schemaVersion: 1, hidden: ['provider', 'account', 'count'] }),
+      );
+      const result = loadColumnVisibility();
+      expect(result.has('provider')).toBe(false);
+      expect(result.has('account')).toBe(false);
+      expect(result.has('count')).toBe(true);
+      expect(result.size).toBe(1);
+    });
+  });
+
+  // --- saveColumnVisibility ---
+
+  describe('saveColumnVisibility', () => {
+    test('writes correct JSON shape to localStorage via setItem', () => {
+      const hidden = new Set<import('../state').RecommendationsColumnId>(['count', 'term']);
+      saveColumnVisibility(hidden);
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(
+        'cudly.recs.columnVisibility.v1',
+        expect.stringContaining('"schemaVersion":1'),
+      );
+      const callArg = localStorageMock.setItem.mock.calls[0]?.[1] as string;
+      const parsed = JSON.parse(callArg);
+      expect(parsed.schemaVersion).toBe(1);
+      expect(parsed.hidden).toContain('count');
+      expect(parsed.hidden).toContain('term');
+      expect(parsed.hidden.length).toBe(2);
+    });
+
+    test('writes empty array for no hidden columns', () => {
+      saveColumnVisibility(new Set());
+      const callArg = localStorageMock.setItem.mock.calls[0]?.[1] as string;
+      const parsed = JSON.parse(callArg);
+      expect(parsed.hidden).toEqual([]);
+    });
+  });
+
+  // --- TOGGLEABLE_COLUMNS and COLUMN_DEFS ---
+
+  describe('COLUMN_DEFS and TOGGLEABLE_COLUMNS', () => {
+    test('COLUMN_DEFS contains all 13 column ids', () => {
+      const keys = COLUMN_DEFS.map((c) => c.key);
+      expect(keys).toContain('provider');
+      expect(keys).toContain('account');
+      expect(keys).toContain('service');
+      expect(keys).toContain('resource_type');
+      expect(keys).toContain('region');
+      expect(keys).toContain('count');
+      expect(keys).toContain('term');
+      expect(keys).toContain('payment');
+      expect(keys).toContain('savings');
+      expect(keys).toContain('upfront_cost');
+      expect(keys).toContain('monthly_cost');
+      expect(keys).toContain('on_demand_monthly');
+      expect(keys).toContain('effective_savings_pct');
+      expect(COLUMN_DEFS.length).toBe(13);
+    });
+
+    test('TOGGLEABLE_COLUMNS excludes fixed identity columns', () => {
+      const keys = TOGGLEABLE_COLUMNS.map((c) => c.key);
+      expect(keys).not.toContain('provider');
+      expect(keys).not.toContain('account');
+      expect(keys).not.toContain('service');
+      expect(keys).not.toContain('resource_type');
+      // All other 8 (including payment) should be toggleable
+      expect(keys).toContain('region');
+      expect(keys).toContain('count');
+      expect(keys).toContain('term');
+      expect(keys).toContain('payment');
+      expect(keys).toContain('savings');
+      expect(keys).toContain('upfront_cost');
+      expect(keys).toContain('monthly_cost');
+      expect(keys).toContain('effective_savings_pct');
+    });
   });
 });

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -1649,6 +1649,149 @@ function ensureRecommendationsTabObserver(): void {
 }
 
 // ---------------------------------------------------------------------------
+// Column-visibility popover (issue #318)
+//
+// Separate state from the column-filter popover (openPopover / outsideClickHandler
+// etc.) to avoid conflating the two interactions.  Shares the positionPopover()
+// helper for positioning.
+// ---------------------------------------------------------------------------
+
+interface VisibilityPopoverState {
+  el: HTMLDivElement;
+  checkboxes: Map<state.RecommendationsColumnId, HTMLInputElement>;
+}
+
+let openVisibilityPopover: VisibilityPopoverState | null = null;
+let visOutsideClickHandler: ((e: MouseEvent) => void) | null = null;
+let visEscKeyHandler: ((e: KeyboardEvent) => void) | null = null;
+
+function closeVisibilityPopover(): void {
+  if (!openVisibilityPopover) return;
+  openVisibilityPopover.el.remove();
+  openVisibilityPopover = null;
+  if (visOutsideClickHandler) {
+    document.removeEventListener('mousedown', visOutsideClickHandler);
+    visOutsideClickHandler = null;
+  }
+  if (visEscKeyHandler) {
+    document.removeEventListener('keydown', visEscKeyHandler);
+    visEscKeyHandler = null;
+  }
+}
+
+function openVisibilityPopover_(anchor: HTMLElement): void {
+  // Close any open filter popover when visibility popover opens (only one popover
+  // at a time keeps the UI from getting cluttered).
+  closePopover();
+
+  if (openVisibilityPopover) {
+    closeVisibilityPopover();
+    return; // toggle: second click on the button closes the popover
+  }
+
+  const popover = document.createElement('div');
+  popover.className = 'column-visibility-popover';
+  popover.setAttribute('role', 'dialog');
+  popover.setAttribute('aria-label', 'Show/hide columns');
+  popover.style.display = 'none';
+  document.body.appendChild(popover);
+
+  const title = document.createElement('p');
+  title.className = 'column-visibility-title';
+  title.textContent = 'Show/hide columns';
+  popover.appendChild(title);
+
+  const hidden = state.getHiddenColumns();
+  const checkboxes = new Map<state.RecommendationsColumnId, HTMLInputElement>();
+
+  for (const col of TOGGLEABLE_COLUMNS) {
+    const row = document.createElement('label');
+    row.className = 'column-visibility-row';
+
+    const cb = document.createElement('input');
+    cb.type = 'checkbox';
+    cb.checked = !hidden.has(col.key);
+    cb.setAttribute('aria-label', col.label);
+    checkboxes.set(col.key, cb);
+
+    cb.addEventListener('change', () => {
+      const currentHidden = new Set(state.getHiddenColumns());
+      if (cb.checked) {
+        currentHidden.delete(col.key);
+      } else {
+        currentHidden.add(col.key);
+      }
+      state.setHiddenColumns(currentHidden);
+      saveColumnVisibility(currentHidden);
+      rerenderRecommendations();
+    });
+
+    row.appendChild(cb);
+    row.appendChild(document.createTextNode(' ' + col.label));
+    popover.appendChild(row);
+  }
+
+  openVisibilityPopover = { el: popover, checkboxes };
+  positionPopover(popover, anchor);
+
+  // Keyboard: Escape closes.
+  visEscKeyHandler = (e: KeyboardEvent): void => {
+    if (e.key === 'Escape') {
+      closeVisibilityPopover();
+      anchor.focus();
+    }
+  };
+  document.addEventListener('keydown', visEscKeyHandler);
+
+  // Click-outside closes.
+  visOutsideClickHandler = (e: MouseEvent): void => {
+    const target = e.target as Node;
+    if (!popover.contains(target) && !anchor.contains(target)) {
+      closeVisibilityPopover();
+    }
+  };
+  // Defer one tick so the current click event (which opened the popover) doesn't
+  // immediately close it via the click-outside handler.
+  setTimeout(() => {
+    document.addEventListener('mousedown', visOutsideClickHandler!);
+  }, 0);
+}
+
+// mountColumnsButton mounts the "Columns ▾" button in the filter-status bar once
+// and updates its label on subsequent calls to reflect hidden-column count.
+function mountColumnsButton(bar: HTMLElement): void {
+  let btn = bar.querySelector<HTMLButtonElement>('.column-visibility-btn');
+  if (!btn) {
+    btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'column-visibility-btn';
+    bar.appendChild(btn);
+    btn.addEventListener('click', () => {
+      openVisibilityPopover_(btn!);
+    });
+    btn.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        openVisibilityPopover_(btn!);
+      }
+    });
+  }
+  // Update label to reflect hidden-column count.
+  const hiddenCount = state.getHiddenColumns().size;
+  btn.textContent = hiddenCount > 0 ? `Columns ▾ (${hiddenCount} hidden)` : 'Columns ▾';
+  btn.setAttribute('aria-pressed', hiddenCount > 0 ? 'true' : 'false');
+
+  // Re-sync checkboxes if the popover is open (in case a filter popover commit
+  // changed visible state while the popover was open — rare but possible).
+  if (openVisibilityPopover) {
+    const currentHidden = state.getHiddenColumns();
+    for (const [key, cb] of openVisibilityPopover.checkboxes) {
+      cb.checked = !currentHidden.has(key);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
 
 // Render (or update) the filter-status bar: a "Clear filters (N)" button
 // when at least one column filter is active, plus an aria-live region
@@ -1744,6 +1887,29 @@ function renderFilterStatusBar(loadedCount: number, visibleCount: number): void 
 
   // issue #319: cost-period selector. Always mount regardless of group state.
   mountCostPeriodSelector(bar);
+
+  // issue #318: "Columns ▾" button — mount-once, always visible.
+  // Shows the column-visibility popover; label updates on re-render to
+  // reflect any active hidden-column count.
+  mountColumnsButton(bar);
+
+  // Sort-hidden indicator: show a note when the active sort column is hidden
+  // so users aren't confused by inexplicable row ordering (#318).
+  let sortHiddenNote = bar.querySelector<HTMLSpanElement>('.sort-hidden-note');
+  const sortCol = state.getRecommendationsSort().column;
+  const hidden = state.getHiddenColumns();
+  if (hidden.has(sortCol)) {
+    if (!sortHiddenNote) {
+      sortHiddenNote = document.createElement('span');
+      sortHiddenNote.className = 'sort-hidden-note';
+      bar.appendChild(sortHiddenNote);
+    }
+    // Use the period-aware label so the note mirrors the active period.
+    const hiddenLabel = getColumnLabel(sortCol, state.getCostPeriod());
+    sortHiddenNote.textContent = `(sorted by hidden column: ${hiddenLabel})`;
+  } else {
+    if (sortHiddenNote) sortHiddenNote.remove();
+  }
 }
 
 /**
@@ -2151,11 +2317,12 @@ function buildVariantRowMarkup(
   </tr>`;
 }
 
-// The total column count for colspan on summary rows: checkbox col + N data cols.
-// Derived from COLUMN_DEFS so it automatically stays correct when columns are added/removed.
-const TABLE_COL_COUNT = 1 + COLUMN_DEFS.length;
 
-function buildListMarkup(recommendations: LocalRecommendation[], selectedRecs: ReadonlySet<string>): string {
+function buildListMarkup(
+  recommendations: LocalRecommendation[],
+  selectedRecs: ReadonlySet<string>,
+  visibleCols: readonly ColumnDef[] = COLUMN_DEFS,
+): string {
   const sort = state.getRecommendationsSort();
   const filters = state.getRecommendationsColumnFilters();
   const period = state.getCostPeriod();
@@ -2182,13 +2349,19 @@ function buildListMarkup(recommendations: LocalRecommendation[], selectedRecs: R
   // with the Potential Monthly Savings card after #272 / #279 brought
   // the same range to the summary header. Removed (closes #278).
 
+  // Summary row colspan: the big cell covers resource_type (always shown) + all
+  // visible toggleable columns. The 3 fixed identity cells (provider, account,
+  // service) always render separately, so this colspan = 1 + visible toggleable count.
+  const visibleToggleableCols = visibleCols.filter((c) => TOGGLEABLE_COLUMN_KEYS.has(c.key));
+  const summaryColspan = 1 + visibleToggleableCols.length;
+
   // Build tbody rows: grouped for multi-variant cells, flat for single-variant.
   const rows: string[] = [];
   for (const key of sortedKeys) {
     const variants = groups.get(key)!;
     if (variants.length === 1) {
       // Single-variant: render flat, no group header, no indent.
-      rows.push(buildVariantRowMarkup(variants[0]!, selectedRecs, false));
+      rows.push(buildVariantRowMarkup(variants[0]!, selectedRecs, false, visibleCols));
       continue;
     }
 
@@ -2231,7 +2404,7 @@ function buildListMarkup(recommendations: LocalRecommendation[], selectedRecs: R
     <td><span class="provider-badge ${providerBadgeClass(rep.provider)}">${escapeHtml(providerDisplayName(rep.provider))}</span></td>
     <td>${escapeHtml(accountName)}</td>
     <td><span class="service-badge">${escapeHtml(rep.service)}</span></td>
-    <td colspan="${TABLE_COL_COUNT - 4}" class="rec-cell-summary-content">
+    <td colspan="${summaryColspan}" class="rec-cell-summary-content">
       <span class="rec-cell-identity">${escapeHtml(rep.resource_type)}${rep.engine ? ` (${escapeHtml(rep.engine)})` : ''} &mdash; ${escapeHtml(rep.region)} &mdash; ${variants.length} variants</span>
       <span class="rec-cell-range">${savingsDisplay} &middot; upfront: ${upfrontDisplay} &middot; term: ${termDisplay}</span>
     </td>
@@ -2240,7 +2413,7 @@ function buildListMarkup(recommendations: LocalRecommendation[], selectedRecs: R
     if (isExpanded) {
       const sortedVariants = sortVariantsInCell(variants);
       for (const v of sortedVariants) {
-        rows.push(buildVariantRowMarkup(v, selectedRecs, true));
+        rows.push(buildVariantRowMarkup(v, selectedRecs, true, visibleCols));
       }
     }
   }
@@ -2252,7 +2425,7 @@ function buildListMarkup(recommendations: LocalRecommendation[], selectedRecs: R
           <th class="checkbox-col">
             <input type="checkbox" id="select-all-recs" aria-label="Select all recommendations">
           </th>
-          ${COLUMN_DEFS.map((c) => sortHeader(c.key)).join('')}
+          ${visibleCols.map((c) => sortHeader(c.key)).join('')}
         </tr>
       </thead>
       <tbody>
@@ -2358,6 +2531,82 @@ function saveBulkPurchaseState(s: BulkPurchaseToolbarState): void {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Column visibility — localStorage persistence (issue #318)
+// ---------------------------------------------------------------------------
+
+// TOGGLEABLE_COLUMNS — the subset of COLUMN_DEFS whose visibility can be toggled.
+// Provider, Account, Service, and Resource Type are "cell identity anchors" on
+// multi-variant summary rows and are always visible in v1.
+export const TOGGLEABLE_COLUMNS: readonly ColumnDef[] = COLUMN_DEFS.filter(
+  (c) => !(['provider', 'account', 'service', 'resource_type'] as string[]).includes(c.key),
+);
+
+const TOGGLEABLE_COLUMN_KEYS = new Set<state.RecommendationsColumnId>(
+  TOGGLEABLE_COLUMNS.map((c) => c.key),
+);
+
+const COLUMN_VISIBILITY_LS_KEY = 'cudly.recs.columnVisibility.v1';
+const COLUMN_VISIBILITY_SCHEMA_VERSION = 1;
+
+interface ColumnVisibilitySchema {
+  schemaVersion: number;
+  hidden: string[];
+}
+
+/** Load hidden columns from localStorage. Returns empty set on any error. Exported for tests. */
+export function loadColumnVisibility(): Set<state.RecommendationsColumnId> {
+  try {
+    const raw = localStorage.getItem(COLUMN_VISIBILITY_LS_KEY);
+    if (!raw) return new Set();
+    const parsed = JSON.parse(raw) as Partial<ColumnVisibilitySchema>;
+    if (parsed.schemaVersion !== COLUMN_VISIBILITY_SCHEMA_VERSION) return new Set();
+    if (!Array.isArray(parsed.hidden)) return new Set();
+    // Whitelist: only accept known toggleable column keys so stale/unknown
+    // values from future versions are silently dropped.
+    const valid = parsed.hidden.filter(
+      (k): k is state.RecommendationsColumnId => TOGGLEABLE_COLUMN_KEYS.has(k as state.RecommendationsColumnId),
+    );
+    return new Set(valid);
+  } catch {
+    return new Set();
+  }
+}
+
+/** Persist hidden columns to localStorage. Exported for tests. */
+export function saveColumnVisibility(hidden: ReadonlySet<state.RecommendationsColumnId>): void {
+  try {
+    const payload: ColumnVisibilitySchema = {
+      schemaVersion: COLUMN_VISIBILITY_SCHEMA_VERSION,
+      hidden: Array.from(hidden),
+    };
+    localStorage.setItem(COLUMN_VISIBILITY_LS_KEY, JSON.stringify(payload));
+  } catch {
+    // Private-browsing / quota-exceeded — non-fatal.
+  }
+}
+
+// Seed flag: set to true once column visibility is loaded from localStorage
+// on first render so subsequent renders don't overwrite in-session toggles.
+let columnVisibilitySeeded = false;
+
+/**
+ * Reset column-visibility seeded state. Exported for tests only — not part of
+ * the public API. Call in beforeEach to ensure tests don't share seeding state.
+ */
+export function resetColumnVisibilityState(): void {
+  columnVisibilitySeeded = false;
+  state.setHiddenColumns(new Set());
+}
+
+/** Returns the subset of COLUMN_DEFS that are currently visible. */
+function visibleColumns(): readonly ColumnDef[] {
+  const hidden = state.getHiddenColumns();
+  if (hidden.size === 0) return COLUMN_DEFS;
+  return COLUMN_DEFS.filter((c) => !hidden.has(c.key));
+}
+
+// ---------------------------------------------------------------------------
 // Mount-once-then-update lifecycle for the sticky bottom action box.
 // mountBottomActionBox builds the DOM (input/select/button identities) and
 // wires listeners exactly once. updateBottomActionBox refreshes only the
@@ -3027,6 +3276,14 @@ function renderRecommendationsList(loadedRecs: LocalRecommendation[]): void {
   const container = document.getElementById('recommendations-list');
   if (!container) return;
 
+  // Seed column visibility from localStorage on the first render.
+  // columnVisibilitySeeded stays true for the rest of the session so
+  // in-session toggles (via the "Columns ▾" popover) are not overwritten.
+  if (!columnVisibilitySeeded) {
+    state.setHiddenColumns(loadColumnVisibility());
+    columnVisibilitySeeded = true;
+  }
+
   // Pipeline:
   //   loaded -> applyColumnFilters -> visible
   //   state.setVisibleRecommendations(visible)   (read by plans.ts:savePlan)
@@ -3059,12 +3316,16 @@ function renderRecommendationsList(loadedRecs: LocalRecommendation[]): void {
     return;
   }
 
+  // Compute the visible column set once per render — passed to buildListMarkup
+  // so header and row rendering use the same snapshot of column visibility state.
+  const visibleCols = visibleColumns();
+
   const selectedIDs = state.getSelectedRecommendationIDs();
   // Dynamic table markup: every caller-provided value passes through
   // escapeHtml or is a number. The string is built in buildListMarkup.
   // NOTE: buildListMarkup also populates lastVisibleGroupKeys, so it MUST
   // run before renderFilterStatusBar (which reads it for the Expand-All button).
-  container.innerHTML = buildListMarkup(recommendations, selectedIDs);
+  container.innerHTML = buildListMarkup(recommendations, selectedIDs, visibleCols);
 
   // Filter status: Clear-filters badge + aria-live count + Expand-All toggle.
   // Rendered AFTER buildListMarkup so lastVisibleGroupKeys is populated.

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -1756,7 +1756,7 @@ function openVisibilityPopover_(anchor: HTMLElement): void {
   // immediately close it via the click-outside handler.
   const handler = visOutsideClickHandler;
   setTimeout(() => {
-    if (handler) {
+    if (handler && openVisibilityPopover && visOutsideClickHandler === handler) {
       document.addEventListener('mousedown', handler);
     }
   }, 0);

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -1754,8 +1754,11 @@ function openVisibilityPopover_(anchor: HTMLElement): void {
   };
   // Defer one tick so the current click event (which opened the popover) doesn't
   // immediately close it via the click-outside handler.
+  const handler = visOutsideClickHandler;
   setTimeout(() => {
-    document.addEventListener('mousedown', visOutsideClickHandler!);
+    if (handler) {
+      document.addEventListener('mousedown', handler);
+    }
   }, 0);
 }
 

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -1661,6 +1661,7 @@ function ensureRecommendationsTabObserver(): void {
 interface VisibilityPopoverState {
   el: HTMLDivElement;
   checkboxes: Map<state.RecommendationsColumnId, HTMLInputElement>;
+  trigger: HTMLElement;
 }
 
 let openVisibilityPopover: VisibilityPopoverState | null = null;
@@ -1669,7 +1670,9 @@ let visEscKeyHandler: ((e: KeyboardEvent) => void) | null = null;
 
 function closeVisibilityPopover(): void {
   if (!openVisibilityPopover) return;
-  openVisibilityPopover.el.remove();
+  const { el, trigger } = openVisibilityPopover;
+  el.remove();
+  trigger.setAttribute('aria-expanded', 'false');
   openVisibilityPopover = null;
   if (visOutsideClickHandler) {
     document.removeEventListener('mousedown', visOutsideClickHandler);
@@ -1733,7 +1736,8 @@ function openVisibilityPopover_(anchor: HTMLElement): void {
     popover.appendChild(row);
   }
 
-  openVisibilityPopover = { el: popover, checkboxes };
+  openVisibilityPopover = { el: popover, checkboxes, trigger: anchor };
+  anchor.setAttribute('aria-expanded', 'true');
   positionPopover(popover, anchor);
 
   // Keyboard: Escape closes.
@@ -1770,6 +1774,8 @@ function mountColumnsButton(bar: HTMLElement): void {
     btn = document.createElement('button');
     btn.type = 'button';
     btn.className = 'column-visibility-btn';
+    btn.setAttribute('aria-haspopup', 'dialog');
+    btn.setAttribute('aria-expanded', 'false');
     bar.appendChild(btn);
     btn.addEventListener('click', () => {
       openVisibilityPopover_(btn!);

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -895,19 +895,55 @@ export function pickBestVariantPerCell(recs: readonly LocalRecommendation[]): Lo
   return result;
 }
 
-// Static labels for columns whose header is period-invariant.
-const STATIC_COLUMN_LABELS: Record<string, string> = {
-  provider: 'Provider',
-  account: 'Account',
-  service: 'Service',
-  resource_type: 'Resource Type',
-  region: 'Region',
-  count: 'Count',
-  term: 'Term',
-  payment: 'Payment',
-  upfront_cost: 'Upfront Cost',
-  effective_savings_pct: 'Effective %',
-};
+// ---------------------------------------------------------------------------
+// COLUMN_DEFS — single source of truth for the recommendations table columns.
+//
+// Order here matches the rendered column order (left to right), excluding the
+// leading checkbox column which is always visible and never sortable/filterable.
+//
+// Both the table header (<th> generation) and the data rows (<td> generation)
+// derive from this array so adding a new column only requires one edit here.
+//
+// `kind` drives the column-filter popover: 'numeric' → text input with
+// comparison operators; 'categorical' → checkbox list of distinct values.
+//
+// `label` is the canonical (monthly-period) header. The 3 period-varying
+// cost columns (`savings`, `monthly_cost`, `on_demand_monthly`) are handled
+// separately by `getColumnLabel` per-period, so their entry here is only
+// used as the data-attribute / fallback label, not the rendered <th>.
+// ---------------------------------------------------------------------------
+export interface ColumnDef {
+  key: state.RecommendationsColumnId;
+  label: string;
+  kind: 'numeric' | 'categorical';
+}
+
+export const COLUMN_DEFS: readonly ColumnDef[] = [
+  { key: 'provider',              label: 'Provider',          kind: 'categorical' },
+  { key: 'account',               label: 'Account',           kind: 'categorical' },
+  { key: 'service',               label: 'Service',           kind: 'categorical' },
+  { key: 'resource_type',         label: 'Resource Type',     kind: 'categorical' },
+  { key: 'region',                label: 'Region',            kind: 'categorical' },
+  { key: 'count',                 label: 'Count',             kind: 'numeric'     },
+  { key: 'term',                  label: 'Term',              kind: 'categorical' },
+  { key: 'payment',               label: 'Payment',           kind: 'categorical' },
+  { key: 'savings',               label: 'Monthly Savings',   kind: 'numeric'     },
+  { key: 'upfront_cost',          label: 'Upfront Cost',      kind: 'numeric'     },
+  { key: 'monthly_cost',          label: 'Monthly Cost',      kind: 'numeric'     },
+  { key: 'on_demand_monthly',     label: 'On-Demand Monthly', kind: 'numeric'     },
+  { key: 'effective_savings_pct', label: 'Effective %',       kind: 'numeric'     },
+];
+
+// Static labels for columns whose header is period-invariant. Derived from
+// COLUMN_DEFS so the source-of-truth still drives what's displayed; the
+// 3 period-varying cost columns are filtered out and handled by
+// getColumnLabel's switch instead.
+const PERIOD_VARYING_COLUMNS = new Set<string>(['savings', 'monthly_cost', 'on_demand_monthly']);
+const STATIC_COLUMN_LABELS: Record<string, string> = Object.fromEntries(
+  COLUMN_DEFS
+    .filter((c) => !PERIOD_VARYING_COLUMNS.has(c.key))
+    .map((c) => [c.key, c.label]),
+);
 
 /**
  * Return the human-readable column header for `column` given the active
@@ -1116,9 +1152,11 @@ function numericCellValue(r: LocalRecommendation, col: state.RecommendationsColu
 // when the input is document.activeElement (mid-typing protection).
 // ---------------------------------------------------------------------------
 
-const NUMERIC_COLUMNS: ReadonlySet<state.RecommendationsColumnId> = new Set([
-  'count', 'savings', 'upfront_cost', 'monthly_cost', 'on_demand_monthly', 'effective_savings_pct',
-]);
+// Derived from COLUMN_DEFS — numeric columns get a text-input filter; categoricals
+// get a checkbox-list filter.  Kept as a Set for O(1) membership tests.
+const NUMERIC_COLUMNS: ReadonlySet<state.RecommendationsColumnId> = new Set(
+  COLUMN_DEFS.filter((c) => c.kind === 'numeric').map((c) => c.key),
+);
 
 interface PopoverState {
   column: state.RecommendationsColumnId;
@@ -2018,13 +2056,6 @@ function providerBadgeClass(provider: string): string {
   return n === 'aws' || n === 'azure' || n === 'gcp' ? n : '';
 }
 
-// Columns that get the per-column header filter button. Order matches the
-// table column order (excluding the leading checkbox column, which is
-// neither sortable nor filterable).
-const FILTERABLE_COLUMNS: readonly state.RecommendationsColumnId[] = [
-  'provider', 'account', 'service', 'resource_type', 'region',
-  'count', 'term', 'payment', 'savings', 'upfront_cost', 'monthly_cost', 'on_demand_monthly', 'effective_savings_pct',
-];
 
 // Map raw payment_option values to display labels for the Payment column.
 const PAYMENT_DISPLAY_LABELS: Record<string, string> = {
@@ -2039,10 +2070,67 @@ function formatPayment(payment: string | undefined): string {
   return PAYMENT_DISPLAY_LABELS[payment] ?? payment;
 }
 
+// renderColumnCell renders a single <td> for the given column key.
+// All column cell rendering is centralised here so buildVariantRowMarkup
+// can iterate over COLUMN_DEFS (or a visibility-filtered subset in
+// Commit 2) without knowing each column's HTML shape.
+function renderColumnCell(key: state.RecommendationsColumnId, rec: LocalRecommendation, ctx: {
+  accountName: string;
+  badge: string;
+  pct: number | null;
+  pctClass: string;
+  pctText: string;
+  period: CostPeriod;
+}): string {
+  switch (key) {
+    case 'provider':
+      return `<td><span class="provider-badge ${providerBadgeClass(rec.provider)}">${escapeHtml(providerDisplayName(rec.provider))}</span></td>`;
+    case 'account':
+      return `<td>${escapeHtml(ctx.accountName)}</td>`;
+    case 'service':
+      return `<td><span class="service-badge">${escapeHtml(rec.service)}</span></td>`;
+    case 'resource_type':
+      return `<td title="${escapeHtml(rec.resource_type)}">${escapeHtml(rec.resource_type)}${rec.engine ? ` (${escapeHtml(rec.engine)})` : ''}${ctx.badge}</td>`;
+    case 'region':
+      return `<td>${escapeHtml(rec.region)}</td>`;
+    case 'count':
+      return `<td>${rec.count}</td>`;
+    case 'term':
+      return `<td>${formatTerm(rec.term)}</td>`;
+    case 'payment':
+      return `<td>${formatPayment(rec.payment)}</td>`;
+    case 'savings':
+      // issue #319: savings display value scales with the active cost period.
+      return `<td class="savings">${formatCostForPeriod(rec.savings, ctx.period)}</td>`;
+    case 'upfront_cost':
+      // upfront_cost is one-time, not recurring \u2014 period-invariant.
+      return `<td>${formatCurrency(rec.upfront_cost)}</td>`;
+    case 'monthly_cost':
+      // issue #319: monthly_cost display scales with period; null still renders as em-dash.
+      return `<td>${formatCostForPeriod(rec.monthly_cost, ctx.period)}</td>`;
+    case 'on_demand_monthly':
+      // issue #319: on-demand baseline scales with period to stay consistent
+      // with the savings + monthly_cost columns.
+      return `<td>${formatCostForPeriod(onDemandMonthly(rec), ctx.period)}</td>`;
+    case 'effective_savings_pct':
+      return `<td${ctx.pctClass}>${ctx.pctText}</td>`;
+  }
+}
+
 // Helper: render one variant row (a single LocalRecommendation) with optional
 // indentation styling for multi-variant cells.
-function buildVariantRowMarkup(rec: LocalRecommendation, selectedRecs: ReadonlySet<string>, isNested: boolean): string {
-  // issue #319: savings + monthly_cost display values scale with the active period.
+//
+// `cols` defaults to all COLUMN_DEFS; Commit 2 (column visibility) passes a
+// visibility-filtered subset so hidden columns are absent from the DOM.
+function buildVariantRowMarkup(
+  rec: LocalRecommendation,
+  selectedRecs: ReadonlySet<string>,
+  isNested: boolean,
+  cols: readonly ColumnDef[] = COLUMN_DEFS,
+): string {
+  // issue #319: cost-bearing cells scale with the active period; resolved
+  // once per row and threaded through ctx so renderColumnCell doesn't
+  // re-read state on every cell.
   const period = state.getCostPeriod();
   const savingsClass = rec.savings > 1000 ? 'high-savings' : rec.savings > 100 ? 'medium-savings' : '';
   const isSelected = selectedRecs.has(rec.id);
@@ -2052,34 +2140,20 @@ function buildVariantRowMarkup(rec: LocalRecommendation, selectedRecs: ReadonlyS
   const pct = effectiveSavingsPct(rec);
   const pctClass = pct !== null && pct < 0 ? ' class="effective-pct-negative"' : '';
   const pctText = pct === null ? '\u2014' : pct.toFixed(1) + '%';
-  // The base value is monthly; render via formatCostForPeriod so the
-  // displayed value scales with the active cost-period selector (#319).
-  const odmText = formatCostForPeriod(onDemandMonthly(rec), period);
   const nestedClass = isNested ? ' rec-variant-row' : '';
+  const cellCtx = { accountName, badge, pct, pctClass, pctText, period };
   return `
   <tr class="recommendation-row${nestedClass} ${savingsClass} ${isSelected ? 'selected' : ''}" data-rec-id="${recId}">
     <td class="checkbox-col">
       <input type="checkbox" data-rec-id="${recId}" ${isSelected ? 'checked' : ''} aria-label="Select recommendation">
     </td>
-    <td><span class="provider-badge ${providerBadgeClass(rec.provider)}">${escapeHtml(providerDisplayName(rec.provider))}</span></td>
-    <td>${escapeHtml(accountName)}</td>
-    <td><span class="service-badge">${escapeHtml(rec.service)}</span></td>
-    <td title="${escapeHtml(rec.resource_type)}">${escapeHtml(rec.resource_type)}${rec.engine ? ` (${escapeHtml(rec.engine)})` : ''}${badge}</td>
-    <td>${escapeHtml(rec.region)}</td>
-    <td>${rec.count}</td>
-    <td>${formatTerm(rec.term)}</td>
-    <td>${formatPayment(rec.payment)}</td>
-    <td class="savings">${formatCostForPeriod(rec.savings, period)}</td>
-    <td>${formatCurrency(rec.upfront_cost)}</td>
-    <td>${formatCostForPeriod(rec.monthly_cost, period)}</td>
-    <td>${odmText}</td>
-    <td${pctClass}>${pctText}</td>
+    ${cols.map((c) => renderColumnCell(c.key, rec, cellCtx)).join('')}
   </tr>`;
 }
 
-// The total column count for colspan on summary rows: checkbox col + 14 data cols = 15.
-// (PR #322 added the on-demand monthly column as a 14th data column.)
-const TABLE_COL_COUNT = 15;
+// The total column count for colspan on summary rows: checkbox col + N data cols.
+// Derived from COLUMN_DEFS so it automatically stays correct when columns are added/removed.
+const TABLE_COL_COUNT = 1 + COLUMN_DEFS.length;
 
 function buildListMarkup(recommendations: LocalRecommendation[], selectedRecs: ReadonlySet<string>): string {
   const sort = state.getRecommendationsSort();
@@ -2178,7 +2252,7 @@ function buildListMarkup(recommendations: LocalRecommendation[], selectedRecs: R
           <th class="checkbox-col">
             <input type="checkbox" id="select-all-recs" aria-label="Select all recommendations">
           </th>
-          ${FILTERABLE_COLUMNS.map(sortHeader).join('')}
+          ${COLUMN_DEFS.map((c) => sortHeader(c.key)).join('')}
         </tr>
       </thead>
       <tbody>

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -1641,9 +1641,11 @@ function ensureRecommendationsTabObserver(): void {
   const tab = document.getElementById('recommendations-tab');
   if (!tab) return;
   recommendationsTabObserver = new MutationObserver(() => {
-    if (!tab.classList.contains('active') && openPopover) {
+    if (tab.classList.contains('active')) return;
+    if (openPopover) {
       closePopover();
     }
+    closeVisibilityPopover();
   });
   recommendationsTabObserver.observe(tab, { attributes: true, attributeFilter: ['class'] });
 }
@@ -2354,6 +2356,7 @@ function buildListMarkup(
   // service) always render separately, so this colspan = 1 + visible toggleable count.
   const visibleToggleableCols = visibleCols.filter((c) => TOGGLEABLE_COLUMN_KEYS.has(c.key));
   const summaryColspan = 1 + visibleToggleableCols.length;
+  const visibleKeys = new Set(visibleCols.map((c) => c.key));
 
   // Build tbody rows: grouped for multi-variant cells, flat for single-variant.
   const rows: string[] = [];
@@ -2393,6 +2396,24 @@ function buildListMarkup(
       : formatTermRange(summary.termMin, summary.termMax);
 
     const chevron = isExpanded ? '\u25bc' : '\u25b6';
+    const identityParts = [
+      `${escapeHtml(rep.resource_type)}${rep.engine ? ` (${escapeHtml(rep.engine)})` : ''}`,
+    ];
+    if (visibleKeys.has('region')) {
+      identityParts.push(escapeHtml(rep.region));
+    }
+    identityParts.push(`${variants.length} variants`);
+
+    const rangeParts: string[] = [];
+    if (visibleKeys.has('savings')) {
+      rangeParts.push(savingsDisplay);
+    }
+    if (visibleKeys.has('upfront_cost')) {
+      rangeParts.push(`upfront: ${upfrontDisplay}`);
+    }
+    if (visibleKeys.has('term')) {
+      rangeParts.push(`term: ${termDisplay}`);
+    }
 
     rows.push(`
   <tr class="rec-cell-summary-row" data-cell-key="${escapeHtml(key)}">
@@ -2405,8 +2426,8 @@ function buildListMarkup(
     <td>${escapeHtml(accountName)}</td>
     <td><span class="service-badge">${escapeHtml(rep.service)}</span></td>
     <td colspan="${summaryColspan}" class="rec-cell-summary-content">
-      <span class="rec-cell-identity">${escapeHtml(rep.resource_type)}${rep.engine ? ` (${escapeHtml(rep.engine)})` : ''} &mdash; ${escapeHtml(rep.region)} &mdash; ${variants.length} variants</span>
-      <span class="rec-cell-range">${savingsDisplay} &middot; upfront: ${upfrontDisplay} &middot; term: ${termDisplay}</span>
+      <span class="rec-cell-identity">${identityParts.join(' &mdash; ')}</span>
+      ${rangeParts.length > 0 ? `<span class="rec-cell-range">${rangeParts.join(' &middot; ')}</span>` : ''}
     </td>
   </tr>`);
 

--- a/frontend/src/state.ts
+++ b/frontend/src/state.ts
@@ -215,5 +215,8 @@ export function getHiddenColumns(): ReadonlySet<RecommendationsColumnId> {
 }
 
 export function setHiddenColumns(hidden: ReadonlySet<RecommendationsColumnId>): void {
-  hiddenColumns = new Set(hidden);
+  // Filter out fixed anchor columns that must always remain visible
+  const fixedColumns: ReadonlySet<RecommendationsColumnId> = new Set(['provider', 'account', 'service', 'resource_type']);
+  const filtered = Array.from(hidden).filter((col) => !fixedColumns.has(col));
+  hiddenColumns = new Set(filtered);
 }

--- a/frontend/src/state.ts
+++ b/frontend/src/state.ts
@@ -211,7 +211,7 @@ export function setCostPeriod(period: CostPeriod): void {
 let hiddenColumns: Set<RecommendationsColumnId> = new Set();
 
 export function getHiddenColumns(): ReadonlySet<RecommendationsColumnId> {
-  return hiddenColumns;
+  return new Set(hiddenColumns);
 }
 
 export function setHiddenColumns(hidden: ReadonlySet<RecommendationsColumnId>): void {

--- a/frontend/src/state.ts
+++ b/frontend/src/state.ts
@@ -201,3 +201,19 @@ export function setCostPeriod(period: CostPeriod): void {
     // Non-fatal; in-memory fallback remains correct for the session.
   }
 }
+
+// ---------------------------------------------------------------------------
+// Per-column visibility state (issue #318).
+// A column id in this set is HIDDEN; an absent id is visible (default visible).
+// In-memory only; the localStorage layer lives in recommendations.ts alongside
+// the other localStorage helpers (loadBulkPurchaseState / saveBulkPurchaseState).
+// ---------------------------------------------------------------------------
+let hiddenColumns: Set<RecommendationsColumnId> = new Set();
+
+export function getHiddenColumns(): ReadonlySet<RecommendationsColumnId> {
+  return hiddenColumns;
+}
+
+export function setHiddenColumns(hidden: ReadonlySet<RecommendationsColumnId>): void {
+  hiddenColumns = new Set(hidden);
+}

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -906,9 +906,8 @@ tr.recommendation-row:hover {
 /* Sort-hidden indicator */
 .recommendations-filter-status .sort-hidden-note {
     font-size: 0.82em;
-    color: `#666`;
+    color: #666;
     font-style: italic;
-}
 }
 
 /* Column-visibility popover */

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -883,6 +883,67 @@ tr.recommendation-row:hover {
     color: #1a73e8;
 }
 
+/* issue #318: "Columns ▾" button in the filter-status bar */
+.recommendations-filter-status .column-visibility-btn {
+    background: transparent;
+    border: 1px solid #d0d7de;
+    border-radius: 3px;
+    padding: 0.25rem 0.6rem;
+    font-size: 0.85em;
+    cursor: pointer;
+    color: #555;
+}
+.recommendations-filter-status .column-visibility-btn:hover {
+    border-color: #1a73e8;
+    color: #1a73e8;
+}
+.recommendations-filter-status .column-visibility-btn[aria-pressed="true"] {
+    background: #e8f0fe;
+    border-color: #a9c7f5;
+    color: #1a73e8;
+}
+
+/* Sort-hidden indicator */
+.recommendations-filter-status .sort-hidden-note {
+    font-size: 0.82em;
+    color: #888;
+    font-style: italic;
+}
+
+/* Column-visibility popover */
+.column-visibility-popover {
+    position: absolute;
+    z-index: 1200;
+    background: #fff;
+    border: 1px solid #d0d7de;
+    border-radius: 6px;
+    box-shadow: 0 4px 16px rgba(0,0,0,0.13);
+    padding: 0.6rem 0.75rem;
+    min-width: 180px;
+    max-height: 360px;
+    overflow-y: auto;
+}
+.column-visibility-popover .column-visibility-title {
+    margin: 0 0 0.4rem;
+    font-size: 0.8em;
+    font-weight: 600;
+    color: #444;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+.column-visibility-popover .column-visibility-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.25rem 0;
+    font-size: 0.88em;
+    cursor: pointer;
+    white-space: nowrap;
+}
+.column-visibility-popover .column-visibility-row:hover {
+    color: #1a73e8;
+}
+
 /* Page-level range banner above the table */
 .rec-range-banner {
     padding: 0.4rem 0.75rem;

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -906,8 +906,9 @@ tr.recommendation-row:hover {
 /* Sort-hidden indicator */
 .recommendations-filter-status .sort-hidden-note {
     font-size: 0.82em;
-    color: #888;
+    color: `#666`;
     font-style: italic;
+}
 }
 
 /* Column-visibility popover */


### PR DESCRIPTION
## Summary

- Adds a **"Columns ▾"** button in the recommendations filter-status bar that opens a portal popover for per-column show/hide toggling
- 8 toggleable columns: Region, Count, Term, Payment, Monthly Savings, Upfront Cost, Monthly Cost, Effective %; the 4 fixed "cell identity anchors" (Provider, Account, Service, Resource Type) are always shown (v1 — see #318 for v2 roadmap)
- Persists selections to `localStorage` with a versioned schema (`cudly.recs.columnVisibility.v1`); unknown/stale keys are silently filtered for forward compatibility
- Sort-hidden indicator in the filter-status bar warns when the active sort column is currently hidden
- Full keyboard accessibility: Escape closes and returns focus; Enter/Space opens; click-outside dismisses

## Implementation details

- `state.ts`: `hiddenColumns` Set + `getHiddenColumns` / `setHiddenColumns`
- `TOGGLEABLE_COLUMNS` / `TOGGLEABLE_COLUMN_KEYS` derived from `COLUMN_DEFS` (Commit 1 refactor)
- `loadColumnVisibility` / `saveColumnVisibility` with whitelisting guard
- `resetColumnVisibilityState()` exported for test isolation
- `visibleColumns()` computed once per render, passed to `buildListMarkup` + `buildVariantRowMarkup`
- `summaryColspan` = 1 + visible-toggleable-count (replaces hardcoded `TABLE_COL_COUNT - 4`)
- `mountColumnsButton`: mount-once lifecycle, label shows "(N hidden)", `aria-pressed` reflects active state; re-syncs open-popover checkboxes on each render
- 14 new tests via `localStorageMock` covering all load/save edge-cases

## Test plan

- [x] `npm run build` passes with no TS errors
- [x] `npm test -- --testPathPattern=recommendations` — 181 tests pass
- [ ] Manual: open the app, verify "Columns ▾" button appears above the table
- [ ] Manual: toggle a column hidden — verify it disappears from header and rows
- [ ] Manual: reload the page — verify hidden columns persist from localStorage
- [ ] Manual: hide the sort column — verify sort-hidden note appears
- [ ] Manual: Escape key closes popover and returns focus to the button
- [ ] Manual: click-outside closes popover

Closes #318

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Toggle individual column visibility in the recommendations table; key identity columns remain fixed
  * Visibility preferences persist across sessions and can be reset
  * Column visibility popover in the filter/status bar with hidden-column count and a note when sorting by a hidden column
  * Headers, rows and multi-variant summary cells adapt to currently visible columns

* **Style**
  * UI styles for the visibility button, popover, and related states

* **Tests**
  * Coverage for persistence, malformed data handling, fixed vs toggleable columns, and hidden-column rendering in grouped rows

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/326)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->