### PR TITLE
feat(frontend,email): Archera Insurance CTA in modals + education pages + email mentions (closes #314)

### DIFF
--- a/frontend/src/__tests__/archera.test.ts
+++ b/frontend/src/__tests__/archera.test.ts
@@ -1,0 +1,443 @@
+/**
+ * Tests for the Archera Insurance CTA and education overlay (issue #314).
+ *
+ * Covers:
+ *   - renderArcheraCTA: element structure, discernible name, click handler
+ *   - openArcheraPage('what-is-archera'): Page A content, crosslink to B,
+ *     signup link attributes, back button
+ *   - openArcheraPage('how-it-works'): Page B content, crosslink to A,
+ *     signup link attributes, back button
+ *   - closeArcheraPage: hides and clears the container
+ *   - openPurchaseModal: CTA is rendered inside #purchase-details
+ *   - openCreatePlanModal / openNewPlanModal: CTA is injected once into
+ *     #plan-modal; re-opening does not duplicate it
+ */
+
+import {
+  renderArcheraCTA,
+  openArcheraPage,
+  closeArcheraPage,
+  ARCHERA_SIGNUP_URL,
+} from '../archera';
+import { openPurchaseModal } from '../recommendations';
+import { openCreatePlanModal, openNewPlanModal } from '../plans';
+
+// ---------------------------------------------------------------------------
+// Mocks required by recommendations.ts and plans.ts
+// ---------------------------------------------------------------------------
+
+jest.mock('../api', () => ({
+  getRecommendations: jest.fn(),
+  refreshRecommendations: jest.fn(),
+  listAccounts: jest.fn().mockResolvedValue([]),
+  getConfig: jest.fn().mockResolvedValue({ global: {} }),
+  listAccountServiceOverrides: jest.fn().mockResolvedValue([]),
+  getPlans: jest.fn(),
+  getPlannedPurchases: jest.fn().mockResolvedValue({ purchases: [] }),
+  listPlanAccounts: jest.fn().mockResolvedValue([]),
+  setPlanAccounts: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../api/recommendations', () => ({
+  getRecommendationDetail: jest.fn().mockResolvedValue({
+    id: 'rec-default',
+    usage_history: [],
+    confidence_bucket: 'low',
+    provenance_note: '',
+  }),
+  getRecommendationsFreshness: jest.fn().mockResolvedValue({
+    last_collected_at: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+    last_collection_error: null,
+  }),
+  refreshRecommendations: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock('../toast', () => ({
+  showToast: jest.fn(() => ({ dismiss: jest.fn() })),
+}));
+
+jest.mock('../state', () => ({
+  getCurrentProvider: jest.fn().mockReturnValue('all'),
+  getRecommendations: jest.fn().mockReturnValue([]),
+  getSelectedRecommendationIDs: jest.fn().mockReturnValue(new Set()),
+  getVisibleRecommendations: jest.fn().mockReturnValue([]),
+  setVisibleRecommendations: jest.fn(),
+}));
+
+jest.mock('../history', () => ({
+  viewPlanHistory: jest.fn(),
+}));
+
+jest.mock('../commitmentOptions', () => ({
+  populateTermSelect: jest.fn(),
+  populatePaymentSelect: jest.fn(),
+  isValidCombination: jest.fn().mockReturnValue(true),
+  normalizePaymentValue: jest.fn((v: string) => v),
+}));
+
+jest.mock('../confirmDialog', () => ({
+  confirmDialog: jest.fn(() => Promise.resolve(true)),
+}));
+
+// ---------------------------------------------------------------------------
+// DOM setup helpers
+// ---------------------------------------------------------------------------
+
+/** Minimal DOM structure used by the education overlay tests. */
+function buildArcheraContainer(): void {
+  const container = document.createElement('div');
+  container.id = 'archera-page-container';
+  container.className = 'hidden';
+  document.body.appendChild(container);
+}
+
+/** Minimal DOM for openPurchaseModal: #purchase-details + #purchase-modal. */
+function buildPurchaseModalDOM(): void {
+  document.body.appendChild((() => {
+    const modal = document.createElement('div');
+    modal.id = 'purchase-modal';
+    modal.className = 'modal hidden';
+
+    const content = document.createElement('div');
+    content.className = 'modal-content modal-wide';
+
+    const details = document.createElement('div');
+    details.id = 'purchase-details';
+    content.appendChild(details);
+
+    const buttons = document.createElement('div');
+    buttons.className = 'modal-buttons';
+    const cancelBtn = document.createElement('button');
+    cancelBtn.id = 'close-purchase-modal-btn';
+    cancelBtn.textContent = 'Cancel';
+    buttons.appendChild(cancelBtn);
+    const execBtn = document.createElement('button');
+    execBtn.id = 'execute-purchase-btn';
+    execBtn.textContent = 'Send for Approval';
+    buttons.appendChild(execBtn);
+    content.appendChild(buttons);
+
+    modal.appendChild(content);
+    return modal;
+  })());
+}
+
+/** Minimal DOM for plan modal tests. */
+function buildPlanModalDOM(): void {
+  const modal = document.createElement('div');
+  modal.id = 'plan-modal';
+  modal.className = 'modal hidden';
+  modal.setAttribute('role', 'dialog');
+  modal.setAttribute('aria-modal', 'true');
+
+  const content = document.createElement('div');
+  content.className = 'modal-content modal-wide';
+
+  const h2 = document.createElement('h2');
+  h2.id = 'plan-modal-title';
+  h2.textContent = 'Create Purchase Plan';
+  content.appendChild(h2);
+
+  const form = document.createElement('form');
+  form.id = 'plan-form';
+
+  // Required hidden input
+  const planId = document.createElement('input');
+  planId.type = 'hidden';
+  planId.id = 'plan-id';
+  form.appendChild(planId);
+
+  // Modal buttons (must exist so injectPlanModalCTA can find them)
+  const buttons = document.createElement('div');
+  buttons.className = 'modal-buttons';
+  const cancelBtn = document.createElement('button');
+  cancelBtn.id = 'close-plan-modal-btn';
+  cancelBtn.textContent = 'Cancel';
+  buttons.appendChild(cancelBtn);
+  const saveBtn = document.createElement('button');
+  saveBtn.type = 'submit';
+  saveBtn.textContent = 'Save Plan';
+  buttons.appendChild(saveBtn);
+  form.appendChild(buttons);
+
+  content.appendChild(form);
+  modal.appendChild(content);
+  document.body.appendChild(modal);
+}
+
+// ---------------------------------------------------------------------------
+// renderArcheraCTA
+// ---------------------------------------------------------------------------
+
+describe('renderArcheraCTA', () => {
+  it('returns a <p> element with class archera-cta', () => {
+    const el = renderArcheraCTA();
+    expect(el.tagName).toBe('P');
+    expect(el.classList.contains('archera-cta')).toBe(true);
+  });
+
+  it('contains the commitment-overuse CTA text', () => {
+    const el = renderArcheraCTA();
+    expect(el.textContent).toContain('Worried about committing');
+    expect(el.textContent).toContain('Archera Insurance');
+    expect(el.textContent).toContain('commitment-overuse');
+  });
+
+  it('contains a button with discernible name to trigger the overlay', () => {
+    const el = renderArcheraCTA();
+    const btn = el.querySelector('button.archera-cta-link');
+    expect(btn).not.toBeNull();
+    expect(btn!.textContent).toMatch(/learn how it works/i);
+  });
+
+  it('opens Page A when the CTA button is clicked', () => {
+    buildArcheraContainer();
+    const el = renderArcheraCTA();
+    document.body.appendChild(el);
+
+    const btn = el.querySelector<HTMLButtonElement>('button.archera-cta-link')!;
+    btn.click();
+
+    const container = document.getElementById('archera-page-container')!;
+    expect(container.classList.contains('hidden')).toBe(false);
+    expect(container.textContent).toContain('What is Archera Insurance?');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Education overlay — Page A
+// ---------------------------------------------------------------------------
+
+describe('openArcheraPage("what-is-archera") — Page A', () => {
+  beforeEach(() => {
+    buildArcheraContainer();
+  });
+
+  it('makes #archera-page-container visible', () => {
+    openArcheraPage('what-is-archera');
+    const container = document.getElementById('archera-page-container')!;
+    expect(container.classList.contains('hidden')).toBe(false);
+  });
+
+  it('renders the Page A heading', () => {
+    openArcheraPage('what-is-archera');
+    const h1 = document.querySelector('#archera-page-container h1');
+    expect(h1?.textContent).toBe('What is Archera Insurance?');
+  });
+
+  it('contains a "How it works" section', () => {
+    openArcheraPage('what-is-archera');
+    expect(document.getElementById('archera-page-container')!.textContent).toContain(
+      'How it works',
+    );
+  });
+
+  it('contains a signup link with correct href, target=_blank, and rel=noopener noreferrer', () => {
+    openArcheraPage('what-is-archera');
+    const link = document.querySelector<HTMLAnchorElement>(
+      '#archera-page-container a.archera-signup-btn',
+    );
+    expect(link).not.toBeNull();
+    expect(link!.href).toBe(ARCHERA_SIGNUP_URL);
+    expect(link!.target).toBe('_blank');
+    expect(link!.rel).toBe('noopener noreferrer');
+  });
+
+  it('has a cross-link button to Page B', () => {
+    openArcheraPage('what-is-archera');
+    const btns = document.querySelectorAll<HTMLButtonElement>(
+      '#archera-page-container button.archera-cta-link',
+    );
+    const toB = Array.from(btns).find(b => b.textContent?.includes('integration works'));
+    expect(toB).not.toBeUndefined();
+  });
+
+  it('clicking the cross-link navigates to Page B', () => {
+    openArcheraPage('what-is-archera');
+    const btns = document.querySelectorAll<HTMLButtonElement>(
+      '#archera-page-container button.archera-cta-link',
+    );
+    const toB = Array.from(btns).find(b => b.textContent?.includes('integration works'))!;
+    toB.click();
+    const h1 = document.querySelector('#archera-page-container h1');
+    expect(h1?.textContent).toContain('integration works');
+  });
+
+  it('has a back button that closes the overlay', () => {
+    openArcheraPage('what-is-archera');
+    const back = document.querySelector<HTMLButtonElement>(
+      '#archera-page-container .archera-page-back',
+    )!;
+    expect(back).not.toBeNull();
+    back.click();
+    const container = document.getElementById('archera-page-container')!;
+    expect(container.classList.contains('hidden')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Education overlay — Page B
+// ---------------------------------------------------------------------------
+
+describe('openArcheraPage("how-it-works") — Page B', () => {
+  beforeEach(() => {
+    buildArcheraContainer();
+  });
+
+  it('renders the Page B heading', () => {
+    openArcheraPage('how-it-works');
+    const h1 = document.querySelector('#archera-page-container h1');
+    expect(h1?.textContent).toContain('integration works');
+  });
+
+  it('contains a step list', () => {
+    openArcheraPage('how-it-works');
+    const ol = document.querySelector('#archera-page-container ol.archera-steps');
+    expect(ol).not.toBeNull();
+    expect(ol!.querySelectorAll('li').length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('contains a signup link with correct href, target=_blank, and rel=noopener noreferrer', () => {
+    openArcheraPage('how-it-works');
+    const link = document.querySelector<HTMLAnchorElement>(
+      '#archera-page-container a.archera-signup-btn',
+    );
+    expect(link).not.toBeNull();
+    expect(link!.href).toBe(ARCHERA_SIGNUP_URL);
+    expect(link!.target).toBe('_blank');
+    expect(link!.rel).toBe('noopener noreferrer');
+  });
+
+  it('has a cross-link button back to Page A', () => {
+    openArcheraPage('how-it-works');
+    const btns = document.querySelectorAll<HTMLButtonElement>(
+      '#archera-page-container button.archera-cta-link',
+    );
+    const toA = Array.from(btns).find(b => b.textContent?.includes('What is Archera'));
+    expect(toA).not.toBeUndefined();
+  });
+
+  it('clicking the cross-link navigates back to Page A', () => {
+    openArcheraPage('how-it-works');
+    const btns = document.querySelectorAll<HTMLButtonElement>(
+      '#archera-page-container button.archera-cta-link',
+    );
+    const toA = Array.from(btns).find(b => b.textContent?.includes('What is Archera'))!;
+    toA.click();
+    const h1 = document.querySelector('#archera-page-container h1');
+    expect(h1?.textContent).toBe('What is Archera Insurance?');
+  });
+
+  it('has a back button that closes the overlay', () => {
+    openArcheraPage('how-it-works');
+    const back = document.querySelector<HTMLButtonElement>(
+      '#archera-page-container .archera-page-back',
+    )!;
+    back.click();
+    const container = document.getElementById('archera-page-container')!;
+    expect(container.classList.contains('hidden')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// closeArcheraPage
+// ---------------------------------------------------------------------------
+
+describe('closeArcheraPage', () => {
+  it('adds .hidden and clears content', () => {
+    buildArcheraContainer();
+    openArcheraPage('what-is-archera');
+    closeArcheraPage();
+    const container = document.getElementById('archera-page-container')!;
+    expect(container.classList.contains('hidden')).toBe(true);
+    expect(container.childNodes.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// openPurchaseModal — CTA in purchase-details
+// ---------------------------------------------------------------------------
+
+describe('openPurchaseModal — Archera CTA', () => {
+  beforeEach(() => {
+    buildPurchaseModalDOM();
+    buildArcheraContainer();
+  });
+
+  it('renders .archera-cta inside #purchase-details', async () => {
+    await openPurchaseModal([]);
+    const details = document.getElementById('purchase-details')!;
+    const cta = details.querySelector('.archera-cta');
+    expect(cta).not.toBeNull();
+  });
+
+  it('CTA text mentions Archera Insurance', async () => {
+    await openPurchaseModal([]);
+    const cta = document.querySelector('#purchase-details .archera-cta')!;
+    expect(cta.textContent).toContain('Archera Insurance');
+  });
+
+  it('CTA is re-rendered fresh on each modal open (no duplication)', async () => {
+    await openPurchaseModal([]);
+    await openPurchaseModal([]);
+    const ctas = document.querySelectorAll('#purchase-details .archera-cta');
+    expect(ctas.length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// openCreatePlanModal / openNewPlanModal — CTA in plan modal
+// ---------------------------------------------------------------------------
+
+describe('openCreatePlanModal — Archera CTA', () => {
+  beforeEach(() => {
+    buildPlanModalDOM();
+    buildArcheraContainer();
+  });
+
+  it('injects #archera-plan-cta into #plan-modal', () => {
+    openCreatePlanModal();
+    const cta = document.getElementById('archera-plan-cta');
+    expect(cta).not.toBeNull();
+    expect(cta!.textContent).toContain('Archera Insurance');
+  });
+
+  it('CTA appears before .modal-buttons', () => {
+    openCreatePlanModal();
+    const form = document.getElementById('plan-form')!;
+    const children = Array.from(form.children);
+    const ctaIdx = children.findIndex(el => el.id === 'archera-plan-cta');
+    const btnsIdx = children.findIndex(el => el.classList.contains('modal-buttons'));
+    expect(ctaIdx).toBeGreaterThanOrEqual(0);
+    expect(btnsIdx).toBeGreaterThanOrEqual(0);
+    expect(ctaIdx).toBeLessThan(btnsIdx);
+  });
+
+  it('does not duplicate the CTA on repeated opens', () => {
+    openCreatePlanModal();
+    openCreatePlanModal();
+    const ctas = document.querySelectorAll('#plan-modal .archera-cta');
+    expect(ctas.length).toBe(1);
+  });
+});
+
+describe('openNewPlanModal — Archera CTA', () => {
+  beforeEach(() => {
+    buildPlanModalDOM();
+    buildArcheraContainer();
+  });
+
+  it('injects #archera-plan-cta into #plan-modal', () => {
+    openNewPlanModal();
+    const cta = document.getElementById('archera-plan-cta');
+    expect(cta).not.toBeNull();
+    expect(cta!.textContent).toContain('Archera Insurance');
+  });
+
+  it('does not duplicate the CTA if opened multiple times', () => {
+    openNewPlanModal();
+    openNewPlanModal();
+    const ctas = document.querySelectorAll('#plan-modal .archera-cta');
+    expect(ctas.length).toBe(1);
+  });
+});

--- a/frontend/src/__tests__/archera.test.ts
+++ b/frontend/src/__tests__/archera.test.ts
@@ -3,27 +3,25 @@
  *
  * Covers:
  *   - renderArcheraCTA: element structure, discernible name, click handler
- *   - openArcheraPage('what-is-archera'): Page A content, crosslink to B,
- *     signup link attributes, back button
- *   - openArcheraPage('how-it-works'): Page B content, crosslink to A,
- *     signup link attributes, back button
+ *   - openArcheraPage: education page content, signup link attributes, back button
  *   - closeArcheraPage: hides and clears the container
  *   - openPurchaseModal: CTA is rendered inside #purchase-details
  *   - openCreatePlanModal / openNewPlanModal: CTA is injected once into
  *     #plan-modal; re-opening does not duplicate it
+ *   - handleArcheraDeeplink: both legacy and current URL paths open the
+ *     single merged page
  */
 
 import {
-  renderArcheraCTA,
   openArcheraPage,
   closeArcheraPage,
+  openArcheraOfferModal,
+  closeArcheraOfferModal,
   handleArcheraDeeplink,
   ARCHERA_SIGNUP_URL,
   ARCHERA_PAGE_A_PATH,
   ARCHERA_PAGE_B_PATH,
 } from '../archera';
-import { openPurchaseModal } from '../recommendations';
-import { openCreatePlanModal, openNewPlanModal } from '../plans';
 
 // ---------------------------------------------------------------------------
 // Mocks required by recommendations.ts and plans.ts
@@ -83,15 +81,13 @@ jest.mock('../confirmDialog', () => ({
 }));
 
 // ---------------------------------------------------------------------------
-// Global DOM teardown — prevents stale-node collisions between test suites.
+// Global DOM teardown: prevents stale-node collisions between test suites.
 // ---------------------------------------------------------------------------
 
 afterEach(() => {
-  ['archera-page-container', 'purchase-modal', 'plan-modal'].forEach(id => {
+  ['archera-page-container', 'archera-offer-modal-container'].forEach(id => {
     document.getElementById(id)?.remove();
   });
-  // Also remove any loose .archera-cta elements appended directly to body.
-  document.querySelectorAll('.archera-cta').forEach(el => el.remove());
 });
 
 // ---------------------------------------------------------------------------
@@ -106,152 +102,62 @@ function buildArcheraContainer(): void {
   document.body.appendChild(container);
 }
 
-/** Minimal DOM for openPurchaseModal: #purchase-details + #purchase-modal. */
-function buildPurchaseModalDOM(): void {
-  document.body.appendChild((() => {
-    const modal = document.createElement('div');
-    modal.id = 'purchase-modal';
-    modal.className = 'modal hidden';
-
-    const content = document.createElement('div');
-    content.className = 'modal-content modal-wide';
-
-    const details = document.createElement('div');
-    details.id = 'purchase-details';
-    content.appendChild(details);
-
-    const buttons = document.createElement('div');
-    buttons.className = 'modal-buttons';
-    const cancelBtn = document.createElement('button');
-    cancelBtn.id = 'close-purchase-modal-btn';
-    cancelBtn.textContent = 'Cancel';
-    buttons.appendChild(cancelBtn);
-    const execBtn = document.createElement('button');
-    execBtn.id = 'execute-purchase-btn';
-    execBtn.textContent = 'Send for Approval';
-    buttons.appendChild(execBtn);
-    content.appendChild(buttons);
-
-    modal.appendChild(content);
-    return modal;
-  })());
-}
-
-/** Minimal DOM for plan modal tests. */
-function buildPlanModalDOM(): void {
-  const modal = document.createElement('div');
-  modal.id = 'plan-modal';
-  modal.className = 'modal hidden';
-  modal.setAttribute('role', 'dialog');
-  modal.setAttribute('aria-modal', 'true');
-
-  const content = document.createElement('div');
-  content.className = 'modal-content modal-wide';
-
-  const h2 = document.createElement('h2');
-  h2.id = 'plan-modal-title';
-  h2.textContent = 'Create Purchase Plan';
-  content.appendChild(h2);
-
-  const form = document.createElement('form');
-  form.id = 'plan-form';
-
-  // Required hidden input
-  const planId = document.createElement('input');
-  planId.type = 'hidden';
-  planId.id = 'plan-id';
-  form.appendChild(planId);
-
-  // Modal buttons (must exist so injectPlanModalCTA can find them)
-  const buttons = document.createElement('div');
-  buttons.className = 'modal-buttons';
-  const cancelBtn = document.createElement('button');
-  cancelBtn.id = 'close-plan-modal-btn';
-  cancelBtn.textContent = 'Cancel';
-  buttons.appendChild(cancelBtn);
-  const saveBtn = document.createElement('button');
-  saveBtn.type = 'submit';
-  saveBtn.textContent = 'Save Plan';
-  buttons.appendChild(saveBtn);
-  form.appendChild(buttons);
-
-  content.appendChild(form);
-  modal.appendChild(content);
-  document.body.appendChild(modal);
+/** Minimal DOM structure used by the offer modal tests. */
+function buildArcheraOfferContainer(): void {
+  const container = document.createElement('div');
+  container.id = 'archera-offer-modal-container';
+  container.className = 'hidden';
+  document.body.appendChild(container);
 }
 
 // ---------------------------------------------------------------------------
-// renderArcheraCTA
+// Education overlay (single merged page)
 // ---------------------------------------------------------------------------
 
-describe('renderArcheraCTA', () => {
-  it('returns a <p> element with class archera-cta', () => {
-    const el = renderArcheraCTA();
-    expect(el.tagName).toBe('P');
-    expect(el.classList.contains('archera-cta')).toBe(true);
-  });
-
-  it('contains the "Insure this commitment with Archera" CTA text for default context', () => {
-    const el = renderArcheraCTA();
-    expect(el.textContent).toContain('Insure this commitment with Archera');
-  });
-
-  it('contains the "Insure this plan with Archera" CTA text for plan context', () => {
-    const el = renderArcheraCTA('plan');
-    expect(el.textContent).toContain('Insure this plan with Archera');
-  });
-
-  it('contains a button with discernible name to trigger the overlay', () => {
-    const el = renderArcheraCTA();
-    const btn = el.querySelector('button.archera-cta-link');
-    expect(btn).not.toBeNull();
-    expect(btn!.textContent).toMatch(/Archera/i);
-  });
-
-  it('opens Page A when the CTA button is clicked', () => {
-    buildArcheraContainer();
-    const el = renderArcheraCTA();
-    document.body.appendChild(el);
-
-    const btn = el.querySelector<HTMLButtonElement>('button.archera-cta-link')!;
-    btn.click();
-
-    const container = document.getElementById('archera-page-container')!;
-    expect(container.classList.contains('hidden')).toBe(false);
-    expect(container.textContent).toContain('What is Archera Insurance?');
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Education overlay — Page A
-// ---------------------------------------------------------------------------
-
-describe('openArcheraPage("what-is-archera") — Page A', () => {
+describe('openArcheraPage', () => {
   beforeEach(() => {
     buildArcheraContainer();
   });
 
   it('makes #archera-page-container visible', () => {
-    openArcheraPage('what-is-archera');
+    openArcheraPage();
     const container = document.getElementById('archera-page-container')!;
     expect(container.classList.contains('hidden')).toBe(false);
   });
 
-  it('renders the Page A heading', () => {
-    openArcheraPage('what-is-archera');
+  it('renders the "Archera Insurance" heading', () => {
+    openArcheraPage();
     const h1 = document.querySelector('#archera-page-container h1');
-    expect(h1?.textContent).toBe('What is Archera Insurance?');
+    expect(h1?.textContent).toBe('Archera Insurance');
   });
 
-  it('contains a "How it works" section', () => {
-    openArcheraPage('what-is-archera');
+  it('contains a "How it works" section with a step list', () => {
+    openArcheraPage();
+    const container = document.getElementById('archera-page-container')!;
+    expect(container.textContent).toContain('How it works');
+    const ol = container.querySelector('ol.archera-steps');
+    expect(ol).not.toBeNull();
+    expect(ol!.querySelectorAll('li').length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('contains a "When it makes sense" section', () => {
+    openArcheraPage();
     expect(document.getElementById('archera-page-container')!.textContent).toContain(
-      'How it works',
+      'When it makes sense',
     );
   });
 
+  it('contains the Full disclosure paragraph (merged from the old Disclaimers list)', () => {
+    openArcheraPage();
+    const text = document.getElementById('archera-page-container')!.textContent!;
+    expect(text).toContain('Full disclosure:');
+    // Key facts from the prior Disclaimers section still surface.
+    expect(text).toMatch(/Insurance terms.*set entirely by Archera/i);
+    expect(text).toMatch(/no visibility into your Archera/i);
+  });
+
   it('contains a signup link with correct href, target=_blank, and rel=noopener noreferrer', () => {
-    openArcheraPage('what-is-archera');
+    openArcheraPage();
     const link = document.querySelector<HTMLAnchorElement>(
       '#archera-page-container a.archera-signup-btn',
     );
@@ -261,28 +167,8 @@ describe('openArcheraPage("what-is-archera") — Page A', () => {
     expect(link!.rel).toBe('noopener noreferrer');
   });
 
-  it('has a cross-link button to Page B', () => {
-    openArcheraPage('what-is-archera');
-    const btns = document.querySelectorAll<HTMLButtonElement>(
-      '#archera-page-container button.archera-cta-link',
-    );
-    const toB = Array.from(btns).find(b => b.textContent?.includes('integration works'));
-    expect(toB).not.toBeUndefined();
-  });
-
-  it('clicking the cross-link navigates to Page B', () => {
-    openArcheraPage('what-is-archera');
-    const btns = document.querySelectorAll<HTMLButtonElement>(
-      '#archera-page-container button.archera-cta-link',
-    );
-    const toB = Array.from(btns).find(b => b.textContent?.includes('integration works'))!;
-    toB.click();
-    const h1 = document.querySelector('#archera-page-container h1');
-    expect(h1?.textContent).toContain('integration works');
-  });
-
   it('has a back button that closes the overlay', () => {
-    openArcheraPage('what-is-archera');
+    openArcheraPage();
     const back = document.querySelector<HTMLButtonElement>(
       '#archera-page-container .archera-page-back',
     )!;
@@ -291,69 +177,13 @@ describe('openArcheraPage("what-is-archera") — Page A', () => {
     const container = document.getElementById('archera-page-container')!;
     expect(container.classList.contains('hidden')).toBe(true);
   });
-});
 
-// ---------------------------------------------------------------------------
-// Education overlay — Page B
-// ---------------------------------------------------------------------------
-
-describe('openArcheraPage("how-it-works") — Page B', () => {
-  beforeEach(() => {
-    buildArcheraContainer();
-  });
-
-  it('renders the Page B heading', () => {
-    openArcheraPage('how-it-works');
-    const h1 = document.querySelector('#archera-page-container h1');
-    expect(h1?.textContent).toContain('integration works');
-  });
-
-  it('contains a step list', () => {
-    openArcheraPage('how-it-works');
-    const ol = document.querySelector('#archera-page-container ol.archera-steps');
-    expect(ol).not.toBeNull();
-    expect(ol!.querySelectorAll('li').length).toBeGreaterThanOrEqual(3);
-  });
-
-  it('contains a signup link with correct href, target=_blank, and rel=noopener noreferrer', () => {
-    openArcheraPage('how-it-works');
-    const link = document.querySelector<HTMLAnchorElement>(
-      '#archera-page-container a.archera-signup-btn',
-    );
-    expect(link).not.toBeNull();
-    expect(link!.href).toBe(ARCHERA_SIGNUP_URL);
-    expect(link!.target).toBe('_blank');
-    expect(link!.rel).toBe('noopener noreferrer');
-  });
-
-  it('has a cross-link button back to Page A', () => {
-    openArcheraPage('how-it-works');
-    const btns = document.querySelectorAll<HTMLButtonElement>(
-      '#archera-page-container button.archera-cta-link',
-    );
-    const toA = Array.from(btns).find(b => b.textContent?.includes('What is Archera'));
-    expect(toA).not.toBeUndefined();
-  });
-
-  it('clicking the cross-link navigates back to Page A', () => {
-    openArcheraPage('how-it-works');
-    const btns = document.querySelectorAll<HTMLButtonElement>(
-      '#archera-page-container button.archera-cta-link',
-    );
-    const toA = Array.from(btns).find(b => b.textContent?.includes('What is Archera'))!;
-    toA.click();
-    const h1 = document.querySelector('#archera-page-container h1');
-    expect(h1?.textContent).toBe('What is Archera Insurance?');
-  });
-
-  it('has a back button that closes the overlay', () => {
-    openArcheraPage('how-it-works');
-    const back = document.querySelector<HTMLButtonElement>(
-      '#archera-page-container .archera-page-back',
-    )!;
-    back.click();
+  it('re-rendering replaces content rather than stacking', () => {
+    openArcheraPage();
+    openArcheraPage();
     const container = document.getElementById('archera-page-container')!;
-    expect(container.classList.contains('hidden')).toBe(true);
+    const h1s = container.querySelectorAll('h1');
+    expect(h1s.length).toBe(1);
   });
 });
 
@@ -364,7 +194,7 @@ describe('openArcheraPage("how-it-works") — Page B', () => {
 describe('closeArcheraPage', () => {
   it('adds .hidden and clears content', () => {
     buildArcheraContainer();
-    openArcheraPage('what-is-archera');
+    openArcheraPage();
     closeArcheraPage();
     const container = document.getElementById('archera-page-container')!;
     expect(container.classList.contains('hidden')).toBe(true);
@@ -373,142 +203,161 @@ describe('closeArcheraPage', () => {
 });
 
 // ---------------------------------------------------------------------------
-// openPurchaseModal — CTA in purchase-details
+// openArcheraOfferModal (post-action small modal)
 // ---------------------------------------------------------------------------
 
-describe('openPurchaseModal — Archera CTA', () => {
+describe('openArcheraOfferModal', () => {
   beforeEach(() => {
-    buildPurchaseModalDOM();
+    buildArcheraOfferContainer();
     buildArcheraContainer();
   });
 
-  it('renders .archera-cta inside #purchase-details', async () => {
-    await openPurchaseModal([]);
-    const details = document.getElementById('purchase-details')!;
-    const cta = details.querySelector('.archera-cta');
-    expect(cta).not.toBeNull();
+  it('makes #archera-offer-modal-container visible', () => {
+    openArcheraOfferModal('purchase');
+    const container = document.getElementById('archera-offer-modal-container')!;
+    expect(container.classList.contains('hidden')).toBe(false);
   });
 
-  it('CTA text mentions Archera', async () => {
-    await openPurchaseModal([]);
-    const cta = document.querySelector('#purchase-details .archera-cta')!;
-    expect(cta.textContent).toContain('Archera');
-    expect(cta.textContent).toContain('Insure this commitment');
+  it('shows the purchase-context headline by default', () => {
+    openArcheraOfferModal();
+    const title = document.getElementById('archera-offer-title');
+    expect(title?.textContent).toMatch(/commitments?/i);
   });
 
-  it('CTA is re-rendered fresh on each modal open (no duplication)', async () => {
-    await openPurchaseModal([]);
-    await openPurchaseModal([]);
-    const ctas = document.querySelectorAll('#purchase-details .archera-cta');
-    expect(ctas.length).toBe(1);
+  it('shows the plan-context headline for context=plan', () => {
+    openArcheraOfferModal('plan');
+    const title = document.getElementById('archera-offer-title');
+    expect(title?.textContent).toMatch(/plan/i);
+  });
+
+  it('renders the disclosure line in the modal', () => {
+    openArcheraOfferModal('purchase');
+    const container = document.getElementById('archera-offer-modal-container')!;
+    expect(container.textContent).toMatch(/sponsors/i);
+    expect(container.textContent).toMatch(/works fully without/i);
+  });
+
+  it('has a "Sign up at Archera" link with correct href, target=_blank, rel=noopener noreferrer', () => {
+    openArcheraOfferModal('purchase');
+    const link = document.querySelector<HTMLAnchorElement>(
+      '#archera-offer-modal-container a.archera-offer-signup',
+    );
+    expect(link).not.toBeNull();
+    expect(link!.href).toBe(ARCHERA_SIGNUP_URL);
+    expect(link!.target).toBe('_blank');
+    expect(link!.rel).toBe('noopener noreferrer');
+  });
+
+  it('has a "No thanks" button that closes the modal', () => {
+    openArcheraOfferModal('purchase');
+    const skip = document.querySelector<HTMLButtonElement>(
+      '#archera-offer-modal-container button.archera-offer-skip',
+    )!;
+    expect(skip.textContent).toMatch(/no thanks/i);
+    skip.click();
+    const container = document.getElementById('archera-offer-modal-container')!;
+    expect(container.classList.contains('hidden')).toBe(true);
+  });
+
+  it('outside-click on the backdrop closes the modal', () => {
+    openArcheraOfferModal('purchase');
+    const backdrop = document.querySelector<HTMLElement>(
+      '#archera-offer-modal-container .archera-offer-backdrop',
+    )!;
+    backdrop.click();
+    const container = document.getElementById('archera-offer-modal-container')!;
+    expect(container.classList.contains('hidden')).toBe(true);
+  });
+
+  it('ESC key closes the modal', () => {
+    openArcheraOfferModal('purchase');
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    const container = document.getElementById('archera-offer-modal-container')!;
+    expect(container.classList.contains('hidden')).toBe(true);
+  });
+
+  it('"Learn more" is a collapsed drop-down that expands inside the modal', () => {
+    openArcheraOfferModal('purchase');
+    const details = document.querySelector<HTMLDetailsElement>(
+      '#archera-offer-modal-container details.archera-offer-learnmore',
+    )!;
+    expect(details).not.toBeNull();
+    // Starts collapsed: open attribute absent, body content is not visible
+    // to assistive tech (jsdom doesn't compute layout, but the <details>
+    // semantic is what matters).
+    expect(details.open).toBe(false);
+    // Summary carries the discoverable label.
+    const summary = details.querySelector('summary');
+    expect(summary?.textContent).toMatch(/learn more/i);
+    // Expanding the details surfaces the full education body inline.
+    details.open = true;
+    const body = details.querySelector('.archera-offer-learnmore-body');
+    expect(body).not.toBeNull();
+    expect(body!.textContent).toContain('How it works');
+    expect(body!.textContent).toContain('When it makes sense');
+    expect(body!.textContent).toContain('Full disclosure:');
+    // The offer modal itself stays open — the drop-down is inline.
+    const container = document.getElementById('archera-offer-modal-container')!;
+    expect(container.classList.contains('hidden')).toBe(false);
+  });
+
+  it('re-opening replaces content rather than stacking', () => {
+    openArcheraOfferModal('purchase');
+    openArcheraOfferModal('plan');
+    const container = document.getElementById('archera-offer-modal-container')!;
+    const panels = container.querySelectorAll('.archera-offer-panel');
+    expect(panels.length).toBe(1);
+    const title = document.getElementById('archera-offer-title');
+    expect(title?.textContent).toMatch(/plan/i);
   });
 });
 
 // ---------------------------------------------------------------------------
-// openCreatePlanModal / openNewPlanModal — CTA in plan modal
+// closeArcheraOfferModal
 // ---------------------------------------------------------------------------
 
-describe('openCreatePlanModal — Archera CTA', () => {
-  beforeEach(() => {
-    buildPlanModalDOM();
-    buildArcheraContainer();
-  });
-
-  it('injects #archera-plan-cta into #plan-modal', () => {
-    openCreatePlanModal();
-    const cta = document.getElementById('archera-plan-cta');
-    expect(cta).not.toBeNull();
-    expect(cta!.textContent).toContain('Archera');
-    expect(cta!.textContent).toContain('Insure this plan');
-  });
-
-  it('CTA appears before .modal-buttons', () => {
-    openCreatePlanModal();
-    const form = document.getElementById('plan-form')!;
-    const children = Array.from(form.children);
-    const ctaIdx = children.findIndex(el => el.id === 'archera-plan-cta');
-    const btnsIdx = children.findIndex(el => el.classList.contains('modal-buttons'));
-    expect(ctaIdx).toBeGreaterThanOrEqual(0);
-    expect(btnsIdx).toBeGreaterThanOrEqual(0);
-    expect(ctaIdx).toBeLessThan(btnsIdx);
-  });
-
-  it('does not duplicate the CTA on repeated opens', () => {
-    openCreatePlanModal();
-    openCreatePlanModal();
-    const ctas = document.querySelectorAll('#plan-modal .archera-cta');
-    expect(ctas.length).toBe(1);
-  });
-});
-
-describe('openNewPlanModal — Archera CTA', () => {
-  beforeEach(() => {
-    buildPlanModalDOM();
-    buildArcheraContainer();
-  });
-
-  it('injects #archera-plan-cta into #plan-modal', () => {
-    openNewPlanModal();
-    const cta = document.getElementById('archera-plan-cta');
-    expect(cta).not.toBeNull();
-    expect(cta!.textContent).toContain('Archera');
-    expect(cta!.textContent).toContain('Insure this plan');
-  });
-
-  it('does not duplicate the CTA if opened multiple times', () => {
-    openNewPlanModal();
-    openNewPlanModal();
-    const ctas = document.querySelectorAll('#plan-modal .archera-cta');
-    expect(ctas.length).toBe(1);
+describe('closeArcheraOfferModal', () => {
+  it('adds .hidden and clears content', () => {
+    buildArcheraOfferContainer();
+    openArcheraOfferModal('purchase');
+    closeArcheraOfferModal();
+    const container = document.getElementById('archera-offer-modal-container')!;
+    expect(container.classList.contains('hidden')).toBe(true);
+    expect(container.childNodes.length).toBe(0);
   });
 });
 
 // ---------------------------------------------------------------------------
-// Transparency disclosures — Page A and Page B
+// Transparency disclosure
 // ---------------------------------------------------------------------------
 
-describe('transparency disclosures', () => {
+describe('transparency disclosure', () => {
   beforeEach(() => {
     buildArcheraContainer();
   });
 
-  it('Page A contains "CUDly works fully without Archera" fact', () => {
-    openArcheraPage('what-is-archera');
+  it('contains the "CUDly works fully without Archera" fact', () => {
+    openArcheraPage();
     const text = document.getElementById('archera-page-container')!.textContent!;
     expect(text).toMatch(/fully without Archera/i);
   });
 
-  it('Page A contains the Archera sponsorship fact', () => {
-    openArcheraPage('what-is-archera');
+  it('contains the Archera sponsorship fact', () => {
+    openArcheraPage();
     const text = document.getElementById('archera-page-container')!.textContent!;
     expect(text).toMatch(/sponsors/i);
     expect(text).toMatch(/revenue/i);
   });
 
-  it('Page A disclosure heading reads "Why is CUDly telling me about this?"', () => {
-    openArcheraPage('what-is-archera');
+  it('disclosure is rendered as a "Full disclosure:" paragraph (no heading)', () => {
+    openArcheraPage();
     const container = document.getElementById('archera-page-container')!;
-    const disclosure = container.querySelector('.archera-disclosure h2');
-    expect(disclosure?.textContent).toMatch(/Why is CUDly telling me about this/i);
-  });
-
-  it('Page B contains the "CUDly works fully without Archera" fact', () => {
-    openArcheraPage('how-it-works');
-    const text = document.getElementById('archera-page-container')!.textContent!;
-    expect(text).toMatch(/fully without Archera/i);
-  });
-
-  it('Page B contains the Archera sponsorship fact', () => {
-    openArcheraPage('how-it-works');
-    const text = document.getElementById('archera-page-container')!.textContent!;
-    expect(text).toMatch(/sponsors/i);
-  });
-
-  it('Page B disclosure heading reads "Disclosure"', () => {
-    openArcheraPage('how-it-works');
-    const container = document.getElementById('archera-page-container')!;
-    const disclosure = container.querySelector('.archera-disclosure h2');
-    expect(disclosure?.textContent).toBe('Disclosure');
+    const disclosure = container.querySelector<HTMLParagraphElement>('p.archera-disclosure');
+    expect(disclosure).not.toBeNull();
+    expect(disclosure!.textContent).toMatch(/Full disclosure:/);
+    // Heading-level "Why is CUDly telling me about this?" has been removed
+    // along with the duplicate user-interest paragraph (folded into lead).
+    expect(container.textContent).not.toMatch(/Why is CUDly telling me about this/i);
   });
 });
 
@@ -533,7 +382,7 @@ describe('handleArcheraDeeplink', () => {
     expect(container.classList.contains('hidden')).toBe(true);
   });
 
-  it('returns true and opens Page A for ARCHERA_PAGE_A_PATH', () => {
+  it('returns true and opens the overlay for ARCHERA_PAGE_A_PATH', () => {
     Object.defineProperty(window, 'location', {
       value: { pathname: ARCHERA_PAGE_A_PATH },
       writable: true,
@@ -543,10 +392,10 @@ describe('handleArcheraDeeplink', () => {
     expect(result).toBe(true);
     const container = document.getElementById('archera-page-container')!;
     expect(container.classList.contains('hidden')).toBe(false);
-    expect(container.querySelector('h1')?.textContent).toBe('What is Archera Insurance?');
+    expect(container.querySelector('h1')?.textContent).toBe('Archera Insurance');
   });
 
-  it('returns true and opens Page B for ARCHERA_PAGE_B_PATH', () => {
+  it('returns true and opens the same overlay for legacy ARCHERA_PAGE_B_PATH', () => {
     Object.defineProperty(window, 'location', {
       value: { pathname: ARCHERA_PAGE_B_PATH },
       writable: true,
@@ -556,6 +405,6 @@ describe('handleArcheraDeeplink', () => {
     expect(result).toBe(true);
     const container = document.getElementById('archera-page-container')!;
     expect(container.classList.contains('hidden')).toBe(false);
-    expect(container.querySelector('h1')?.textContent).toContain('integration works');
+    expect(container.querySelector('h1')?.textContent).toBe('Archera Insurance');
   });
 });

--- a/frontend/src/__tests__/archera.test.ts
+++ b/frontend/src/__tests__/archera.test.ts
@@ -310,6 +310,67 @@ describe('openArcheraOfferModal', () => {
     const title = document.getElementById('archera-offer-title');
     expect(title?.textContent).toMatch(/plan/i);
   });
+
+  it('re-opening tears down the previous open\'s ESC listener (no leak)', () => {
+    // Spy on document.addEventListener so we can count keydown handlers
+    // attached across the two opens. Without the cleanup-before-open
+    // guard the second open would have added a second handler without
+    // removing the first.
+    const addSpy = jest.spyOn(document, 'addEventListener');
+    const removeSpy = jest.spyOn(document, 'removeEventListener');
+    try {
+      openArcheraOfferModal('purchase');
+      const addsAfterFirst = addSpy.mock.calls.filter(c => c[0] === 'keydown').length;
+      const removesAfterFirst = removeSpy.mock.calls.filter(c => c[0] === 'keydown').length;
+      openArcheraOfferModal('plan');
+      const addsAfterSecond = addSpy.mock.calls.filter(c => c[0] === 'keydown').length;
+      const removesAfterSecond = removeSpy.mock.calls.filter(c => c[0] === 'keydown').length;
+      // Second open must remove the first open's handler before adding a new one.
+      expect(addsAfterSecond - addsAfterFirst).toBe(1);
+      expect(removesAfterSecond - removesAfterFirst).toBe(1);
+    } finally {
+      addSpy.mockRestore();
+      removeSpy.mockRestore();
+    }
+  });
+
+  it('traps Tab focus inside the panel (Tab from last → first)', () => {
+    openArcheraOfferModal('purchase');
+    const panel = document.querySelector<HTMLElement>(
+      '#archera-offer-modal-container .archera-offer-panel',
+    )!;
+    const focusables = panel.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), summary, [tabindex]:not([tabindex="-1"])',
+    );
+    expect(focusables.length).toBeGreaterThanOrEqual(2);
+    const first = focusables[0]!;
+    const last = focusables[focusables.length - 1]!;
+    // Focus the last element, then dispatch Tab — focus should wrap to first.
+    last.focus();
+    expect(document.activeElement).toBe(last);
+    const evt = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
+    panel.dispatchEvent(evt);
+    expect(document.activeElement).toBe(first);
+    expect(evt.defaultPrevented).toBe(true);
+  });
+
+  it('traps Shift+Tab focus inside the panel (Shift+Tab from first → last)', () => {
+    openArcheraOfferModal('purchase');
+    const panel = document.querySelector<HTMLElement>(
+      '#archera-offer-modal-container .archera-offer-panel',
+    )!;
+    const focusables = panel.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), summary, [tabindex]:not([tabindex="-1"])',
+    );
+    const first = focusables[0]!;
+    const last = focusables[focusables.length - 1]!;
+    first.focus();
+    expect(document.activeElement).toBe(first);
+    const evt = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true, bubbles: true, cancelable: true });
+    panel.dispatchEvent(evt);
+    expect(document.activeElement).toBe(last);
+    expect(evt.defaultPrevented).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/__tests__/archera.test.ts
+++ b/frontend/src/__tests__/archera.test.ts
@@ -17,7 +17,10 @@ import {
   renderArcheraCTA,
   openArcheraPage,
   closeArcheraPage,
+  handleArcheraDeeplink,
   ARCHERA_SIGNUP_URL,
+  ARCHERA_PAGE_A_PATH,
+  ARCHERA_PAGE_B_PATH,
 } from '../archera';
 import { openPurchaseModal } from '../recommendations';
 import { openCreatePlanModal, openNewPlanModal } from '../plans';
@@ -78,6 +81,18 @@ jest.mock('../commitmentOptions', () => ({
 jest.mock('../confirmDialog', () => ({
   confirmDialog: jest.fn(() => Promise.resolve(true)),
 }));
+
+// ---------------------------------------------------------------------------
+// Global DOM teardown — prevents stale-node collisions between test suites.
+// ---------------------------------------------------------------------------
+
+afterEach(() => {
+  ['archera-page-container', 'purchase-modal', 'plan-modal'].forEach(id => {
+    document.getElementById(id)?.remove();
+  });
+  // Also remove any loose .archera-cta elements appended directly to body.
+  document.querySelectorAll('.archera-cta').forEach(el => el.remove());
+});
 
 // ---------------------------------------------------------------------------
 // DOM setup helpers
@@ -176,18 +191,21 @@ describe('renderArcheraCTA', () => {
     expect(el.classList.contains('archera-cta')).toBe(true);
   });
 
-  it('contains the commitment-overuse CTA text', () => {
+  it('contains the "Insure this commitment with Archera" CTA text for default context', () => {
     const el = renderArcheraCTA();
-    expect(el.textContent).toContain('Worried about committing');
-    expect(el.textContent).toContain('Archera Insurance');
-    expect(el.textContent).toContain('commitment-overuse');
+    expect(el.textContent).toContain('Insure this commitment with Archera');
+  });
+
+  it('contains the "Insure this plan with Archera" CTA text for plan context', () => {
+    const el = renderArcheraCTA('plan');
+    expect(el.textContent).toContain('Insure this plan with Archera');
   });
 
   it('contains a button with discernible name to trigger the overlay', () => {
     const el = renderArcheraCTA();
     const btn = el.querySelector('button.archera-cta-link');
     expect(btn).not.toBeNull();
-    expect(btn!.textContent).toMatch(/learn how it works/i);
+    expect(btn!.textContent).toMatch(/Archera/i);
   });
 
   it('opens Page A when the CTA button is clicked', () => {
@@ -371,10 +389,11 @@ describe('openPurchaseModal — Archera CTA', () => {
     expect(cta).not.toBeNull();
   });
 
-  it('CTA text mentions Archera Insurance', async () => {
+  it('CTA text mentions Archera', async () => {
     await openPurchaseModal([]);
     const cta = document.querySelector('#purchase-details .archera-cta')!;
-    expect(cta.textContent).toContain('Archera Insurance');
+    expect(cta.textContent).toContain('Archera');
+    expect(cta.textContent).toContain('Insure this commitment');
   });
 
   it('CTA is re-rendered fresh on each modal open (no duplication)', async () => {
@@ -399,7 +418,8 @@ describe('openCreatePlanModal — Archera CTA', () => {
     openCreatePlanModal();
     const cta = document.getElementById('archera-plan-cta');
     expect(cta).not.toBeNull();
-    expect(cta!.textContent).toContain('Archera Insurance');
+    expect(cta!.textContent).toContain('Archera');
+    expect(cta!.textContent).toContain('Insure this plan');
   });
 
   it('CTA appears before .modal-buttons', () => {
@@ -431,7 +451,8 @@ describe('openNewPlanModal — Archera CTA', () => {
     openNewPlanModal();
     const cta = document.getElementById('archera-plan-cta');
     expect(cta).not.toBeNull();
-    expect(cta!.textContent).toContain('Archera Insurance');
+    expect(cta!.textContent).toContain('Archera');
+    expect(cta!.textContent).toContain('Insure this plan');
   });
 
   it('does not duplicate the CTA if opened multiple times', () => {
@@ -439,5 +460,102 @@ describe('openNewPlanModal — Archera CTA', () => {
     openNewPlanModal();
     const ctas = document.querySelectorAll('#plan-modal .archera-cta');
     expect(ctas.length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Transparency disclosures — Page A and Page B
+// ---------------------------------------------------------------------------
+
+describe('transparency disclosures', () => {
+  beforeEach(() => {
+    buildArcheraContainer();
+  });
+
+  it('Page A contains "CUDly works fully without Archera" fact', () => {
+    openArcheraPage('what-is-archera');
+    const text = document.getElementById('archera-page-container')!.textContent!;
+    expect(text).toMatch(/fully without Archera/i);
+  });
+
+  it('Page A contains the Archera sponsorship fact', () => {
+    openArcheraPage('what-is-archera');
+    const text = document.getElementById('archera-page-container')!.textContent!;
+    expect(text).toMatch(/sponsors/i);
+    expect(text).toMatch(/revenue/i);
+  });
+
+  it('Page A disclosure heading reads "Why is CUDly telling me about this?"', () => {
+    openArcheraPage('what-is-archera');
+    const container = document.getElementById('archera-page-container')!;
+    const disclosure = container.querySelector('.archera-disclosure h2');
+    expect(disclosure?.textContent).toMatch(/Why is CUDly telling me about this/i);
+  });
+
+  it('Page B contains the "CUDly works fully without Archera" fact', () => {
+    openArcheraPage('how-it-works');
+    const text = document.getElementById('archera-page-container')!.textContent!;
+    expect(text).toMatch(/fully without Archera/i);
+  });
+
+  it('Page B contains the Archera sponsorship fact', () => {
+    openArcheraPage('how-it-works');
+    const text = document.getElementById('archera-page-container')!.textContent!;
+    expect(text).toMatch(/sponsors/i);
+  });
+
+  it('Page B disclosure heading reads "Disclosure"', () => {
+    openArcheraPage('how-it-works');
+    const container = document.getElementById('archera-page-container')!;
+    const disclosure = container.querySelector('.archera-disclosure h2');
+    expect(disclosure?.textContent).toBe('Disclosure');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleArcheraDeeplink
+// ---------------------------------------------------------------------------
+
+describe('handleArcheraDeeplink', () => {
+  beforeEach(() => {
+    buildArcheraContainer();
+  });
+
+  it('returns false and does not open overlay for a non-Archera path', () => {
+    Object.defineProperty(window, 'location', {
+      value: { pathname: '/dashboard' },
+      writable: true,
+      configurable: true,
+    });
+    const result = handleArcheraDeeplink();
+    expect(result).toBe(false);
+    const container = document.getElementById('archera-page-container')!;
+    expect(container.classList.contains('hidden')).toBe(true);
+  });
+
+  it('returns true and opens Page A for ARCHERA_PAGE_A_PATH', () => {
+    Object.defineProperty(window, 'location', {
+      value: { pathname: ARCHERA_PAGE_A_PATH },
+      writable: true,
+      configurable: true,
+    });
+    const result = handleArcheraDeeplink();
+    expect(result).toBe(true);
+    const container = document.getElementById('archera-page-container')!;
+    expect(container.classList.contains('hidden')).toBe(false);
+    expect(container.querySelector('h1')?.textContent).toBe('What is Archera Insurance?');
+  });
+
+  it('returns true and opens Page B for ARCHERA_PAGE_B_PATH', () => {
+    Object.defineProperty(window, 'location', {
+      value: { pathname: ARCHERA_PAGE_B_PATH },
+      writable: true,
+      configurable: true,
+    });
+    const result = handleArcheraDeeplink();
+    expect(result).toBe(true);
+    const container = document.getElementById('archera-page-container')!;
+    expect(container.classList.contains('hidden')).toBe(false);
+    expect(container.querySelector('h1')?.textContent).toContain('integration works');
   });
 });

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -18,6 +18,7 @@ import { setupRIExchangeHandlers, saveAutomationSettings } from './riexchange';
 import { showToast } from './toast';
 import { confirmDialog } from './confirmDialog';
 import { handlePurchaseDeeplink } from './purchases-deeplink';
+import { handleArcheraDeeplink } from './archera';
 import { closeModal } from './modal';
 
 /**
@@ -66,6 +67,10 @@ export async function init(): Promise<void> {
     // through so the user lands on the History tab with their action's
     // outcome rendered as a toast.
     await handlePurchaseDeeplink();
+    // Archera education deep-links (/archera-insurance, /archera-insurance/
+    // how-it-works) open the overlay panel on top of the dashboard. Normal
+    // tab routing still runs underneath so the app is fully functional.
+    handleArcheraDeeplink();
     const target = applyTabFromPath();
     let url = '/' + target;
     if (target === 'settings') {

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -18,7 +18,7 @@ import { setupRIExchangeHandlers, saveAutomationSettings } from './riexchange';
 import { showToast } from './toast';
 import { confirmDialog } from './confirmDialog';
 import { handlePurchaseDeeplink } from './purchases-deeplink';
-import { handleArcheraDeeplink } from './archera';
+import { handleArcheraDeeplink, openArcheraOfferModal } from './archera';
 import { closeModal } from './modal';
 
 /**
@@ -365,6 +365,13 @@ async function handleExecutePurchase(): Promise<void> {
       });
     }
     await loadDashboard();
+    // Offer Archera Insurance after a successful approval submission.
+    // The actual cloud commitment isn't charged until the approver clicks
+    // the email link, but the user has now committed their intent — this
+    // is the natural moment to surface optional insurance coverage.
+    // Only fires on the success path; on email_sent=false we still opened
+    // a pending execution so the offer is still relevant.
+    openArcheraOfferModal('purchase');
   } catch (error) {
     const err = error as Error;
     showToast({ message: `Failed to send purchase for approval: ${err.message}`, kind: 'error' });
@@ -488,6 +495,13 @@ async function handleFanOutExecute(buckets: FanOutBucket[]): Promise<void> {
     });
   }
   await loadDashboard();
+
+  // Offer Archera Insurance when at least one bucket succeeded. Skipping
+  // the offer on the all-fail path keeps the modal from layering on top
+  // of an error toast for a user who has nothing to insure yet.
+  if (succeeded > 0) {
+    openArcheraOfferModal('purchase');
+  }
 
   if (executeBtn) {
     executeBtn.disabled = false;

--- a/frontend/src/archera.ts
+++ b/frontend/src/archera.ts
@@ -90,10 +90,16 @@ export function openArcheraPage(pageId: ArcheraPageId): void {
   const container = document.getElementById('archera-page-container');
   if (!container) return;
 
-  // Save the currently focused element so we can restore focus on close.
-  _previouslyFocused = document.activeElement instanceof HTMLElement
-    ? document.activeElement
-    : null;
+  // Capture the currently focused element only when the overlay is
+  // transitioning from hidden to visible, so that page-switch calls
+  // (A → B while already open) don't overwrite the original opener's
+  // focus reference. closeArcheraPage restores it and resets the variable.
+  const isCurrentlyHidden = container.classList.contains('hidden');
+  if (isCurrentlyHidden) {
+    _previouslyFocused = document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
+  }
 
   // Clear existing content via DOM methods (no innerHTML to avoid XSS lint).
   while (container.firstChild) container.removeChild(container.firstChild);

--- a/frontend/src/archera.ts
+++ b/frontend/src/archera.ts
@@ -83,6 +83,11 @@ export function openArcheraOfferModal(context: ArcheraContext = 'purchase'): voi
       : null;
   }
 
+  // Re-open path: tear down any document-level listeners attached by a
+  // prior open() so we don't leak them by overwriting _offerModalCleanup
+  // below. Idempotent: no-op if no prior open is in flight.
+  if (_offerModalCleanup) _offerModalCleanup();
+
   while (container.firstChild) container.removeChild(container.firstChild);
   container.classList.remove('hidden');
 
@@ -178,13 +183,42 @@ export function openArcheraOfferModal(context: ArcheraContext = 'purchase'): voi
 
   panel.appendChild(actions);
 
-  // Keyboard: ESC closes. Outside-click is handled by the backdrop above.
+  // Keyboard handling:
+  //   - Document-level keydown: ESC closes (works regardless of where focus is).
+  //   - Panel-level keydown: Tab / Shift+Tab trap focus inside the dialog
+  //     so keyboard users can't tab into background controls (required
+  //     for role="dialog" aria-modal="true" to actually be modal).
   const escHandler = (e: KeyboardEvent): void => {
     if (e.key === 'Escape') closeArcheraOfferModal();
   };
   document.addEventListener('keydown', escHandler);
+
+  const trapHandler = (e: KeyboardEvent): void => {
+    if (e.key !== 'Tab') return;
+    // Re-query each Tab press because the <details> drop-down expands the
+    // focusable set when opened — caching at modal-build time would miss
+    // those nested focusables.
+    const focusables = panel.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]),' +
+        ' textarea:not([disabled]), summary, [tabindex]:not([tabindex="-1"])',
+    );
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    if (!first || !last) return;
+    const active = document.activeElement as HTMLElement | null;
+    if (e.shiftKey && active === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && active === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  };
+  panel.addEventListener('keydown', trapHandler);
+
   _offerModalCleanup = () => {
     document.removeEventListener('keydown', escHandler);
+    panel.removeEventListener('keydown', trapHandler);
     _offerModalCleanup = null;
   };
 

--- a/frontend/src/archera.ts
+++ b/frontend/src/archera.ts
@@ -24,39 +24,58 @@
 /** Canonical Archera signup URL with CUDly attribution. */
 export const ARCHERA_SIGNUP_URL = 'https://archera.ai/signup?mode=cudly';
 
+/**
+ * Frontend URL path for Page A (What is Archera Insurance?).
+ * Used as the `ArcheraEducationURL` in email templates so the link from
+ * the approval / confirmation email lands directly on this page.
+ * Must stay in sync with the path checked in handleArcheraDeeplink().
+ */
+export const ARCHERA_PAGE_A_PATH = '/archera-insurance';
+
+/**
+ * Frontend URL path for Page B (How the integration works).
+ * Must stay in sync with the path checked in handleArcheraDeeplink().
+ */
+export const ARCHERA_PAGE_B_PATH = '/archera-insurance/how-it-works';
+
 /** Page identifiers for the education overlay. */
 export type ArcheraPageId = 'what-is-archera' | 'how-it-works';
 
+/** Context for the CTA — controls the link text. */
+export type ArcheraCTAContext = 'purchase' | 'plan';
+
 /**
- * Return a small CTA paragraph element:
- *   "💡 Worried about committing? Archera Insurance underwrites
- *    commitment-overuse — learn how it works →"
+ * Module-scoped reference to the element that was focused when the overlay
+ * was last opened. Restored by closeArcheraPage so keyboard users return to
+ * their original position.
+ */
+let _previouslyFocused: HTMLElement | null = null;
+
+/**
+ * Return a small CTA paragraph element linking to the Archera Insurance
+ * education overlay.
  *
- * Clicking the button opens Page A (the "What is Archera Insurance?" overlay).
+ * - context 'purchase' (default): "Insure this commitment with Archera →"
+ * - context 'plan':               "Insure this plan with Archera →"
+ *
  * The element uses the `.archera-cta` CSS class for muted, non-pushy styling.
+ * Clicking opens the "What is Archera Insurance?" overlay (Page A).
+ *
+ * TODO(@cristim): final copy review — confirm exact CTA wording before merge.
  *
  * Exported for use in openPurchaseModal (recommendations.ts) and
  * openCreatePlanModal / openNewPlanModal (plans.ts).
  */
-export function renderArcheraCTA(): HTMLParagraphElement {
+export function renderArcheraCTA(context: ArcheraCTAContext = 'purchase'): HTMLParagraphElement {
   const p = document.createElement('p');
   p.className = 'archera-cta';
-
-  const icon = document.createElement('span');
-  icon.setAttribute('aria-hidden', 'true');
-  icon.textContent = '💡 ';
-  p.appendChild(icon);
-
-  p.appendChild(
-    document.createTextNode(
-      'Worried about committing? Archera Insurance underwrites commitment-overuse — ',
-    ),
-  );
 
   const btn = document.createElement('button');
   btn.className = 'archera-cta-link';
   btn.type = 'button';
-  btn.textContent = 'learn how it works →';
+  // TODO(@cristim): final copy review
+  btn.textContent =
+    context === 'plan' ? 'Insure this plan with Archera →' : 'Insure this commitment with Archera →';
   btn.addEventListener('click', () => openArcheraPage('what-is-archera'));
   p.appendChild(btn);
 
@@ -70,6 +89,11 @@ export function renderArcheraCTA(): HTMLParagraphElement {
 export function openArcheraPage(pageId: ArcheraPageId): void {
   const container = document.getElementById('archera-page-container');
   if (!container) return;
+
+  // Save the currently focused element so we can restore focus on close.
+  _previouslyFocused = document.activeElement instanceof HTMLElement
+    ? document.activeElement
+    : null;
 
   // Clear existing content via DOM methods (no innerHTML to avoid XSS lint).
   while (container.firstChild) container.removeChild(container.firstChild);
@@ -97,6 +121,45 @@ export function closeArcheraPage(): void {
   if (!container) return;
   container.classList.add('hidden');
   while (container.firstChild) container.removeChild(container.firstChild);
+
+  // Restore focus to the element that was active before the overlay opened,
+  // provided it is still in the document and is focusable.
+  if (
+    _previouslyFocused !== null &&
+    document.contains(_previouslyFocused) &&
+    typeof _previouslyFocused.focus === 'function'
+  ) {
+    _previouslyFocused.focus();
+  }
+  _previouslyFocused = null;
+}
+
+/**
+ * Deep-link handler for Archera education page URLs.
+ *
+ * Called from app.ts `init()` after authentication, before normal tab
+ * routing. If the current URL path is `/archera-insurance` or
+ * `/archera-insurance/how-it-works`, opens the corresponding overlay.
+ * The normal tab routing then runs underneath (dashboard becomes active),
+ * so the user has a fully functional app behind the overlay.
+ *
+ * Returns true if the path matched and the overlay was opened, false
+ * if no match (caller can continue with normal routing as-is).
+ *
+ * The path constants ARCHERA_PAGE_A_PATH / ARCHERA_PAGE_B_PATH are the
+ * source of truth for the URLs used in email templates (ArcheraEducationURL).
+ */
+export function handleArcheraDeeplink(): boolean {
+  const path = window.location.pathname.replace(/\/+$/, '');
+  if (path === ARCHERA_PAGE_B_PATH) {
+    openArcheraPage('how-it-works');
+    return true;
+  }
+  if (path === ARCHERA_PAGE_A_PATH || path.startsWith(ARCHERA_PAGE_A_PATH + '/')) {
+    openArcheraPage('what-is-archera');
+    return true;
+  }
+  return false;
 }
 
 // ---------------------------------------------------------------------------
@@ -110,14 +173,18 @@ function buildPageA(root: HTMLElement): void {
   h1.textContent = 'What is Archera Insurance?';
   root.appendChild(h1);
 
+  // Transparency disclosure — lead with this, don't bury it.
+  // TODO(@cristim): final disclosure copy — substance (no-gating + sponsorship) must stay.
+  appendDisclosureSection(root);
+
   // TODO(@cristim): final copy — review wording with Archera before publishing
   const intro = document.createElement('p');
   intro.className = 'archera-page-lead';
   intro.textContent =
     'Cloud commitment discounts (Reserved Instances, Savings Plans, CUDs) offer ' +
     'significant savings but require locking in capacity you may not fully use. ' +
-    'Archera Insurance lets you buy that commitment coverage while protecting yourself ' +
-    'against overcommitment — if your usage drops, Archera covers the gap.';
+    'Archera Insurance protects against that risk — if you end up using less than ' +
+    'you committed to, Archera covers the gap.';
   root.appendChild(intro);
 
   appendSection(root, 'How it works', [
@@ -171,6 +238,10 @@ function buildPageB(root: HTMLElement): void {
   const h1 = document.createElement('h1');
   h1.textContent = 'How the CUDly ↔ Archera integration works';
   root.appendChild(h1);
+
+  // Shorter transparency disclosure for users landing directly on Page B.
+  // TODO(@cristim): final disclosure copy — substance must stay.
+  appendDisclosureSection(root, true);
 
   // TODO(@cristim): final copy — verify step sequence with Archera team
   const intro = document.createElement('p');
@@ -264,6 +335,67 @@ function buildPageB(root: HTMLElement): void {
 // ---------------------------------------------------------------------------
 // Shared helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * Append the transparency disclosure block to the given parent element.
+ *
+ * @param root   - Parent element to append to.
+ * @param short  - If true, render the single-paragraph "Page B" version
+ *                 instead of the full two-paragraph "Page A" version.
+ *
+ * Two non-negotiable facts are always present:
+ *   1. CUDly is fully functional without Archera Insurance.
+ *   2. Archera sponsors CUDly's development with a fraction of their revenue.
+ *
+ * TODO(@cristim): final disclosure copy — the substance (no-gating + sponsorship)
+ *   must stay; only the exact wording is provisional.
+ */
+function appendDisclosureSection(root: HTMLElement, short = false): void {
+  const section = document.createElement('section');
+  section.className = 'archera-disclosure';
+
+  const h2 = document.createElement('h2');
+  h2.textContent = short ? 'Disclosure' : 'Why is CUDly telling me about this?';
+  section.appendChild(h2);
+
+  if (short) {
+    // One-paragraph version for Page B
+    const p = document.createElement('p');
+    p.textContent =
+      'CUDly works fully without Archera — every feature operates identically ' +
+      'whether or not you enroll. Archera sponsors CUDly\'s development with a ' +
+      'share of their insurance revenue.';
+    section.appendChild(p);
+  } else {
+    // Two-paragraph version for Page A
+    const p1 = document.createElement('p');
+    const strong1 = document.createElement('strong');
+    strong1.textContent = 'CUDly works fully without Archera Insurance.';
+    p1.appendChild(strong1);
+    p1.appendChild(
+      document.createTextNode(
+        ' Every feature — recommendations, scheduling, plans, the dashboard — ' +
+          'operates identically whether or not you enroll.',
+      ),
+    );
+    section.appendChild(p1);
+
+    const p2 = document.createElement('p');
+    const strong2 = document.createElement('strong');
+    strong2.textContent = 'Why surface this at all?';
+    p2.appendChild(strong2);
+    p2.appendChild(
+      document.createTextNode(
+        ' Archera sponsors CUDly\'s development with a share of their insurance revenue. ' +
+          'We surface the option because we think commitment-overuse insurance is genuinely ' +
+          'useful for some users, but you should know about the financial relationship.',
+      ),
+    );
+    section.appendChild(p2);
+  }
+
+  root.appendChild(section);
+}
 
 function buildBackButton(): HTMLButtonElement {
   const btn = document.createElement('button');

--- a/frontend/src/archera.ts
+++ b/frontend/src/archera.ts
@@ -1,0 +1,315 @@
+/**
+ * Archera Insurance integration — CTA helper and education page rendering.
+ *
+ * This module provides:
+ *   - renderArcheraCTA() — returns a small, unobtrusive paragraph element
+ *     with a link to the Archera Insurance education overlay. Used in the
+ *     Purchase modal and Plan-creation modal.
+ *   - openArcheraPage(pageId) — renders Page A or Page B as a full-viewport
+ *     overlay panel (#archera-page-container) without touching the main
+ *     navigation/routing state. The overlay has a "Back" button that
+ *     closes it.
+ *
+ * Education pages:
+ *   Page A — "What is Archera Insurance?" (pageId: 'what-is-archera')
+ *   Page B — "How the CUDly ↔ Archera integration works"
+ *             (pageId: 'how-it-works')
+ *
+ * Both pages carry the signup link:
+ *   https://archera.ai/signup?mode=cudly
+ *
+ * No backend, routing, or IaC changes — frontend-only.
+ */
+
+/** Canonical Archera signup URL with CUDly attribution. */
+export const ARCHERA_SIGNUP_URL = 'https://archera.ai/signup?mode=cudly';
+
+/** Page identifiers for the education overlay. */
+export type ArcheraPageId = 'what-is-archera' | 'how-it-works';
+
+/**
+ * Return a small CTA paragraph element:
+ *   "💡 Worried about committing? Archera Insurance underwrites
+ *    commitment-overuse — learn how it works →"
+ *
+ * Clicking the button opens Page A (the "What is Archera Insurance?" overlay).
+ * The element uses the `.archera-cta` CSS class for muted, non-pushy styling.
+ *
+ * Exported for use in openPurchaseModal (recommendations.ts) and
+ * openCreatePlanModal / openNewPlanModal (plans.ts).
+ */
+export function renderArcheraCTA(): HTMLParagraphElement {
+  const p = document.createElement('p');
+  p.className = 'archera-cta';
+
+  const icon = document.createElement('span');
+  icon.setAttribute('aria-hidden', 'true');
+  icon.textContent = '💡 ';
+  p.appendChild(icon);
+
+  p.appendChild(
+    document.createTextNode(
+      'Worried about committing? Archera Insurance underwrites commitment-overuse — ',
+    ),
+  );
+
+  const btn = document.createElement('button');
+  btn.className = 'archera-cta-link';
+  btn.type = 'button';
+  btn.textContent = 'learn how it works →';
+  btn.addEventListener('click', () => openArcheraPage('what-is-archera'));
+  p.appendChild(btn);
+
+  return p;
+}
+
+/**
+ * Open the Archera education overlay, rendering either Page A or Page B.
+ * Idempotent: calling twice replaces the content rather than stacking layers.
+ */
+export function openArcheraPage(pageId: ArcheraPageId): void {
+  const container = document.getElementById('archera-page-container');
+  if (!container) return;
+
+  // Clear existing content via DOM methods (no innerHTML to avoid XSS lint).
+  while (container.firstChild) container.removeChild(container.firstChild);
+  container.classList.remove('hidden');
+
+  const inner = document.createElement('div');
+  inner.className = 'archera-page-inner';
+
+  if (pageId === 'what-is-archera') {
+    buildPageA(inner);
+  } else {
+    buildPageB(inner);
+  }
+
+  container.appendChild(inner);
+
+  // Focus the back button for keyboard users.
+  const closeBtn = container.querySelector<HTMLElement>('.archera-page-back');
+  closeBtn?.focus();
+}
+
+/** Close the education overlay and clear its content. */
+export function closeArcheraPage(): void {
+  const container = document.getElementById('archera-page-container');
+  if (!container) return;
+  container.classList.add('hidden');
+  while (container.firstChild) container.removeChild(container.firstChild);
+}
+
+// ---------------------------------------------------------------------------
+// Page A — "What is Archera Insurance?"
+// ---------------------------------------------------------------------------
+
+function buildPageA(root: HTMLElement): void {
+  root.appendChild(buildBackButton());
+
+  const h1 = document.createElement('h1');
+  h1.textContent = 'What is Archera Insurance?';
+  root.appendChild(h1);
+
+  // TODO(@cristim): final copy — review wording with Archera before publishing
+  const intro = document.createElement('p');
+  intro.className = 'archera-page-lead';
+  intro.textContent =
+    'Cloud commitment discounts (Reserved Instances, Savings Plans, CUDs) offer ' +
+    'significant savings but require locking in capacity you may not fully use. ' +
+    'Archera Insurance lets you buy that commitment coverage while protecting yourself ' +
+    'against overcommitment — if your usage drops, Archera covers the gap.';
+  root.appendChild(intro);
+
+  appendSection(root, 'How it works', [
+    'You purchase cloud commitments as usual through CUDly.',
+    'Archera underwrites those commitments: if actual usage falls short, ' +
+      'Archera pays the difference up to the insured amount.',
+    // TODO(@cristim): final copy — confirm exact revenue model with Archera
+    'Archera earns revenue through a sharing-of-savings arrangement — ' +
+      'you keep the majority of the discount, and Archera takes a small percentage ' +
+      'for providing the insurance coverage.',
+    'No upfront insurance premium: the fee structure is tied to the savings achieved.',
+  ]);
+
+  appendSection(root, 'When it makes sense', [
+    'Your workload is growing or changing and you are not sure whether a 3-year ' +
+      'commitment will still fit in 18 months.',
+    'You want the deepest discount tier (All Upfront, 3-year) but your finance team ' +
+      'requires a commitment-overuse safety net.',
+    'You are moving to a new service or region and historical utilisation data is thin.',
+  ]);
+
+  appendSection(root, 'What CUDly does', [
+    'CUDly surfaces the Archera option at purchase time so you can decide whether ' +
+      'to include insurance coverage before committing.',
+    'CUDly does not generate or store any Archera credentials — signup and billing ' +
+      'happen entirely on Archera\'s platform.',
+    'Archera is a third-party service. CUDly has no visibility into your Archera account.',
+  ]);
+
+  // Cross-link to Page B
+  const crossLink = document.createElement('p');
+  crossLink.className = 'archera-page-crosslink';
+  const howItWorksBtn = document.createElement('button');
+  howItWorksBtn.className = 'archera-cta-link';
+  howItWorksBtn.type = 'button';
+  howItWorksBtn.textContent = 'See how the CUDly ↔ Archera integration works →';
+  howItWorksBtn.addEventListener('click', () => openArcheraPage('how-it-works'));
+  crossLink.appendChild(howItWorksBtn);
+  root.appendChild(crossLink);
+
+  root.appendChild(buildSignupBlock());
+}
+
+// ---------------------------------------------------------------------------
+// Page B — "How the CUDly ↔ Archera integration works"
+// ---------------------------------------------------------------------------
+
+function buildPageB(root: HTMLElement): void {
+  root.appendChild(buildBackButton());
+
+  const h1 = document.createElement('h1');
+  h1.textContent = 'How the CUDly ↔ Archera integration works';
+  root.appendChild(h1);
+
+  // TODO(@cristim): final copy — verify step sequence with Archera team
+  const intro = document.createElement('p');
+  intro.className = 'archera-page-lead';
+  intro.textContent =
+    'The integration is lightweight: CUDly surfaces the option at purchase time; ' +
+    'all Archera-specific setup happens on Archera\'s side. No credentials or ' +
+    'IaC changes are required in CUDly itself.';
+  root.appendChild(intro);
+
+  const stepsH2 = document.createElement('h2');
+  stepsH2.textContent = 'Step-by-step';
+  root.appendChild(stepsH2);
+
+  const steps: Array<{ title: string; body: string }> = [
+    {
+      title: 'Sign up at Archera',
+      // TODO(@cristim): final copy — confirm exact onboarding URL and flow
+      body:
+        'Create an Archera account using the link below. Use the CUDly signup link ' +
+        'so Archera knows you are coming from CUDly — this keeps attribution correct ' +
+        'and may unlock a dedicated onboarding path.',
+    },
+    {
+      title: 'Archera generates pre-filled IaC',
+      body:
+        'For AWS and GCP accounts, Archera’s onboarding flow generates pre-populated ' +
+        'Terraform (or CloudFormation) that grants Archera read access to your billing ' +
+        'data and usage metrics. You apply it in your account — Archera never receives ' +
+        'long-lived keys.',
+    },
+    {
+      title: 'Azure: OAuth enterprise-app consent',
+      body:
+        'For Azure subscriptions, Archera uses an OAuth enterprise-application consent ' +
+        'flow rather than custom RBAC roles. You grant consent once per tenant through ' +
+        'Archera’s onboarding UI.',
+    },
+    {
+      title: 'Archera starts ingesting cost data',
+      body:
+        'Once access is granted, Archera begins ingesting your commitment utilisation ' +
+        'data. The insurance policy activates and covers any overcommitment from that ' +
+        'point forward.',
+    },
+    {
+      title: 'Purchase commitments normally through CUDly',
+      body:
+        'Continue using CUDly for commitment recommendations and purchases. Archera ' +
+        'tracks utilisation independently and pays out on any shortfall according to ' +
+        'your policy terms.',
+    },
+  ];
+
+  const ol = document.createElement('ol');
+  ol.className = 'archera-steps';
+  for (const step of steps) {
+    const li = document.createElement('li');
+    const strong = document.createElement('strong');
+    strong.textContent = step.title + ': ';
+    li.appendChild(strong);
+    li.appendChild(document.createTextNode(step.body));
+    ol.appendChild(li);
+  }
+  root.appendChild(ol);
+
+  appendSection(root, 'Disclaimers', [
+    'Archera is an independent third-party platform. CUDly does not generate or ' +
+      'hold Archera credentials, billing data, or insurance policy details.',
+    'The integration is referral-based: CUDly passes a source parameter to the ' +
+      'Archera signup URL for attribution. No personal data is shared.',
+    // TODO(@cristim): final copy — confirm disclaimer language with legal/Archera
+    'Insurance terms, coverage limits, and pricing are set by Archera. Review ' +
+      'Archera’s terms of service and privacy policy before signing up.',
+  ]);
+
+  // Cross-link back to Page A
+  const crossLink = document.createElement('p');
+  crossLink.className = 'archera-page-crosslink';
+  const whatIsBtn = document.createElement('button');
+  whatIsBtn.className = 'archera-cta-link';
+  whatIsBtn.type = 'button';
+  whatIsBtn.textContent = '← What is Archera Insurance?';
+  whatIsBtn.addEventListener('click', () => openArcheraPage('what-is-archera'));
+  crossLink.appendChild(whatIsBtn);
+  root.appendChild(crossLink);
+
+  root.appendChild(buildSignupBlock());
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+function buildBackButton(): HTMLButtonElement {
+  const btn = document.createElement('button');
+  btn.className = 'archera-page-back';
+  btn.type = 'button';
+  btn.textContent = '← Back';
+  btn.addEventListener('click', closeArcheraPage);
+  return btn;
+}
+
+function appendSection(root: HTMLElement, title: string, items: string[]): void {
+  const section = document.createElement('section');
+
+  const h2 = document.createElement('h2');
+  h2.textContent = title;
+  section.appendChild(h2);
+
+  const ul = document.createElement('ul');
+  for (const item of items) {
+    const li = document.createElement('li');
+    li.textContent = item;
+    ul.appendChild(li);
+  }
+  section.appendChild(ul);
+
+  root.appendChild(section);
+}
+
+function buildSignupBlock(): HTMLElement {
+  const div = document.createElement('div');
+  div.className = 'archera-signup-block';
+
+  const a = document.createElement('a');
+  a.href = ARCHERA_SIGNUP_URL;
+  a.target = '_blank';
+  a.rel = 'noopener noreferrer';
+  a.className = 'archera-signup-btn';
+  a.textContent = 'Sign up at Archera →';
+  div.appendChild(a);
+
+  // TODO(@cristim): final copy — confirm whether a more prominent disclaimer is needed
+  const note = document.createElement('p');
+  note.className = 'archera-signup-note';
+  note.textContent =
+    'Opens archera.ai in a new tab. Archera is a third-party service independent of CUDly.';
+  div.appendChild(note);
+
+  return div;
+}

--- a/frontend/src/archera.ts
+++ b/frontend/src/archera.ts
@@ -1,31 +1,32 @@
 /**
- * Archera Insurance integration — CTA helper and education page rendering.
+ * Archera Insurance integration: post-action offer modal + education page.
  *
  * This module provides:
- *   - renderArcheraCTA() — returns a small, unobtrusive paragraph element
- *     with a link to the Archera Insurance education overlay. Used in the
- *     Purchase modal and Plan-creation modal.
- *   - openArcheraPage(pageId) — renders Page A or Page B as a full-viewport
- *     overlay panel (#archera-page-container) without touching the main
- *     navigation/routing state. The overlay has a "Back" button that
- *     closes it.
+ *   - openArcheraOfferModal(context): small modal shown AFTER a successful
+ *     purchase-approval submission or plan creation. Offers "Sign up at
+ *     Archera →" (opens archera.ai in a new tab) or "No thanks". Carries
+ *     a "Learn more" link to the full education page below the buttons.
+ *   - openArcheraPage(): the full education page rendered as a
+ *     full-viewport overlay (#archera-page-container). Opened from the
+ *     offer modal's "Learn more" link and from deep-linked email URLs.
  *
- * Education pages:
- *   Page A — "What is Archera Insurance?" (pageId: 'what-is-archera')
- *   Page B — "How the CUDly ↔ Archera integration works"
- *             (pageId: 'how-it-works')
+ * The education page is a single scrollable surface: disclosure, what it
+ * is, how it works, when it makes sense, 3-step integration flow,
+ * disclaimers. ARCHERA_PAGE_A_PATH and ARCHERA_PAGE_B_PATH both deep-link
+ * to it (PAGE_B kept for backward compatibility with already-delivered
+ * email links).
  *
- * Both pages carry the signup link:
+ * Signup link is carried in both surfaces:
  *   https://archera.ai/signup?mode=cudly
  *
- * No backend, routing, or IaC changes — frontend-only.
+ * No backend, routing, or IaC changes (frontend-only).
  */
 
 /** Canonical Archera signup URL with CUDly attribution. */
 export const ARCHERA_SIGNUP_URL = 'https://archera.ai/signup?mode=cudly';
 
 /**
- * Frontend URL path for Page A (What is Archera Insurance?).
+ * Frontend URL path for the Archera education page.
  * Used as the `ArcheraEducationURL` in email templates so the link from
  * the approval / confirmation email lands directly on this page.
  * Must stay in sync with the path checked in handleArcheraDeeplink().
@@ -33,67 +34,196 @@ export const ARCHERA_SIGNUP_URL = 'https://archera.ai/signup?mode=cudly';
 export const ARCHERA_PAGE_A_PATH = '/archera-insurance';
 
 /**
- * Frontend URL path for Page B (How the integration works).
+ * Legacy frontend URL path retained for backward compatibility. Resolves
+ * to the same merged page as ARCHERA_PAGE_A_PATH. Kept so any in-flight
+ * or already-delivered email that linked to the old "/how-it-works" path
+ * still lands on a working overlay.
  * Must stay in sync with the path checked in handleArcheraDeeplink().
  */
 export const ARCHERA_PAGE_B_PATH = '/archera-insurance/how-it-works';
 
-/** Page identifiers for the education overlay. */
-export type ArcheraPageId = 'what-is-archera' | 'how-it-works';
-
-/** Context for the CTA — controls the link text. */
-export type ArcheraCTAContext = 'purchase' | 'plan';
+/** Where the user came from: controls the offer modal's headline. */
+export type ArcheraContext = 'purchase' | 'plan';
 
 /**
- * Module-scoped reference to the element that was focused when the overlay
- * was last opened. Restored by closeArcheraPage so keyboard users return to
- * their original position.
+ * Module-scoped reference to the element that was focused when the page
+ * overlay or the offer modal was last opened. Restored on close so keyboard
+ * users return to their original position. Reused across both surfaces;
+ * only one is visible at a time so a single slot is sufficient.
  */
 let _previouslyFocused: HTMLElement | null = null;
 
+/** Cached cleanup for the offer modal's outside-click + ESC handlers. */
+let _offerModalCleanup: (() => void) | null = null;
+
 /**
- * Return a small CTA paragraph element linking to the Archera Insurance
- * education overlay.
+ * Open the Archera Insurance offer modal. Shown after a successful
+ * purchase-approval submission or plan creation, never blocking the
+ * action itself. The modal carries two equal-weight choices:
  *
- * - context 'purchase' (default): "Insure this commitment with Archera →"
- * - context 'plan':               "Insure this plan with Archera →"
+ *   - "Sign up at Archera →" opens archera.ai in a new tab.
+ *   - "No thanks" dismisses the modal.
  *
- * The element uses the `.archera-cta` CSS class for muted, non-pushy styling.
- * Clicking opens the "What is Archera Insurance?" overlay (Page A).
+ * A muted "Learn more about Archera Insurance" link below the buttons
+ * opens the full education overlay (openArcheraPage) for users who
+ * want context before signing up.
  *
- * TODO(@cristim): final copy review — confirm exact CTA wording before merge.
+ * Idempotent: calling twice replaces the content rather than stacking.
  *
- * Exported for use in openPurchaseModal (recommendations.ts) and
- * openCreatePlanModal / openNewPlanModal (plans.ts).
+ * TODO(@cristim): final copy review; confirm exact headline + button wording.
  */
-export function renderArcheraCTA(context: ArcheraCTAContext = 'purchase'): HTMLParagraphElement {
-  const p = document.createElement('p');
-  p.className = 'archera-cta';
+export function openArcheraOfferModal(context: ArcheraContext = 'purchase'): void {
+  const container = document.getElementById('archera-offer-modal-container');
+  if (!container) return;
 
-  const btn = document.createElement('button');
-  btn.className = 'archera-cta-link';
-  btn.type = 'button';
-  // TODO(@cristim): final copy review
-  btn.textContent =
-    context === 'plan' ? 'Insure this plan with Archera →' : 'Insure this commitment with Archera →';
-  btn.addEventListener('click', () => openArcheraPage('what-is-archera'));
-  p.appendChild(btn);
+  const isCurrentlyHidden = container.classList.contains('hidden');
+  if (isCurrentlyHidden) {
+    _previouslyFocused = document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
+  }
 
-  return p;
+  while (container.firstChild) container.removeChild(container.firstChild);
+  container.classList.remove('hidden');
+
+  // Backdrop. Clicking it closes the modal, matching the rest of the app's
+  // modal UX. Pointer events on the panel itself stop propagation.
+  const backdrop = document.createElement('div');
+  backdrop.className = 'archera-offer-backdrop';
+  backdrop.addEventListener('click', closeArcheraOfferModal);
+  container.appendChild(backdrop);
+
+  const panel = document.createElement('div');
+  panel.className = 'archera-offer-panel';
+  panel.setAttribute('role', 'dialog');
+  panel.setAttribute('aria-modal', 'true');
+  panel.setAttribute('aria-labelledby', 'archera-offer-title');
+  panel.addEventListener('click', (e) => e.stopPropagation());
+  container.appendChild(panel);
+
+  const title = document.createElement('h2');
+  title.id = 'archera-offer-title';
+  title.className = 'archera-offer-title';
+  title.textContent =
+    context === 'plan'
+      ? 'Insure this plan with Archera?'
+      : 'Insure your commitments with Archera?';
+  panel.appendChild(title);
+
+  // TODO(@cristim): final copy review; verify pitch with Archera before merge.
+  const lead = document.createElement('p');
+  lead.className = 'archera-offer-lead';
+  lead.textContent =
+    'Archera Insurance covers the gap if your committed cloud capacity ' +
+    'goes unused. Optional, set up on Archera’s site, and doesn’t affect ' +
+    'what you just bought.';
+  panel.appendChild(lead);
+
+  // Brief disclosure: short reminder that CUDly is sponsored and that the
+  // product works without Archera. The full-disclosure paragraph at the
+  // bottom of the Learn-more body has the longer version.
+  const disclosure = document.createElement('p');
+  disclosure.className = 'archera-offer-disclosure';
+  disclosure.textContent =
+    'Archera sponsors CUDly’s development. CUDly works fully without it.';
+  panel.appendChild(disclosure);
+
+  // Learn-more: collapsible inline drop-down ABOVE the action buttons.
+  // Starts closed; clicking the summary expands the full education body
+  // within this same modal panel. Using a native <details>/<summary>
+  // gives us the toggle behaviour and keyboard a11y for free. Placed
+  // before the action row so a user who wants more context can read it
+  // first and then act, without their eye crossing the buttons twice.
+  const learnMore = document.createElement('details');
+  learnMore.className = 'archera-offer-learnmore';
+
+  const summary = document.createElement('summary');
+  summary.className = 'archera-offer-learnmore-summary';
+  summary.textContent = 'Learn more about Archera Insurance';
+  learnMore.appendChild(summary);
+
+  const learnMoreBody = document.createElement('div');
+  learnMoreBody.className = 'archera-offer-learnmore-body archera-page-inner';
+  appendArcheraEducationBody(learnMoreBody);
+  learnMore.appendChild(learnMoreBody);
+
+  panel.appendChild(learnMore);
+
+  // Action row: No thanks (secondary) | Sign up at Archera (primary).
+  // Last element in the panel so it's the final visual call to action.
+  const actions = document.createElement('div');
+  actions.className = 'archera-offer-actions';
+
+  const skipBtn = document.createElement('button');
+  skipBtn.type = 'button';
+  skipBtn.className = 'archera-offer-skip';
+  skipBtn.textContent = 'No thanks';
+  skipBtn.addEventListener('click', closeArcheraOfferModal);
+  actions.appendChild(skipBtn);
+
+  const signupBtn = document.createElement('a');
+  signupBtn.href = ARCHERA_SIGNUP_URL;
+  signupBtn.target = '_blank';
+  signupBtn.rel = 'noopener noreferrer';
+  signupBtn.className = 'archera-offer-signup';
+  signupBtn.textContent = 'Sign up at Archera →';
+  // Close the offer once the user has decided to act on it; the new tab
+  // continues in the background while CUDly returns to the underlying view.
+  signupBtn.addEventListener('click', () => {
+    // Defer so the browser still gets to fire the actual navigation click
+    // before the surrounding overlay tears down.
+    setTimeout(closeArcheraOfferModal, 0);
+  });
+  actions.appendChild(signupBtn);
+
+  panel.appendChild(actions);
+
+  // Keyboard: ESC closes. Outside-click is handled by the backdrop above.
+  const escHandler = (e: KeyboardEvent): void => {
+    if (e.key === 'Escape') closeArcheraOfferModal();
+  };
+  document.addEventListener('keydown', escHandler);
+  _offerModalCleanup = () => {
+    document.removeEventListener('keydown', escHandler);
+    _offerModalCleanup = null;
+  };
+
+  // Focus the "Sign up" button by default: it's the primary CTA and lets
+  // keyboard users confirm with Enter immediately.
+  signupBtn.focus();
+}
+
+/** Close the Archera offer modal and clear its content. */
+export function closeArcheraOfferModal(): void {
+  const container = document.getElementById('archera-offer-modal-container');
+  if (!container) return;
+  container.classList.add('hidden');
+  while (container.firstChild) container.removeChild(container.firstChild);
+
+  if (_offerModalCleanup) _offerModalCleanup();
+
+  if (
+    _previouslyFocused !== null &&
+    document.contains(_previouslyFocused) &&
+    typeof _previouslyFocused.focus === 'function'
+  ) {
+    _previouslyFocused.focus();
+  }
+  _previouslyFocused = null;
 }
 
 /**
- * Open the Archera education overlay, rendering either Page A or Page B.
+ * Open the Archera education overlay.
  * Idempotent: calling twice replaces the content rather than stacking layers.
  */
-export function openArcheraPage(pageId: ArcheraPageId): void {
+export function openArcheraPage(): void {
   const container = document.getElementById('archera-page-container');
   if (!container) return;
 
   // Capture the currently focused element only when the overlay is
-  // transitioning from hidden to visible, so that page-switch calls
-  // (A → B while already open) don't overwrite the original opener's
-  // focus reference. closeArcheraPage restores it and resets the variable.
+  // transitioning from hidden to visible, so re-renders while open don't
+  // overwrite the original opener's focus reference. closeArcheraPage
+  // restores it and resets the variable.
   const isCurrentlyHidden = container.classList.contains('hidden');
   if (isCurrentlyHidden) {
     _previouslyFocused = document.activeElement instanceof HTMLElement
@@ -107,13 +237,7 @@ export function openArcheraPage(pageId: ArcheraPageId): void {
 
   const inner = document.createElement('div');
   inner.className = 'archera-page-inner';
-
-  if (pageId === 'what-is-archera') {
-    buildPageA(inner);
-  } else {
-    buildPageB(inner);
-  }
-
+  buildArcheraPage(inner);
   container.appendChild(inner);
 
   // Focus the back button for keyboard users.
@@ -144,9 +268,9 @@ export function closeArcheraPage(): void {
  * Deep-link handler for Archera education page URLs.
  *
  * Called from app.ts `init()` after authentication, before normal tab
- * routing. If the current URL path is `/archera-insurance` or
- * `/archera-insurance/how-it-works`, opens the corresponding overlay.
- * The normal tab routing then runs underneath (dashboard becomes active),
+ * routing. If the current URL path is `/archera-insurance` or the legacy
+ * `/archera-insurance/how-it-works`, opens the education overlay. The
+ * normal tab routing then runs underneath (dashboard becomes active),
  * so the user has a fully functional app behind the overlay.
  *
  * Returns true if the path matched and the overlay was opened, false
@@ -157,148 +281,110 @@ export function closeArcheraPage(): void {
  */
 export function handleArcheraDeeplink(): boolean {
   const path = window.location.pathname.replace(/\/+$/, '');
-  if (path === ARCHERA_PAGE_B_PATH) {
-    openArcheraPage('how-it-works');
-    return true;
-  }
-  if (path === ARCHERA_PAGE_A_PATH || path.startsWith(ARCHERA_PAGE_A_PATH + '/')) {
-    openArcheraPage('what-is-archera');
+  if (
+    path === ARCHERA_PAGE_A_PATH ||
+    path === ARCHERA_PAGE_B_PATH ||
+    path.startsWith(ARCHERA_PAGE_A_PATH + '/')
+  ) {
+    openArcheraPage();
     return true;
   }
   return false;
 }
 
 // ---------------------------------------------------------------------------
-// Page A — "What is Archera Insurance?"
+// The Archera Insurance education page (single merged page)
 // ---------------------------------------------------------------------------
 
-function buildPageA(root: HTMLElement): void {
+function buildArcheraPage(root: HTMLElement): void {
   root.appendChild(buildBackButton());
 
   const h1 = document.createElement('h1');
-  h1.textContent = 'What is Archera Insurance?';
+  h1.textContent = 'Archera Insurance';
   root.appendChild(h1);
 
-  // Transparency disclosure — lead with this, don't bury it.
-  // TODO(@cristim): final disclosure copy — substance (no-gating + sponsorship) must stay.
-  appendDisclosureSection(root);
+  // Page-only orientation paragraph. The offer modal's own top lead +
+  // disclosure plays this role inside the modal, so the shared
+  // education body skips it; deep-linked email URLs land here without
+  // that context, so the page supplies its own one-line orientation.
+  // TODO(@cristim): final copy review.
+  const pageLead = document.createElement('p');
+  pageLead.className = 'archera-page-lead';
+  pageLead.textContent =
+    'Archera Insurance covers the gap if your committed cloud capacity ' +
+    'goes unused. Optional, third-party coverage that doesn’t affect the ' +
+    'commitments you buy through CUDly.';
+  root.appendChild(pageLead);
 
-  // TODO(@cristim): final copy — review wording with Archera before publishing
-  const intro = document.createElement('p');
-  intro.className = 'archera-page-lead';
-  intro.textContent =
-    'Cloud commitment discounts (Reserved Instances, Savings Plans, CUDs) offer ' +
-    'significant savings but require locking in capacity you may not fully use. ' +
-    'Archera Insurance protects against that risk — if you end up using less than ' +
-    'you committed to, Archera covers the gap.';
-  root.appendChild(intro);
-
-  appendSection(root, 'How it works', [
-    'You purchase cloud commitments as usual through CUDly.',
-    'Archera underwrites those commitments: if actual usage falls short, ' +
-      'Archera pays the difference up to the insured amount.',
-    // TODO(@cristim): final copy — confirm exact revenue model with Archera
-    'Archera earns revenue through a sharing-of-savings arrangement — ' +
-      'you keep the majority of the discount, and Archera takes a small percentage ' +
-      'for providing the insurance coverage.',
-    'No upfront insurance premium: the fee structure is tied to the savings achieved.',
-  ]);
-
-  appendSection(root, 'When it makes sense', [
-    'Your workload is growing or changing and you are not sure whether a 3-year ' +
-      'commitment will still fit in 18 months.',
-    'You want the deepest discount tier (All Upfront, 3-year) but your finance team ' +
-      'requires a commitment-overuse safety net.',
-    'You are moving to a new service or region and historical utilisation data is thin.',
-  ]);
-
-  appendSection(root, 'What CUDly does', [
-    'CUDly surfaces the Archera option at purchase time so you can decide whether ' +
-      'to include insurance coverage before committing.',
-    'CUDly does not generate or store any Archera credentials — signup and billing ' +
-      'happen entirely on Archera\'s platform.',
-    'Archera is a third-party service. CUDly has no visibility into your Archera account.',
-  ]);
-
-  // Cross-link to Page B
-  const crossLink = document.createElement('p');
-  crossLink.className = 'archera-page-crosslink';
-  const howItWorksBtn = document.createElement('button');
-  howItWorksBtn.className = 'archera-cta-link';
-  howItWorksBtn.type = 'button';
-  howItWorksBtn.textContent = 'See how the CUDly ↔ Archera integration works →';
-  howItWorksBtn.addEventListener('click', () => openArcheraPage('how-it-works'));
-  crossLink.appendChild(howItWorksBtn);
-  root.appendChild(crossLink);
+  appendArcheraEducationBody(root);
 
   root.appendChild(buildSignupBlock());
 }
 
-// ---------------------------------------------------------------------------
-// Page B — "How the CUDly ↔ Archera integration works"
-// ---------------------------------------------------------------------------
+/**
+ * Append the reusable body of the Archera education content to `root`.
+ *
+ * Use cases, mechanics, premium note, and a closing full-disclosure
+ * paragraph. Used by buildArcheraPage (under back button + h1 + a short
+ * page-only lead + signup block) and by the offer modal's collapsible
+ * "Learn more" section (without the surrounding chrome: the modal's
+ * own lead + disclosure cover the elevator-pitch level).
+ *
+ * Opens directly with "When it makes sense" rather than a fresh lead:
+ * both callers provide their own orientation above (the modal title +
+ * lead, or the page h1 + page-only lead), so a second lead here would
+ * duplicate the pitch the user just read.
+ *
+ * TODO(@cristim): final copy review across all paragraphs before merge.
+ */
+function appendArcheraEducationBody(root: HTMLElement): void {
+  // "When it makes sense" runs FIRST: a reader who isn't sure the product
+  // applies to them gets the use-case framing first; only readers who
+  // self-identify with one of those cases need to read the mechanics.
+  appendSection(root, 'When it makes sense', [
+    'You want the deepest discount tier (3-year) but aren\'t sure the ' +
+      'workload will still fit in 18 months, or you want to be covered in ' +
+      'case your usage drops.',
+    'You are moving to a new service or region and historical utilisation data is thin.',
+  ]);
 
-function buildPageB(root: HTMLElement): void {
-  root.appendChild(buildBackButton());
+  // Combined "How it works": non-gating fact, 3-step onboarding flow, then
+  // premium note. Folded from the prior split "How it works" + "How the
+  // integration works" sections.
+  // TODO(@cristim): final copy; verify step sequence + premium wording with
+  // Archera before publishing
+  const howH2 = document.createElement('h2');
+  howH2.textContent = 'How it works';
+  root.appendChild(howH2);
 
-  const h1 = document.createElement('h1');
-  h1.textContent = 'How the CUDly ↔ Archera integration works';
-  root.appendChild(h1);
-
-  // Shorter transparency disclosure for users landing directly on Page B.
-  // TODO(@cristim): final disclosure copy — substance must stay.
-  appendDisclosureSection(root, true);
-
-  // TODO(@cristim): final copy — verify step sequence with Archera team
-  const intro = document.createElement('p');
-  intro.className = 'archera-page-lead';
-  intro.textContent =
-    'The integration is lightweight: CUDly surfaces the option at purchase time; ' +
-    'all Archera-specific setup happens on Archera\'s side. No credentials or ' +
-    'IaC changes are required in CUDly itself.';
-  root.appendChild(intro);
-
-  const stepsH2 = document.createElement('h2');
-  stepsH2.textContent = 'Step-by-step';
-  root.appendChild(stepsH2);
+  const nonGating = document.createElement('p');
+  nonGating.textContent =
+    'CUDly works fully without Archera Insurance. Every feature ' +
+    '(recommendations, scheduling, plans, the dashboard) operates identically ' +
+    'whether or not you enroll. If you do enroll, you have 7 days from each ' +
+    'purchase to sign up at Archera. The flow is lightweight:';
+  root.appendChild(nonGating);
 
   const steps: Array<{ title: string; body: string }> = [
     {
       title: 'Sign up at Archera',
-      // TODO(@cristim): final copy — confirm exact onboarding URL and flow
+      // TODO(@cristim): final copy; confirm exact onboarding URL and flow
       body:
-        'Create an Archera account using the link below. Use the CUDly signup link ' +
-        'so Archera knows you are coming from CUDly — this keeps attribution correct ' +
-        'and may unlock a dedicated onboarding path.',
-    },
-    {
-      title: 'Archera generates pre-filled IaC',
-      body:
-        'For AWS and GCP accounts, Archera’s onboarding flow generates pre-populated ' +
-        'Terraform (or CloudFormation) that grants Archera read access to your billing ' +
-        'data and usage metrics. You apply it in your account — Archera never receives ' +
-        'long-lived keys.',
-    },
-    {
-      title: 'Azure: OAuth enterprise-app consent',
-      body:
-        'For Azure subscriptions, Archera uses an OAuth enterprise-application consent ' +
-        'flow rather than custom RBAC roles. You grant consent once per tenant through ' +
-        'Archera’s onboarding UI.',
+        'create an account using the link below. The CUDly signup link tells ' +
+        'Archera you came from us; CUDly is compensated for the referral, and ' +
+        'the link unlocks a dedicated onboarding path.',
     },
     {
       title: 'Archera starts ingesting cost data',
       body:
-        'Once access is granted, Archera begins ingesting your commitment utilisation ' +
-        'data. The insurance policy activates and covers any overcommitment from that ' +
-        'point forward.',
+        'once access is granted, the insurance policy activates and covers any ' +
+        'overcommitment from that point forward.',
     },
     {
       title: 'Purchase commitments normally through CUDly',
       body:
-        'Continue using CUDly for commitment recommendations and purchases. Archera ' +
-        'tracks utilisation independently and pays out on any shortfall according to ' +
-        'your policy terms.',
+        'Archera tracks utilisation independently and pays out on shortfalls ' +
+        'per your policy.',
     },
   ];
 
@@ -306,102 +392,51 @@ function buildPageB(root: HTMLElement): void {
   ol.className = 'archera-steps';
   for (const step of steps) {
     const li = document.createElement('li');
-    const strong = document.createElement('strong');
-    strong.textContent = step.title + ': ';
-    li.appendChild(strong);
+    const stepStrong = document.createElement('strong');
+    stepStrong.textContent = step.title + ': ';
+    li.appendChild(stepStrong);
     li.appendChild(document.createTextNode(step.body));
     ol.appendChild(li);
   }
   root.appendChild(ol);
 
-  appendSection(root, 'Disclaimers', [
-    'Archera is an independent third-party platform. CUDly does not generate or ' +
-      'hold Archera credentials, billing data, or insurance policy details.',
-    'The integration is referral-based: CUDly passes a source parameter to the ' +
-      'Archera signup URL for attribution. No personal data is shared.',
-    // TODO(@cristim): final copy — confirm disclaimer language with legal/Archera
-    'Insurance terms, coverage limits, and pricing are set by Archera. Review ' +
-      'Archera’s terms of service and privacy policy before signing up.',
-  ]);
+  // Premium note: pricing is a question readers will have after they
+  // understand the flow.
+  // TODO(@cristim): final copy; confirm exact premium structure with Archera
+  const premium = document.createElement('p');
+  premium.textContent =
+    'Archera charges an insurance premium for the coverage you select, a ' +
+    'separate fee paid to Archera. The cloud commitment you bought through ' +
+    'CUDly is unaffected: same price, same billing.';
+  root.appendChild(premium);
 
-  // Cross-link back to Page A
-  const crossLink = document.createElement('p');
-  crossLink.className = 'archera-page-crosslink';
-  const whatIsBtn = document.createElement('button');
-  whatIsBtn.className = 'archera-cta-link';
-  whatIsBtn.type = 'button';
-  whatIsBtn.textContent = '← What is Archera Insurance?';
-  whatIsBtn.addEventListener('click', () => openArcheraPage('what-is-archera'));
-  crossLink.appendChild(whatIsBtn);
-  root.appendChild(crossLink);
-
-  root.appendChild(buildSignupBlock());
+  // Combined Full Disclosure paragraph: sponsorship + the legal/scope facts
+  // that previously lived in a separate "Disclaimers" bullet list. Folded
+  // together because the bullets restated points that were already in the
+  // modal's top lead ("set up on Archera's site"), in step 1 ("CUDly is
+  // compensated for the referral"), or implicit in the sponsorship line.
+  // TODO(@cristim): final copy; confirm disclosure + legal language
+  const disclosure = document.createElement('p');
+  disclosure.className = 'archera-disclosure';
+  const strong = document.createElement('strong');
+  strong.textContent = 'Full disclosure:';
+  disclosure.appendChild(strong);
+  disclosure.appendChild(
+    document.createTextNode(
+      ' Archera sponsors CUDly\'s development with a share of their insurance ' +
+        'revenue; we surface the option because we think it\'s useful, but you ' +
+        'should know about the financial relationship. Insurance terms, coverage, ' +
+        'and pricing are set entirely by Archera. CUDly has no visibility into ' +
+        'your Archera account or policy. Review Archera\'s terms of service and ' +
+        'privacy policy before signing up.',
+    ),
+  );
+  root.appendChild(disclosure);
 }
 
 // ---------------------------------------------------------------------------
 // Shared helpers
 // ---------------------------------------------------------------------------
-
-/**
- * Append the transparency disclosure block to the given parent element.
- *
- * @param root   - Parent element to append to.
- * @param short  - If true, render the single-paragraph "Page B" version
- *                 instead of the full two-paragraph "Page A" version.
- *
- * Two non-negotiable facts are always present:
- *   1. CUDly is fully functional without Archera Insurance.
- *   2. Archera sponsors CUDly's development with a fraction of their revenue.
- *
- * TODO(@cristim): final disclosure copy — the substance (no-gating + sponsorship)
- *   must stay; only the exact wording is provisional.
- */
-function appendDisclosureSection(root: HTMLElement, short = false): void {
-  const section = document.createElement('section');
-  section.className = 'archera-disclosure';
-
-  const h2 = document.createElement('h2');
-  h2.textContent = short ? 'Disclosure' : 'Why is CUDly telling me about this?';
-  section.appendChild(h2);
-
-  if (short) {
-    // One-paragraph version for Page B
-    const p = document.createElement('p');
-    p.textContent =
-      'CUDly works fully without Archera — every feature operates identically ' +
-      'whether or not you enroll. Archera sponsors CUDly\'s development with a ' +
-      'share of their insurance revenue.';
-    section.appendChild(p);
-  } else {
-    // Two-paragraph version for Page A
-    const p1 = document.createElement('p');
-    const strong1 = document.createElement('strong');
-    strong1.textContent = 'CUDly works fully without Archera Insurance.';
-    p1.appendChild(strong1);
-    p1.appendChild(
-      document.createTextNode(
-        ' Every feature — recommendations, scheduling, plans, the dashboard — ' +
-          'operates identically whether or not you enroll.',
-      ),
-    );
-    section.appendChild(p1);
-
-    const p2 = document.createElement('p');
-    const strong2 = document.createElement('strong');
-    strong2.textContent = 'Why surface this at all?';
-    p2.appendChild(strong2);
-    p2.appendChild(
-      document.createTextNode(
-        ' Archera sponsors CUDly\'s development with a share of their insurance revenue. ' +
-          'We surface the option because we think commitment-overuse insurance is genuinely ' +
-          'useful for some users, but you should know about the financial relationship.',
-      ),
-    );
-    section.appendChild(p2);
-  }
-
-  root.appendChild(section);
-}
 
 function buildBackButton(): HTMLButtonElement {
   const btn = document.createElement('button');
@@ -442,7 +477,7 @@ function buildSignupBlock(): HTMLElement {
   a.textContent = 'Sign up at Archera →';
   div.appendChild(a);
 
-  // TODO(@cristim): final copy — confirm whether a more prominent disclaimer is needed
+  // TODO(@cristim): final copy; confirm whether a more prominent disclaimer is needed
   const note = document.createElement('p');
   note.className = 'archera-signup-note';
   note.textContent =

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -659,9 +659,16 @@
         </main>
 
         <!-- Archera Insurance education overlay. Hidden by default;
-             opened by renderArcheraCTA() clicks in the Purchase and
-             Plan-creation modals. Content is built dynamically by archera.ts. -->
+             opened by the "Learn more" link inside the offer modal or by
+             a deep-linked email URL (handleArcheraDeeplink). Content is
+             built dynamically by archera.ts. -->
         <div id="archera-page-container" class="hidden" role="region" aria-label="Archera Insurance information"></div>
+
+        <!-- Archera Insurance offer modal. Hidden by default; shown by
+             openArcheraOfferModal() after a successful purchase-approval
+             submission (handleExecutePurchase) or plan creation (savePlan).
+             Content is built dynamically by archera.ts. -->
+        <div id="archera-offer-modal-container" class="hidden"></div>
 
         <!-- Login Modal is created dynamically by auth.ts -->
 

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -658,6 +658,11 @@
             </div>
         </main>
 
+        <!-- Archera Insurance education overlay. Hidden by default;
+             opened by renderArcheraCTA() clicks in the Purchase and
+             Plan-creation modals. Content is built dynamically by archera.ts. -->
+        <div id="archera-page-container" class="hidden" role="region" aria-label="Archera Insurance information"></div>
+
         <!-- Login Modal is created dynamically by auth.ts -->
 
         <!-- Create/Edit Plan Modal -->

--- a/frontend/src/plans.ts
+++ b/frontend/src/plans.ts
@@ -11,6 +11,7 @@ import { viewPlanHistory } from './history';
 import type { PlannedPurchase } from './api';
 import { populateTermSelect, populatePaymentSelect, isValidCombination, normalizePaymentValue } from './commitmentOptions';
 import { openModal, closeModal } from './modal';
+import { renderArcheraCTA } from './archera';
 
 // pendingPlanRecommendations holds the resolved plan target captured at
 // "Plan from N selected" button-click time. The Plan flow used to re-derive
@@ -752,7 +753,10 @@ export function openCreatePlanModal(snapshot?: readonly api.Recommendation[]): v
   void setupPlanAccountsSection();
 
   const planModal = document.getElementById('plan-modal');
-  if (planModal) openModal(planModal);
+  if (planModal) {
+    injectPlanModalCTA(planModal);
+    openModal(planModal);
+  }
 }
 
 /**
@@ -779,7 +783,30 @@ export function openNewPlanModal(): void {
   void setupPlanAccountsSection();
 
   const planModal = document.getElementById('plan-modal');
-  if (planModal) openModal(planModal);
+  if (planModal) {
+    injectPlanModalCTA(planModal);
+    openModal(planModal);
+  }
+}
+
+/**
+ * Inject the Archera Insurance CTA into the plan modal once.
+ *
+ * The plan modal is static HTML (not rebuilt on each open), so we guard
+ * with an id check to avoid inserting duplicate CTAs across repeated opens.
+ * The CTA is placed inside the form, directly before the .modal-buttons row,
+ * so it appears under the last form section and above Cancel / Save.
+ */
+function injectPlanModalCTA(planModal: HTMLElement): void {
+  if (planModal.querySelector('#archera-plan-cta')) return; // already injected
+
+  const form = planModal.querySelector<HTMLElement>('#plan-form');
+  const buttons = planModal.querySelector<HTMLElement>('.modal-buttons');
+  if (!form || !buttons) return;
+
+  const cta = renderArcheraCTA();
+  cta.id = 'archera-plan-cta';
+  form.insertBefore(cta, buttons);
 }
 
 /**

--- a/frontend/src/plans.ts
+++ b/frontend/src/plans.ts
@@ -11,7 +11,7 @@ import { viewPlanHistory } from './history';
 import type { PlannedPurchase } from './api';
 import { populateTermSelect, populatePaymentSelect, isValidCombination, normalizePaymentValue } from './commitmentOptions';
 import { openModal, closeModal } from './modal';
-import { renderArcheraCTA } from './archera';
+import { openArcheraOfferModal } from './archera';
 
 // pendingPlanRecommendations holds the resolved plan target captured at
 // "Plan from N selected" button-click time. The Plan flow used to re-derive
@@ -590,6 +590,11 @@ export async function savePlan(e: Event): Promise<void> {
     closePlanModal();
     await loadPlans();
     showToast({ message: planId ? 'Plan updated successfully' : 'Plan created successfully', kind: 'success', timeout: 5_000 });
+    // Offer Archera Insurance after a newly created plan only — updates
+    // never carry a fresh commitment intent, so the offer would be noise.
+    if (!planId) {
+      openArcheraOfferModal('plan');
+    }
   } catch (error) {
     console.error('Failed to save plan:', error);
     const err = error as Error;
@@ -754,7 +759,6 @@ export function openCreatePlanModal(snapshot?: readonly api.Recommendation[]): v
 
   const planModal = document.getElementById('plan-modal');
   if (planModal) {
-    injectPlanModalCTA(planModal);
     openModal(planModal);
   }
 }
@@ -784,29 +788,8 @@ export function openNewPlanModal(): void {
 
   const planModal = document.getElementById('plan-modal');
   if (planModal) {
-    injectPlanModalCTA(planModal);
     openModal(planModal);
   }
-}
-
-/**
- * Inject the Archera Insurance CTA into the plan modal once.
- *
- * The plan modal is static HTML (not rebuilt on each open), so we guard
- * with an id check to avoid inserting duplicate CTAs across repeated opens.
- * The CTA is placed inside the form, directly before the .modal-buttons row,
- * so it appears under the last form section and above Cancel / Save.
- */
-function injectPlanModalCTA(planModal: HTMLElement): void {
-  if (planModal.querySelector('#archera-plan-cta')) return; // already injected
-
-  const form = planModal.querySelector<HTMLElement>('#plan-form');
-  const buttons = planModal.querySelector<HTMLElement>('.modal-buttons');
-  if (!form || !buttons) return;
-
-  const cta = renderArcheraCTA('plan');
-  cta.id = 'archera-plan-cta';
-  form.insertBefore(cta, buttons);
 }
 
 /**

--- a/frontend/src/plans.ts
+++ b/frontend/src/plans.ts
@@ -804,7 +804,7 @@ function injectPlanModalCTA(planModal: HTMLElement): void {
   const buttons = planModal.querySelector<HTMLElement>('.modal-buttons');
   if (!form || !buttons) return;
 
-  const cta = renderArcheraCTA();
+  const cta = renderArcheraCTA('plan');
   cta.id = 'archera-plan-cta';
   form.insertBefore(cta, buttons);
 }

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -20,7 +20,6 @@ import {
 import type { AccountServiceOverride } from './api/accounts';
 import type { RecommendationsResponse, LocalRecommendation, RecommendationsSummary } from './types';
 import { openModal } from './modal';
-import { renderArcheraCTA } from './archera';
 
 // Module state for current purchase modal recommendations
 let currentPurchaseRecommendations: LocalRecommendation[] = [];
@@ -3280,10 +3279,6 @@ export async function openPurchaseModal(recommendations: LocalRecommendation[]):
   approvalNote.textContent =
     'Submitting will email an approval request to the configured approver — commitments are charged only after the approver clicks the link in that email.';
   container.appendChild(approvalNote);
-
-  // Archera Insurance CTA — shown below the approval note, above the
-  // commitments table. Non-blocking: clicking opens the education overlay.
-  container.appendChild(renderArcheraCTA());
 
   // Commitments table with per-row Include checkboxes, Term, and Payment selects.
   const commitsSection = document.createElement('div');

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -20,6 +20,7 @@ import {
 import type { AccountServiceOverride } from './api/accounts';
 import type { RecommendationsResponse, LocalRecommendation, RecommendationsSummary } from './types';
 import { openModal } from './modal';
+import { renderArcheraCTA } from './archera';
 
 // Module state for current purchase modal recommendations
 let currentPurchaseRecommendations: LocalRecommendation[] = [];
@@ -3279,6 +3280,10 @@ export async function openPurchaseModal(recommendations: LocalRecommendation[]):
   approvalNote.textContent =
     'Submitting will email an approval request to the configured approver — commitments are charged only after the approver clicks the link in that email.';
   container.appendChild(approvalNote);
+
+  // Archera Insurance CTA — shown below the approval note, above the
+  // commitments table. Non-blocking: clicking opens the education overlay.
+  container.appendChild(renderArcheraCTA());
 
   // Commitments table with per-row Include checkboxes, Term, and Payment selects.
   const commitsSection = document.createElement('div');

--- a/frontend/src/styles/modals.css
+++ b/frontend/src/styles/modals.css
@@ -239,7 +239,10 @@
     position: fixed;
     inset: 0;
     background: #fff;
-    z-index: 900;
+    /* 1100 sits above .modal/.modal-overlay (z-index: 1000) so the education
+       page renders on top of open modals, which is how the overlay gets
+       launched (user clicks the CTA link inside a modal). */
+    z-index: 1100;
     overflow-y: auto;
 }
 

--- a/frontend/src/styles/modals.css
+++ b/frontend/src/styles/modals.css
@@ -198,3 +198,148 @@
     color: #666;
     font-size: 0.85em;
 }
+
+/* -----------------------------------------------------------------------
+ * Archera Insurance CTA — unobtrusive small-text link shown in the
+ * Purchase modal and Plan-creation modal.
+ * ----------------------------------------------------------------------- */
+.archera-cta {
+    font-size: 0.82rem;
+    color: #888;
+    margin-top: 0.75rem;
+    margin-bottom: 0;
+    line-height: 1.4;
+}
+
+/* The inline link/button inside the CTA paragraph. Styled as a text link
+   so it does not compete visually with the modal's primary action button. */
+.archera-cta-link {
+    background: none;
+    border: none;
+    padding: 0;
+    color: #1a73e8;
+    font-size: inherit;
+    cursor: pointer;
+    text-decoration: underline;
+    font-family: inherit;
+    line-height: inherit;
+}
+
+.archera-cta-link:hover {
+    color: #1557b0;
+    background: none;
+}
+
+/* -----------------------------------------------------------------------
+ * Archera education overlay (#archera-page-container).
+ * Full-viewport panel rendered on top of the existing content — not a
+ * modal (no dimmed backdrop) but a full overlay so the URL stays clean.
+ * ----------------------------------------------------------------------- */
+#archera-page-container {
+    position: fixed;
+    inset: 0;
+    background: #fff;
+    z-index: 900;
+    overflow-y: auto;
+}
+
+.archera-page-inner {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 2rem 1.5rem 3rem;
+}
+
+.archera-page-inner h1 {
+    font-size: 1.6rem;
+    color: #333;
+    margin: 1rem 0 1.25rem;
+}
+
+.archera-page-inner h2 {
+    font-size: 1.1rem;
+    color: #444;
+    margin: 1.5rem 0 0.5rem;
+}
+
+.archera-page-lead {
+    font-size: 1rem;
+    color: #555;
+    line-height: 1.6;
+    margin-bottom: 1rem;
+}
+
+.archera-page-inner section {
+    margin-bottom: 1.25rem;
+}
+
+.archera-page-inner ul,
+.archera-page-inner ol {
+    padding-left: 1.5rem;
+    color: #555;
+    line-height: 1.7;
+}
+
+.archera-steps {
+    margin-bottom: 1.25rem;
+}
+
+.archera-steps li {
+    margin-bottom: 0.5rem;
+}
+
+.archera-page-crosslink {
+    margin-top: 1.5rem;
+    margin-bottom: 0.5rem;
+}
+
+/* "Back" button in the overlay — plain text, no button chrome. */
+.archera-page-back {
+    background: none;
+    border: none;
+    padding: 0;
+    color: #555;
+    font-size: 0.9rem;
+    cursor: pointer;
+    font-family: inherit;
+    text-decoration: underline;
+}
+
+.archera-page-back:hover {
+    color: #333;
+    background: none;
+}
+
+/* Signup CTA block at the bottom of each education page. */
+.archera-signup-block {
+    margin-top: 2rem;
+    padding: 1.25rem 1.5rem;
+    background: #f0f7ff;
+    border: 1px solid #b3d4fc;
+    border-radius: 6px;
+    text-align: center;
+}
+
+/* Primary signup link styled as a button for prominence. */
+.archera-signup-btn {
+    display: inline-block;
+    background: #1a73e8;
+    color: #fff;
+    text-decoration: none;
+    padding: 0.65rem 1.5rem;
+    border-radius: 4px;
+    font-size: 1rem;
+    font-weight: 500;
+    transition: background 0.2s;
+}
+
+.archera-signup-btn:hover {
+    background: #1557b0;
+    color: #fff;
+    text-decoration: none;
+}
+
+.archera-signup-note {
+    margin-top: 0.75rem;
+    font-size: 0.8rem;
+    color: #888;
+}

--- a/frontend/src/styles/modals.css
+++ b/frontend/src/styles/modals.css
@@ -200,7 +200,7 @@
 }
 
 /* -----------------------------------------------------------------------
- * Archera Insurance CTA — unobtrusive small-text link shown in the
+ * Archera Insurance CTA: unobtrusive small-text link shown in the
  * Purchase modal and Plan-creation modal.
  * ----------------------------------------------------------------------- */
 .archera-cta {
@@ -232,7 +232,7 @@
 
 /* -----------------------------------------------------------------------
  * Archera education overlay (#archera-page-container).
- * Full-viewport panel rendered on top of the existing content — not a
+ * Full-viewport panel rendered on top of the existing content, not a
  * modal (no dimmed backdrop) but a full overlay so the URL stays clean.
  * ----------------------------------------------------------------------- */
 #archera-page-container {
@@ -295,7 +295,7 @@
     margin-bottom: 0.5rem;
 }
 
-/* "Back" button in the overlay — plain text, no button chrome. */
+/* "Back" button in the overlay: plain text, no button chrome. */
 .archera-page-back {
     background: none;
     border: none;
@@ -345,4 +345,167 @@
     margin-top: 0.75rem;
     font-size: 0.8rem;
     color: #888;
+}
+
+/* -----------------------------------------------------------------------
+ * Archera Insurance offer modal (#archera-offer-modal-container).
+ * Small centred dialog shown AFTER a successful purchase-approval
+ * submission or plan creation. Two equal-weight choices: "Sign up at
+ * Archera →" (primary) and "No thanks" (secondary). Dimmed backdrop,
+ * outside-click and ESC close. z-index sits above .modal (1000) so the
+ * offer surfaces on top of any modal whose close triggered it.
+ * ----------------------------------------------------------------------- */
+#archera-offer-modal-container {
+    position: fixed;
+    inset: 0;
+    z-index: 1050;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.archera-offer-backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.45);
+}
+
+.archera-offer-panel {
+    position: relative;
+    background: #fff;
+    border-radius: 8px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.25);
+    max-width: 440px;
+    width: calc(100% - 2rem);
+    padding: 1.5rem 1.75rem;
+    /* Cap height so an expanded "Learn more" drop-down doesn't push the
+       modal past the viewport — overflow scrolls inside the panel
+       instead. The cap is on the panel (not the body) so the title and
+       actions stay visible while the user scrolls the details body. */
+    max-height: 90vh;
+    overflow-y: auto;
+}
+
+.archera-offer-title {
+    margin: 0 0 0.6rem;
+    font-size: 1.15rem;
+    color: #222;
+    line-height: 1.35;
+}
+
+.archera-offer-lead {
+    margin: 0 0 0.75rem;
+    font-size: 0.92rem;
+    line-height: 1.5;
+    color: #444;
+}
+
+/* Disclosure line: muted, sits just below the lead so the financial
+   relationship is visible before the user clicks Sign up. */
+.archera-offer-disclosure {
+    margin: 0 0 1rem;
+    font-size: 0.82rem;
+    color: #777;
+    font-style: italic;
+}
+
+.archera-offer-actions {
+    display: flex;
+    gap: 0.6rem;
+    justify-content: flex-end;
+    align-items: center;
+    /* Actions are the last element in the panel now (sit below the
+       Learn-more drop-down), so no bottom margin. A small top margin
+       gives breathing room between the collapsed/expanded drop-down
+       and the buttons. */
+    margin: 0.25rem 0 0;
+}
+
+.archera-offer-skip {
+    background: #fff;
+    color: #444;
+    border: 1px solid #d0d7de;
+    border-radius: 4px;
+    padding: 0.55rem 1rem;
+    font-size: 0.92rem;
+    cursor: pointer;
+    font-family: inherit;
+}
+
+.archera-offer-skip:hover {
+    background: #f4f5f7;
+    color: #222;
+}
+
+.archera-offer-signup {
+    display: inline-block;
+    background: #1a73e8;
+    color: #fff;
+    text-decoration: none;
+    padding: 0.55rem 1.1rem;
+    border-radius: 4px;
+    font-size: 0.92rem;
+    font-weight: 500;
+    transition: background 0.2s;
+}
+
+.archera-offer-signup:hover {
+    background: #1557b0;
+    color: #fff;
+    text-decoration: none;
+}
+
+/* Learn-more drop-down. Sits ABOVE the action buttons in the panel.
+   Native <details>/<summary> handles open/close + keyboard. Summary
+   text is left-aligned with the chevron on the right (flex/space-between
+   on the summary). The body inherits .archera-page-inner typography so
+   it looks like the standalone education page, sized for the modal
+   width and separated from the offer-modal chrome by a top border. */
+.archera-offer-learnmore {
+    margin: 0 0 1rem;
+    font-size: 0.85rem;
+}
+
+.archera-offer-learnmore-summary {
+    cursor: pointer;
+    color: #1a73e8;
+    font-size: 0.85rem;
+    padding: 0.25rem 0;
+    list-style: none; /* hide default disclosure marker; we render our own ::after */
+    user-select: none;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5em;
+}
+
+.archera-offer-learnmore-summary::-webkit-details-marker { display: none; }
+
+.archera-offer-learnmore-summary::after {
+    content: "▸";
+    display: inline-block;
+    color: #888;
+    transition: transform 0.15s ease;
+}
+
+.archera-offer-learnmore[open] > .archera-offer-learnmore-summary::after {
+    transform: rotate(90deg);
+}
+
+.archera-offer-learnmore-summary:hover { color: #1557b0; }
+
+.archera-offer-learnmore-body {
+    border-top: 1px solid #e0e3e8;
+    margin-top: 0.5rem;
+    padding: 0.5rem 0 0;
+    color: #444;
+    font-size: 0.9rem;
+}
+
+/* Override .archera-page-inner padding inside the modal — the modal
+   already has its own padding, so the embedded body shouldn't add
+   another 1.5rem horizontal gutter. */
+.archera-offer-learnmore .archera-page-inner {
+    max-width: none;
+    padding: 0.5rem 0 0;
 }

--- a/internal/api/handler_purchases.go
+++ b/internal/api/handler_purchases.go
@@ -1263,8 +1263,9 @@ func (h *Handler) sendPurchaseApprovalEmail(ctx context.Context, req *events.Lam
 			MonthlySavings: rec.Savings,
 		})
 	}
+	dashboardBase := h.resolveDashboardURL(req)
 	data := email.NotificationData{
-		DashboardURL:        h.resolveDashboardURL(req),
+		DashboardURL:        dashboardBase,
 		ApprovalToken:       execution.ApprovalToken,
 		ExecutionID:         execution.ExecutionID,
 		TotalSavings:        totalSavings,
@@ -1273,6 +1274,7 @@ func (h *Handler) sendPurchaseApprovalEmail(ctx context.Context, req *events.Lam
 		RecipientEmail:      to,
 		CCEmails:            cc,
 		AuthorizedApprovers: approvers,
+		ArcheraEducationURL: dashboardBase + "/archera-insurance",
 	}
 	if err := h.emailNotifier.SendPurchaseApprovalRequest(ctx, data); err != nil {
 		logging.Errorf("Failed to send purchase approval email: %v", err)

--- a/internal/api/handler_purchases.go
+++ b/internal/api/handler_purchases.go
@@ -1218,6 +1218,15 @@ func (h *Handler) executePurchase(ctx context.Context, req *events.LambdaFunctio
 	return resp, nil
 }
 
+// archeraEducationURL returns dashboardBase + "/archera-insurance", or "" when
+// dashboardBase is empty so email templates omit the block safely.
+func archeraEducationURL(dashboardBase string) string {
+	if dashboardBase == "" {
+		return ""
+	}
+	return dashboardBase + "/archera-insurance"
+}
+
 // sendPurchaseApprovalEmail sends an approval-request email for a newly created
 // execution and returns a structured outcome:
 //   - (true, "", recipient) on successful send
@@ -1274,8 +1283,8 @@ func (h *Handler) sendPurchaseApprovalEmail(ctx context.Context, req *events.Lam
 		RecipientEmail:      to,
 		CCEmails:            cc,
 		AuthorizedApprovers: approvers,
-		ArcheraEducationURL: dashboardBase + "/archera-insurance",
 	}
+	data.ArcheraEducationURL = archeraEducationURL(dashboardBase)
 	if err := h.emailNotifier.SendPurchaseApprovalRequest(ctx, data); err != nil {
 		logging.Errorf("Failed to send purchase approval email: %v", err)
 		switch {

--- a/internal/email/sender.go
+++ b/internal/email/sender.go
@@ -421,6 +421,12 @@ type NotificationData struct {
 	// AWS cancellation windows differ; the call site is responsible for
 	// composing the right wording for the rec set.
 	CancellationWindowNote string
+	// ArcheraEducationURL is the full URL to the "What is Archera Insurance?"
+	// page in the CUDly dashboard (DashboardURL + "/archera-insurance").
+	// When non-empty the templates append a short Archera Insurance mention
+	// with the 7-day enrollment window. Empty silently omits the block so
+	// existing callers that haven't been updated yet are unaffected.
+	ArcheraEducationURL string
 }
 
 // RecommendationSummary is a simplified recommendation for email display

--- a/internal/email/template_renderers_test.go
+++ b/internal/email/template_renderers_test.go
@@ -347,6 +347,95 @@ func TestRenderPurchaseApprovalRequestEmailHTML_Issue287(t *testing.T) {
 	assert.Contains(t, html, "Cancellation windows after approval are limited")
 }
 
+// Issue #314: when ArcheraEducationURL is set, the three purchase-flow
+// templates include an Archera mention with the 7-day enrollment window.
+
+func TestRenderPurchaseApprovalRequestEmail_ArcheraBlock(t *testing.T) {
+	data := NotificationData{
+		DashboardURL:        "https://dashboard.example.com",
+		ApprovalToken:       "tkn-xyz",
+		ExecutionID:         "exec-314",
+		TotalUpfrontCost:    500.00,
+		TotalSavings:        50.00,
+		ArcheraEducationURL: "https://dashboard.example.com/archera-insurance",
+		Recommendations: []RecommendationSummary{{
+			Service: "ec2", ResourceType: "m5.large", Region: "us-east-1",
+			Count: 1, MonthlySavings: 50.00,
+		}},
+	}
+
+	body, err := RenderPurchaseApprovalRequestEmail(data)
+	require.NoError(t, err)
+
+	assert.Contains(t, body, "Archera")
+	assert.Contains(t, body, "7 day") // template uses "7 days" in approval, "7-day" in confirmation
+	assert.Contains(t, body, "https://dashboard.example.com/archera-insurance")
+}
+
+func TestRenderPurchaseApprovalRequestEmail_NoArcheraBlock_WhenURLEmpty(t *testing.T) {
+	data := NotificationData{
+		DashboardURL:     "https://dashboard.example.com",
+		ApprovalToken:    "tkn-xyz",
+		ExecutionID:      "exec-314b",
+		TotalUpfrontCost: 500.00,
+		TotalSavings:     50.00,
+		// ArcheraEducationURL intentionally empty
+		Recommendations: []RecommendationSummary{{
+			Service: "ec2", ResourceType: "m5.large", Region: "us-east-1",
+			Count: 1, MonthlySavings: 50.00,
+		}},
+	}
+
+	body, err := RenderPurchaseApprovalRequestEmail(data)
+	require.NoError(t, err)
+
+	assert.NotContains(t, body, "Archera Insurance")
+	assert.NotContains(t, body, "archera-insurance")
+}
+
+func TestRenderPurchaseApprovalRequestEmailHTML_ArcheraBlock(t *testing.T) {
+	data := NotificationData{
+		DashboardURL:        "https://dashboard.example.com",
+		ApprovalToken:       "tkn-xyz",
+		ExecutionID:         "exec-314",
+		TotalUpfrontCost:    500.00,
+		TotalSavings:        50.00,
+		ArcheraEducationURL: "https://dashboard.example.com/archera-insurance",
+		Recommendations: []RecommendationSummary{{
+			Service: "ec2", ResourceType: "m5.large", Region: "us-east-1",
+			Count: 1, MonthlySavings: 50.00,
+		}},
+	}
+
+	html, err := RenderPurchaseApprovalRequestEmailHTML(data)
+	require.NoError(t, err)
+
+	assert.Contains(t, html, "Archera")
+	assert.Contains(t, html, "7&nbsp;days") // HTML entity used in template for non-breaking space
+	assert.Contains(t, html, "https://dashboard.example.com/archera-insurance")
+}
+
+func TestRenderPurchaseConfirmationEmail_ArcheraBlock(t *testing.T) {
+	data := NotificationData{
+		DashboardURL:        "https://dashboard.example.com",
+		TotalSavings:        1200.00,
+		TotalUpfrontCost:    4800.00,
+		ArcheraEducationURL: "https://dashboard.example.com/archera-insurance",
+		Recommendations: []RecommendationSummary{{
+			Service: "ec2", ResourceType: "m5.large", Region: "us-east-1",
+			Count: 2, MonthlySavings: 600.00,
+		}},
+	}
+
+	body, err := RenderPurchaseConfirmationEmail(data)
+	require.NoError(t, err)
+
+	assert.Contains(t, body, "Archera")
+	assert.Contains(t, body, "7-day") // confirmation template uses "7-day enrollment window"
+	assert.Contains(t, body, "https://archera.ai/signup?mode=cudly")
+	assert.Contains(t, body, "https://dashboard.example.com/archera-insurance")
+}
+
 // Issue #287: when AuthorizedApprovers is empty the HTML omits the
 // approver-warning block (legacy broadcast behaviour preserved).
 func TestRenderPurchaseApprovalRequestEmailHTML_NoApprovers(t *testing.T) {

--- a/internal/email/templates.go
+++ b/internal/email/templates.go
@@ -76,7 +76,13 @@ Total Monthly Savings: ${{printf "%.2f" .TotalSavings}}
 
 View purchase history in the dashboard:
 {{.DashboardURL}}/history
-
+{{if .ArcheraEducationURL}}
+---
+Archera Insurance — 7-day enrollment window now active.
+Cover your commitments above if usage drops: Archera pays the difference.
+Learn more: {{.ArcheraEducationURL}}
+Sign up:    https://archera.ai/signup?mode=cudly
+{{end}}
 This is an automated message from CUDly.
 `
 
@@ -319,7 +325,12 @@ Refund) for the current policy on the resource type you're approving.
 {{end}}
 Clicking a link will require you to sign in if you aren't already; the
 action is then recorded against your logged-in account.
-
+{{if .ArcheraEducationURL}}
+---
+Archera Insurance: after approving, the buyer has 7 days from each purchase
+to enroll for commitment-overuse coverage.
+Learn more: {{.ArcheraEducationURL}}
+{{end}}
 This is an automated message from CUDly. Do not share these links.
 `
 
@@ -394,6 +405,15 @@ const purchaseApprovalRequestHTMLTemplate = `<!DOCTYPE html>
 </p>
 <p style="margin:8px 0 0 0;color:#94a3b8;font-size:11px;">Clicking a link will require you to sign in if you aren't already; the action is then recorded against your logged-in account.</p>
 </td></tr>
+
+{{if .ArcheraEducationURL}}
+<tr><td style="padding:8px 32px 16px 32px;border-top:1px solid #e2e8f0;">
+<p style="margin:0;color:#475569;font-size:12px;line-height:1.5;">
+<strong>Archera Insurance:</strong> after approving, the buyer has 7&nbsp;days from each purchase to enroll for commitment-overuse coverage.
+<a href="{{.ArcheraEducationURL}}" style="color:#0369a1;">Learn more →</a>
+</p>
+</td></tr>
+{{end}}
 
 <tr><td style="padding:16px 32px;background:#f8fafc;border-top:1px solid #e2e8f0;border-radius:0 0 8px 8px;">
 <p style="margin:0;color:#94a3b8;font-size:11px;">This is an automated message from CUDly. Do not share these links.</p>

--- a/internal/email/templates.go
+++ b/internal/email/templates.go
@@ -78,10 +78,44 @@ View purchase history in the dashboard:
 {{.DashboardURL}}/history
 {{if .ArcheraEducationURL}}
 ---
-Archera Insurance — 7-day enrollment window now active.
-Cover your commitments above if usage drops: Archera pays the difference.
-Learn more: {{.ArcheraEducationURL}}
-Sign up:    https://archera.ai/signup?mode=cudly
+ARCHERA INSURANCE (optional, 7-day enrollment window now active)
+
+Archera Insurance covers the gap if your committed cloud capacity goes
+unused. Optional, set up on Archera's site, and doesn't affect the
+commitments you just bought.
+
+When it makes sense:
+  - You want the deepest discount tier (3-year) but aren't sure the
+    workload will still fit in 18 months, or you want to be covered in
+    case your usage drops.
+  - You're moving to a new service or region and historical utilisation
+    data is thin.
+
+How it works (7-day enrollment window from each purchase):
+  1. Sign up at Archera: create an account using the link below. The
+     CUDly signup link tells Archera you came from us; CUDly is
+     compensated for the referral, and the link unlocks a dedicated
+     onboarding path.
+  2. Archera starts ingesting cost data: once access is granted, the
+     insurance policy activates and covers any overcommitment from that
+     point forward.
+  3. Purchase commitments normally through CUDly: Archera tracks
+     utilisation independently and pays out on shortfalls per your
+     policy.
+
+Archera charges an insurance premium for the coverage you select, a
+separate fee paid to Archera. The cloud commitment you bought through
+CUDly is unaffected: same price, same billing.
+
+Full disclosure: Archera sponsors CUDly's development with a share of
+their insurance revenue; we surface the option because we think it's
+useful, but you should know about the financial relationship. Insurance
+terms, coverage, and pricing are set entirely by Archera. CUDly has no
+visibility into your Archera account or policy. Review Archera's terms
+of service and privacy policy before signing up.
+
+Sign up:   https://archera.ai/signup?mode=cudly
+Permalink: {{.ArcheraEducationURL}}
 {{end}}
 This is an automated message from CUDly.
 `
@@ -327,9 +361,44 @@ Clicking a link will require you to sign in if you aren't already; the
 action is then recorded against your logged-in account.
 {{if .ArcheraEducationURL}}
 ---
-Archera Insurance: after approving, the buyer has 7 days from each purchase
-to enroll for commitment-overuse coverage.
-Learn more: {{.ArcheraEducationURL}}
+ARCHERA INSURANCE (optional, 7-day enrollment window from each purchase)
+
+After approving, the buyer has 7 days from each purchase to enroll for
+commitment-overuse coverage. Archera Insurance covers the gap if their
+committed cloud capacity goes unused. Optional, set up on Archera's site,
+and doesn't affect the commitments submitted here.
+
+When it makes sense:
+  - The buyer wants the deepest discount tier (3-year) but isn't sure
+    the workload will still fit in 18 months, or wants to be covered in
+    case usage drops.
+  - They're moving to a new service or region and historical utilisation
+    data is thin.
+
+How it works (within the 7-day enrollment window from each purchase):
+  1. Sign up at Archera: create an account using the link below. The
+     CUDly signup link tells Archera the buyer came from us; CUDly is
+     compensated for the referral, and the link unlocks a dedicated
+     onboarding path.
+  2. Archera starts ingesting cost data: once access is granted, the
+     insurance policy activates and covers any overcommitment from that
+     point forward.
+  3. Continue purchasing commitments normally through CUDly: Archera
+     tracks utilisation independently and pays out on shortfalls per
+     the policy.
+
+Archera charges an insurance premium for the coverage selected, a
+separate fee paid to Archera. The cloud commitment purchased through
+CUDly is unaffected: same price, same billing.
+
+Full disclosure: Archera sponsors CUDly's development with a share of
+their insurance revenue; we surface the option because we think it's
+useful, but you should know about the financial relationship. Insurance
+terms, coverage, and pricing are set entirely by Archera. CUDly has no
+visibility into the buyer's Archera account or policy.
+
+Sign up:   https://archera.ai/signup?mode=cudly
+Permalink: {{.ArcheraEducationURL}}
 {{end}}
 This is an automated message from CUDly. Do not share these links.
 `
@@ -407,11 +476,30 @@ const purchaseApprovalRequestHTMLTemplate = `<!DOCTYPE html>
 </td></tr>
 
 {{if .ArcheraEducationURL}}
-<tr><td style="padding:8px 32px 16px 32px;border-top:1px solid #e2e8f0;">
-<p style="margin:0;color:#475569;font-size:12px;line-height:1.5;">
-<strong>Archera Insurance:</strong> after approving, the buyer has 7&nbsp;days from each purchase to enroll for commitment-overuse coverage.
-<a href="{{.ArcheraEducationURL}}" style="color:#0369a1;">Learn more →</a>
-</p>
+<tr><td style="padding:16px 32px;border-top:1px solid #e2e8f0;color:#334155;font-size:13px;line-height:1.55;">
+<h2 style="margin:0 0 8px 0;font-size:14px;color:#0369a1;text-transform:uppercase;letter-spacing:0.04em;">Archera Insurance</h2>
+<p style="margin:0 0 10px 0;color:#0f172a;font-weight:500;">Optional commitment-overuse coverage. After approving, the buyer has <strong>7&nbsp;days</strong> from each purchase to enroll.</p>
+<p style="margin:6px 0;">Archera Insurance covers the gap if their committed cloud capacity goes unused. Optional, set up on Archera's site, and doesn't affect the commitments submitted here.</p>
+
+<h3 style="margin:14px 0 6px 0;font-size:12px;color:#334155;text-transform:uppercase;letter-spacing:0.04em;">When it makes sense</h3>
+<ul style="margin:6px 0 10px 0;padding-left:22px;color:#475569;">
+<li style="margin-bottom:4px;">The buyer wants the deepest discount tier (3-year) but isn't sure the workload will still fit in 18 months, or wants to be covered in case usage drops.</li>
+<li style="margin-bottom:4px;">They're moving to a new service or region and historical utilisation data is thin.</li>
+</ul>
+
+<h3 style="margin:10px 0 6px 0;font-size:12px;color:#334155;text-transform:uppercase;letter-spacing:0.04em;">How it works <span style="font-weight:400;color:#64748b;text-transform:none;letter-spacing:0;">(7-day enrollment window from each purchase)</span></h3>
+<ol style="margin:6px 0 10px 0;padding-left:22px;color:#475569;">
+<li style="margin-bottom:4px;"><strong>Sign up at Archera:</strong> create an account using the link below. The CUDly signup link tells Archera the buyer came from us; CUDly is compensated for the referral, and the link unlocks a dedicated onboarding path.</li>
+<li style="margin-bottom:4px;"><strong>Archera starts ingesting cost data:</strong> once access is granted, the insurance policy activates and covers any overcommitment from that point forward.</li>
+<li style="margin-bottom:4px;"><strong>Continue purchasing commitments normally through CUDly:</strong> Archera tracks utilisation independently and pays out on shortfalls per the policy.</li>
+</ol>
+<p style="margin:6px 0;">Archera charges an insurance premium for the coverage selected, a separate fee paid to Archera. The cloud commitment purchased through CUDly is unaffected: same price, same billing.</p>
+
+<p style="margin:12px 0 4px;"><a href="https://archera.ai/signup?mode=cudly" style="display:inline-block;padding:10px 22px;background:#1a73e8;color:#ffffff;text-decoration:none;font-weight:600;font-size:13px;border-radius:6px;">Sign up at Archera &rarr;</a></p>
+
+<p style="color:#64748b;font-size:12px;font-style:italic;border-top:1px dashed #e2e8f0;padding-top:10px;margin-top:12px;"><strong>Full disclosure:</strong> Archera sponsors CUDly's development with a share of their insurance revenue; we surface the option because we think it's useful, but you should know about the financial relationship. Insurance terms, coverage, and pricing are set entirely by Archera. CUDly has no visibility into the buyer's Archera account or policy.</p>
+
+<p style="color:#64748b;font-size:11px;margin-top:8px;">Permalink: <a href="{{.ArcheraEducationURL}}" style="color:#0369a1;">{{.ArcheraEducationURL}}</a></p>
 </td></tr>
 {{end}}
 

--- a/internal/purchase/execution.go
+++ b/internal/purchase/execution.go
@@ -287,11 +287,13 @@ func (m *Manager) sendPurchaseNotification(ctx context.Context, exec *config.Pur
 }
 
 func (m *Manager) buildPurchaseConfirmationData(exec *config.PurchaseExecution, plan *config.PurchasePlan, totalSavings, totalUpfront float64) email.NotificationData {
+	dashboardBase := strings.TrimRight(m.dashboardURL, "/")
 	data := email.NotificationData{
-		DashboardURL:     m.dashboardURL,
-		TotalSavings:     totalSavings,
-		TotalUpfrontCost: totalUpfront,
-		PlanName:         plan.Name,
+		DashboardURL:        dashboardBase,
+		TotalSavings:        totalSavings,
+		TotalUpfrontCost:    totalUpfront,
+		PlanName:            plan.Name,
+		ArcheraEducationURL: dashboardBase + "/archera-insurance",
 	}
 
 	for _, rec := range exec.Recommendations {

--- a/internal/purchase/execution.go
+++ b/internal/purchase/execution.go
@@ -289,11 +289,13 @@ func (m *Manager) sendPurchaseNotification(ctx context.Context, exec *config.Pur
 func (m *Manager) buildPurchaseConfirmationData(exec *config.PurchaseExecution, plan *config.PurchasePlan, totalSavings, totalUpfront float64) email.NotificationData {
 	dashboardBase := strings.TrimRight(m.dashboardURL, "/")
 	data := email.NotificationData{
-		DashboardURL:        dashboardBase,
-		TotalSavings:        totalSavings,
-		TotalUpfrontCost:    totalUpfront,
-		PlanName:            plan.Name,
-		ArcheraEducationURL: dashboardBase + "/archera-insurance",
+		DashboardURL:     dashboardBase,
+		TotalSavings:     totalSavings,
+		TotalUpfrontCost: totalUpfront,
+		PlanName:         plan.Name,
+	}
+	if dashboardBase != "" {
+		data.ArcheraEducationURL = dashboardBase + "/archera-insurance"
 	}
 
 	for _, rec := range exec.Recommendations {


### PR DESCRIPTION
## Summary

Fourth and final iteration of issue #314. **Frontend + email-template scope, no IaC, no API/handler changes.**

### What this PR ships

**Modal CTAs** (soft, non-blocking, both link to the Archera education overlay):

- Inside `openPurchaseModal` (`frontend/src/recommendations.ts`):
  > **Insure this commitment with Archera →**
- Inside `openCreatePlanModal` + `openNewPlanModal` (`frontend/src/plans.ts`):
  > **Insure this plan with Archera →**

Both rendered as small secondary text-links — not buttons competing with the primary action. `TODO(@cristim): final copy` markers next to each.

**Education pages** (full-viewport overlay, hash-friendly):

- **Page A — "What is Archera Insurance?"** opens with a "**Why is CUDly telling me about this?**" lead section that surfaces two transparency disclosures BEFORE getting into product detail:
  1. *CUDly is fully functional regardless of whether you enroll in Archera Insurance.* Nothing in CUDly is gated.
  2. *Archera sponsors CUDly's development with a fraction of their insurance revenue.* The honest reason CUDly surfaces this option.

  Then: plain-language explainer of commitment-overuse insurance, when it makes sense, and the 7-day post-purchase enrollment window.

- **Page B — "How the CUDly ↔ Archera integration works"** carries a shorter "**Disclosure**" subheading near the top mirroring both facts in one sentence each, then the step-by-step integration flow (signup → Archera's own pre-filled IaC for AWS/GCP / OAuth consent for Azure → cost-data ingestion).

Both pages cross-link and carry `https://archera.ai/signup?mode=cudly` (`target=_blank`, `rel="noopener noreferrer"`).

**Email surfaces** (new in this iteration):

- `internal/email/templates.go` → `purchaseApprovalRequestTemplate` (plain text) + `purchaseApprovalRequestHTMLTemplate` (HTML): brief Archera Insurance mention near the bottom noting the buyer will have **7 days from each purchase** to enroll. Links to the education page.
- `internal/email/templates.go` → `purchaseConfirmationTemplate`: more prominent placement (7-day clock now active) with direct signup link.
- `template_renderers.go` extended to populate `ArcheraEducationURL` on the relevant data structs.

Skipped (per #314's body): `purchaseFailedTemplate`, `scheduledPurchaseTemplate`, RI exchange templates.

**Regression-guard tests:**
- Both education pages assert presence of both disclosure facts (no-gating + sponsorship-revenue) — so future copy edits can't silently remove them.
- Email render tests assert "Archera" + "7 days" + signup-link string in both approval and confirmation templates.

## Why the previous directions were abandoned

| PR | Direction | Why closed |
|---|---|---|
| #310 | Bundle Archera IAM trust policy into CUDly's federation IaC | (a) External ID is derived from customer's Archera org ID which only exists post-signup; (b) Azure integration is OAuth consent, not RBAC role; (c) Archera ships pre-filled IaC themselves — duplicating creates drift surface |
| #315 | Shared Terraform module + Settings → Federation Setup checkbox | Same three problems + Settings is the wrong conversion moment |
| (cancelled) | Settings checkbox + signup link | Settings is the wrong UX moment — high-intent surfaces are at purchase time |
| **#336 (this)** | Modal CTA + education pages + email mentions | Right surfaces, no IAM duplication, transparency disclosures land where users will see them |

## Acceptance criteria

- [x] Purchase modal renders the simplified CTA; click opens Page A.
- [x] Plan-creation modal (both `openCreatePlanModal` and `openNewPlanModal` paths) renders the simplified CTA; same target.
- [x] Page A leads with the transparency disclosures (no-gating + sponsorship) before product detail.
- [x] Page B includes a "Disclosure" subheading mirroring both facts.
- [x] Both pages cross-link + carry signup link.
- [x] `purchaseApprovalRequestTemplate` + HTML variant mention Archera + 7-day window + education-page link.
- [x] `purchaseConfirmationTemplate` mentions Archera + 7-day window + direct signup link.
- [x] Frontend tests for CTAs + page navigation + signup-link attributes.
- [x] Regression-guard tests asserting both disclosure facts appear on both pages.
- [x] Email render tests asserting Archera mention + 7-day window + signup link.
- [x] Accessibility: CTAs are `<button>` elements with discernible names; overlay has `role=region` + `aria-label`; back button keyboard-reachable; heading hierarchy (h1 → h2) within overlay.
- [x] `TODO(@cristim): final copy` / `TODO(@cristim): final disclosure copy` markers left wherever wording is provisional.

## Not in scope

- Settings → Federation Setup checkbox (dropped from earlier iterations).
- API / handler changes — none.
- Bundle template changes — none (`internal/iacfiles/templates/`, `iac/federation/`, `iac/modules/`, `terraform/environments/<cloud>/archera.tf`, `scripts/generate-federation-iac.go`, `scripts/check-archera-parity.sh` — untouched).
- Authentication / payment integration — none (signup happens on Archera's side).

## TODO(@cristim) markers left for review

| Location | What needs review |
|---|---|
| Page A "Why is CUDly telling me about this?" | Final disclosure copy (no-gating + sponsorship wording) |
| Page A intro paragraph | Plain-language explainer wording |
| Page A "How it works" section | Revenue model description |
| Page B "Disclosure" subheading | Shorter disclosure wording |
| Page B step 1 | Confirm exact onboarding URL/flow with Archera |
| Page B step 2 | Confirm "Terraform/CloudFormation" for AWS and GCP |
| Page B "Disclaimers" | Disclaimer language with legal/Archera |
| Both modal CTAs | "Insure this commitment with Archera →" / "Insure this plan with Archera →" wording |
| Both email templates | Final Archera section copy + 7-day window wording |

## Closes / Supersedes

- Closes #314
- Supersedes #310 (closed without merging)
- Supersedes #315 (closed without merging)
- #305 closed as not-planned (the original IaC-bundling approach was rejected)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Archera education overlay and post-purchase/plan offer modal with deeplink support, signup CTA, and improved keyboard/focus behavior
* **Style**
  * Added styling for Archera overlay, modal, CTA, disclosure and responsive layout
* **Email**
  * Purchase-related emails now conditionally include Archera enrollment info and signup links (7-day enrollment wording)
* **Tests**
  * New UI tests for overlay/modal flows and email template tests verifying Archera content inclusion

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/336)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->