### PR TITLE
fix(local-dev): docker-compose + .env.example cover the new required env vars (closes #334)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,7 +64,7 @@ CREDENTIAL_ENCRYPTION_ALLOW_DEV_KEY=1
 # (1) production uses the same var name pointing at a real ARN/name;
 # (2) the dev value is co-located with its lookup key so future readers
 # can trace the chain in one file.
-ADMIN_EMAIL=admin@example.com
+ADMIN_EMAIL=admin@cudly.local
 ADMIN_PASSWORD_SECRET=ADMIN_PASSWORD_DEV
 ADMIN_PASSWORD_DEV=LocalDev!Pass123
 API_KEY_SECRET_ARN=ADMIN_API_KEY_DEV

--- a/.env.example
+++ b/.env.example
@@ -11,14 +11,35 @@
 # ---------------------------------------------------------------------
 # Required: secrets resolver
 # ---------------------------------------------------------------------
-# SECRET_PROVIDER selects which cloud secret store the resolver fetches
-# from. Default `aws` matches the email factory's default backend
-# (internal/email/factory.go) — using a value the email factory does
-# not understand (e.g. `env`) makes app startup fail because email
-# init runs unconditionally. For local dev that doesn't actually call
-# email or secret-store paths, `aws` is a safe placeholder.
-#   aws | gcp | azure
-SECRET_PROVIDER=aws
+# SECRET_PROVIDER selects which secret store the resolver fetches from.
+#   aws  | gcp | azure  — production: real Secrets Manager / Key Vault
+#   env                 — local dev: resolve secret names to env vars
+# In `env` mode, every secret-ref var (ADMIN_PASSWORD_SECRET,
+# API_KEY_SECRET_ARN, etc.) holds the NAME of another env var whose
+# value is the actual secret. See `internal/secrets/env_resolver.go`.
+# Pairs with EMAIL_ENABLED=false so the email factory's no-op sender
+# kicks in (see PR #333) — otherwise `env` is not a recognised email
+# backend and the factory would fail dispatch.
+SECRET_PROVIDER=env
+
+# ---------------------------------------------------------------------
+# Required: scheduled-task auth mode (no default — must be explicit)
+# ---------------------------------------------------------------------
+# Selects how the internal /api/scheduled/* endpoints authenticate.
+#   oidc      — production: verify Google-issued OIDC ID tokens
+#   bearer    — shared-secret token in Authorization header
+#   disabled  — local dev: no auth check
+# Required by `internal/server/scheduledauth/config.go`; app refuses
+# to start when unset.
+SCHEDULED_TASK_AUTH_MODE=disabled
+
+# ---------------------------------------------------------------------
+# Required: email gate (factory short-circuit, see PR #333)
+# ---------------------------------------------------------------------
+# When `false`, internal/email/factory.go returns a no-op sender that
+# logs each invocation at debug level instead of dispatching to a
+# cloud-specific backend. Pair with SECRET_PROVIDER=env for local dev.
+EMAIL_ENABLED=false
 
 # ---------------------------------------------------------------------
 # Required: credential encryption key
@@ -35,9 +56,20 @@ CREDENTIAL_ENCRYPTION_ALLOW_DEV_KEY=1
 # CREDENTIAL_ENCRYPTION_KEY=<64-hex-chars>
 
 # ---------------------------------------------------------------------
-# Required for production: admin auth + API
+# Required: admin auth + API
 # ---------------------------------------------------------------------
+# With SECRET_PROVIDER=env, the *_SECRET / *_SECRET_ARN vars hold the
+# NAME of another env var whose value is the actual secret. The matched
+# env var must then be defined below. Two reasons for the indirection:
+# (1) production uses the same var name pointing at a real ARN/name;
+# (2) the dev value is co-located with its lookup key so future readers
+# can trace the chain in one file.
 ADMIN_EMAIL=admin@example.com
+ADMIN_PASSWORD_SECRET=ADMIN_PASSWORD_DEV
+ADMIN_PASSWORD_DEV=LocalDev!Pass123
+API_KEY_SECRET_ARN=ADMIN_API_KEY_DEV
+ADMIN_API_KEY_DEV=cudly-local-dev-api-key-not-for-prod
+# Production examples (override SECRET_PROVIDER and these):
 # ADMIN_PASSWORD_SECRET=arn:aws:secretsmanager:us-east-1:000000000000:secret:cudly-admin-password-PLACEHOLDER
 # API_KEY_SECRET_ARN=arn:aws:secretsmanager:us-east-1:000000000000:secret:cudly-api-key-PLACEHOLDER
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,10 +42,29 @@ services:
       DB_AUTO_MIGRATE: "true"
       DB_MIGRATIONS_PATH: /app/internal/database/postgres/migrations
 
-      # Secret provider (use aws with empty credentials for local dev)
-      SECRET_PROVIDER: aws
-      # Email disabled for local development (no SNS topic)
+      # Secret provider — "env" reads secrets from env vars (local-dev only).
+      # Production uses "aws" / "azure" / "gcp" with real Secrets Manager.
+      SECRET_PROVIDER: env
+
+      # Admin password secret: the EnvResolver looks up the env var whose
+      # NAME equals ADMIN_PASSWORD_SECRET. Here it points at ADMIN_PASSWORD_DEV.
+      ADMIN_PASSWORD_SECRET: ADMIN_PASSWORD_DEV
+      ADMIN_PASSWORD_DEV: "LocalDev!Pass123"
+      ADMIN_EMAIL: admin@cudly.local
+
+      # API-key secret: same pattern — name → env var that holds the value.
+      # Frontend asks for this in the admin-setup modal.
+      API_KEY_SECRET_ARN: ADMIN_API_KEY_DEV
+      ADMIN_API_KEY_DEV: "cudly-local-dev-api-key-not-for-prod"
+
+      # Credential encryption: dev key (all-zero) is gated behind this flag.
+      CREDENTIAL_ENCRYPTION_ALLOW_DEV_KEY: "1"
+
+      # Email disabled for local development (no SNS topic / SES creds)
       EMAIL_ENABLED: "false"
+      # Scheduled-task auth: OIDC for prod, disabled for local dev so the
+      # internal /api/scheduled/* endpoints don't require Google ID tokens.
+      SCHEDULED_TASK_AUTH_MODE: disabled
 
       # Application settings
       ENVIRONMENT: development


### PR DESCRIPTION
## Summary

A fresh `docker-compose up -d` on this branch crashes on startup because
the compose file is missing several env vars the app now requires.
This PR adds them with local-dev defaults and documents the same
contract in `.env.example` so anyone running outside compose has a
one-stop reference.

## Failure chain this fixes

Without this PR, a fresh `docker-compose up -d` hits these one by one:

1. `scheduled-task auth init: SCHEDULED_TASK_AUTH_MODE is unset` —
   `internal/server/scheduledauth/config.go` requires explicit choice.
2. `ADMIN_PASSWORD_SECRET environment variable is required but not
   set; refusing to start without a Secrets Manager ARN`.
3. (After #333 lands) `SECRET_PROVIDER=aws` + empty AWS creds was
   working by luck; switching to `env` is the correct local-dev path.
4. Frontend admin-setup modal asks for an API key (sourced from
   `API_KEY_SECRET_ARN` → fails when empty).

## Changes

`docker-compose.yml` (`app` service environment block):

- `SECRET_PROVIDER: env` (was `aws`) — pairs with `EMAIL_ENABLED=false`
  so the no-op email sender from #333 kicks in.
- `SCHEDULED_TASK_AUTH_MODE: disabled`.
- `ADMIN_PASSWORD_SECRET` / `API_KEY_SECRET_ARN` as VAR-NAME
  indirections pointing at concrete dev values
  (`ADMIN_PASSWORD_DEV` / `ADMIN_API_KEY_DEV`).
- `ADMIN_EMAIL: admin@cudly.local`.
- `CREDENTIAL_ENCRYPTION_ALLOW_DEV_KEY: "1"`.

`.env.example`:

- Updated `SECRET_PROVIDER` block to remove the now-stale "env will
  fail" warning and explain the new contract.
- Added `SCHEDULED_TASK_AUTH_MODE` section.
- Added `EMAIL_ENABLED` section with cross-reference to #333.
- Added the VAR-NAME-indirection pattern for `*_SECRET` / `*_SECRET_ARN`
  with concrete dev values co-located so future readers can trace the
  chain in one file. Kept the AWS-ARN production examples as
  commented-out alternatives.

## Dependency

**Depends on #333** (no-op email sender). Without that, the email
factory crashes on `SECRET_PROVIDER=env`. Sequencing intentional —
this PR is a no-op until #333 merges.

Closes #334.

## Test plan

- [x] `docker compose up -d postgres app frontend` brings the stack to
      healthy on a fresh checkout.
- [x] `curl http://localhost:8080/api/health` → HTTP 200.
- [x] Frontend at http://localhost:3001 serves `index.html`.
- [x] Admin-setup modal accepts the documented dev defaults
      (API key `cudly-local-dev-api-key-not-for-prod`,
       email `admin@cudly.local`,
       password `LocalDev!Pass123`).
- [ ] No regressions for prod deploys (the new vars are unset there;
      the cloud secret resolver handles them).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched local dev to environment-based secret resolution instead of cloud provider integration.
  * Replaced production credential examples with local-dev placeholder credentials and inline dev keys for easier local setup.
  * Defaulted scheduled task auth to disabled and disabled email sending in local development mode.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/335)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->