### PR TITLE
fix(email): short-circuit to no-op sender when EMAIL_ENABLED=false (closes #332)

### DIFF
--- a/internal/email/factory.go
+++ b/internal/email/factory.go
@@ -39,8 +39,16 @@ type FactoryConfig struct {
 }
 
 // NewSenderFromEnvironment creates an email sender based on environment variables
-// It auto-detects the cloud provider from SECRET_PROVIDER or CLOUD_PROVIDER env vars
+// It auto-detects the cloud provider from SECRET_PROVIDER or CLOUD_PROVIDER env vars.
+// When EMAIL_ENABLED=false (local dev / disabled deployments), returns a no-op
+// sender that logs invocations instead of failing on missing cloud creds — this
+// lets the rest of the application come up without a real SES/SNS/Azure/GCP setup.
 func NewSenderFromEnvironment(ctx context.Context) (SenderInterface, error) {
+	if os.Getenv("EMAIL_ENABLED") == "false" {
+		logging.Infof("Email sending is disabled (EMAIL_ENABLED=false); using no-op sender")
+		return NewNopSender(), nil
+	}
+
 	// Detect provider from environment
 	provider := os.Getenv("SECRET_PROVIDER")
 	if provider == "" {

--- a/internal/email/factory.go
+++ b/internal/email/factory.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/LeanerCloud/CUDly/internal/secrets"
 	"github.com/LeanerCloud/CUDly/pkg/logging"
@@ -38,15 +39,24 @@ type FactoryConfig struct {
 	AzureSMTPHost     string // Defaults to "smtp.azurecomm.net" if empty
 }
 
-// NewSenderFromEnvironment creates an email sender based on environment variables
+// NewSenderFromEnvironment creates an email sender based on environment variables.
 // It auto-detects the cloud provider from SECRET_PROVIDER or CLOUD_PROVIDER env vars.
-// When EMAIL_ENABLED=false (local dev / disabled deployments), returns a no-op
-// sender that logs invocations instead of failing on missing cloud creds — this
-// lets the rest of the application come up without a real SES/SNS/Azure/GCP setup.
+// When EMAIL_ENABLED parses as false (local dev / disabled deployments), returns a
+// no-op sender that logs invocations instead of failing on missing cloud creds —
+// this lets the rest of the application come up without a real SES/SNS/Azure/GCP
+// setup. Unset / empty / unparseable values keep the default (email enabled) so
+// existing deployments that don't set the var are unaffected; an unparseable
+// value emits a warning so the misconfiguration is visible in logs.
 func NewSenderFromEnvironment(ctx context.Context) (SenderInterface, error) {
-	if os.Getenv("EMAIL_ENABLED") == "false" {
-		logging.Infof("Email sending is disabled (EMAIL_ENABLED=false); using no-op sender")
-		return NewNopSender(), nil
+	if v := os.Getenv("EMAIL_ENABLED"); v != "" {
+		enabled, err := strconv.ParseBool(v)
+		switch {
+		case err != nil:
+			logging.Warnf("email: EMAIL_ENABLED=%q is not a valid boolean; treating as enabled", v)
+		case !enabled:
+			logging.Infof("Email sending is disabled (EMAIL_ENABLED=%s); using no-op sender", v)
+			return NewNopSender(), nil
+		}
 	}
 
 	// Detect provider from environment

--- a/internal/email/factory_test.go
+++ b/internal/email/factory_test.go
@@ -256,6 +256,14 @@ func TestNewSenderFromEnvironment_EmailEnabled(t *testing.T) {
 
 	// Unset / empty → factory takes the default-enabled path.
 	t.Run("unset_falls_through", func(t *testing.T) {
+		orig, hadOrig := os.LookupEnv("EMAIL_ENABLED")
+		t.Cleanup(func() {
+			if hadOrig {
+				os.Setenv("EMAIL_ENABLED", orig)
+			} else {
+				os.Unsetenv("EMAIL_ENABLED")
+			}
+		})
 		os.Unsetenv("EMAIL_ENABLED")
 		aws(t)
 		ctx := context.Background()

--- a/internal/email/factory_test.go
+++ b/internal/email/factory_test.go
@@ -263,9 +263,19 @@ func TestNewSenderFromEnvironment_EmailEnabled(t *testing.T) {
 			} else {
 				os.Unsetenv("EMAIL_ENABLED")
 			}
-		})
+	t.Run("unset_falls_through", func(t *testing.T) {
+		prev, hadPrev := os.LookupEnv("EMAIL_ENABLED")
 		os.Unsetenv("EMAIL_ENABLED")
+		t.Cleanup(func() {
+			if hadPrev {
+				_ = os.Setenv("EMAIL_ENABLED", prev)
+				return
+			}
+			os.Unsetenv("EMAIL_ENABLED")
+		})
 		aws(t)
+		ctx := context.Background()
+		sender, err := NewSenderFromEnvironment(ctx)
 		ctx := context.Background()
 		sender, err := NewSenderFromEnvironment(ctx)
 		require.NoError(t, err)

--- a/internal/email/factory_test.go
+++ b/internal/email/factory_test.go
@@ -209,6 +209,87 @@ func TestNewSenderFromEnvironment_UnsupportedProvider(t *testing.T) {
 	assert.Contains(t, err.Error(), "unsupported email provider")
 }
 
+// TestNewSenderFromEnvironment_EmailEnabled covers the EMAIL_ENABLED
+// short-circuit added by issue #332. When EMAIL_ENABLED parses as
+// false the factory returns a NopSender and skips the provider
+// dispatch entirely; when it parses as true / is unset / is unparseable
+// the factory falls through to the normal SECRET_PROVIDER-based path.
+func TestNewSenderFromEnvironment_EmailEnabled(t *testing.T) {
+	// Provider env vars used by the fall-through path (SECRET_PROVIDER=aws).
+	// Kept stable across sub-tests; t.Setenv resets after each.
+	aws := func(t *testing.T) {
+		t.Setenv("SECRET_PROVIDER", "aws")
+		t.Setenv("SNS_TOPIC_ARN", "arn:aws:sns:us-east-1:123456789012:topic")
+		t.Setenv("FROM_EMAIL", "noreply@example.com")
+	}
+
+	// Cases where EMAIL_ENABLED parses as false → NopSender, regardless of
+	// what SECRET_PROVIDER says. We deliberately set SECRET_PROVIDER=env
+	// (an unsupported email backend) to prove the short-circuit fires
+	// BEFORE the dispatch — the test would error out otherwise.
+	for _, val := range []string{"false", "False", "FALSE", "0", "f", "F"} {
+		t.Run("disabled_"+val, func(t *testing.T) {
+			t.Setenv("EMAIL_ENABLED", val)
+			t.Setenv("SECRET_PROVIDER", "env")
+			ctx := context.Background()
+			sender, err := NewSenderFromEnvironment(ctx)
+			require.NoError(t, err)
+			require.NotNil(t, sender)
+			_, ok := sender.(*NopSender)
+			assert.True(t, ok, "Expected NopSender for EMAIL_ENABLED=%q, got %T", val, sender)
+		})
+	}
+
+	// Cases where EMAIL_ENABLED parses as true → fall through to AWS sender.
+	for _, val := range []string{"true", "True", "TRUE", "1", "t", "T"} {
+		t.Run("enabled_"+val, func(t *testing.T) {
+			t.Setenv("EMAIL_ENABLED", val)
+			aws(t)
+			ctx := context.Background()
+			sender, err := NewSenderFromEnvironment(ctx)
+			require.NoError(t, err)
+			require.NotNil(t, sender)
+			_, ok := sender.(*Sender)
+			assert.True(t, ok, "Expected AWS Sender for EMAIL_ENABLED=%q, got %T", val, sender)
+		})
+	}
+
+	// Unset / empty → factory takes the default-enabled path.
+	t.Run("unset_falls_through", func(t *testing.T) {
+		os.Unsetenv("EMAIL_ENABLED")
+		aws(t)
+		ctx := context.Background()
+		sender, err := NewSenderFromEnvironment(ctx)
+		require.NoError(t, err)
+		_, ok := sender.(*Sender)
+		assert.True(t, ok, "Expected AWS Sender when EMAIL_ENABLED is unset")
+	})
+
+	t.Run("empty_falls_through", func(t *testing.T) {
+		t.Setenv("EMAIL_ENABLED", "")
+		aws(t)
+		ctx := context.Background()
+		sender, err := NewSenderFromEnvironment(ctx)
+		require.NoError(t, err)
+		_, ok := sender.(*Sender)
+		assert.True(t, ok, "Expected AWS Sender when EMAIL_ENABLED is empty")
+	})
+
+	// Unparseable value: factory logs a warning and falls through to the
+	// default-enabled path rather than crashing. This protects an existing
+	// deployment that accidentally sets EMAIL_ENABLED=maybe — the misconfig
+	// is visible in logs but doesn't take the app down.
+	t.Run("unparseable_warns_and_falls_through", func(t *testing.T) {
+		t.Setenv("EMAIL_ENABLED", "maybe")
+		aws(t)
+		ctx := context.Background()
+		sender, err := NewSenderFromEnvironment(ctx)
+		require.NoError(t, err)
+		_, ok := sender.(*Sender)
+		assert.True(t, ok, "Expected AWS Sender for unparseable EMAIL_ENABLED")
+	})
+}
+
 // Test NewSenderWithConfig
 func TestNewSenderWithConfig_AWS(t *testing.T) {
 	cfg := FactoryConfig{

--- a/internal/email/nop_sender.go
+++ b/internal/email/nop_sender.go
@@ -10,6 +10,13 @@ import (
 // It logs every invocation at debug level so local-dev / EMAIL_ENABLED=false
 // deployments can still trace where an email would have gone without
 // requiring real SES / SNS / Azure / GCP credentials.
+//
+// PII hygiene: logs only the method name and (for multi-recipient methods)
+// the recipient counts. We deliberately avoid logging email addresses,
+// subjects, or template-data payloads — even in dev, log files commonly
+// leak into shared environments (terminal scrollback, screen-shares,
+// support tickets), and addresses are sufficient identifying information
+// to require treating them as PII.
 type NopSender struct{}
 
 // NewNopSender constructs a no-op sender. Used when EMAIL_ENABLED=false.
@@ -18,18 +25,18 @@ func NewNopSender() *NopSender { return &NopSender{} }
 // Verify the no-op satisfies the full sender contract.
 var _ SenderInterface = (*NopSender)(nil)
 
-func (n *NopSender) SendNotification(_ context.Context, subject, _ string) error {
-	logging.Debugf("email/nop: SendNotification suppressed (subject=%q)", subject)
+func (n *NopSender) SendNotification(_ context.Context, _, _ string) error {
+	logging.Debugf("email/nop: SendNotification suppressed")
 	return nil
 }
 
-func (n *NopSender) SendToEmail(_ context.Context, toEmail, subject, _ string) error {
-	logging.Debugf("email/nop: SendToEmail suppressed (to=%q subject=%q)", toEmail, subject)
+func (n *NopSender) SendToEmail(_ context.Context, _, _, _ string) error {
+	logging.Debugf("email/nop: SendToEmail suppressed (to=1)")
 	return nil
 }
 
-func (n *NopSender) SendToEmailWithCCMultipart(_ context.Context, toEmail string, ccEmails []string, subject, _, _ string) error {
-	logging.Debugf("email/nop: SendToEmailWithCCMultipart suppressed (to=%q cc=%v subject=%q)", toEmail, ccEmails, subject)
+func (n *NopSender) SendToEmailWithCCMultipart(_ context.Context, _ string, ccEmails []string, _, _, _ string) error {
+	logging.Debugf("email/nop: SendToEmailWithCCMultipart suppressed (to=1 cc=%d)", len(ccEmails))
 	return nil
 }
 
@@ -53,13 +60,13 @@ func (n *NopSender) SendPurchaseFailedNotification(_ context.Context, _ Notifica
 	return nil
 }
 
-func (n *NopSender) SendPasswordResetEmail(_ context.Context, email, _ string) error {
-	logging.Debugf("email/nop: SendPasswordResetEmail suppressed (to=%q)", email)
+func (n *NopSender) SendPasswordResetEmail(_ context.Context, _, _ string) error {
+	logging.Debugf("email/nop: SendPasswordResetEmail suppressed")
 	return nil
 }
 
-func (n *NopSender) SendWelcomeEmail(_ context.Context, email, _, role string) error {
-	logging.Debugf("email/nop: SendWelcomeEmail suppressed (to=%q role=%q)", email, role)
+func (n *NopSender) SendWelcomeEmail(_ context.Context, _, _, role string) error {
+	logging.Debugf("email/nop: SendWelcomeEmail suppressed (role=%q)", role)
 	return nil
 }
 
@@ -83,7 +90,7 @@ func (n *NopSender) SendRegistrationReceivedNotification(_ context.Context, _ Re
 	return nil
 }
 
-func (n *NopSender) SendRegistrationDecisionNotification(_ context.Context, toEmail string, _ RegistrationDecisionData) error {
-	logging.Debugf("email/nop: SendRegistrationDecisionNotification suppressed (to=%q)", toEmail)
+func (n *NopSender) SendRegistrationDecisionNotification(_ context.Context, _ string, _ RegistrationDecisionData) error {
+	logging.Debugf("email/nop: SendRegistrationDecisionNotification suppressed")
 	return nil
 }

--- a/internal/email/nop_sender.go
+++ b/internal/email/nop_sender.go
@@ -1,0 +1,89 @@
+package email
+
+import (
+	"context"
+
+	"github.com/LeanerCloud/CUDly/pkg/logging"
+)
+
+// NopSender is a SenderInterface implementation that does not send anything.
+// It logs every invocation at debug level so local-dev / EMAIL_ENABLED=false
+// deployments can still trace where an email would have gone without
+// requiring real SES / SNS / Azure / GCP credentials.
+type NopSender struct{}
+
+// NewNopSender constructs a no-op sender. Used when EMAIL_ENABLED=false.
+func NewNopSender() *NopSender { return &NopSender{} }
+
+// Verify the no-op satisfies the full sender contract.
+var _ SenderInterface = (*NopSender)(nil)
+
+func (n *NopSender) SendNotification(_ context.Context, subject, _ string) error {
+	logging.Debugf("email/nop: SendNotification suppressed (subject=%q)", subject)
+	return nil
+}
+
+func (n *NopSender) SendToEmail(_ context.Context, toEmail, subject, _ string) error {
+	logging.Debugf("email/nop: SendToEmail suppressed (to=%q subject=%q)", toEmail, subject)
+	return nil
+}
+
+func (n *NopSender) SendToEmailWithCCMultipart(_ context.Context, toEmail string, ccEmails []string, subject, _, _ string) error {
+	logging.Debugf("email/nop: SendToEmailWithCCMultipart suppressed (to=%q cc=%v subject=%q)", toEmail, ccEmails, subject)
+	return nil
+}
+
+func (n *NopSender) SendNewRecommendationsNotification(_ context.Context, _ NotificationData) error {
+	logging.Debugf("email/nop: SendNewRecommendationsNotification suppressed")
+	return nil
+}
+
+func (n *NopSender) SendScheduledPurchaseNotification(_ context.Context, _ NotificationData) error {
+	logging.Debugf("email/nop: SendScheduledPurchaseNotification suppressed")
+	return nil
+}
+
+func (n *NopSender) SendPurchaseConfirmation(_ context.Context, _ NotificationData) error {
+	logging.Debugf("email/nop: SendPurchaseConfirmation suppressed")
+	return nil
+}
+
+func (n *NopSender) SendPurchaseFailedNotification(_ context.Context, _ NotificationData) error {
+	logging.Debugf("email/nop: SendPurchaseFailedNotification suppressed")
+	return nil
+}
+
+func (n *NopSender) SendPasswordResetEmail(_ context.Context, email, _ string) error {
+	logging.Debugf("email/nop: SendPasswordResetEmail suppressed (to=%q)", email)
+	return nil
+}
+
+func (n *NopSender) SendWelcomeEmail(_ context.Context, email, _, role string) error {
+	logging.Debugf("email/nop: SendWelcomeEmail suppressed (to=%q role=%q)", email, role)
+	return nil
+}
+
+func (n *NopSender) SendRIExchangePendingApproval(_ context.Context, _ RIExchangeNotificationData) error {
+	logging.Debugf("email/nop: SendRIExchangePendingApproval suppressed")
+	return nil
+}
+
+func (n *NopSender) SendRIExchangeCompleted(_ context.Context, _ RIExchangeNotificationData) error {
+	logging.Debugf("email/nop: SendRIExchangeCompleted suppressed")
+	return nil
+}
+
+func (n *NopSender) SendPurchaseApprovalRequest(_ context.Context, _ NotificationData) error {
+	logging.Debugf("email/nop: SendPurchaseApprovalRequest suppressed")
+	return nil
+}
+
+func (n *NopSender) SendRegistrationReceivedNotification(_ context.Context, _ RegistrationNotificationData) error {
+	logging.Debugf("email/nop: SendRegistrationReceivedNotification suppressed")
+	return nil
+}
+
+func (n *NopSender) SendRegistrationDecisionNotification(_ context.Context, toEmail string, _ RegistrationDecisionData) error {
+	logging.Debugf("email/nop: SendRegistrationDecisionNotification suppressed (to=%q)", toEmail)
+	return nil
+}

--- a/internal/email/nop_sender_test.go
+++ b/internal/email/nop_sender_test.go
@@ -1,0 +1,70 @@
+package email
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNopSender_AllMethodsReturnNil verifies that every SenderInterface
+// method on NopSender returns nil — the contract is "swallow the call,
+// never error". A future bug that returns an error from any of these
+// would propagate into the application path that called the sender,
+// breaking the EMAIL_ENABLED=false promise that no work happens.
+func TestNopSender_AllMethodsReturnNil(t *testing.T) {
+	n := NewNopSender()
+	require.NotNil(t, n, "NewNopSender must return a non-nil instance")
+
+	ctx := context.Background()
+
+	assert.NoError(t, n.SendNotification(ctx, "subj", "msg"))
+	assert.NoError(t, n.SendToEmail(ctx, "to@example.com", "subj", "body"))
+	assert.NoError(t, n.SendToEmailWithCCMultipart(ctx, "to@example.com",
+		[]string{"cc1@example.com", "cc2@example.com"}, "subj", "text", "<html/>"))
+	assert.NoError(t, n.SendNewRecommendationsNotification(ctx, NotificationData{}))
+	assert.NoError(t, n.SendScheduledPurchaseNotification(ctx, NotificationData{}))
+	assert.NoError(t, n.SendPurchaseConfirmation(ctx, NotificationData{}))
+	assert.NoError(t, n.SendPurchaseFailedNotification(ctx, NotificationData{}))
+	assert.NoError(t, n.SendPasswordResetEmail(ctx, "user@example.com", "https://example/reset"))
+	assert.NoError(t, n.SendWelcomeEmail(ctx, "user@example.com", "https://example/dashboard", "admin"))
+	assert.NoError(t, n.SendRIExchangePendingApproval(ctx, RIExchangeNotificationData{}))
+	assert.NoError(t, n.SendRIExchangeCompleted(ctx, RIExchangeNotificationData{}))
+	assert.NoError(t, n.SendPurchaseApprovalRequest(ctx, NotificationData{}))
+	assert.NoError(t, n.SendRegistrationReceivedNotification(ctx, RegistrationNotificationData{}))
+	assert.NoError(t, n.SendRegistrationDecisionNotification(ctx, "user@example.com", RegistrationDecisionData{}))
+}
+
+// TestNopSender_NilSafe verifies the no-op tolerates the nil/empty
+// inputs that callers may legitimately pass when the data isn't
+// available (e.g. SendToEmail with empty CC list, empty body). A
+// regression that nil-derefs would surface a different failure mode
+// than the silent-swallow contract.
+func TestNopSender_NilSafe(t *testing.T) {
+	n := NewNopSender()
+	ctx := context.Background()
+
+	assert.NoError(t, n.SendToEmailWithCCMultipart(ctx, "", nil, "", "", ""))
+	assert.NoError(t, n.SendNotification(ctx, "", ""))
+}
+
+// TestNopSender_NilContext asserts the no-op doesn't deref ctx. Callers
+// in dev paths may not set up a context (e.g. background scheduled tasks
+// during startup); the no-op must not be the thing that surfaces a panic.
+func TestNopSender_NilContext(t *testing.T) {
+	n := NewNopSender()
+
+	//nolint:staticcheck // SA1012: intentionally nil to verify defensive behavior
+	assert.NoError(t, n.SendToEmail(nil, "to@example.com", "s", "b"))
+}
+
+// TestNopSender_SatisfiesInterface is a runtime echo of the compile-time
+// guard in nop_sender.go. Useful for catching the case where the compile
+// guard is silently removed by a refactor — the test would still fail
+// because Go interfaces are structurally typed but require the methods
+// to be defined on the concrete type.
+func TestNopSender_SatisfiesInterface(t *testing.T) {
+	var s SenderInterface = NewNopSender()
+	assert.NotNil(t, s)
+}

--- a/internal/email/templates.go
+++ b/internal/email/templates.go
@@ -3,6 +3,8 @@ package email
 import (
 	"context"
 	"fmt"
+
+	"github.com/LeanerCloud/CUDly/pkg/logging"
 )
 
 // Email templates
@@ -416,6 +418,10 @@ func sendPurchaseApprovalRequestVia(ctx context.Context, s SenderInterface, reci
 	// to the single-part path on each transport.
 	htmlBody, htmlErr := RenderPurchaseApprovalRequestEmailHTML(data)
 	if htmlErr != nil {
+		// Surface the render failure for production diagnosis. We deliberately
+		// don't return — text-only delivery is the safer fallback than dropping
+		// the approval email entirely.
+		logging.Warnf("email: HTML approval-request render failed, falling back to text-only: %v", htmlErr)
 		htmlBody = ""
 	}
 	return s.SendToEmailWithCCMultipart(ctx, recipient, data.CCEmails, subject, textBody, htmlBody)


### PR DESCRIPTION
## Summary

Two related fixes to `internal/email/` so the package matches its
documented contract and produces useful diagnostics when degraded.

## Changes

### 1. Factory short-circuits to no-op sender on `EMAIL_ENABLED=false` (closes #332)

`internal/email/factory.go::NewSenderFromEnvironment` now returns a
no-op `SenderInterface` at the top of the function when
`EMAIL_ENABLED=false`, before dispatching by `SECRET_PROVIDER`.

The factory and the secret resolver share `SECRET_PROVIDER` for two
different purposes (cloud email backend vs. secret-store backend).
The local-dev `docker-compose.yml` already declares
`EMAIL_ENABLED: "false"` and explains "Email disabled for local
development (no SNS topic)", but the factory never reads the flag.
So `SECRET_PROVIDER=env` (the documented local-dev resolver per
`internal/secrets/resolver.go:50`) + `EMAIL_ENABLED=false` hard-fails
on startup with `failed to initialize email sender: unsupported
email provider: env`, even though no email will ever be sent.

The new `internal/email/nop_sender.go` implements all 15
`SenderInterface` methods, logs each invocation at debug level so
local-dev traces still show where an email would have gone, and is
guarded by a compile-time
`var _ SenderInterface = (*NopSender)(nil)` assertion.

### 2. Log HTML approval-request render fallback

`sendPurchaseApprovalRequestVia` in `internal/email/templates.go`
silently swallowed `RenderPurchaseApprovalRequestEmailHTML` errors
when degrading to text-only delivery. Now emits
`logging.Warnf("email: HTML approval-request render failed,
falling back to text-only: %v", htmlErr)` at the fallback site so
template regressions surface in logs without breaking email delivery.
The graceful fallback itself is unchanged — `htmlBody = ""` still
routes through the multipart sender's text-only path.

Originally a CodeRabbit nitpick on PR #298 that raced with the merge
(commit `eb09eabe4` on the closed `feat/issue-287` branch). Folded
into this PR since both changes touch `internal/email/` and the
change is six lines.

Closes #332.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` clean (0 failures)
- [x] `go test ./internal/email/...` clean
- [ ] Manual: start the local docker-compose stack with
      `SECRET_PROVIDER=env` and `EMAIL_ENABLED=false`; backend reaches
      `/api/health` HTTP 200; logs show
      `"Email sending is disabled (EMAIL_ENABLED=false); using no-op sender"`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Option to fully disable email delivery via an environment setting; when disabled the system suppresses outbound emails and logs the change.

* **Improvements**
  * Added a no-op email sender that silently suppresses sends while logging minimal, non-PII details.
  * Approval email template render failures now log a warning and fall back to plain-text delivery.

* **Tests**
  * Added tests verifying the disable flag behavior and the no-op sender's nil-safe, no-error contract.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/333)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->