### PR TITLE
fix(email): unbreak factory_test.go after #333 merge glitch

### DIFF
--- a/internal/email/factory_test.go
+++ b/internal/email/factory_test.go
@@ -256,14 +256,6 @@ func TestNewSenderFromEnvironment_EmailEnabled(t *testing.T) {
 
 	// Unset / empty → factory takes the default-enabled path.
 	t.Run("unset_falls_through", func(t *testing.T) {
-		orig, hadOrig := os.LookupEnv("EMAIL_ENABLED")
-		t.Cleanup(func() {
-			if hadOrig {
-				os.Setenv("EMAIL_ENABLED", orig)
-			} else {
-				os.Unsetenv("EMAIL_ENABLED")
-			}
-	t.Run("unset_falls_through", func(t *testing.T) {
 		prev, hadPrev := os.LookupEnv("EMAIL_ENABLED")
 		os.Unsetenv("EMAIL_ENABLED")
 		t.Cleanup(func() {
@@ -274,8 +266,6 @@ func TestNewSenderFromEnvironment_EmailEnabled(t *testing.T) {
 			os.Unsetenv("EMAIL_ENABLED")
 		})
 		aws(t)
-		ctx := context.Background()
-		sender, err := NewSenderFromEnvironment(ctx)
 		ctx := context.Background()
 		sender, err := NewSenderFromEnvironment(ctx)
 		require.NoError(t, err)


### PR DESCRIPTION
## Summary

- PR #333 (closes #332) merged 25 min ago left `internal/email/factory_test.go` with two overlapping `t.Run("unset_falls_through", ...)` blocks — one missing its closing braces, one followed by duplicated `ctx :=` / `sender, err :=` lines. The file no longer parses.
- This trips `gofmt` + `go vet` in the **`pre-commit`** workflow on **every** open PR against `feat/multicloud-web-frontend` (#326, #335, #336, …). Independent of any individual PR's changes — the broken bytes live on the base.
- Keep the `prev/hadPrev` version of the sub-test (the one that actually `Unsetenv`s `EMAIL_ENABLED` first, which is what the test name describes), drop the orphaned `orig/hadOrig` fragment, and remove the duplicate ctx/sender pair.

## Reproduction

```bash
git checkout origin/feat/multicloud-web-frontend
gofmt -l internal/email/factory_test.go
# internal/email/factory_test.go:309:2: missing ',' before newline in argument list
# internal/email/factory_test.go:312:6: expected '(', found TestNewSenderWithConfig_AWS
# ...
```

Or check the failing pre-commit step on any open PR against the base — same error shape.

## Test plan

- [x] `gofmt -l internal/email/factory_test.go` — clean
- [x] `go vet ./internal/email/...` — clean
- [x] `go test ./internal/email/...` — 306 tests pass
- [ ] CI on this PR's `pre-commit` job goes green (this is the workflow that was previously red on every PR)
- [ ] After merge, re-run CI on PR #326 / #335 / #336 and confirm the same pre-commit step now passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved environment variable cleanup and restoration in email factory tests for more robust test isolation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/337)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->