### PR TITLE
feat(cli): size purchases by target RI/SP utilization (--target-utilization, closes #338)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,21 @@ go install github.com/LeanerCloud/CUDly/cmd@latest
 |------|-------------|---------|
 | `-p, --payment` | Payment option: `all-upfront`, `partial-upfront`, `no-upfront` | no-upfront |
 | `-t, --term` | Term in years: `1` or `3` | 3 |
-| `-c, --coverage` | Coverage percentage (0-100) | 80 |
+| `-c, --coverage` | Coverage percentage (0-100) — % of each recommendation's instance count to purchase | 80 |
+| `-u, --target-utilization` | Target post-purchase utilization % (0-100). Sizes purchases so projected utilization stays >= target. Overrides `--coverage`. | 0 (disabled) |
 | `--max-instances` | Maximum instances to purchase (0 = unlimited) | 0 |
 | `--override-count` | Override recommended count with specific value | 0 |
+
+> **`--coverage` vs `--target-utilization`** — two different sizing
+> levers. `--coverage` is "how much of the recommendation should I
+> buy?" (scales the instance count proportionally). `--target-utilization`
+> is "how aggressively can the commitment be used?" (sizes the buy
+> against historical hourly usage so each unit hits the target
+> utilization). **Counter-intuitively, a higher `--target-utilization`
+> means buying *fewer* commitments**: utilization is used÷bought, so
+> raising the target shrinks the bought side. Use `--target-utilization`
+> when you'd rather under-buy and spill to on-demand than over-buy and
+> leave commitments idle.
 
 ### Execution Control
 

--- a/README.md
+++ b/README.md
@@ -115,20 +115,20 @@ go install github.com/LeanerCloud/CUDly/cmd@latest
 | `-p, --payment` | Payment option: `all-upfront`, `partial-upfront`, `no-upfront` | no-upfront |
 | `-t, --term` | Term in years: `1` or `3` | 3 |
 | `-c, --coverage` | Coverage percentage (0-100) — % of each recommendation's instance count to purchase | 80 |
-| `-u, --target-utilization` | Target post-purchase utilization % (0-100). Sizes purchases so projected utilization stays >= target. Overrides `--coverage`. | 0 (disabled) |
+| `-u, --target-coverage` | Target % (0-100) of historical demand to cover with commitments; the rest spills to on-demand. Sizes counts so projected coverage approximates target, projected utilization stays near 100%. Overrides `--coverage`. | 0 (disabled) |
 | `--max-instances` | Maximum instances to purchase (0 = unlimited) | 0 |
 | `--override-count` | Override recommended count with specific value | 0 |
 
-> **`--coverage` vs `--target-utilization`** — two different sizing
-> levers. `--coverage` is "how much of the recommendation should I
-> buy?" (scales the instance count proportionally). `--target-utilization`
-> is "how aggressively can the commitment be used?" (sizes the buy
-> against historical hourly usage so each unit hits the target
-> utilization). **Counter-intuitively, a higher `--target-utilization`
-> means buying *fewer* commitments**: utilization is used÷bought, so
-> raising the target shrinks the bought side. Use `--target-utilization`
-> when you'd rather under-buy and spill to on-demand than over-buy and
-> leave commitments idle.
+> **`--coverage` vs `--target-coverage`**: two related but distinct
+> sizing levers. `--coverage` scales each AWS recommendation's instance
+> count by a fixed fraction (`rec.Count * coverage/100`).
+> `--target-coverage` sizes against historical average hourly usage
+> instead (`floor(avg * target/100)`), so the resulting count reflects
+> real demand rather than AWS's recommended count. Both lean the same
+> direction (higher value = more RIs, lower value = fewer), but
+> `--target-coverage` is the right lever when the historical-usage
+> signal is what you want to size by and you're explicitly leaving
+> on-demand headroom for growth or bursts.
 
 ### Execution Control
 

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -144,10 +144,8 @@ func ApplyCoverage(recs []common.Recommendation, coverage float64) []common.Reco
 			if details, ok := rec.Details.(*common.SavingsPlanDetails); ok {
 				newDetails := *details // Copy the struct
 				newDetails.HourlyCommitment = newDetails.HourlyCommitment * ratio
+				adjusted = common.ScaleRecommendationCosts(adjusted, ratio)
 				adjusted.Details = &newDetails
-				adjusted.CommitmentCost = rec.CommitmentCost * ratio
-				adjusted.OnDemandCost = rec.OnDemandCost * ratio
-				adjusted.EstimatedSavings = rec.EstimatedSavings * ratio
 			} else {
 				AppLogger.Printf("WARNING: SP recommendation for service %q has unexpected Details type %T; passing through unscaled\n", rec.Service, rec.Details)
 			}
@@ -167,14 +165,8 @@ func ApplyCoverage(recs []common.Recommendation, coverage float64) []common.Reco
 		newCount := int(float64(rec.Count) * ratio)
 		if newCount > 0 {
 			sizedRatio := float64(newCount) / float64(rec.Count)
+			adjusted = common.ScaleRecommendationCosts(adjusted, sizedRatio)
 			adjusted.Count = newCount
-			adjusted.CommitmentCost = rec.CommitmentCost * sizedRatio
-			adjusted.OnDemandCost = rec.OnDemandCost * sizedRatio
-			adjusted.EstimatedSavings = rec.EstimatedSavings * sizedRatio
-			if rec.RecurringMonthlyCost != nil {
-				scaled := *rec.RecurringMonthlyCost * sizedRatio
-				adjusted.RecurringMonthlyCost = &scaled
-			}
 			result = append(result, adjusted)
 		}
 	}
@@ -390,15 +382,8 @@ func applyTargetCoverageRI(rec common.Recommendation, targetPct float64) (common
 	} else {
 		ratio = float64(nTarget)
 	}
-	adjusted := rec
+	adjusted := common.ScaleRecommendationCosts(rec, ratio)
 	adjusted.Count = nTarget
-	adjusted.CommitmentCost = rec.CommitmentCost * ratio
-	adjusted.OnDemandCost = rec.OnDemandCost * ratio
-	adjusted.EstimatedSavings = rec.EstimatedSavings * ratio
-	if rec.RecurringMonthlyCost != nil {
-		scaled := *rec.RecurringMonthlyCost * ratio
-		adjusted.RecurringMonthlyCost = &scaled
-	}
 
 	// Projection metrics. ProjectedCoverage is TOTAL coverage (existing +
 	// new) so operators can see the figure they actually targeted.
@@ -454,15 +439,8 @@ func applyTargetCoverageSP(rec common.Recommendation, targetPct float64) (common
 	ratio := targetPct / 100.0
 	newDetails := *details // copy
 	newDetails.HourlyCommitment = newDetails.HourlyCommitment * ratio
-	adjusted := rec
+	adjusted := common.ScaleRecommendationCosts(rec, ratio)
 	adjusted.Details = &newDetails
-	adjusted.CommitmentCost = rec.CommitmentCost * ratio
-	adjusted.OnDemandCost = rec.OnDemandCost * ratio
-	adjusted.EstimatedSavings = rec.EstimatedSavings * ratio
-	if rec.RecurringMonthlyCost != nil {
-		scaled := *rec.RecurringMonthlyCost * ratio
-		adjusted.RecurringMonthlyCost = &scaled
-	}
 	// Shrinking commitment raises projected utilization by 1/ratio
 	// (used is fixed = orig_commit * RecUtil, bought is orig_commit * ratio).
 	// Clamp to 100 since utilization caps at full use.

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"math"
 	"os"
 	"strings"
 	"sync"
@@ -154,6 +155,217 @@ func ApplyCoverage(recs []common.Recommendation, coverage float64) []common.Reco
 		}
 	}
 	return result
+}
+
+// ApplyTargetUtilization sizes RI/SP recommendations so projected post-purchase
+// utilization stays >= targetPct. See ApplyCoverage for the alternative
+// coverage-based sizing; the two are dispatched via applySizing.
+//
+// Semantics inversion vs. intuition: higher targetPct means fewer commitments
+// bought (smaller waste ceiling), not more. The math is "utilization =
+// used/bought", so raising the target reduces the bought side.
+//
+// RIs:
+//
+//	n_target = floor(AverageInstancesUsedPerHour / (targetPct/100))
+//	capped at rec.Count (we never exceed AWS's recommended ceiling).
+//	If n_target == 0 → drop with explanatory INFO log (target unreachable).
+//	If AverageInstancesUsedPerHour <= 0 → pass through (no signal); counted
+//	in the per-run skip summary.
+//
+// SPs:
+//
+//	If RecommendedUtilization >= targetPct → no scaling (AWS already projects
+//	above target).
+//	Else ratio = RecommendedUtilization / targetPct (always < 1). Scale
+//	SavingsPlanDetails.HourlyCommitment and rec.EstimatedSavings — matching
+//	exactly the fields ApplyCoverage scales on the SP branch, so the two
+//	sizing modes stay structurally consistent.
+//	If RecommendedUtilization <= 0 → pass through; counted in skip summary.
+//
+// Recs of any other CommitmentType are passed through unmodified (warned
+// once per type per run).
+func ApplyTargetUtilization(recs []common.Recommendation, targetPct float64) []common.Recommendation {
+	if targetPct <= 0 || targetPct > 100 {
+		// Validation ensures we never get here in production, but be defensive
+		// so a buggy caller doesn't divide by zero.
+		AppLogger.Printf("WARNING: ApplyTargetUtilization called with targetPct=%.2f outside (0,100]; returning recs unchanged\n", targetPct)
+		return recs
+	}
+
+	target := targetPct / 100.0
+	result := make([]common.Recommendation, 0, len(recs))
+	var skipped int
+	unsupportedSeen := make(map[common.CommitmentType]bool)
+
+	for _, rec := range recs {
+		adjusted, kept, missingSignal := applyTargetUtilizationOne(rec, target, targetPct, unsupportedSeen)
+		if missingSignal {
+			skipped++
+		}
+		if kept {
+			result = append(result, adjusted)
+		}
+	}
+
+	if skipped > 0 {
+		AppLogger.Printf("INFO: --target-utilization=%.1f%% skipped %d of %d recommendations with no utilization signal (passed through unchanged)\n",
+			targetPct, skipped, len(recs))
+	}
+
+	return result
+}
+
+// applyTargetUtilizationOne dispatches a single recommendation through the
+// appropriate branch. Returns (rec, kept, missingSignal):
+//   - kept=true → caller appends `rec` (the adjusted or pass-through value).
+//   - kept=false → caller drops the rec (only the RI "target unreachable"
+//     branch returns this; an INFO log already fired).
+//   - missingSignal=true → counted toward the end-of-run skip summary.
+//
+// Split out of ApplyTargetUtilization to keep that function under gocyclo's
+// complexity threshold.
+func applyTargetUtilizationOne(rec common.Recommendation, target, targetPct float64, unsupportedSeen map[common.CommitmentType]bool) (common.Recommendation, bool, bool) {
+	switch {
+	case common.IsSavingsPlan(rec.Service):
+		adjusted, ok := applyTargetUtilizationSP(rec, targetPct)
+		if !ok {
+			// SP no-signal: pass through unchanged.
+			return rec, true, true
+		}
+		return adjusted, true, false
+	case rec.CommitmentType == common.CommitmentReservedInstance:
+		adjusted, ok := applyTargetUtilizationRI(rec, target, targetPct)
+		if !ok {
+			// Distinguish "no signal" (pass through, count in summary) from
+			// "target unreachable" (drop with already-fired INFO log).
+			if rec.AverageInstancesUsedPerHour <= 0 {
+				return rec, true, true
+			}
+			return rec, false, false
+		}
+		return adjusted, true, false
+	default:
+		if !unsupportedSeen[rec.CommitmentType] {
+			AppLogger.Printf("WARNING: --target-utilization not supported for CommitmentType=%q; passing recommendations through unchanged\n", rec.CommitmentType)
+			unsupportedSeen[rec.CommitmentType] = true
+		}
+		return rec, true, false
+	}
+}
+
+// applyTargetUtilizationRI is the RI branch of ApplyTargetUtilization. Returns
+// (adjusted, true) on success, (rec, false) when the rec should be passed
+// through unscaled (no signal) or dropped (target unreachable). Caller
+// distinguishes the two via rec.AverageInstancesUsedPerHour.
+func applyTargetUtilizationRI(rec common.Recommendation, target, targetPct float64) (common.Recommendation, bool) {
+	if rec.AverageInstancesUsedPerHour <= 0 {
+		// No signal — caller will pass through and count in the summary.
+		return rec, false
+	}
+
+	avg := rec.AverageInstancesUsedPerHour
+	uncappedTarget := int(math.Floor(avg / target))
+
+	// Cap at rec.Count: never buy more than AWS recommended.
+	nTarget := uncappedTarget
+	capped := false
+	if nTarget > rec.Count {
+		nTarget = rec.Count
+		capped = true
+	}
+
+	if nTarget == 0 {
+		// Target unreachable: even buying 1 instance would over-utilize beyond
+		// the user's target. Drop with explanatory log per issue #338 AC.
+		AppLogger.Printf("INFO: --target-utilization=%.1f%% unreachable for %s/%s/%s (avg used %.2f/hr requires <1 instance for target) — dropped recommendation\n",
+			targetPct, rec.Service, rec.Region, rec.ResourceType, avg)
+		// Returning (_, false) with avg > 0 signals "drop, don't pass through".
+		// applyTargetUtilizationRI's caller branches on
+		// rec.AverageInstancesUsedPerHour to distinguish drop vs no-signal.
+		return rec, false
+	}
+
+	if capped {
+		// Target was too lenient — AWS's ceiling binds before we reach the
+		// target's "buy this many" suggestion.
+		AppLogger.Printf("INFO: --target-utilization=%.1f%% would have recommended %d instances for %s/%s/%s but capped at AWS ceiling of %d\n",
+			targetPct, uncappedTarget, rec.Service, rec.Region, rec.ResourceType, nTarget)
+	}
+
+	adjusted := rec
+	adjusted.Count = nTarget
+
+	// Cost-scaling — mirror ApplyCoverage's RI branch (only Count is scaled
+	// implicitly via the new count; ApplyCoverage doesn't scale RI cost
+	// fields explicitly either, so we don't here).
+
+	// Projection metrics.
+	projUtil := avg / float64(nTarget) * 100.0
+	if projUtil > 100 {
+		projUtil = 100
+	}
+	projCov := float64(nTarget) / avg * 100.0
+	if projCov > 100 {
+		projCov = 100
+	}
+	adjusted.ProjectedUtilization = projUtil
+	adjusted.ProjectedCoverage = projCov
+	return adjusted, true
+}
+
+// applyTargetUtilizationSP is the SP branch of ApplyTargetUtilization. Returns
+// (adjusted, true) when the rec is kept, (rec, false) when it should be
+// skipped (caller passes through unscaled and counts in the skip summary).
+func applyTargetUtilizationSP(rec common.Recommendation, targetPct float64) (common.Recommendation, bool) {
+	if rec.RecommendedUtilization <= 0 {
+		return rec, false
+	}
+
+	adjusted := rec
+	if rec.RecommendedUtilization >= targetPct {
+		// AWS already projects at-or-above target — no scaling, but we do
+		// surface the projected utilization in the output.
+		adjusted.ProjectedUtilization = rec.RecommendedUtilization
+		// ProjectedCoverage is intentionally left at zero for SPs — see
+		// the package doc on the field; we don't have total-demand-$ from
+		// CE to compute SP coverage cleanly.
+		return adjusted, true
+	}
+
+	// AWS projects below target. Scale commitment down by ratio = recommended/target
+	// so projected utilization rises to exactly target.
+	ratio := rec.RecommendedUtilization / targetPct
+
+	// Only the SP fields that ApplyCoverage scales — HourlyCommitment (via
+	// the polymorphic Details copy) and EstimatedSavings. Do NOT touch
+	// CommitmentCost, OnDemandCost, or SavingsPercentage; ApplyCoverage
+	// doesn't either, and divergence would silently desync the two modes.
+	if details, ok := rec.Details.(*common.SavingsPlanDetails); ok {
+		newDetails := *details // copy
+		newDetails.HourlyCommitment = newDetails.HourlyCommitment * ratio
+		adjusted.Details = &newDetails
+		adjusted.EstimatedSavings = rec.EstimatedSavings * ratio
+	} else {
+		AppLogger.Printf("WARNING: SP recommendation for service %q has unexpected Details type %T; passing through unscaled\n", rec.Service, rec.Details)
+	}
+
+	adjusted.ProjectedUtilization = targetPct
+	// ProjectedCoverage left at zero for SPs (see above).
+	return adjusted, true
+}
+
+// applySizing chooses target-utilization or coverage sizing.
+//
+// coverage is the effective % to apply when target-utilization is unset
+// (the main path passes cfg.Coverage; the CSV path passes csvModeCoverage,
+// which substitutes the default 80% with 100% so CSV-driven counts aren't
+// silently dropped).
+func applySizing(recs []common.Recommendation, cfg Config, coverage float64) []common.Recommendation {
+	if cfg.TargetUtilization > 0 {
+		return ApplyTargetUtilization(recs, cfg.TargetUtilization)
+	}
+	return ApplyCoverage(recs, coverage)
 }
 
 // ApplyCountOverride overrides the count for all recommendations

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -188,9 +188,8 @@ func ApplyCoverage(recs []common.Recommendation, coverage float64) []common.Reco
 // RIs:
 //
 //	gap = (targetPct - ExistingCoveragePct) / 100
-//	n_target = floor(AverageInstancesUsedPerHour * gap)
+//	n_target = ceil(AverageInstancesUsedPerHour * gap)
 //	If gap <= 0 (existing already at/above target) → drop with INFO log.
-//	If n_target == 0 (gap too small to justify a single RI) → drop with INFO log.
 //	If AverageInstancesUsedPerHour <= 0 → pass through (no signal); counted
 //	in the per-run skip summary.
 //	Projected coverage = ExistingCoveragePct + n_target/avg * 100 (total
@@ -198,7 +197,14 @@ func ApplyCoverage(recs []common.Recommendation, coverage float64) []common.Reco
 //	avg/n_target * 100 clamped to 100.
 //	ExistingCoveragePct is sourced from CE GetReservationCoverage in the
 //	same pool; zero means "no signal" and the formula falls back to the
-//	no-existing-commitments path.
+//	no-existing-commitments path. For RDS, the coverage lookup keys by
+//	(region, instance_type, engine) — the per-engine fetcher in
+//	coverage.go avoids the cross-engine bleed that floor + per-pool
+//	aggregate produced.
+//	Ceil (rather than floor or round) ensures any non-zero gap with
+//	non-zero demand buys at least 1 RI — AWS's recommendation list
+//	always proposes a count, and silently dropping single-instance pools
+//	was the worse failure mode than slight over-target on tiny pools.
 //
 // SPs:
 //
@@ -300,8 +306,8 @@ func applyTargetCoverageRI(rec common.Recommendation, targetPct float64) (common
 	//
 	// Keep the subtraction in percentage units (subtract first, divide by 100
 	// after) so whole-percent values don't lose precision: 0.70 - 0.60 in
-	// float64 rounds to 0.0999... and floor(avg * that) silently rounds the
-	// count down by 1.
+	// float64 rounds to 0.0999... and ceil(avg * that) would silently round
+	// up by 1.
 	gapPct := targetPct - rec.ExistingCoveragePct
 	if gapPct <= 0 {
 		// Existing commitments already meet or exceed the target; no purchase
@@ -312,12 +318,19 @@ func applyTargetCoverageRI(rec common.Recommendation, targetPct float64) (common
 			targetPct, rec.ExistingCoveragePct, rec.Service, rec.Region, rec.ResourceType)
 		return rec, false
 	}
-	nTarget := int(math.Floor(avg * gapPct / 100.0))
+	// Round up so any non-zero gap with non-zero demand buys at least 1 RI.
+	// Floor used to drop single-instance pools (avg=1, gap=80% → floor(0.8)=0)
+	// which made --target-coverage=80 silently skip a third of the AWS-console
+	// recommendation list. Ceil matches AWS's behaviour of recommending 1 RI
+	// for any non-empty pool; the slight over-target on small pools (avg=2,
+	// target=80% gives 2 RIs = 100% coverage) is acceptable — under-target
+	// silence was the worse failure mode.
+	nTarget := int(math.Ceil(avg * gapPct / 100.0))
 
 	if nTarget == 0 {
-		// Coverage gap too small to justify even a single RI for this pool's avg
-		// usage (e.g. avg=0.5 with target=70% yields floor(0.35)=0). Drop with
-		// an explanatory log so operators can see what the flag did.
+		// Defensive: math.Ceil on a positive product never returns 0, but a
+		// truncation or tiny-float edge case could. Drop with a log if it
+		// somehow happens.
 		AppLogger.Printf("INFO: --target-coverage=%.1f%% sizes %s/%s/%s to 0 instances (avg used %.2f/hr, gap %.2f%% produces <1 RI); dropped recommendation\n",
 			targetPct, rec.Service, rec.Region, rec.ResourceType, avg, gapPct)
 		// Returning (_, false) with avg > 0 signals "drop, don't pass through".

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -155,13 +155,26 @@ func ApplyCoverage(recs []common.Recommendation, coverage float64) []common.Reco
 			continue
 		}
 
-		// For RIs, reduce the count and scale cost-bearing fields proportionally.
+		// For RIs, reduce the count and scale cost-bearing fields by the
+		// DISCRETE count ratio (newCount / rec.Count) rather than the
+		// requested ratio. Truncating newCount to an int then multiplying
+		// costs by the unrounded ratio desynchronises Count and costs:
+		// e.g. rec.Count=3 + ratio=0.5 yields newCount=1 (33% of instances)
+		// but costs would scale to 50%, overstating the sized purchase
+		// price by ~50%. Mirrors ApplyTargetCoverage / family-NU sizing.
+		// rec.Count is guaranteed > 0 here because newCount > 0 implies
+		// rec.Count >= 1 (int(0 * ratio) is 0 for any ratio).
 		newCount := int(float64(rec.Count) * ratio)
 		if newCount > 0 {
+			sizedRatio := float64(newCount) / float64(rec.Count)
 			adjusted.Count = newCount
-			adjusted.CommitmentCost = rec.CommitmentCost * ratio
-			adjusted.OnDemandCost = rec.OnDemandCost * ratio
-			adjusted.EstimatedSavings = rec.EstimatedSavings * ratio
+			adjusted.CommitmentCost = rec.CommitmentCost * sizedRatio
+			adjusted.OnDemandCost = rec.OnDemandCost * sizedRatio
+			adjusted.EstimatedSavings = rec.EstimatedSavings * sizedRatio
+			if rec.RecurringMonthlyCost != nil {
+				scaled := *rec.RecurringMonthlyCost * sizedRatio
+				adjusted.RecurringMonthlyCost = &scaled
+			}
 			result = append(result, adjusted)
 		}
 	}

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -187,14 +187,18 @@ func ApplyCoverage(recs []common.Recommendation, coverage float64) []common.Reco
 //
 // RIs:
 //
-//	n_target = floor(AverageInstancesUsedPerHour * targetPct/100)
-//	If n_target == 0 → drop with explanatory INFO log (target too low to
-//	support even one RI for this rec).
+//	gap = (targetPct - ExistingCoveragePct) / 100
+//	n_target = floor(AverageInstancesUsedPerHour * gap)
+//	If gap <= 0 (existing already at/above target) → drop with INFO log.
+//	If n_target == 0 (gap too small to justify a single RI) → drop with INFO log.
 //	If AverageInstancesUsedPerHour <= 0 → pass through (no signal); counted
 //	in the per-run skip summary.
-//	Projected coverage = n_target/avg * 100 (clamps below targetPct slightly
-//	because of integer floor; e.g. avg=31.3 with target=70 gives n=21,
-//	cov=67%). Projected utilization = avg/n_target * 100 clamped to 100.
+//	Projected coverage = ExistingCoveragePct + n_target/avg * 100 (total
+//	coverage after the purchase, clamped to 100). Projected utilization =
+//	avg/n_target * 100 clamped to 100.
+//	ExistingCoveragePct is sourced from CE GetReservationCoverage in the
+//	same pool; zero means "no signal" and the formula falls back to the
+//	no-existing-commitments path.
 //
 // SPs:
 //
@@ -217,13 +221,12 @@ func ApplyTargetCoverage(recs []common.Recommendation, targetPct float64) []comm
 		return recs
 	}
 
-	target := targetPct / 100.0
 	result := make([]common.Recommendation, 0, len(recs))
 	var skipped int
 	unsupportedSeen := make(map[common.CommitmentType]bool)
 
 	for _, rec := range recs {
-		adjusted, kept, missingSignal := applyTargetCoverageOne(rec, target, targetPct, unsupportedSeen)
+		adjusted, kept, missingSignal := applyTargetCoverageOne(rec, targetPct, unsupportedSeen)
 		if missingSignal {
 			skipped++
 		}
@@ -249,7 +252,7 @@ func ApplyTargetCoverage(recs []common.Recommendation, targetPct float64) []comm
 //
 // Split out of ApplyTargetCoverage to keep that function under gocyclo's
 // complexity threshold.
-func applyTargetCoverageOne(rec common.Recommendation, target, targetPct float64, unsupportedSeen map[common.CommitmentType]bool) (common.Recommendation, bool, bool) {
+func applyTargetCoverageOne(rec common.Recommendation, targetPct float64, unsupportedSeen map[common.CommitmentType]bool) (common.Recommendation, bool, bool) {
 	switch {
 	case common.IsSavingsPlan(rec.Service):
 		adjusted, ok := applyTargetCoverageSP(rec, targetPct)
@@ -259,7 +262,7 @@ func applyTargetCoverageOne(rec common.Recommendation, target, targetPct float64
 		}
 		return adjusted, true, false
 	case rec.CommitmentType == common.CommitmentReservedInstance:
-		adjusted, ok := applyTargetCoverageRI(rec, target, targetPct)
+		adjusted, ok := applyTargetCoverageRI(rec, targetPct)
 		if !ok {
 			// Distinguish "no signal" (pass through, count in summary) from
 			// "target unreachable" (drop with already-fired INFO log).
@@ -282,26 +285,41 @@ func applyTargetCoverageOne(rec common.Recommendation, target, targetPct float64
 // (adjusted, true) on success, (rec, false) when the rec should be passed
 // through unscaled (no signal) or dropped (target unreachable). Caller
 // distinguishes the two via rec.AverageInstancesUsedPerHour.
-func applyTargetCoverageRI(rec common.Recommendation, target, targetPct float64) (common.Recommendation, bool) {
+func applyTargetCoverageRI(rec common.Recommendation, targetPct float64) (common.Recommendation, bool) {
 	if rec.AverageInstancesUsedPerHour <= 0 {
 		// No signal — caller will pass through and count in the summary.
 		return rec, false
 	}
 
 	avg := rec.AverageInstancesUsedPerHour
-	// Under-buy sizing: leave (1 - target)% of historical demand on-demand.
-	// nTarget = floor(avg * target) is the integer RI count whose coverage is
-	// at-most targetPct against historical average usage. Using floor (rather
-	// than round) errs on the side of buying fewer RIs, which matches the
-	// flag's intent: deliberately leave headroom on-demand.
-	nTarget := int(math.Floor(avg * target))
+	// Under-buy sizing accounts for any existing commitments in the same pool:
+	// the count we still need is the coverage gap (target − existing) against
+	// historical demand. ExistingCoveragePct comes from CE GetReservationCoverage
+	// (populated upstream when available) and defaults to zero so recs without
+	// the fetched signal fall back to the no-existing-commitments path.
+	//
+	// Keep the subtraction in percentage units (subtract first, divide by 100
+	// after) so whole-percent values don't lose precision: 0.70 - 0.60 in
+	// float64 rounds to 0.0999... and floor(avg * that) silently rounds the
+	// count down by 1.
+	gapPct := targetPct - rec.ExistingCoveragePct
+	if gapPct <= 0 {
+		// Existing commitments already meet or exceed the target; no purchase
+		// needed in this pool. Drop with an info log so operators can see what
+		// the flag did. Returning (_, false) with avg > 0 signals "drop, don't
+		// pass through".
+		AppLogger.Printf("INFO: --target-coverage=%.1f%% already met by existing coverage %.1f%% for %s/%s/%s; dropped recommendation\n",
+			targetPct, rec.ExistingCoveragePct, rec.Service, rec.Region, rec.ResourceType)
+		return rec, false
+	}
+	nTarget := int(math.Floor(avg * gapPct / 100.0))
 
 	if nTarget == 0 {
-		// Target too low to justify even a single RI for this rec's avg
-		// usage (e.g. avg=0.5 with target=70% yields floor(0.35)=0). Drop
-		// with an explanatory log so operators can see what the flag did.
-		AppLogger.Printf("INFO: --target-coverage=%.1f%% sizes %s/%s/%s to 0 instances (avg used %.2f/hr, target produces <1 RI); dropped recommendation\n",
-			targetPct, rec.Service, rec.Region, rec.ResourceType, avg)
+		// Coverage gap too small to justify even a single RI for this pool's avg
+		// usage (e.g. avg=0.5 with target=70% yields floor(0.35)=0). Drop with
+		// an explanatory log so operators can see what the flag did.
+		AppLogger.Printf("INFO: --target-coverage=%.1f%% sizes %s/%s/%s to 0 instances (avg used %.2f/hr, gap %.2f%% produces <1 RI); dropped recommendation\n",
+			targetPct, rec.Service, rec.Region, rec.ResourceType, avg, gapPct)
 		// Returning (_, false) with avg > 0 signals "drop, don't pass through".
 		// applyTargetCoverageRI's caller branches on
 		// rec.AverageInstancesUsedPerHour to distinguish drop vs no-signal.
@@ -313,7 +331,9 @@ func applyTargetCoverageRI(rec common.Recommendation, target, targetPct float64)
 	// proposal. SavingsPercentage is invariant (savings vs on-demand ratio).
 	// rec.Count is the AWS pre-sizing count at this point (parser sets Count
 	// == RecommendedCount and we haven't mutated either yet), so dividing by
-	// it gives the correct scaling factor.
+	// it gives the correct scaling factor. AWS's rec.Count is sized to reach
+	// ~100% coverage net of existing commitments, so scaling by nTarget/rec.Count
+	// equivalently scales by gap/(1-existing_cov), which is the correct ratio.
 	ratio := float64(nTarget) / float64(rec.Count)
 	adjusted := rec
 	adjusted.Count = nTarget
@@ -321,12 +341,15 @@ func applyTargetCoverageRI(rec common.Recommendation, target, targetPct float64)
 	adjusted.OnDemandCost = rec.OnDemandCost * ratio
 	adjusted.EstimatedSavings = rec.EstimatedSavings * ratio
 
-	// Projection metrics.
+	// Projection metrics. ProjectedCoverage is TOTAL coverage (existing +
+	// new) so operators can see the figure they actually targeted.
+	// ProjectedUtilization stays at the per-purchase fill rate; under-buy
+	// keeps nTarget <= avg so it always clamps to 100%.
 	projUtil := avg / float64(nTarget) * 100.0
 	if projUtil > 100 {
 		projUtil = 100
 	}
-	projCov := float64(nTarget) / avg * 100.0
+	projCov := rec.ExistingCoveragePct + float64(nTarget)/avg*100.0
 	if projCov > 100 {
 		projCov = 100
 	}

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -185,35 +185,31 @@ func ApplyCoverage(recs []common.Recommendation, coverage float64) []common.Reco
 // commitments actually purchased), not the over-buy semantics that floor
 // produces; see the #338 review discussion for the redirect.
 //
-// RIs (hybrid: AWS-scaled floor + existing-coverage subtraction):
+// RIs (existing-aware, per-pool):
 //
-//	awsScaled    = ceil(rec.Count * targetPct / 100)
-//	existingAware = ceil(avg * (targetPct - ExistingCoveragePct) / 100)
-//	                (only when the gap is positive; else 0)
-//	n_target      = max(awsScaled, existingAware)
-//
-//	The MAX keeps the AWS-scaled count as a floor so pools where CE
-//	coverage reports 100% but AWS still recommends new RIs (typical when
-//	existing RIs are near expiry, or when per-account vs org-wide
-//	averaging in CE under-counts a specific account's actual coverage)
-//	still get sized. The existing-aware branch wins when target exceeds
-//	AWS's implied target or when rec.Count is zero.
-//
+//	gap = (targetPct - ExistingCoveragePct) / 100
+//	n_target = ceil(AverageInstancesUsedPerHour * gap)
+//	If gap <= 0 (existing already at/above target) → drop with INFO log.
 //	If AverageInstancesUsedPerHour <= 0 → pass through (no signal); counted
 //	in the per-run skip summary.
-//	If both candidates are zero (no AWS rec + existing >= target) → drop
-//	with INFO log.
-//
 //	Projected coverage = ExistingCoveragePct + n_target/avg * 100 (total
 //	coverage after the purchase, clamped to 100). Projected utilization =
 //	avg/n_target * 100 clamped to 100.
+//
 //	ExistingCoveragePct is sourced from CE GetReservationCoverage in the
-//	same pool; zero means "no signal". For RDS the coverage lookup keys
-//	by (region, instance_type, engine) — the per-engine fetcher in
-//	coverage.go avoids the cross-engine bleed that the per-pool
-//	aggregate produced.
-//	Ceil (rather than floor or round) ensures any non-zero candidate
-//	rounds up to at least 1 RI, matching AWS's recommendation shape.
+//	same pool; zero means "no signal" and the formula falls back to the
+//	no-existing-commitments path. For RDS, the coverage lookup keys by
+//	(region, instance_type, engine) — the per-engine fetcher in
+//	coverage.go avoids the cross-engine bleed that a per-pool aggregate
+//	would produce.
+//	Ceil (rather than floor) ensures any non-zero gap with non-zero
+//	demand buys at least 1 RI, matching AWS's recommendation shape and
+//	avoiding the "single-instance pool silently dropped" failure mode.
+//
+//	Pools where CE reports 100% existing coverage but AWS still recommends
+//	new RIs (typical when existing RIs are near expiry) are dropped here —
+//	the existing coverage is honoured strictly. Surfacing expiring RIs is
+//	a separate concern tracked elsewhere.
 //
 // SPs:
 //
@@ -307,51 +303,39 @@ func applyTargetCoverageRI(rec common.Recommendation, targetPct float64) (common
 	}
 
 	avg := rec.AverageInstancesUsedPerHour
-	// Hybrid sizing: take the MAX of two candidates so we never undershoot
-	// AWS's recommendation when CE-side existing-coverage data is missing
-	// signal (e.g. RIs about to expire, per-account vs org-wide averaging
-	// discrepancies, etc.).
+	// Under-buy sizing accounts for any existing commitments in the same pool:
+	// the count we still need is the coverage gap (target − existing) against
+	// historical demand. ExistingCoveragePct comes from CE GetReservationCoverage
+	// (populated upstream when available) and defaults to zero so recs without
+	// the fetched signal fall back to the no-existing-commitments path.
 	//
-	//   awsScaled    = ceil(rec.Count × targetPct/100)
-	//     Trusts AWS's rec.Count as the AWS-side optimal count. Scaling by
-	//     target/100 gives the user's chosen fraction of that, matching the
-	//     shape of a --coverage-style run.
-	//
-	//   existingAware = ceil(avg × gap/100) where gap = targetPct - existing
-	//     Subtracts existing pool coverage so we don't double-buy what's
-	//     already reserved. Honours target as a coverage target on demand.
-	//
-	// max(awsScaled, existingAware) always buys at least the AWS-scaled
-	// count, so pools where CE coverage looks 100%-covered but AWS still
-	// recommends new RIs (typical when existing RIs are near expiry) still
-	// get sized. When existing-aware would buy more (e.g. target above AWS's
-	// implied target, or rec.Count == 0), we honour that too.
-	//
-	// Keep the gap subtraction in percentage units before dividing by 100 so
-	// whole-percent values don't lose precision: 0.70 - 0.60 in float64
-	// rounds to 0.0999... and ceil(avg * that) would silently round up by 1.
-	awsScaled := 0
-	if rec.Count > 0 {
-		awsScaled = int(math.Ceil(float64(rec.Count) * targetPct / 100.0))
-	}
+	// Keep the subtraction in percentage units (subtract first, divide by 100
+	// after) so whole-percent values don't lose precision: 0.70 - 0.60 in
+	// float64 rounds to 0.0999... and ceil(avg * that) would silently round
+	// up by 1.
 	gapPct := targetPct - rec.ExistingCoveragePct
-	existingAware := 0
-	if gapPct > 0 {
-		// Ceil ensures any non-zero gap with non-zero demand buys at least 1 RI.
-		existingAware = int(math.Ceil(avg * gapPct / 100.0))
+	if gapPct <= 0 {
+		// Existing commitments already meet or exceed the target; no purchase
+		// needed in this pool. Drop with an info log so operators can see what
+		// the flag did. Returning (_, false) with avg > 0 signals "drop, don't
+		// pass through".
+		AppLogger.Printf("INFO: --target-coverage=%.1f%% already met by existing coverage %.1f%% for %s/%s/%s; dropped recommendation\n",
+			targetPct, rec.ExistingCoveragePct, rec.Service, rec.Region, rec.ResourceType)
+		return rec, false
 	}
-	nTarget := awsScaled
-	if existingAware > nTarget {
-		nTarget = existingAware
-	}
+	// Ceil so any non-zero gap with non-zero demand buys at least 1 RI —
+	// AWS's recommendation list always proposes a count, and silently dropping
+	// single-instance pools was the worse failure mode than slight over-target
+	// on tiny pools. The pre-existing-coverage version of this branch used
+	// floor and silently skipped a third of the AWS-console recommendations.
+	nTarget := int(math.Ceil(avg * gapPct / 100.0))
 
 	if nTarget == 0 {
-		// Both candidates produced zero: AWS didn't recommend (rec.Count==0)
-		// AND existing coverage already meets/exceeds target (gap <= 0).
-		// No purchase warranted in this pool. Drop with an info log so
-		// operators can see what the flag did.
-		AppLogger.Printf("INFO: --target-coverage=%.1f%% met for %s/%s/%s (rec.Count=0, existing=%.1f%%); dropped recommendation\n",
-			targetPct, rec.Service, rec.Region, rec.ResourceType, rec.ExistingCoveragePct)
+		// Defensive: math.Ceil on a positive product never returns 0, but a
+		// truncation or tiny-float edge case could. Drop with a log if it
+		// somehow happens.
+		AppLogger.Printf("INFO: --target-coverage=%.1f%% sizes %s/%s/%s to 0 instances (avg used %.2f/hr, gap %.2f%% produces <1 RI); dropped recommendation\n",
+			targetPct, rec.Service, rec.Region, rec.ResourceType, avg, gapPct)
 		// Returning (_, false) with avg > 0 signals "drop, don't pass through".
 		// applyTargetCoverageRI's caller branches on
 		// rec.AverageInstancesUsedPerHour to distinguish drop vs no-signal.

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -382,6 +382,10 @@ func applyTargetCoverageRI(rec common.Recommendation, targetPct float64) (common
 	adjusted.CommitmentCost = rec.CommitmentCost * ratio
 	adjusted.OnDemandCost = rec.OnDemandCost * ratio
 	adjusted.EstimatedSavings = rec.EstimatedSavings * ratio
+	if rec.RecurringMonthlyCost != nil {
+		scaled := *rec.RecurringMonthlyCost * ratio
+		adjusted.RecurringMonthlyCost = &scaled
+	}
 
 	// Projection metrics. ProjectedCoverage is TOTAL coverage (existing +
 	// new) so operators can see the figure they actually targeted.
@@ -442,6 +446,10 @@ func applyTargetCoverageSP(rec common.Recommendation, targetPct float64) (common
 	adjusted.CommitmentCost = rec.CommitmentCost * ratio
 	adjusted.OnDemandCost = rec.OnDemandCost * ratio
 	adjusted.EstimatedSavings = rec.EstimatedSavings * ratio
+	if rec.RecurringMonthlyCost != nil {
+		scaled := *rec.RecurringMonthlyCost * ratio
+		adjusted.RecurringMonthlyCost = &scaled
+	}
 	// Shrinking commitment raises projected utilization by 1/ratio
 	// (used is fixed = orig_commit * RecUtil, bought is orig_commit * ratio).
 	// Clamp to 100 since utilization caps at full use.

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -157,39 +157,52 @@ func ApplyCoverage(recs []common.Recommendation, coverage float64) []common.Reco
 	return result
 }
 
-// ApplyTargetUtilization sizes RI/SP recommendations so projected post-purchase
-// utilization stays >= targetPct. See ApplyCoverage for the alternative
-// coverage-based sizing; the two are dispatched via applySizing.
+// ApplyTargetCoverage sizes RI/SP recommendations so that projected
+// post-purchase COVERAGE lands near targetPct, leaving (100-targetPct)% of
+// historical demand on-demand as headroom. See ApplyCoverage for the simpler
+// rec.Count-scaled coverage flag; the two are dispatched via applySizing.
 //
-// Semantics inversion vs. intuition: higher targetPct means fewer commitments
-// bought (smaller waste ceiling), not more. The math is "utilization =
-// used/bought", so raising the target reduces the bought side.
+// AWS's recommendation count is sized for ~100% coverage of historical demand
+// (average instances used per hour). --target-coverage is the lever the
+// operator uses to deliberately under-buy that baseline, accepting more
+// on-demand spend in exchange for less idle commitment when demand is bursty
+// or trending down.
+//
+// The flag name says "utilization" because the original framing (issue #338)
+// was a utilization floor. In practice operators set values like 70 or 80
+// expecting coverage near that figure (with utilization staying ~100% on the
+// commitments actually purchased), not the over-buy semantics that floor
+// produces; see the #338 review discussion for the redirect.
 //
 // RIs:
 //
-//	n_target = floor(AverageInstancesUsedPerHour / (targetPct/100))
-//	capped at rec.Count (we never exceed AWS's recommended ceiling).
-//	If n_target == 0 → drop with explanatory INFO log (target unreachable).
+//	n_target = floor(AverageInstancesUsedPerHour * targetPct/100)
+//	If n_target == 0 → drop with explanatory INFO log (target too low to
+//	support even one RI for this rec).
 //	If AverageInstancesUsedPerHour <= 0 → pass through (no signal); counted
 //	in the per-run skip summary.
+//	Projected coverage = n_target/avg * 100 (clamps below targetPct slightly
+//	because of integer floor; e.g. avg=31.3 with target=70 gives n=21,
+//	cov=67%). Projected utilization = avg/n_target * 100 clamped to 100.
 //
 // SPs:
 //
-//	If RecommendedUtilization >= targetPct → no scaling (AWS already projects
-//	above target).
-//	Else ratio = RecommendedUtilization / targetPct (always < 1). Scale
-//	SavingsPlanDetails.HourlyCommitment and rec.EstimatedSavings — matching
-//	exactly the fields ApplyCoverage scales on the SP branch, so the two
-//	sizing modes stay structurally consistent.
+//	Scale SavingsPlanDetails.HourlyCommitment and EstimatedSavings by
+//	targetPct/100 (the same lever ApplyCoverage's SP branch uses, but with
+//	the explicit utilization-target framing). RecommendedUtilization is used
+//	only as the no-signal guard: when AWS hasn't returned a projected
+//	utilization figure, we pass the rec through unchanged and count it in
+//	the skip summary, since we can't sanity-check what the scaled commitment
+//	would mean.
 //	If RecommendedUtilization <= 0 → pass through; counted in skip summary.
 //
 // Recs of any other CommitmentType are passed through unmodified (warned
 // once per type per run).
-func ApplyTargetUtilization(recs []common.Recommendation, targetPct float64) []common.Recommendation {
+func ApplyTargetCoverage(recs []common.Recommendation, targetPct float64) []common.Recommendation {
 	if targetPct <= 0 || targetPct > 100 {
 		// Validation ensures we never get here in production, but be defensive
 		// so a buggy caller doesn't divide by zero.
-		AppLogger.Printf("WARNING: ApplyTargetUtilization called with targetPct=%.2f outside (0,100]; returning recs unchanged\n", targetPct)
+		AppLogger.Printf("WARNING: ApplyTargetCoverage called with targetPct=%.2f outside (0,100]; returning recs unchanged\n", targetPct)
 		return recs
 	}
 
@@ -199,7 +212,7 @@ func ApplyTargetUtilization(recs []common.Recommendation, targetPct float64) []c
 	unsupportedSeen := make(map[common.CommitmentType]bool)
 
 	for _, rec := range recs {
-		adjusted, kept, missingSignal := applyTargetUtilizationOne(rec, target, targetPct, unsupportedSeen)
+		adjusted, kept, missingSignal := applyTargetCoverageOne(rec, target, targetPct, unsupportedSeen)
 		if missingSignal {
 			skipped++
 		}
@@ -209,33 +222,33 @@ func ApplyTargetUtilization(recs []common.Recommendation, targetPct float64) []c
 	}
 
 	if skipped > 0 {
-		AppLogger.Printf("INFO: --target-utilization=%.1f%% skipped %d of %d recommendations with no utilization signal (passed through unchanged)\n",
+		AppLogger.Printf("INFO: --target-coverage=%.1f%% skipped %d of %d recommendations with no utilization signal (passed through unchanged)\n",
 			targetPct, skipped, len(recs))
 	}
 
 	return result
 }
 
-// applyTargetUtilizationOne dispatches a single recommendation through the
+// applyTargetCoverageOne dispatches a single recommendation through the
 // appropriate branch. Returns (rec, kept, missingSignal):
 //   - kept=true → caller appends `rec` (the adjusted or pass-through value).
 //   - kept=false → caller drops the rec (only the RI "target unreachable"
 //     branch returns this; an INFO log already fired).
 //   - missingSignal=true → counted toward the end-of-run skip summary.
 //
-// Split out of ApplyTargetUtilization to keep that function under gocyclo's
+// Split out of ApplyTargetCoverage to keep that function under gocyclo's
 // complexity threshold.
-func applyTargetUtilizationOne(rec common.Recommendation, target, targetPct float64, unsupportedSeen map[common.CommitmentType]bool) (common.Recommendation, bool, bool) {
+func applyTargetCoverageOne(rec common.Recommendation, target, targetPct float64, unsupportedSeen map[common.CommitmentType]bool) (common.Recommendation, bool, bool) {
 	switch {
 	case common.IsSavingsPlan(rec.Service):
-		adjusted, ok := applyTargetUtilizationSP(rec, targetPct)
+		adjusted, ok := applyTargetCoverageSP(rec, targetPct)
 		if !ok {
 			// SP no-signal: pass through unchanged.
 			return rec, true, true
 		}
 		return adjusted, true, false
 	case rec.CommitmentType == common.CommitmentReservedInstance:
-		adjusted, ok := applyTargetUtilizationRI(rec, target, targetPct)
+		adjusted, ok := applyTargetCoverageRI(rec, target, targetPct)
 		if !ok {
 			// Distinguish "no signal" (pass through, count in summary) from
 			// "target unreachable" (drop with already-fired INFO log).
@@ -247,50 +260,41 @@ func applyTargetUtilizationOne(rec common.Recommendation, target, targetPct floa
 		return adjusted, true, false
 	default:
 		if !unsupportedSeen[rec.CommitmentType] {
-			AppLogger.Printf("WARNING: --target-utilization not supported for CommitmentType=%q; passing recommendations through unchanged\n", rec.CommitmentType)
+			AppLogger.Printf("WARNING: --target-coverage not supported for CommitmentType=%q; passing recommendations through unchanged\n", rec.CommitmentType)
 			unsupportedSeen[rec.CommitmentType] = true
 		}
 		return rec, true, false
 	}
 }
 
-// applyTargetUtilizationRI is the RI branch of ApplyTargetUtilization. Returns
+// applyTargetCoverageRI is the RI branch of ApplyTargetCoverage. Returns
 // (adjusted, true) on success, (rec, false) when the rec should be passed
 // through unscaled (no signal) or dropped (target unreachable). Caller
 // distinguishes the two via rec.AverageInstancesUsedPerHour.
-func applyTargetUtilizationRI(rec common.Recommendation, target, targetPct float64) (common.Recommendation, bool) {
+func applyTargetCoverageRI(rec common.Recommendation, target, targetPct float64) (common.Recommendation, bool) {
 	if rec.AverageInstancesUsedPerHour <= 0 {
 		// No signal — caller will pass through and count in the summary.
 		return rec, false
 	}
 
 	avg := rec.AverageInstancesUsedPerHour
-	uncappedTarget := int(math.Floor(avg / target))
-
-	// Cap at rec.Count: never buy more than AWS recommended.
-	nTarget := uncappedTarget
-	capped := false
-	if nTarget > rec.Count {
-		nTarget = rec.Count
-		capped = true
-	}
+	// Under-buy sizing: leave (1 - target)% of historical demand on-demand.
+	// nTarget = floor(avg * target) is the integer RI count whose coverage is
+	// at-most targetPct against historical average usage. Using floor (rather
+	// than round) errs on the side of buying fewer RIs, which matches the
+	// flag's intent: deliberately leave headroom on-demand.
+	nTarget := int(math.Floor(avg * target))
 
 	if nTarget == 0 {
-		// Target unreachable: even buying 1 instance would over-utilize beyond
-		// the user's target. Drop with explanatory log per issue #338 AC.
-		AppLogger.Printf("INFO: --target-utilization=%.1f%% unreachable for %s/%s/%s (avg used %.2f/hr requires <1 instance for target) — dropped recommendation\n",
+		// Target too low to justify even a single RI for this rec's avg
+		// usage (e.g. avg=0.5 with target=70% yields floor(0.35)=0). Drop
+		// with an explanatory log so operators can see what the flag did.
+		AppLogger.Printf("INFO: --target-coverage=%.1f%% sizes %s/%s/%s to 0 instances (avg used %.2f/hr, target produces <1 RI); dropped recommendation\n",
 			targetPct, rec.Service, rec.Region, rec.ResourceType, avg)
 		// Returning (_, false) with avg > 0 signals "drop, don't pass through".
-		// applyTargetUtilizationRI's caller branches on
+		// applyTargetCoverageRI's caller branches on
 		// rec.AverageInstancesUsedPerHour to distinguish drop vs no-signal.
 		return rec, false
-	}
-
-	if capped {
-		// Target was too lenient — AWS's ceiling binds before we reach the
-		// target's "buy this many" suggestion.
-		AppLogger.Printf("INFO: --target-utilization=%.1f%% would have recommended %d instances for %s/%s/%s but capped at AWS ceiling of %d\n",
-			targetPct, uncappedTarget, rec.Service, rec.Region, rec.ResourceType, nTarget)
 	}
 
 	adjusted := rec
@@ -314,71 +318,68 @@ func applyTargetUtilizationRI(rec common.Recommendation, target, targetPct float
 	return adjusted, true
 }
 
-// applyTargetUtilizationSP is the SP branch of ApplyTargetUtilization. Returns
+// applyTargetCoverageSP is the SP branch of ApplyTargetCoverage. Returns
 // (adjusted, true) when the rec is kept, (rec, false) when it should be
 // skipped (caller passes through unscaled and counts in the skip summary).
-func applyTargetUtilizationSP(rec common.Recommendation, targetPct float64) (common.Recommendation, bool) {
+func applyTargetCoverageSP(rec common.Recommendation, targetPct float64) (common.Recommendation, bool) {
 	if rec.RecommendedUtilization <= 0 {
 		return rec, false
 	}
 	// Also treat a $0 HourlyCommitment as "no signal" — CE occasionally
 	// returns placeholder recs with zero commitment. Sizing such a rec
 	// would produce nonsense ($0 commitment * ratio = $0) while still
-	// claiming the target utilization is achieved, which is incoherent.
+	// claiming the target coverage is achieved, which is incoherent.
 	// Pass through unchanged and count in the skip summary.
 	if details, ok := rec.Details.(*common.SavingsPlanDetails); ok && details.HourlyCommitment <= 0 {
 		return rec, false
 	}
 
-	adjusted := rec
-	if rec.RecommendedUtilization >= targetPct {
-		// AWS already projects at-or-above target — no scaling, but we do
-		// surface the projected utilization in the output.
-		adjusted.ProjectedUtilization = rec.RecommendedUtilization
-		// ProjectedCoverage is intentionally left at zero for SPs — see
-		// the package doc on the field; we don't have total-demand-$ from
-		// CE to compute SP coverage cleanly.
-		return adjusted, true
-	}
-
-	// AWS projects below target. Scale commitment down by ratio = recommended/target
-	// so projected utilization rises to exactly target.
-	ratio := rec.RecommendedUtilization / targetPct
-
-	// Only the SP fields that ApplyCoverage scales — HourlyCommitment (via
-	// the polymorphic Details copy) and EstimatedSavings. Do NOT touch
-	// CommitmentCost, OnDemandCost, or SavingsPercentage; ApplyCoverage
-	// doesn't either, and divergence would silently desync the two modes.
+	// Under-buy: scale HourlyCommitment and EstimatedSavings by target/100
+	// against AWS's recommended commitment. This deliberately spends less than
+	// AWS suggested, leaving (100-target)% of the SP's projected workload on
+	// on-demand. RecommendedUtilization is consulted only as a no-signal guard
+	// above (a zero value means we can't sanity-check the result); the scaling
+	// itself uses targetPct directly rather than a recUtil/target ratio so the
+	// flag's intent is honoured even when AWS already projects above target.
 	//
 	// If Details isn't a *SavingsPlanDetails (defensive — should always be
 	// for SP recs), log a warning and pass through UNCHANGED — including
-	// leaving ProjectedUtilization at zero. Setting projected metrics on a
+	// leaving ProjectedUtilization at zero. Setting projection fields on a
 	// rec whose commitment fields couldn't be scaled would produce a
-	// misleading row (utilization=target%, savings=full-unscaled), which
-	// is exactly the wrong signal to the user.
+	// misleading row (projection=target%, savings=full-unscaled).
 	details, ok := rec.Details.(*common.SavingsPlanDetails)
 	if !ok {
 		AppLogger.Printf("WARNING: SP recommendation for service %q has unexpected Details type %T; passing through unscaled\n", rec.Service, rec.Details)
 		return rec, true
 	}
+	ratio := targetPct / 100.0
 	newDetails := *details // copy
 	newDetails.HourlyCommitment = newDetails.HourlyCommitment * ratio
+	adjusted := rec
 	adjusted.Details = &newDetails
 	adjusted.EstimatedSavings = rec.EstimatedSavings * ratio
-	adjusted.ProjectedUtilization = targetPct
-	// ProjectedCoverage left at zero for SPs (see above).
+	// Shrinking commitment raises projected utilization by 1/ratio
+	// (used is fixed = orig_commit * RecUtil, bought is orig_commit * ratio).
+	// Clamp to 100 since utilization caps at full use.
+	projUtil := rec.RecommendedUtilization / ratio
+	if projUtil > 100 {
+		projUtil = 100
+	}
+	adjusted.ProjectedUtilization = projUtil
+	// ProjectedCoverage stays zero for SPs — CE doesn't expose total-demand-$
+	// for a clean coverage figure (see field doc on Recommendation).
 	return adjusted, true
 }
 
-// applySizing chooses target-utilization or coverage sizing.
+// applySizing chooses target-coverage or coverage sizing.
 //
-// coverage is the effective % to apply when target-utilization is unset
+// coverage is the effective % to apply when target-coverage is unset
 // (the main path passes cfg.Coverage; the CSV path passes csvModeCoverage,
 // which substitutes the default 80% with 100% so CSV-driven counts aren't
 // silently dropped).
 func applySizing(recs []common.Recommendation, cfg Config, coverage float64) []common.Recommendation {
-	if cfg.TargetUtilization > 0 {
-		return ApplyTargetUtilization(recs, cfg.TargetUtilization)
+	if cfg.TargetCoverage > 0 {
+		return ApplyTargetCoverage(recs, cfg.TargetCoverage)
 	}
 	return ApplyCoverage(recs, coverage)
 }

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -113,7 +113,14 @@ func CalculateTotalInstances(recs []common.Recommendation) int {
 	return total
 }
 
-// ApplyCoverage applies coverage percentage to recommendations
+// ApplyCoverage applies coverage percentage to recommendations.
+//
+// All cost-bearing fields (CommitmentCost, OnDemandCost, EstimatedSavings,
+// and for SPs the SavingsPlanDetails.HourlyCommitment) scale by coverage/100
+// so the returned Recommendation represents the sized purchase rather than
+// AWS's pre-sized proposal. SavingsPercentage is invariant (savings vs
+// on-demand ratio) and stays unscaled. Pre-sizing values can still be
+// recovered: RecommendedCount holds AWS's pre-sized count for RIs.
 func ApplyCoverage(recs []common.Recommendation, coverage float64) []common.Recommendation {
 	if coverage >= 100 {
 		return recs
@@ -122,7 +129,7 @@ func ApplyCoverage(recs []common.Recommendation, coverage float64) []common.Reco
 		return []common.Recommendation{}
 	}
 
-	// Apply coverage by reducing counts (for RIs) or hourly commitment (for Savings Plans)
+	ratio := coverage / 100.0
 	result := make([]common.Recommendation, 0, len(recs))
 	for _, rec := range recs {
 		adjusted := rec
@@ -136,10 +143,11 @@ func ApplyCoverage(recs []common.Recommendation, coverage float64) []common.Reco
 		if common.IsSavingsPlan(rec.Service) {
 			if details, ok := rec.Details.(*common.SavingsPlanDetails); ok {
 				newDetails := *details // Copy the struct
-				newDetails.HourlyCommitment = newDetails.HourlyCommitment * coverage / 100
+				newDetails.HourlyCommitment = newDetails.HourlyCommitment * ratio
 				adjusted.Details = &newDetails
-				// Also adjust the estimated savings proportionally
-				adjusted.EstimatedSavings = rec.EstimatedSavings * coverage / 100
+				adjusted.CommitmentCost = rec.CommitmentCost * ratio
+				adjusted.OnDemandCost = rec.OnDemandCost * ratio
+				adjusted.EstimatedSavings = rec.EstimatedSavings * ratio
 			} else {
 				AppLogger.Printf("WARNING: SP recommendation for service %q has unexpected Details type %T; passing through unscaled\n", rec.Service, rec.Details)
 			}
@@ -147,10 +155,13 @@ func ApplyCoverage(recs []common.Recommendation, coverage float64) []common.Reco
 			continue
 		}
 
-		// For RIs, reduce the count
-		newCount := int(float64(rec.Count) * coverage / 100)
+		// For RIs, reduce the count and scale cost-bearing fields proportionally.
+		newCount := int(float64(rec.Count) * ratio)
 		if newCount > 0 {
 			adjusted.Count = newCount
+			adjusted.CommitmentCost = rec.CommitmentCost * ratio
+			adjusted.OnDemandCost = rec.OnDemandCost * ratio
+			adjusted.EstimatedSavings = rec.EstimatedSavings * ratio
 			result = append(result, adjusted)
 		}
 	}
@@ -297,12 +308,18 @@ func applyTargetCoverageRI(rec common.Recommendation, target, targetPct float64)
 		return rec, false
 	}
 
+	// Cost-bearing fields scale by the ratio of sized-to-original count, so the
+	// returned rec represents the sized purchase rather than AWS's pre-sized
+	// proposal. SavingsPercentage is invariant (savings vs on-demand ratio).
+	// rec.Count is the AWS pre-sizing count at this point (parser sets Count
+	// == RecommendedCount and we haven't mutated either yet), so dividing by
+	// it gives the correct scaling factor.
+	ratio := float64(nTarget) / float64(rec.Count)
 	adjusted := rec
 	adjusted.Count = nTarget
-
-	// Cost-scaling — mirror ApplyCoverage's RI branch (only Count is scaled
-	// implicitly via the new count; ApplyCoverage doesn't scale RI cost
-	// fields explicitly either, so we don't here).
+	adjusted.CommitmentCost = rec.CommitmentCost * ratio
+	adjusted.OnDemandCost = rec.OnDemandCost * ratio
+	adjusted.EstimatedSavings = rec.EstimatedSavings * ratio
 
 	// Projection metrics.
 	projUtil := avg / float64(nTarget) * 100.0
@@ -334,13 +351,13 @@ func applyTargetCoverageSP(rec common.Recommendation, targetPct float64) (common
 		return rec, false
 	}
 
-	// Under-buy: scale HourlyCommitment and EstimatedSavings by target/100
-	// against AWS's recommended commitment. This deliberately spends less than
-	// AWS suggested, leaving (100-target)% of the SP's projected workload on
-	// on-demand. RecommendedUtilization is consulted only as a no-signal guard
-	// above (a zero value means we can't sanity-check the result); the scaling
-	// itself uses targetPct directly rather than a recUtil/target ratio so the
-	// flag's intent is honoured even when AWS already projects above target.
+	// Under-buy: scale all cost-bearing fields by target/100 against AWS's
+	// recommended commitment. This deliberately spends less than AWS suggested,
+	// leaving (100-target)% of the SP's projected workload on on-demand.
+	// RecommendedUtilization is consulted only as a no-signal guard above (a
+	// zero value means we can't sanity-check the result); the scaling itself
+	// uses targetPct directly rather than a recUtil/target ratio so the flag's
+	// intent is honoured even when AWS already projects above target.
 	//
 	// If Details isn't a *SavingsPlanDetails (defensive — should always be
 	// for SP recs), log a warning and pass through UNCHANGED — including
@@ -357,6 +374,8 @@ func applyTargetCoverageSP(rec common.Recommendation, targetPct float64) (common
 	newDetails.HourlyCommitment = newDetails.HourlyCommitment * ratio
 	adjusted := rec
 	adjusted.Details = &newDetails
+	adjusted.CommitmentCost = rec.CommitmentCost * ratio
+	adjusted.OnDemandCost = rec.OnDemandCost * ratio
 	adjusted.EstimatedSavings = rec.EstimatedSavings * ratio
 	// Shrinking commitment raises projected utilization by 1/ratio
 	// (used is fixed = orig_commit * RecUtil, bought is orig_commit * ratio).

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -185,26 +185,35 @@ func ApplyCoverage(recs []common.Recommendation, coverage float64) []common.Reco
 // commitments actually purchased), not the over-buy semantics that floor
 // produces; see the #338 review discussion for the redirect.
 //
-// RIs:
+// RIs (hybrid: AWS-scaled floor + existing-coverage subtraction):
 //
-//	gap = (targetPct - ExistingCoveragePct) / 100
-//	n_target = ceil(AverageInstancesUsedPerHour * gap)
-//	If gap <= 0 (existing already at/above target) → drop with INFO log.
+//	awsScaled    = ceil(rec.Count * targetPct / 100)
+//	existingAware = ceil(avg * (targetPct - ExistingCoveragePct) / 100)
+//	                (only when the gap is positive; else 0)
+//	n_target      = max(awsScaled, existingAware)
+//
+//	The MAX keeps the AWS-scaled count as a floor so pools where CE
+//	coverage reports 100% but AWS still recommends new RIs (typical when
+//	existing RIs are near expiry, or when per-account vs org-wide
+//	averaging in CE under-counts a specific account's actual coverage)
+//	still get sized. The existing-aware branch wins when target exceeds
+//	AWS's implied target or when rec.Count is zero.
+//
 //	If AverageInstancesUsedPerHour <= 0 → pass through (no signal); counted
 //	in the per-run skip summary.
+//	If both candidates are zero (no AWS rec + existing >= target) → drop
+//	with INFO log.
+//
 //	Projected coverage = ExistingCoveragePct + n_target/avg * 100 (total
 //	coverage after the purchase, clamped to 100). Projected utilization =
 //	avg/n_target * 100 clamped to 100.
 //	ExistingCoveragePct is sourced from CE GetReservationCoverage in the
-//	same pool; zero means "no signal" and the formula falls back to the
-//	no-existing-commitments path. For RDS, the coverage lookup keys by
-//	(region, instance_type, engine) — the per-engine fetcher in
-//	coverage.go avoids the cross-engine bleed that floor + per-pool
+//	same pool; zero means "no signal". For RDS the coverage lookup keys
+//	by (region, instance_type, engine) — the per-engine fetcher in
+//	coverage.go avoids the cross-engine bleed that the per-pool
 //	aggregate produced.
-//	Ceil (rather than floor or round) ensures any non-zero gap with
-//	non-zero demand buys at least 1 RI — AWS's recommendation list
-//	always proposes a count, and silently dropping single-instance pools
-//	was the worse failure mode than slight over-target on tiny pools.
+//	Ceil (rather than floor or round) ensures any non-zero candidate
+//	rounds up to at least 1 RI, matching AWS's recommendation shape.
 //
 // SPs:
 //
@@ -298,41 +307,51 @@ func applyTargetCoverageRI(rec common.Recommendation, targetPct float64) (common
 	}
 
 	avg := rec.AverageInstancesUsedPerHour
-	// Under-buy sizing accounts for any existing commitments in the same pool:
-	// the count we still need is the coverage gap (target − existing) against
-	// historical demand. ExistingCoveragePct comes from CE GetReservationCoverage
-	// (populated upstream when available) and defaults to zero so recs without
-	// the fetched signal fall back to the no-existing-commitments path.
+	// Hybrid sizing: take the MAX of two candidates so we never undershoot
+	// AWS's recommendation when CE-side existing-coverage data is missing
+	// signal (e.g. RIs about to expire, per-account vs org-wide averaging
+	// discrepancies, etc.).
 	//
-	// Keep the subtraction in percentage units (subtract first, divide by 100
-	// after) so whole-percent values don't lose precision: 0.70 - 0.60 in
-	// float64 rounds to 0.0999... and ceil(avg * that) would silently round
-	// up by 1.
-	gapPct := targetPct - rec.ExistingCoveragePct
-	if gapPct <= 0 {
-		// Existing commitments already meet or exceed the target; no purchase
-		// needed in this pool. Drop with an info log so operators can see what
-		// the flag did. Returning (_, false) with avg > 0 signals "drop, don't
-		// pass through".
-		AppLogger.Printf("INFO: --target-coverage=%.1f%% already met by existing coverage %.1f%% for %s/%s/%s; dropped recommendation\n",
-			targetPct, rec.ExistingCoveragePct, rec.Service, rec.Region, rec.ResourceType)
-		return rec, false
+	//   awsScaled    = ceil(rec.Count × targetPct/100)
+	//     Trusts AWS's rec.Count as the AWS-side optimal count. Scaling by
+	//     target/100 gives the user's chosen fraction of that, matching the
+	//     shape of a --coverage-style run.
+	//
+	//   existingAware = ceil(avg × gap/100) where gap = targetPct - existing
+	//     Subtracts existing pool coverage so we don't double-buy what's
+	//     already reserved. Honours target as a coverage target on demand.
+	//
+	// max(awsScaled, existingAware) always buys at least the AWS-scaled
+	// count, so pools where CE coverage looks 100%-covered but AWS still
+	// recommends new RIs (typical when existing RIs are near expiry) still
+	// get sized. When existing-aware would buy more (e.g. target above AWS's
+	// implied target, or rec.Count == 0), we honour that too.
+	//
+	// Keep the gap subtraction in percentage units before dividing by 100 so
+	// whole-percent values don't lose precision: 0.70 - 0.60 in float64
+	// rounds to 0.0999... and ceil(avg * that) would silently round up by 1.
+	awsScaled := 0
+	if rec.Count > 0 {
+		awsScaled = int(math.Ceil(float64(rec.Count) * targetPct / 100.0))
 	}
-	// Round up so any non-zero gap with non-zero demand buys at least 1 RI.
-	// Floor used to drop single-instance pools (avg=1, gap=80% → floor(0.8)=0)
-	// which made --target-coverage=80 silently skip a third of the AWS-console
-	// recommendation list. Ceil matches AWS's behaviour of recommending 1 RI
-	// for any non-empty pool; the slight over-target on small pools (avg=2,
-	// target=80% gives 2 RIs = 100% coverage) is acceptable — under-target
-	// silence was the worse failure mode.
-	nTarget := int(math.Ceil(avg * gapPct / 100.0))
+	gapPct := targetPct - rec.ExistingCoveragePct
+	existingAware := 0
+	if gapPct > 0 {
+		// Ceil ensures any non-zero gap with non-zero demand buys at least 1 RI.
+		existingAware = int(math.Ceil(avg * gapPct / 100.0))
+	}
+	nTarget := awsScaled
+	if existingAware > nTarget {
+		nTarget = existingAware
+	}
 
 	if nTarget == 0 {
-		// Defensive: math.Ceil on a positive product never returns 0, but a
-		// truncation or tiny-float edge case could. Drop with a log if it
-		// somehow happens.
-		AppLogger.Printf("INFO: --target-coverage=%.1f%% sizes %s/%s/%s to 0 instances (avg used %.2f/hr, gap %.2f%% produces <1 RI); dropped recommendation\n",
-			targetPct, rec.Service, rec.Region, rec.ResourceType, avg, gapPct)
+		// Both candidates produced zero: AWS didn't recommend (rec.Count==0)
+		// AND existing coverage already meets/exceeds target (gap <= 0).
+		// No purchase warranted in this pool. Drop with an info log so
+		// operators can see what the flag did.
+		AppLogger.Printf("INFO: --target-coverage=%.1f%% met for %s/%s/%s (rec.Count=0, existing=%.1f%%); dropped recommendation\n",
+			targetPct, rec.Service, rec.Region, rec.ResourceType, rec.ExistingCoveragePct)
 		// Returning (_, false) with avg > 0 signals "drop, don't pass through".
 		// applyTargetCoverageRI's caller branches on
 		// rec.AverageInstancesUsedPerHour to distinguish drop vs no-signal.

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -321,6 +321,14 @@ func applyTargetUtilizationSP(rec common.Recommendation, targetPct float64) (com
 	if rec.RecommendedUtilization <= 0 {
 		return rec, false
 	}
+	// Also treat a $0 HourlyCommitment as "no signal" — CE occasionally
+	// returns placeholder recs with zero commitment. Sizing such a rec
+	// would produce nonsense ($0 commitment * ratio = $0) while still
+	// claiming the target utilization is achieved, which is incoherent.
+	// Pass through unchanged and count in the skip summary.
+	if details, ok := rec.Details.(*common.SavingsPlanDetails); ok && details.HourlyCommitment <= 0 {
+		return rec, false
+	}
 
 	adjusted := rec
 	if rec.RecommendedUtilization >= targetPct {
@@ -341,15 +349,22 @@ func applyTargetUtilizationSP(rec common.Recommendation, targetPct float64) (com
 	// the polymorphic Details copy) and EstimatedSavings. Do NOT touch
 	// CommitmentCost, OnDemandCost, or SavingsPercentage; ApplyCoverage
 	// doesn't either, and divergence would silently desync the two modes.
-	if details, ok := rec.Details.(*common.SavingsPlanDetails); ok {
-		newDetails := *details // copy
-		newDetails.HourlyCommitment = newDetails.HourlyCommitment * ratio
-		adjusted.Details = &newDetails
-		adjusted.EstimatedSavings = rec.EstimatedSavings * ratio
-	} else {
+	//
+	// If Details isn't a *SavingsPlanDetails (defensive — should always be
+	// for SP recs), log a warning and pass through UNCHANGED — including
+	// leaving ProjectedUtilization at zero. Setting projected metrics on a
+	// rec whose commitment fields couldn't be scaled would produce a
+	// misleading row (utilization=target%, savings=full-unscaled), which
+	// is exactly the wrong signal to the user.
+	details, ok := rec.Details.(*common.SavingsPlanDetails)
+	if !ok {
 		AppLogger.Printf("WARNING: SP recommendation for service %q has unexpected Details type %T; passing through unscaled\n", rec.Service, rec.Details)
+		return rec, true
 	}
-
+	newDetails := *details // copy
+	newDetails.HourlyCommitment = newDetails.HourlyCommitment * ratio
+	adjusted.Details = &newDetails
+	adjusted.EstimatedSavings = rec.EstimatedSavings * ratio
 	adjusted.ProjectedUtilization = targetPct
 	// ProjectedCoverage left at zero for SPs (see above).
 	return adjusted, true

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -313,19 +313,19 @@ func applyTargetCoverageRI(rec common.Recommendation, targetPct float64) (common
 	}
 
 	avg := rec.AverageInstancesUsedPerHour
-	// Under-buy sizing scales AWS's rec.Count by the fraction of the
-	// current-to-100% gap we want to fill. AWS's rec.Count is the
-	// per-account incremental count needed to reach 100% coverage; we
-	// want to fill (target − existing) of the (100 − existing) gap, so
-	// the scaling factor is (target − existing) / (100 − existing).
+	// Coverage-anchored under-buy: size linearly off the pool's avg demand
+	// and the absolute gap to target. Both inputs come from
+	// GetReservationCoverage (AvgInstancesPerHour from
+	// TotalRunningHours/window; ExistingCoveragePct from
+	// CoverageHoursPercentage) so the buy lines up with the AWS console's
+	// reservations-coverage report: target%-existing% of avg instances.
 	//
-	// This is more robust than the prior avg*gap formula for multi-account
-	// orgs: CE's ExistingCoveragePct is org-wide averaged, while AWS's
-	// rec.Count is computed per-account, so scaling AWS's already-correct
-	// count by a fractional dial holds up even when CE's existing-coverage
-	// signal is averaged below the per-account truth. The avg signal is
-	// retained only as a no-signal guard above and for the projection
-	// metrics below.
+	// The previous formula anchored on AWS's rec.Count
+	// (floor(rec.Count × gap / (100−existing))), which under-bought when
+	// AWS sized rec.Count for less than full coverage (ROI-curated) and
+	// when CE's org-wide existing% disagreed with rec.Count's per-account
+	// derivation. Anchoring on coverage's own avg removes both mismatches.
+	// rec.Count is retained only for the cost-scaling ratio further down.
 	//
 	// Keep the subtraction in percentage units (subtract first, divide
 	// later) so whole-percent values don't lose precision to float
@@ -340,27 +340,21 @@ func applyTargetCoverageRI(rec common.Recommendation, targetPct float64) (common
 			targetPct, rec.ExistingCoveragePct, rec.Service, rec.Region, rec.ResourceType)
 		return rec, false
 	}
-	// remainingGapPct = 100 − existing. Always positive when gapPct > 0
-	// because gapPct > 0 implies targetPct > existing, and targetPct is
-	// validated to be at most 100, so existing < 100 too.
-	remainingGapPct := 100.0 - rec.ExistingCoveragePct
 	// Floor so we never over-shoot the target on integer-arithmetic edges.
 	// Strict-target semantics: 80% means "at most 80% coverage", not "at
-	// least 80%". Floor under-covers small/odd pools (e.g. AWS rec=2,
-	// target=80 gives 1 RI = 50% rather than 2 RIs = 100%); pools too
-	// small to approximate target are best filtered out via
-	// --min-pool-size upstream.
-	nTarget := int(math.Floor(float64(rec.Count) * gapPct / remainingGapPct))
+	// least 80%". Floor under-covers small/odd pools (e.g. avg=2, target=80
+	// gives 1 RI = 50% rather than 2 RIs = 100%); pools too small to
+	// approximate target are best filtered out via --min-pool-size upstream.
+	nTarget := int(math.Floor(avg * gapPct / 100.0))
 
 	if nTarget == 0 {
-		// Floor produces zero when the gap-of-remaining-gap ratio multiplied
-		// by AWS's rec.Count is less than 1 (small recs or thin gaps).
-		// Drop — buying 1 RI would over-shoot target and the strict-target
-		// intent prefers under-cover (run on-demand) over over-cover
-		// (idle commitment). Use --min-pool-size to filter these out
-		// earlier so they don't show up as drops in the log.
-		AppLogger.Printf("INFO: --target-coverage=%.1f%% sizes %s/%s/%s to 0 instances (rec.Count=%d, gap %.2f%% of remaining %.2f%% produces <1 RI); dropped recommendation\n",
-			targetPct, rec.Service, rec.Region, rec.ResourceType, rec.Count, gapPct, remainingGapPct)
+		// Floor produces zero when avg × gap% < 100 (small pools or thin
+		// gaps). Drop — buying 1 RI would over-shoot target and the
+		// strict-target intent prefers under-cover (run on-demand) over
+		// over-cover (idle commitment). Use --min-pool-size to filter
+		// these out earlier so they don't show up as drops in the log.
+		AppLogger.Printf("INFO: --target-coverage=%.1f%% sizes %s/%s/%s to 0 instances (avg=%.2f, gap=%.2f%% produces <1 RI); dropped recommendation\n",
+			targetPct, rec.Service, rec.Region, rec.ResourceType, avg, gapPct)
 		// Returning (_, false) with avg > 0 signals "drop, don't pass through".
 		// applyTargetCoverageRI's caller branches on
 		// rec.AverageInstancesUsedPerHour to distinguish drop vs no-signal.
@@ -371,11 +365,18 @@ func applyTargetCoverageRI(rec common.Recommendation, targetPct float64) (common
 	// returned rec represents the sized purchase rather than AWS's pre-sized
 	// proposal. SavingsPercentage is invariant (savings vs on-demand ratio).
 	// rec.Count is the AWS pre-sizing count at this point (parser sets Count
-	// == RecommendedCount and we haven't mutated either yet), so dividing by
-	// it gives the correct scaling factor. AWS's rec.Count is sized to reach
-	// ~100% coverage net of existing commitments, so scaling by nTarget/rec.Count
-	// equivalently scales by gap/(1-existing_cov), which is the correct ratio.
-	ratio := float64(nTarget) / float64(rec.Count)
+	// == RecommendedCount and we haven't mutated either yet). When the
+	// coverage-anchored nTarget exceeds rec.Count (AWS sized below full
+	// coverage), the ratio scales costs up linearly — accurate when per-RI
+	// pricing is constant, which it is within a single pool/term/payment
+	// combination. Guarded against rec.Count==0 (malformed rec) by falling
+	// back to nTarget so a zero-cost rec stays zero-cost rather than NaN.
+	var ratio float64
+	if rec.Count > 0 {
+		ratio = float64(nTarget) / float64(rec.Count)
+	} else {
+		ratio = float64(nTarget)
+	}
 	adjusted := rec
 	adjusted.Count = nTarget
 	adjusted.CommitmentCost = rec.CommitmentCost * ratio

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -187,8 +187,18 @@ func ApplyCoverage(recs []common.Recommendation, coverage float64) []common.Reco
 //
 // RIs (existing-aware, per-pool, strict-target):
 //
-//	gap = (targetPct - ExistingCoveragePct) / 100
-//	n_target = floor(AverageInstancesUsedPerHour * gap)
+//	gap            = targetPct - ExistingCoveragePct      (percentage points)
+//	remaining_gap  = 100 - ExistingCoveragePct            (percentage points)
+//	n_target       = floor(rec.Count * gap / remaining_gap)
+//
+//	The formula scales AWS's per-account-incremental rec.Count by the
+//	fraction of the current-to-100% gap we want to fill. For example
+//	with existing=50% and target=80%: gap=30, remaining_gap=50, so we
+//	buy 30/50 = 60% of AWS's rec.Count. Anchoring to rec.Count (which
+//	AWS computed per-linked-account) is more robust in multi-account
+//	orgs than scaling against avg, since CE's ExistingCoveragePct is
+//	org-wide averaged and mixes accounts together.
+//
 //	If gap <= 0 (existing already at/above target) → drop with INFO log.
 //	If n_target == 0 (gap too small to fit one RI) → drop with INFO log.
 //	If AverageInstancesUsedPerHour <= 0 → pass through (no signal); counted
@@ -198,17 +208,13 @@ func ApplyCoverage(recs []common.Recommendation, coverage float64) []common.Reco
 //	avg/n_target * 100 clamped to 100.
 //
 //	ExistingCoveragePct is sourced from CE GetReservationCoverage in the
-//	same pool; zero means "no signal" and the formula falls back to the
-//	no-existing-commitments path. For RDS, the coverage lookup keys by
-//	(region, instance_type, engine) — the per-engine fetcher in
-//	coverage.go avoids the cross-engine bleed that a per-pool aggregate
-//	would produce.
+//	same pool; zero means "no signal" and the formula reduces to
+//	floor(rec.Count * target/100) — i.e. plain target% of AWS's count.
+//	For RDS the coverage lookup keys by (region, instance_type, engine).
 //	Floor (rather than ceil or round) gives strict "at-most-target"
-//	sizing: small/odd pools under-cover rather than over-cover, matching
-//	the operator's intent when they set a target. Pools too small to
-//	approximate the target meaningfully (avg < ~5 for target=80%) should
-//	be filtered upstream via --min-pool-size; floor will drop them as
-//	zero-count otherwise.
+//	sizing. Pools too small to approximate the target meaningfully
+//	should be filtered upstream via --min-pool-size; floor will drop
+//	them as zero-count otherwise.
 //
 //	Pools where CE reports 100% existing coverage but AWS still recommends
 //	new RIs (typical when existing RIs are near expiry) are dropped here —
@@ -307,16 +313,23 @@ func applyTargetCoverageRI(rec common.Recommendation, targetPct float64) (common
 	}
 
 	avg := rec.AverageInstancesUsedPerHour
-	// Under-buy sizing accounts for any existing commitments in the same pool:
-	// the count we still need is the coverage gap (target − existing) against
-	// historical demand. ExistingCoveragePct comes from CE GetReservationCoverage
-	// (populated upstream when available) and defaults to zero so recs without
-	// the fetched signal fall back to the no-existing-commitments path.
+	// Under-buy sizing scales AWS's rec.Count by the fraction of the
+	// current-to-100% gap we want to fill. AWS's rec.Count is the
+	// per-account incremental count needed to reach 100% coverage; we
+	// want to fill (target − existing) of the (100 − existing) gap, so
+	// the scaling factor is (target − existing) / (100 − existing).
 	//
-	// Keep the subtraction in percentage units (subtract first, divide by 100
-	// after) so whole-percent values don't lose precision: 0.70 - 0.60 in
-	// float64 rounds to 0.0999... and ceil(avg * that) would silently round
-	// up by 1.
+	// This is more robust than the prior avg*gap formula for multi-account
+	// orgs: CE's ExistingCoveragePct is org-wide averaged, while AWS's
+	// rec.Count is computed per-account, so scaling AWS's already-correct
+	// count by a fractional dial holds up even when CE's existing-coverage
+	// signal is averaged below the per-account truth. The avg signal is
+	// retained only as a no-signal guard above and for the projection
+	// metrics below.
+	//
+	// Keep the subtraction in percentage units (subtract first, divide
+	// later) so whole-percent values don't lose precision to float
+	// rounding at integer boundaries.
 	gapPct := targetPct - rec.ExistingCoveragePct
 	if gapPct <= 0 {
 		// Existing commitments already meet or exceed the target; no purchase
@@ -327,21 +340,27 @@ func applyTargetCoverageRI(rec common.Recommendation, targetPct float64) (common
 			targetPct, rec.ExistingCoveragePct, rec.Service, rec.Region, rec.ResourceType)
 		return rec, false
 	}
+	// remainingGapPct = 100 − existing. Always positive when gapPct > 0
+	// because gapPct > 0 implies targetPct > existing, and targetPct is
+	// validated to be at most 100, so existing < 100 too.
+	remainingGapPct := 100.0 - rec.ExistingCoveragePct
 	// Floor so we never over-shoot the target on integer-arithmetic edges.
 	// Strict-target semantics: 80% means "at most 80% coverage", not "at
-	// least 80%". Floor under-covers small/odd pools (e.g. avg=2, target=80
-	// gives 1 RI = 50% rather than 2 RIs = 100%); pools too small to
-	// approximate target are best filtered out via --min-pool-size upstream.
-	nTarget := int(math.Floor(avg * gapPct / 100.0))
+	// least 80%". Floor under-covers small/odd pools (e.g. AWS rec=2,
+	// target=80 gives 1 RI = 50% rather than 2 RIs = 100%); pools too
+	// small to approximate target are best filtered out via
+	// --min-pool-size upstream.
+	nTarget := int(math.Floor(float64(rec.Count) * gapPct / remainingGapPct))
 
 	if nTarget == 0 {
-		// Floor produces zero when the gap is too small for even one RI on
-		// this pool's avg usage. Drop — buying 1 RI would over-shoot target
-		// and the strict-target intent prefers under-cover (run on-demand)
-		// over over-cover (idle commitment). Use --min-pool-size to filter
-		// these out earlier so they don't show up as drops in the log.
-		AppLogger.Printf("INFO: --target-coverage=%.1f%% sizes %s/%s/%s to 0 instances (avg used %.2f/hr, gap %.2f%% produces <1 RI); dropped recommendation\n",
-			targetPct, rec.Service, rec.Region, rec.ResourceType, avg, gapPct)
+		// Floor produces zero when the gap-of-remaining-gap ratio multiplied
+		// by AWS's rec.Count is less than 1 (small recs or thin gaps).
+		// Drop — buying 1 RI would over-shoot target and the strict-target
+		// intent prefers under-cover (run on-demand) over over-cover
+		// (idle commitment). Use --min-pool-size to filter these out
+		// earlier so they don't show up as drops in the log.
+		AppLogger.Printf("INFO: --target-coverage=%.1f%% sizes %s/%s/%s to 0 instances (rec.Count=%d, gap %.2f%% of remaining %.2f%% produces <1 RI); dropped recommendation\n",
+			targetPct, rec.Service, rec.Region, rec.ResourceType, rec.Count, gapPct, remainingGapPct)
 		// Returning (_, false) with avg > 0 signals "drop, don't pass through".
 		// applyTargetCoverageRI's caller branches on
 		// rec.AverageInstancesUsedPerHour to distinguish drop vs no-signal.

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -185,11 +185,12 @@ func ApplyCoverage(recs []common.Recommendation, coverage float64) []common.Reco
 // commitments actually purchased), not the over-buy semantics that floor
 // produces; see the #338 review discussion for the redirect.
 //
-// RIs (existing-aware, per-pool):
+// RIs (existing-aware, per-pool, strict-target):
 //
 //	gap = (targetPct - ExistingCoveragePct) / 100
-//	n_target = ceil(AverageInstancesUsedPerHour * gap)
+//	n_target = floor(AverageInstancesUsedPerHour * gap)
 //	If gap <= 0 (existing already at/above target) → drop with INFO log.
+//	If n_target == 0 (gap too small to fit one RI) → drop with INFO log.
 //	If AverageInstancesUsedPerHour <= 0 → pass through (no signal); counted
 //	in the per-run skip summary.
 //	Projected coverage = ExistingCoveragePct + n_target/avg * 100 (total
@@ -202,14 +203,17 @@ func ApplyCoverage(recs []common.Recommendation, coverage float64) []common.Reco
 //	(region, instance_type, engine) — the per-engine fetcher in
 //	coverage.go avoids the cross-engine bleed that a per-pool aggregate
 //	would produce.
-//	Ceil (rather than floor) ensures any non-zero gap with non-zero
-//	demand buys at least 1 RI, matching AWS's recommendation shape and
-//	avoiding the "single-instance pool silently dropped" failure mode.
+//	Floor (rather than ceil or round) gives strict "at-most-target"
+//	sizing: small/odd pools under-cover rather than over-cover, matching
+//	the operator's intent when they set a target. Pools too small to
+//	approximate the target meaningfully (avg < ~5 for target=80%) should
+//	be filtered upstream via --min-pool-size; floor will drop them as
+//	zero-count otherwise.
 //
 //	Pools where CE reports 100% existing coverage but AWS still recommends
 //	new RIs (typical when existing RIs are near expiry) are dropped here —
-//	the existing coverage is honoured strictly. Surfacing expiring RIs is
-//	a separate concern tracked elsewhere.
+//	the existing coverage is honoured strictly. Use --rebuy-window-days to
+//	surface those replacements before the cliff.
 //
 // SPs:
 //
@@ -323,17 +327,19 @@ func applyTargetCoverageRI(rec common.Recommendation, targetPct float64) (common
 			targetPct, rec.ExistingCoveragePct, rec.Service, rec.Region, rec.ResourceType)
 		return rec, false
 	}
-	// Ceil so any non-zero gap with non-zero demand buys at least 1 RI —
-	// AWS's recommendation list always proposes a count, and silently dropping
-	// single-instance pools was the worse failure mode than slight over-target
-	// on tiny pools. The pre-existing-coverage version of this branch used
-	// floor and silently skipped a third of the AWS-console recommendations.
-	nTarget := int(math.Ceil(avg * gapPct / 100.0))
+	// Floor so we never over-shoot the target on integer-arithmetic edges.
+	// Strict-target semantics: 80% means "at most 80% coverage", not "at
+	// least 80%". Floor under-covers small/odd pools (e.g. avg=2, target=80
+	// gives 1 RI = 50% rather than 2 RIs = 100%); pools too small to
+	// approximate target are best filtered out via --min-pool-size upstream.
+	nTarget := int(math.Floor(avg * gapPct / 100.0))
 
 	if nTarget == 0 {
-		// Defensive: math.Ceil on a positive product never returns 0, but a
-		// truncation or tiny-float edge case could. Drop with a log if it
-		// somehow happens.
+		// Floor produces zero when the gap is too small for even one RI on
+		// this pool's avg usage. Drop — buying 1 RI would over-shoot target
+		// and the strict-target intent prefers under-cover (run on-demand)
+		// over over-cover (idle commitment). Use --min-pool-size to filter
+		// these out earlier so they don't show up as drops in the log.
 		AppLogger.Printf("INFO: --target-coverage=%.1f%% sizes %s/%s/%s to 0 instances (avg used %.2f/hr, gap %.2f%% produces <1 RI); dropped recommendation\n",
 			targetPct, rec.Service, rec.Region, rec.ResourceType, avg, gapPct)
 		// Returning (_, false) with avg > 0 signals "drop, don't pass through".

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -931,32 +931,33 @@ func TestApplyTargetCoverage_RI(t *testing.T) {
 		wantProjCovGTE float64 // we assert coverage >= this (handles the float clamping)
 	}{
 		{
-			// avg=8.5, target=95%, existing=0% (no signal).
-			// gap=95, n=ceil(8.5*0.95) = ceil(8.075) = 9.
-			// Projected util = 8.5/9 = 94.4.
-			name:         "RI: target 95 buys 9 (ceil rounds 8.075 up)",
+			// avg=8.5, target=95%, existing=0%. gap=95.
+			// n = floor(8.5 * 0.95) = floor(8.075) = 8.
+			// Projected util = 8.5/8 = 106.25 clamped to 100.
+			// Projected coverage = 8/8.5 = 94.1%, just under target.
+			name:         "RI: target 95 buys 8 (floor rounds 8.075 down)",
 			rec:          mkRI(10, 8.5, 0),
 			target:       95,
-			wantCount:    9,
-			wantProjUtil: 94.44,
+			wantCount:    8,
+			wantProjUtil: 100,
 		},
 		{
-			// avg=10, target=50%, existing=0%. gap=50. n=ceil(5)=5.
-			name:         "RI: target 50 under-buys to leave on-demand headroom",
+			// avg=10, target=50%, existing=0%. gap=50. n=floor(5)=5.
+			name:         "RI: target 50 covers exactly half",
 			rec:          mkRI(10, 10, 0),
 			target:       50,
 			wantCount:    5,
 			wantProjUtil: 100, // 10/5 clamped
 		},
 		{
-			// avg=0.4, target=50%, existing=0%. gap=50. n=ceil(0.2)=1.
-			// Tiny-pool case: ceil keeps the rec alive at 1 RI rather than
-			// dropping. Projected util = 0.4/1 = 40 (under 100, no clamp).
-			name:         "RI: tiny pool rounds up to 1 (ceil)",
-			rec:          mkRI(5, 0.4, 0),
-			target:       50,
-			wantCount:    1,
-			wantProjUtil: 40,
+			// avg=0.4, target=50%, existing=0%. gap=50. n=floor(0.2)=0 → drop.
+			// Tiny-pool case: floor drops rather than over-covering. Operators
+			// who want these pools kept use --min-pool-size to filter
+			// upstream OR accept the on-demand spend.
+			name:        "RI: tiny pool drops (floor rounds down to 0)",
+			rec:         mkRI(5, 0.4, 0),
+			target:      50,
+			wantDropped: true,
 		},
 		{
 			// avg=0 (no signal) → passed through unchanged, counted in skip summary.
@@ -967,13 +968,13 @@ func TestApplyTargetCoverage_RI(t *testing.T) {
 			wantProjUtil: 0, // never set in pass-through
 		},
 		{
-			// avg=4, target=80%, existing=0%. gap=80. n=ceil(3.2)=4.
-			// Projected coverage = 4/4 = 100, over target by ceil's rounding.
-			name:         "RI: target 80 covers 4 of 4 (ceil rounds 3.2 up)",
+			// avg=4, target=80%, existing=0%. gap=80. n=floor(3.2)=3.
+			// Projected coverage = 3/4 = 75, just under target (strict-target).
+			name:         "RI: target 80 covers 3 of 4 (floor rounds 3.2 down)",
 			rec:          mkRI(5, 4, 0),
 			target:       80,
-			wantCount:    4,
-			wantProjUtil: 100,
+			wantCount:    3,
+			wantProjUtil: 100, // 4/3 = 133 clamped
 		},
 	}
 
@@ -1019,14 +1020,14 @@ func TestApplyTargetCoverage_RI_CostScaling(t *testing.T) {
 		SavingsPercentage:           25,
 		AverageInstancesUsedPerHour: 8,
 	}
-	// target=80 → gap=80, n=ceil(8*0.8) = ceil(6.4) = 7 (rec.Count=10).
-	// Ratio = 7/10 = 0.7. Cost-bearing fields scale by 0.7.
+	// target=80 → gap=80, n=floor(8*0.8) = floor(6.4) = 6 (rec.Count=10).
+	// Ratio = 6/10 = 0.6. Cost-bearing fields scale by 0.6.
 	out := ApplyTargetCoverage([]common.Recommendation{rec}, 80)
 	require.Len(t, out, 1)
-	assert.Equal(t, 7, out[0].Count)
-	assert.InDelta(t, 700.0, out[0].CommitmentCost, 0.001, "CommitmentCost scales by Count/rec.Count")
-	assert.InDelta(t, 1400.0, out[0].OnDemandCost, 0.001, "OnDemandCost scales by Count/rec.Count")
-	assert.InDelta(t, 350.0, out[0].EstimatedSavings, 0.001, "EstimatedSavings scales by Count/rec.Count")
+	assert.Equal(t, 6, out[0].Count)
+	assert.InDelta(t, 600.0, out[0].CommitmentCost, 0.001, "CommitmentCost scales by Count/rec.Count")
+	assert.InDelta(t, 1200.0, out[0].OnDemandCost, 0.001, "OnDemandCost scales by Count/rec.Count")
+	assert.InDelta(t, 300.0, out[0].EstimatedSavings, 0.001, "EstimatedSavings scales by Count/rec.Count")
 	assert.Equal(t, 25.0, out[0].SavingsPercentage, "SavingsPercentage is invariant under count scaling")
 }
 
@@ -1091,17 +1092,15 @@ func TestApplyTargetCoverage_RI_ExistingCoverage(t *testing.T) {
 			wantDropped: true,
 		},
 		{
-			// avg=2, existing=70%, target=80%. gap=10. n=ceil(0.2)=1.
-			// Ceil keeps the rec alive even for tiny gaps. Total cov =
-			// 70 + 1/2*100 = 120 → clamped to 100.
-			name:         "Small gap rounds up to 1 RI",
-			rec:          mkRI(5, 2, 70),
-			target:       80,
-			wantCount:    1,
-			wantTotalCov: 100,
+			// avg=2, existing=70%, target=80%. gap=10. n=floor(0.2)=0 → drop.
+			// Strict-target: would over-shoot if we bought 1 RI, so drop.
+			name:        "Small gap rounds down to 0 → drop",
+			rec:         mkRI(5, 2, 70),
+			target:      80,
+			wantDropped: true,
 		},
 		{
-			// avg=10, existing=60%, target=70%. gap=10. n=ceil(1.0)=1.
+			// avg=10, existing=60%, target=70%. gap=10. n=floor(1.0)=1.
 			// Total cov = 60+10 = 70 (hits target exactly).
 			name:         "Small top-up to reach target",
 			rec:          mkRI(10, 10, 60),
@@ -1198,9 +1197,9 @@ func TestApplySizing(t *testing.T) {
 		cfg := Config{TargetCoverage: 80, Coverage: 100}
 		out := applySizing([]common.Recommendation{ri}, cfg, cfg.Coverage)
 		require.Len(t, out, 1)
-		// avg=8, target=80%, existing=0%. gap=80. n=ceil(8*0.8)=ceil(6.4)=7.
-		// ProjectedUtilization = 8/7 = 114 clamped to 100.
-		assert.Equal(t, 7, out[0].Count)
+		// avg=8, target=80%, existing=0%. gap=80. n=floor(8*0.8)=floor(6.4)=6.
+		// ProjectedUtilization = 8/6 = 133 clamped to 100.
+		assert.Equal(t, 6, out[0].Count)
 		assert.Equal(t, 100.0, out[0].ProjectedUtilization)
 	})
 
@@ -1216,9 +1215,9 @@ func TestApplySizing(t *testing.T) {
 }
 
 // TestApplyTargetCoverage_RI_Target100 covers the target == 100 boundary.
-// At target=100 (and existing=0), ceil(avg*1.0) = ceil(avg) — any non-zero
-// avg rounds up to at least 1. Fractional avg above an integer rounds up
-// to the next integer.
+// At target=100 (and existing=0), floor(avg*1.0) = floor(avg) — fractional
+// avg rounds DOWN to the nearest integer. Pools with avg<1 drop entirely
+// (strict-target: don't over-cover even at 100%).
 func TestApplyTargetCoverage_RI_Target100(t *testing.T) {
 	mkRI := func(count int, avg float64) common.Recommendation {
 		return common.Recommendation{
@@ -1237,13 +1236,14 @@ func TestApplyTargetCoverage_RI_Target100(t *testing.T) {
 		wantDropped bool
 		wantCount   int
 	}{
-		// avg=0.999 → ceil(0.999) = 1.
-		{name: "target 100, avg=0.999 → buy 1", rec: mkRI(5, 0.999), wantCount: 1},
-		// avg=1.0 → ceil(1.0) = 1.
+		// avg=0.999 → floor(0.999) = 0 → drop. Use --min-pool-size to
+		// filter such pools out explicitly upstream.
+		{name: "target 100, avg=0.999 → dropped (floor rounds to 0)", rec: mkRI(5, 0.999), wantDropped: true},
+		// avg=1.0 → floor(1.0) = 1.
 		{name: "target 100, avg=1.0 → buy 1", rec: mkRI(5, 1.0), wantCount: 1},
-		// avg=8.7 → ceil(8.7) = 9. Slightly over target but matches AWS rec.
-		{name: "target 100, avg=8.7 → buy 9 (ceil rounds up)", rec: mkRI(10, 8.7), wantCount: 9},
-		// avg=10.0 exactly → ceil(10) = 10.
+		// avg=8.7 → floor(8.7) = 8. Slightly under target (strict-target).
+		{name: "target 100, avg=8.7 → buy 8 (floor rounds down)", rec: mkRI(10, 8.7), wantCount: 8},
+		// avg=10.0 exactly → floor(10) = 10.
 		{name: "target 100, avg=10.0 → buy 10 (perfect match)", rec: mkRI(10, 10.0), wantCount: 10},
 	}
 

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -931,36 +931,36 @@ func TestApplyTargetCoverage_RI(t *testing.T) {
 		wantProjCovGTE float64 // we assert coverage >= this (handles the float clamping)
 	}{
 		{
-			// avg=8.5, target=95% → ceil(8.5*0.95) = ceil(8.075) = 9.
-			// Projected utilization = 8.5/9 = 94.4. Coverage = 9/8.5 = 105.9
-			// clamped to 100.
-			name:         "RI: target 95 buys 9 (ceil rounds 8.075 up)",
+			// rec.Count=10, avg=8.5, target=95%.
+			// awsScaled = ceil(10*0.95) = 10. existingAware = ceil(8.5*0.95) = 9.
+			// max = 10. Projected util = 8.5/10 = 85.
+			name:         "RI: target 95 uses awsScaled floor (10 > 9)",
 			rec:          mkRI(10, 8.5, 85),
 			target:       95,
-			wantCount:    9,
-			wantProjUtil: 94.44,
+			wantCount:    10,
+			wantProjUtil: 85.0,
 		},
 		{
-			// avg=10, target=50% → ceil(10*0.5) = 5. Half of average usage
-			// is reserved; the other half spills to on-demand. Projected
-			// utilization = 10/5 = 200 → clamped to 100 (RIs always full).
-			// Projected coverage = 5/10 = 50, matches target.
-			name:         "RI: target 50 under-buys to leave on-demand headroom",
+			// rec.Count=10, avg=10, target=50%.
+			// awsScaled = ceil(10*0.5) = 5. existingAware = ceil(10*0.5) = 5.
+			// max = 5. Same count via either path.
+			name:         "RI: target 50 sizes to half AWS rec",
 			rec:          mkRI(10, 10, 90),
 			target:       50,
 			wantCount:    5,
 			wantProjUtil: 100, // 10/5 clamped
 		},
 		{
-			// avg=0.4, target=50% → ceil(0.4*0.5) = ceil(0.2) = 1.
-			// Tiny-pool case: ceil rounds up so a single fractional avg
-			// instance still gets one RI rather than the pool being dropped.
-			// Projected utilization = 0.4/1 = 40 (not clamped — below 100).
-			name:         "RI: tiny pool rounds up to 1 (ceil)",
+			// rec.Count=5, avg=0.4, target=50%.
+			// awsScaled = ceil(5*0.5) = 3. existingAware = ceil(0.4*0.5) = 1.
+			// max = 3. The AWS-scaled floor keeps the rec alive even on
+			// tiny-avg pools because the AWS rec list still recommends them.
+			// Projected util = 0.4/3 = 13.3 (under 100, no clamp).
+			name:         "RI: tiny pool gets awsScaled count, not just 1",
 			rec:          mkRI(5, 0.4, 50),
 			target:       50,
-			wantCount:    1,
-			wantProjUtil: 40,
+			wantCount:    3,
+			wantProjUtil: 13.33,
 		},
 		{
 			// avg=0 (no signal) → passed through unchanged, counted in skip summary.
@@ -971,15 +971,14 @@ func TestApplyTargetCoverage_RI(t *testing.T) {
 			wantProjUtil: 0, // never set in pass-through
 		},
 		{
-			// avg=4, target=80% → ceil(4*0.8) = ceil(3.2) = 4. Projected
-			// utilization = 4/4 = 100. Projected coverage = 4/4 = 100,
-			// over target by ceil's rounding; preferable to under-buying
-			// since target=80 expresses a floor on coverage, not a ceiling.
-			name:         "RI: target 80 covers 4 of 4 (ceil rounds 3.2 up)",
+			// rec.Count=5, avg=4, target=80%.
+			// awsScaled = ceil(5*0.8) = 4. existingAware = ceil(4*0.8) = 4.
+			// max = 4.
+			name:         "RI: target 80 covers 4 of 5 AWS-recommended",
 			rec:          mkRI(5, 4, 80),
 			target:       80,
 			wantCount:    4,
-			wantProjUtil: 100,
+			wantProjUtil: 100, // avg/n = 4/4 = 100
 		},
 	}
 
@@ -1025,14 +1024,14 @@ func TestApplyTargetCoverage_RI_CostScaling(t *testing.T) {
 		SavingsPercentage:           25,
 		AverageInstancesUsedPerHour: 8,
 	}
-	// target=80 → ceil(8*0.8) = ceil(6.4) = 7 (under-buy from rec.Count=10).
-	// Ratio = 0.7. All cost-bearing fields scale by this ratio.
+	// target=80 → awsScaled = ceil(10*0.8) = 8. existingAware = ceil(8*0.8) = 7.
+	// max = 8. Ratio = 8/10 = 0.8. Cost-bearing fields scale by 0.8.
 	out := ApplyTargetCoverage([]common.Recommendation{rec}, 80)
 	require.Len(t, out, 1)
-	assert.Equal(t, 7, out[0].Count)
-	assert.InDelta(t, 700.0, out[0].CommitmentCost, 0.001, "CommitmentCost scales by Count/rec.Count")
-	assert.InDelta(t, 1400.0, out[0].OnDemandCost, 0.001, "OnDemandCost scales by Count/rec.Count")
-	assert.InDelta(t, 350.0, out[0].EstimatedSavings, 0.001, "EstimatedSavings scales by Count/rec.Count")
+	assert.Equal(t, 8, out[0].Count)
+	assert.InDelta(t, 800.0, out[0].CommitmentCost, 0.001, "CommitmentCost scales by Count/rec.Count")
+	assert.InDelta(t, 1600.0, out[0].OnDemandCost, 0.001, "OnDemandCost scales by Count/rec.Count")
+	assert.InDelta(t, 400.0, out[0].EstimatedSavings, 0.001, "EstimatedSavings scales by Count/rec.Count")
 	assert.Equal(t, 25.0, out[0].SavingsPercentage, "SavingsPercentage is invariant under count scaling")
 }
 
@@ -1066,56 +1065,69 @@ func TestApplyTargetCoverage_RI_ExistingCoverage(t *testing.T) {
 		wantTotalCov float64 // ProjectedCoverage = existing + new contribution
 	}{
 		{
-			// User's worked example: 20 demand, 10 existing covering 50%, target 80%.
-			// gap = 80-50 = 30 (in pct). n = ceil(20*0.30) = ceil(6.0) = 6.
-			// Total coverage = 50 + 6/20*100 = 80.
-			name:         "User example: 50% existing, 80% target on avg=20 -> buy 6",
+			// User's worked example: rec.Count=10, avg=20, existing=50%, target=80%.
+			// awsScaled = ceil(10*0.8) = 8.
+			// existingAware = ceil(20*0.30) = 6.
+			// max = 8. AWS-scaled floor wins (the hybrid trade — slight
+			// over-target vs the strict 6-RI answer, in exchange for
+			// matching AWS's recommendation shape).
+			// Total cov = 50 + 8/20*100 = 90.
+			name:         "User example: hybrid uses awsScaled floor of 8",
 			rec:          mkRI(10, 20, 50),
 			target:       80,
-			wantCount:    6,
-			wantTotalCov: 80,
+			wantCount:    8,
+			wantTotalCov: 90,
 		},
 		{
-			// existing=0% so no subtraction.
-			// gap=70 (pct). n = ceil(10*0.70) = 7. Total cov = 0+70 = 70.
-			name:         "Zero existing: degenerates to ceil(avg*target)",
+			// rec.Count=10, avg=10, existing=0%, target=70%.
+			// awsScaled = ceil(10*0.7) = 7. existingAware = ceil(10*0.7) = 7.
+			// max = 7. Both candidates agree when existing=0.
+			name:         "Zero existing: both candidates agree",
 			rec:          mkRI(10, 10, 0),
 			target:       70,
 			wantCount:    7,
 			wantTotalCov: 70,
 		},
 		{
-			// Already at target: drop.
-			name:        "Existing meets target exactly: drop",
-			rec:         mkRI(10, 10, 80),
-			target:      80,
-			wantDropped: true,
-		},
-		{
-			// Already over target: drop.
-			name:        "Existing exceeds target: drop",
-			rec:         mkRI(10, 10, 95),
-			target:      80,
-			wantDropped: true,
-		},
-		{
-			// avg=2, existing=70%, target=80%, gap=10 (pct), n=ceil(0.20)=1.
-			// Ceil keeps the rec alive even for tiny gaps. Total cov =
-			// 70 + 1/2*100 = 120 → clamped to 100 (over target by 20%).
-			name:         "Small gap rounds up to 1 RI",
-			rec:          mkRI(5, 2, 70),
+			// rec.Count=10, avg=10, existing=80%, target=80%.
+			// awsScaled = ceil(10*0.8) = 8. existingAware = 0 (gap=0).
+			// max = 8. AWS still recommends so we still buy — hybrid keeps
+			// the rec alive (covers the RI-expiry case CE coverage doesn't
+			// see). Total cov = 80 + 8/10*100 = 160 clamped to 100.
+			name:         "Existing meets target: awsScaled floor still buys",
+			rec:          mkRI(10, 10, 80),
 			target:       80,
-			wantCount:    1,
+			wantCount:    8,
 			wantTotalCov: 100,
 		},
 		{
-			// Near-target top-up: avg=10, existing=60%, target=70%, gap=10 (pct).
-			// n=ceil(1.0)=1. Total cov = 60+10 = 70.
-			name:         "Small top-up to reach target",
+			// rec.Count=10, avg=10, existing=95%, target=80%.
+			// awsScaled = 8. existingAware = 0. max = 8.
+			name:         "Existing exceeds target: awsScaled floor still buys",
+			rec:          mkRI(10, 10, 95),
+			target:       80,
+			wantCount:    8,
+			wantTotalCov: 100,
+		},
+		{
+			// rec.Count=5, avg=2, existing=70%, target=80%.
+			// awsScaled = ceil(5*0.8) = 4. existingAware = ceil(2*0.1) = 1.
+			// max = 4. Total cov = 70 + 4/2*100 = 270 clamped to 100.
+			name:         "Small gap: awsScaled floor of 4 wins over 1",
+			rec:          mkRI(5, 2, 70),
+			target:       80,
+			wantCount:    4,
+			wantTotalCov: 100,
+		},
+		{
+			// rec.Count=10, avg=10, existing=60%, target=70%.
+			// awsScaled = ceil(10*0.7) = 7. existingAware = ceil(10*0.1) = 1.
+			// max = 7. Total cov = 60 + 7/10*100 = 130 clamped to 100.
+			name:         "Small top-up: awsScaled floor of 7 wins over 1",
 			rec:          mkRI(10, 10, 60),
 			target:       70,
-			wantCount:    1,
-			wantTotalCov: 70,
+			wantCount:    7,
+			wantTotalCov: 100,
 		},
 	}
 
@@ -1206,9 +1218,10 @@ func TestApplySizing(t *testing.T) {
 		cfg := Config{TargetCoverage: 80, Coverage: 100}
 		out := applySizing([]common.Recommendation{ri}, cfg, cfg.Coverage)
 		require.Len(t, out, 1)
-		// Under-buy: ceil(8*0.8) = ceil(6.4) = 7. ProjectedUtilization =
-		// 8/7 = 114 clamped to 100 (RIs always fully used when count < avg).
-		assert.Equal(t, 7, out[0].Count)
+		// Hybrid: rec.Count=10, avg=8, target=80%.
+		// awsScaled = ceil(10*0.8) = 8. existingAware = ceil(8*0.8) = 7.
+		// max = 8. ProjectedUtilization = 8/8 = 100.
+		assert.Equal(t, 8, out[0].Count)
 		assert.Equal(t, 100.0, out[0].ProjectedUtilization)
 	})
 
@@ -1223,12 +1236,11 @@ func TestApplySizing(t *testing.T) {
 	})
 }
 
-// TestApplyTargetCoverage_RI_Target100 covers the target == 100 boundary
-// (issue #338 AC: "target == 100 → only purchases with perfectly-matched
-// existing usage"). At target=100 (ratio=1.0), ceil(avg*1.0) is ceil(avg) —
-// so any non-zero avg rounds up to at least 1 (ceil never drops a pool
-// with running demand). Fractional avg above an integer rounds up to the
-// next integer.
+// TestApplyTargetCoverage_RI_Target100 covers the target == 100 boundary.
+// At target=100 (ratio=1.0), awsScaled = ceil(rec.Count*1.0) = rec.Count,
+// which becomes the floor — we always buy AWS's full recommended count.
+// The existingAware branch (ceil(avg*1.0)) only wins when avg > rec.Count,
+// which doesn't happen in practice (AWS sizes rec.Count >= avg).
 func TestApplyTargetCoverage_RI_Target100(t *testing.T) {
 	mkRI := func(count int, avg float64) common.Recommendation {
 		return common.Recommendation{
@@ -1247,15 +1259,14 @@ func TestApplyTargetCoverage_RI_Target100(t *testing.T) {
 		wantDropped bool
 		wantCount   int
 	}{
-		// avg=0.999 → ceil(0.999*1.0) = 1. Ceil ensures any non-zero pool
-		// gets a rec (matches AWS behaviour).
-		{name: "target 100, avg=0.999 → buy 1", rec: mkRI(5, 0.999), wantCount: 1},
-		// avg=1.0 → ceil(1.0*1.0) = 1 → buy 1. projected utilization = 100.
-		{name: "target 100, avg=1.0 → buy 1", rec: mkRI(5, 1.0), wantCount: 1},
-		// avg=8.7 → ceil(8.7*1.0) = 9. Slightly over target but matches AWS rec.
-		{name: "target 100, avg=8.7 → buy 9 (ceil rounds up)", rec: mkRI(10, 8.7), wantCount: 9},
-		// avg=10.0 exactly → ceil(10*1.0) = 10 (exact integer). projected utilization = 100.
-		{name: "target 100, avg=10.0 → buy 10 (perfect match)", rec: mkRI(10, 10.0), wantCount: 10},
+		// rec.Count=5, avg=0.999. awsScaled=5, existingAware=1. max=5.
+		{name: "target 100, rec.Count=5 → awsScaled floor wins", rec: mkRI(5, 0.999), wantCount: 5},
+		// rec.Count=5, avg=1.0. awsScaled=5, existingAware=1. max=5.
+		{name: "target 100, avg=1 with rec.Count=5 → buy 5", rec: mkRI(5, 1.0), wantCount: 5},
+		// rec.Count=10, avg=8.7. awsScaled=10, existingAware=9. max=10.
+		{name: "target 100, rec.Count > avg → awsScaled wins", rec: mkRI(10, 8.7), wantCount: 10},
+		// rec.Count=10, avg=10. awsScaled=10, existingAware=10. max=10.
+		{name: "target 100, rec.Count == avg → match", rec: mkRI(10, 10.0), wantCount: 10},
 	}
 
 	for _, tt := range tests {

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -1005,10 +1005,11 @@ func TestApplyTargetCoverage_RI(t *testing.T) {
 	}
 }
 
-// TestApplyTargetCoverage_RI_CostScaling verifies RI cost fields are NOT
-// scaled when the count is adjusted (matching ApplyCoverage's RI branch,
-// which also leaves cost fields untouched). Divergence would silently
-// mis-cost the dry-run output relative to the coverage path.
+// TestApplyTargetCoverage_RI_CostScaling verifies RI cost-bearing fields
+// scale by the sized-to-original count ratio. SavingsPercentage is invariant.
+// The scaled values let downstream consumers (CSV writer, reporter, audit
+// log) trust rec.CommitmentCost / rec.EstimatedSavings as the sized purchase
+// rather than AWS's pre-sized proposal.
 func TestApplyTargetCoverage_RI_CostScaling(t *testing.T) {
 	rec := common.Recommendation{
 		Service:                     common.ServiceEC2,
@@ -1017,16 +1018,17 @@ func TestApplyTargetCoverage_RI_CostScaling(t *testing.T) {
 		CommitmentCost:              1000,
 		OnDemandCost:                2000,
 		EstimatedSavings:            500,
+		SavingsPercentage:           25,
 		AverageInstancesUsedPerHour: 8,
 	}
-	// target=80 → floor(8*0.8) = 6 (under-buy from rec.Count=10). Cost
-	// fields must match the input exactly; only Count changes.
+	// target=80 → floor(8*0.8) = 6 (under-buy from rec.Count=10). Ratio = 0.6.
 	out := ApplyTargetCoverage([]common.Recommendation{rec}, 80)
 	require.Len(t, out, 1)
 	assert.Equal(t, 6, out[0].Count)
-	assert.Equal(t, 1000.0, out[0].CommitmentCost, "CommitmentCost should be untouched by RI branch")
-	assert.Equal(t, 2000.0, out[0].OnDemandCost, "OnDemandCost should be untouched by RI branch")
-	assert.Equal(t, 500.0, out[0].EstimatedSavings, "EstimatedSavings should be untouched by RI branch")
+	assert.InDelta(t, 600.0, out[0].CommitmentCost, 0.001, "CommitmentCost scales by Count/rec.Count")
+	assert.InDelta(t, 1200.0, out[0].OnDemandCost, 0.001, "OnDemandCost scales by Count/rec.Count")
+	assert.InDelta(t, 300.0, out[0].EstimatedSavings, 0.001, "EstimatedSavings scales by Count/rec.Count")
+	assert.Equal(t, 25.0, out[0].SavingsPercentage, "SavingsPercentage is invariant under count scaling")
 }
 
 // TestApplyTargetCoverage_SP covers the SP sizing branch under under-buy
@@ -1049,30 +1051,31 @@ func TestApplyTargetCoverage_SP(t *testing.T) {
 
 	t.Run("AWS above target — still scales by target (under-buy)", func(t *testing.T) {
 		// RecUtil=95, target=80. Even though AWS projects above target, the
-		// flag's intent is "leave 20% headroom", so commitment shrinks to
-		// 80% of AWS rec. HourlyCommitment: 2.0 * 0.80 = 1.6, savings: 1500
-		// * 0.80 = 1200. Projected util = 95/0.80 = 118.75 clamped to 100.
+		// flag's intent is "leave 20% headroom", so the commitment shrinks
+		// to 80% of AWS rec. All cost-bearing fields scale by 0.8.
+		// Projected util = 95/0.80 = 118.75 clamped to 100.
 		out := ApplyTargetCoverage([]common.Recommendation{mkSP(95)}, 80)
 		require.Len(t, out, 1)
 		assert.InDelta(t, 1.6, out[0].Details.(*common.SavingsPlanDetails).HourlyCommitment, 0.001)
+		assert.InDelta(t, 800.0, out[0].CommitmentCost, 0.001, "CommitmentCost scales by target/100")
+		assert.InDelta(t, 4000.0, out[0].OnDemandCost, 0.001, "OnDemandCost scales by target/100")
 		assert.InDelta(t, 1200.0, out[0].EstimatedSavings, 0.001)
+		assert.Equal(t, 30.0, out[0].SavingsPercentage, "SavingsPercentage is invariant")
 		assert.InDelta(t, 100.0, out[0].ProjectedUtilization, 0.001, "RecUtil/ratio = 95/0.80 = 118.75 clamps to 100")
 		assert.Equal(t, 0.0, out[0].ProjectedCoverage, "SPs intentionally leave ProjectedCoverage at zero")
 	})
 
 	t.Run("AWS below target — scale down by target (under-buy)", func(t *testing.T) {
-		// RecUtil=50, target=80. Commitment shrinks to 80% of AWS rec.
-		// HourlyCommitment: 2.0 * 0.80 = 1.6, savings: 1500 * 0.80 = 1200.
+		// RecUtil=50, target=80. All cost-bearing fields shrink to 80%.
 		// Projected util = 50/0.80 = 62.5 (no clamp needed).
 		out := ApplyTargetCoverage([]common.Recommendation{mkSP(50)}, 80)
 		require.Len(t, out, 1)
 		details := out[0].Details.(*common.SavingsPlanDetails)
 		assert.InDelta(t, 1.6, details.HourlyCommitment, 0.001)
+		assert.InDelta(t, 800.0, out[0].CommitmentCost, 0.001, "CommitmentCost scales by target/100")
+		assert.InDelta(t, 4000.0, out[0].OnDemandCost, 0.001, "OnDemandCost scales by target/100")
 		assert.InDelta(t, 1200.0, out[0].EstimatedSavings, 0.001)
-		// CommitmentCost / OnDemandCost / SavingsPercentage MUST be unchanged.
-		assert.Equal(t, 1000.0, out[0].CommitmentCost, "CommitmentCost must not scale on SP branch (matches ApplyCoverage)")
-		assert.Equal(t, 5000.0, out[0].OnDemandCost, "OnDemandCost must not scale on SP branch (matches ApplyCoverage)")
-		assert.Equal(t, 30.0, out[0].SavingsPercentage, "SavingsPercentage must not scale on SP branch")
+		assert.Equal(t, 30.0, out[0].SavingsPercentage, "SavingsPercentage is invariant")
 		assert.InDelta(t, 62.5, out[0].ProjectedUtilization, 0.001, "RecUtil/ratio = 50/0.80 = 62.5")
 		assert.Equal(t, 0.0, out[0].ProjectedCoverage)
 	})

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -934,19 +934,23 @@ func TestApplyTargetCoverage_RI(t *testing.T) {
 			// avg=8.5, target=95%, existing=0%.
 			// gap=95. n = floor(8.5 * 95/100) = floor(8.075) = 8.
 			// Projected util = 8.5/8 = 106.25 → clamped to 100.
-			name:         "RI: target 95 buys 8 (floor of avg*0.95)",
-			rec:          mkRI(10, 8.5, 0),
-			target:       95,
-			wantCount:    8,
-			wantProjUtil: 100,
+			// Projected cov  = 0 + 8/8.5*100 = 94.117…%
+			name:           "RI: target 95 buys 8 (floor of avg*0.95)",
+			rec:            mkRI(10, 8.5, 0),
+			target:         95,
+			wantCount:      8,
+			wantProjUtil:   100,
+			wantProjCovGTE: 94.0,
 		},
 		{
 			// avg=10, target=50%, existing=0%. n=floor(10*0.5)=5.
-			name:         "RI: target 50 buys half of avg demand",
-			rec:          mkRI(10, 10, 0),
-			target:       50,
-			wantCount:    5,
-			wantProjUtil: 100, // 10/5 clamped
+			// Projected cov = 5/10*100 = 50.0%.
+			name:           "RI: target 50 buys half of avg demand",
+			rec:            mkRI(10, 10, 0),
+			target:         50,
+			wantCount:      5,
+			wantProjUtil:   100, // 10/5 clamped
+			wantProjCovGTE: 50.0,
 		},
 		{
 			// avg=0.4, target=50%, existing=0%.
@@ -962,6 +966,7 @@ func TestApplyTargetCoverage_RI(t *testing.T) {
 		},
 		{
 			// avg=0 (no signal) → passed through unchanged, counted in skip summary.
+			// Projection metrics never set on the pass-through path.
 			name:         "RI: no signal → passed through unmodified",
 			rec:          mkRI(5, 0, 0),
 			target:       80,
@@ -971,11 +976,13 @@ func TestApplyTargetCoverage_RI(t *testing.T) {
 		{
 			// avg=4, target=80%, existing=0%. n=floor(4*0.8)=3.
 			// Projected util = 4/3 = 133% clamped to 100.
-			name:         "RI: target 80 buys floor(avg*0.8)",
-			rec:          mkRI(5, 4, 0),
-			target:       80,
-			wantCount:    3,
-			wantProjUtil: 100,
+			// Projected cov  = 3/4*100 = 75.0%.
+			name:           "RI: target 80 buys floor(avg*0.8)",
+			rec:            mkRI(5, 4, 0),
+			target:         80,
+			wantCount:      3,
+			wantProjUtil:   100,
+			wantProjCovGTE: 75.0,
 		},
 	}
 
@@ -999,6 +1006,14 @@ func TestApplyTargetCoverage_RI(t *testing.T) {
 				if math.Abs(out[0].ProjectedUtilization-tt.wantProjUtil) > 0.01 {
 					t.Errorf("ProjectedUtilization: got %.4f, want %.4f",
 						out[0].ProjectedUtilization, tt.wantProjUtil)
+				}
+			}
+			// Zero means "don't assert" (matches the wantProjUtil convention)
+			// since the pass-through path leaves ProjectedCoverage at zero.
+			if tt.wantProjCovGTE > 0 {
+				if out[0].ProjectedCoverage < tt.wantProjCovGTE-0.01 {
+					t.Errorf("ProjectedCoverage: got %.4f, want >= %.4f",
+						out[0].ProjectedCoverage, tt.wantProjCovGTE)
 				}
 			}
 		})

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -1032,6 +1032,31 @@ func TestApplyTargetCoverage_RI_CostScaling(t *testing.T) {
 	assert.InDelta(t, 1200.0, out[0].OnDemandCost, 0.001, "OnDemandCost scales by nTarget/rec.Count")
 	assert.InDelta(t, 300.0, out[0].EstimatedSavings, 0.001, "EstimatedSavings scales by nTarget/rec.Count")
 	assert.Equal(t, 25.0, out[0].SavingsPercentage, "SavingsPercentage is invariant under count scaling")
+
+	t.Run("RecurringMonthlyCost scales by ratio when populated", func(t *testing.T) {
+		// AWS populated RecurringStandardMonthlyCost for partial/no-upfront
+		// recs; sized purchase must scale this monthly fee by the same
+		// nTarget/rec.Count ratio so total cost (upfront + monthly × term)
+		// reflects what the user actually buys.
+		monthly := 50.0
+		recWithMonthly := rec
+		recWithMonthly.RecurringMonthlyCost = &monthly
+		out := ApplyTargetCoverage([]common.Recommendation{recWithMonthly}, 80)
+		require.Len(t, out, 1)
+		require.NotNil(t, out[0].RecurringMonthlyCost, "scaled pointer should be non-nil")
+		assert.InDelta(t, 30.0, *out[0].RecurringMonthlyCost, 0.001, "monthly cost scales by 6/10")
+		// Original pointer untouched (we allocated a new one).
+		assert.Equal(t, 50.0, monthly, "original RecurringMonthlyCost target should not be mutated")
+	})
+
+	t.Run("RecurringMonthlyCost stays nil when not populated", func(t *testing.T) {
+		// AWS API didn't return RecurringStandardMonthlyCost (all-upfront,
+		// or field missing). The sized rec should also have nil so
+		// downstream renders "unknown" rather than zero.
+		out := ApplyTargetCoverage([]common.Recommendation{rec}, 80)
+		require.Len(t, out, 1)
+		assert.Nil(t, out[0].RecurringMonthlyCost, "nil input → nil output")
+	})
 }
 
 // TestApplyTargetCoverage_RI_ExistingCoverage covers the under-buy formula's

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -344,6 +344,38 @@ func TestApplyCoverage(t *testing.T) {
 	}
 }
 
+// TestApplyCoverage_RICostScaling locks the fix for the CR finding on
+// helpers.go:159-166: cost-bearing fields must scale by the DISCRETE
+// count ratio (newCount / rec.Count), not the raw coverage ratio. With
+// rec.Count=3 and coverage=50%, newCount=int(1.5)=1 (33% of instances)
+// so costs must drop to 33% of original, not 50%, otherwise the sized
+// purchase reads ~50% more expensive than what was actually bought.
+func TestApplyCoverage_RICostScaling(t *testing.T) {
+	monthly := 60.0
+	recs := []common.Recommendation{
+		{
+			Service:              common.ServiceEC2,
+			CommitmentType:       common.CommitmentReservedInstance,
+			Count:                3,
+			CommitmentCost:       900,
+			OnDemandCost:         1800,
+			EstimatedSavings:     300,
+			RecurringMonthlyCost: &monthly,
+		},
+	}
+	out := ApplyCoverage(recs, 50.0)
+	require.Len(t, out, 1)
+	// newCount = int(3 * 0.5) = 1. sizedRatio = 1/3.
+	assert.Equal(t, 1, out[0].Count)
+	assert.InDelta(t, 300.0, out[0].CommitmentCost, 0.01, "CommitmentCost scales by 1/3 (newCount/rec.Count), NOT 0.5 (raw ratio)")
+	assert.InDelta(t, 600.0, out[0].OnDemandCost, 0.01)
+	assert.InDelta(t, 100.0, out[0].EstimatedSavings, 0.01)
+	require.NotNil(t, out[0].RecurringMonthlyCost)
+	assert.InDelta(t, 20.0, *out[0].RecurringMonthlyCost, 0.01, "RecurringMonthlyCost scales by sized ratio too")
+	// Original pointer not mutated.
+	assert.Equal(t, 60.0, monthly)
+}
+
 func TestAdjustRecommendationsForExisting(t *testing.T) {
 	ctx := context.Background()
 

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -898,3 +898,210 @@ func TestAdjustRecommendationsForExisting_PartialCoverage(t *testing.T) {
 	assert.Empty(t, filtered)           // partial coverage stays in passed, not filtered
 	mockClient.AssertExpectations(t)
 }
+
+// TestApplyTargetUtilization covers the RI sizing branch of issue #338's
+// --target-utilization flag. Confirms: floor (not ceil) selection so we
+// hit "utilization >= target", AWS-ceiling cap, drop-when-unreachable,
+// no-signal pass-through, and projected utilization/coverage outputs.
+func TestApplyTargetUtilization_RI(t *testing.T) {
+	mkRI := func(count int, avg, recUtil float64) common.Recommendation {
+		return common.Recommendation{
+			Service:                     common.ServiceEC2,
+			Region:                      "us-east-1",
+			ResourceType:                "t3.medium",
+			Count:                       count,
+			CommitmentType:              common.CommitmentReservedInstance,
+			CommitmentCost:              1000,
+			OnDemandCost:                2000,
+			EstimatedSavings:            500,
+			AverageInstancesUsedPerHour: avg,
+			RecommendedUtilization:      recUtil,
+		}
+	}
+
+	tests := []struct {
+		name           string
+		rec            common.Recommendation
+		target         float64
+		wantDropped    bool
+		wantCount      int
+		wantProjUtil   float64 // 0 means "don't assert"
+		wantProjCovGTE float64 // we assert coverage >= this (handles the float clamping)
+	}{
+		{
+			// avg=8.5, target=95% → floor(8.5/0.95) = floor(8.94) = 8.
+			// projected utilization = 8.5/8 = 106.25 → clamped to 100.
+			name:         "RI: target 95 hits cap with non-integer avg",
+			rec:          mkRI(10, 8.5, 85),
+			target:       95,
+			wantCount:    8,
+			wantProjUtil: 100,
+		},
+		{
+			// avg=10, target=50% → floor(10/0.5) = 20. Capped at rec.Count=10
+			// (target too lenient). Cap log fires (not asserted here).
+			name:         "RI: target 50 hits AWS ceiling cap",
+			rec:          mkRI(10, 10, 90),
+			target:       50,
+			wantCount:    10,
+			wantProjUtil: 100, // 10/10 = 100
+		},
+		{
+			// avg=0.4, target=50% → floor(0.4/0.5) = 0 → drop with log.
+			name:        "RI: target unreachable → dropped",
+			rec:         mkRI(5, 0.4, 50),
+			target:      50,
+			wantDropped: true,
+		},
+		{
+			// avg=0 (no signal) → passed through unchanged, counted in skip summary.
+			name:         "RI: no signal → passed through unmodified",
+			rec:          mkRI(5, 0, 0),
+			target:       80,
+			wantCount:    5,
+			wantProjUtil: 0, // never set in pass-through
+		},
+		{
+			// avg=4, target=80% → floor(4/0.8) = 5. Capped at rec.Count=5
+			// (binding cap, no log fires because uncapped == cap).
+			// projected utilization = 4/5 = 80.
+			name:         "RI: target 80 hits target exactly",
+			rec:          mkRI(5, 4, 80),
+			target:       80,
+			wantCount:    5,
+			wantProjUtil: 80,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recs := []common.Recommendation{tt.rec}
+			out := ApplyTargetUtilization(recs, tt.target)
+			if tt.wantDropped {
+				if len(out) != 0 {
+					t.Fatalf("expected drop; got %d recs", len(out))
+				}
+				return
+			}
+			if len(out) != 1 {
+				t.Fatalf("expected 1 rec; got %d", len(out))
+			}
+			if out[0].Count != tt.wantCount {
+				t.Errorf("Count: got %d, want %d", out[0].Count, tt.wantCount)
+			}
+			if tt.wantProjUtil > 0 {
+				if math.Abs(out[0].ProjectedUtilization-tt.wantProjUtil) > 0.01 {
+					t.Errorf("ProjectedUtilization: got %.4f, want %.4f",
+						out[0].ProjectedUtilization, tt.wantProjUtil)
+				}
+			}
+		})
+	}
+}
+
+// TestApplyTargetUtilization_RI_CostScaling verifies cost fields are NOT
+// scaled when the count is adjusted (matching ApplyCoverage's RI branch,
+// which also leaves cost fields untouched). Divergence would silently
+// mis-cost the dry-run output relative to the coverage path.
+func TestApplyTargetUtilization_RI_CostScaling(t *testing.T) {
+	rec := common.Recommendation{
+		Service:                     common.ServiceEC2,
+		Count:                       10,
+		CommitmentType:              common.CommitmentReservedInstance,
+		CommitmentCost:              1000,
+		OnDemandCost:                2000,
+		EstimatedSavings:            500,
+		AverageInstancesUsedPerHour: 8,
+	}
+	// target=80 → floor(8/0.8) = 10 = rec.Count (no scaling). Cost fields
+	// must match the input exactly.
+	out := ApplyTargetUtilization([]common.Recommendation{rec}, 80)
+	require.Len(t, out, 1)
+	assert.Equal(t, 10, out[0].Count)
+	assert.Equal(t, 1000.0, out[0].CommitmentCost, "CommitmentCost should be untouched by RI branch")
+	assert.Equal(t, 2000.0, out[0].OnDemandCost, "OnDemandCost should be untouched by RI branch")
+	assert.Equal(t, 500.0, out[0].EstimatedSavings, "EstimatedSavings should be untouched by RI branch")
+}
+
+// TestApplyTargetUtilization_SP covers the SP sizing branch. SP sizing
+// scales only HourlyCommitment (inside SavingsPlanDetails) and
+// EstimatedSavings — matching exactly what ApplyCoverage scales for SPs.
+// CommitmentCost / OnDemandCost / SavingsPercentage must NOT change.
+func TestApplyTargetUtilization_SP(t *testing.T) {
+	mkSP := func(recUtil float64) common.Recommendation {
+		return common.Recommendation{
+			Service:                common.ServiceSavingsPlansCompute,
+			CommitmentType:         common.CommitmentSavingsPlan,
+			CommitmentCost:         1000,
+			OnDemandCost:           5000,
+			EstimatedSavings:       1500,
+			SavingsPercentage:      30,
+			RecommendedUtilization: recUtil,
+			Details:                &common.SavingsPlanDetails{HourlyCommitment: 2.0},
+		}
+	}
+
+	t.Run("AWS already above target — no scaling", func(t *testing.T) {
+		out := ApplyTargetUtilization([]common.Recommendation{mkSP(95)}, 80)
+		require.Len(t, out, 1)
+		assert.Equal(t, 2.0, out[0].Details.(*common.SavingsPlanDetails).HourlyCommitment)
+		assert.Equal(t, 1500.0, out[0].EstimatedSavings)
+		assert.Equal(t, 95.0, out[0].ProjectedUtilization)
+		assert.Equal(t, 0.0, out[0].ProjectedCoverage, "SPs intentionally leave ProjectedCoverage at zero")
+	})
+
+	t.Run("AWS below target — scale down", func(t *testing.T) {
+		// RecUtil=50, target=80 → ratio = 50/80 = 0.625.
+		// HourlyCommitment: 2.0 * 0.625 = 1.25
+		// EstimatedSavings: 1500 * 0.625 = 937.5
+		out := ApplyTargetUtilization([]common.Recommendation{mkSP(50)}, 80)
+		require.Len(t, out, 1)
+		details := out[0].Details.(*common.SavingsPlanDetails)
+		assert.InDelta(t, 1.25, details.HourlyCommitment, 0.001)
+		assert.InDelta(t, 937.5, out[0].EstimatedSavings, 0.001)
+		// CommitmentCost / OnDemandCost / SavingsPercentage MUST be unchanged.
+		assert.Equal(t, 1000.0, out[0].CommitmentCost, "CommitmentCost must not scale on SP branch (matches ApplyCoverage)")
+		assert.Equal(t, 5000.0, out[0].OnDemandCost, "OnDemandCost must not scale on SP branch (matches ApplyCoverage)")
+		assert.Equal(t, 30.0, out[0].SavingsPercentage, "SavingsPercentage must not scale on SP branch")
+		assert.Equal(t, 80.0, out[0].ProjectedUtilization)
+		assert.Equal(t, 0.0, out[0].ProjectedCoverage)
+	})
+
+	t.Run("no signal → passed through unchanged", func(t *testing.T) {
+		out := ApplyTargetUtilization([]common.Recommendation{mkSP(0)}, 80)
+		require.Len(t, out, 1)
+		// Original recommendation values intact.
+		assert.Equal(t, 2.0, out[0].Details.(*common.SavingsPlanDetails).HourlyCommitment)
+		assert.Equal(t, 1500.0, out[0].EstimatedSavings)
+		assert.Equal(t, 0.0, out[0].ProjectedUtilization)
+	})
+}
+
+// TestApplySizing checks the routing helper picks the right sizer based
+// on cfg.TargetUtilization being >0 vs ==0.
+func TestApplySizing(t *testing.T) {
+	ri := common.Recommendation{
+		Service:                     common.ServiceEC2,
+		Count:                       10,
+		CommitmentType:              common.CommitmentReservedInstance,
+		AverageInstancesUsedPerHour: 8,
+	}
+
+	t.Run("TargetUtilization > 0 → ApplyTargetUtilization", func(t *testing.T) {
+		cfg := Config{TargetUtilization: 80, Coverage: 100}
+		out := applySizing([]common.Recommendation{ri}, cfg, cfg.Coverage)
+		require.Len(t, out, 1)
+		// floor(8/0.8)=10, capped at rec.Count=10. ProjectedUtilization set.
+		assert.Equal(t, 80.0, out[0].ProjectedUtilization)
+	})
+
+	t.Run("TargetUtilization == 0 → ApplyCoverage", func(t *testing.T) {
+		cfg := Config{TargetUtilization: 0, Coverage: 50}
+		out := applySizing([]common.Recommendation{ri}, cfg, cfg.Coverage)
+		require.Len(t, out, 1)
+		// ApplyCoverage(50) on count=10 → 5. ProjectedUtilization NOT set
+		// (zero) because we took the coverage branch.
+		assert.Equal(t, 5, out[0].Count)
+		assert.Equal(t, 0.0, out[0].ProjectedUtilization)
+	})
+}

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -1031,6 +1031,101 @@ func TestApplyTargetCoverage_RI_CostScaling(t *testing.T) {
 	assert.Equal(t, 25.0, out[0].SavingsPercentage, "SavingsPercentage is invariant under count scaling")
 }
 
+// TestApplyTargetCoverage_RI_ExistingCoverage covers the under-buy formula's
+// existing-commitment branch: gap = (target - existing_cov)/100, then
+// n_target = floor(avg * gap). Matches the worked example from the #338 design
+// thread (20 instances, 10 existing RIs at 50% coverage, target 80% → buy 6).
+func TestApplyTargetCoverage_RI_ExistingCoverage(t *testing.T) {
+	mkRI := func(count int, avg, existingCov float64) common.Recommendation {
+		return common.Recommendation{
+			Service:                     common.ServiceEC2,
+			Region:                      "us-east-1",
+			ResourceType:                "t3.medium",
+			Count:                       count,
+			RecommendedCount:            count,
+			CommitmentType:              common.CommitmentReservedInstance,
+			CommitmentCost:              1000,
+			OnDemandCost:                2000,
+			EstimatedSavings:            500,
+			AverageInstancesUsedPerHour: avg,
+			ExistingCoveragePct:         existingCov,
+		}
+	}
+
+	tests := []struct {
+		name         string
+		rec          common.Recommendation
+		target       float64
+		wantDropped  bool
+		wantCount    int
+		wantTotalCov float64 // ProjectedCoverage = existing + new contribution
+	}{
+		{
+			// User's worked example: 20 demand, 10 existing covering 50%, target 80%.
+			// gap = (80-50)/100 = 0.30. n = floor(20*0.30) = 6.
+			// Total coverage = 50 + 6/20*100 = 80.
+			name:         "User example: 50% existing, 80% target on avg=20 -> buy 6",
+			rec:          mkRI(10, 20, 50),
+			target:       80,
+			wantCount:    6,
+			wantTotalCov: 80,
+		},
+		{
+			// existing=0% degenerates to old behavior.
+			// gap = 0.70. n = floor(10*0.70) = 7. Total cov = 0+70 = 70.
+			name:         "Zero existing: degenerates to floor(avg*target)",
+			rec:          mkRI(10, 10, 0),
+			target:       70,
+			wantCount:    7,
+			wantTotalCov: 70,
+		},
+		{
+			// Already at target: drop.
+			name:        "Existing meets target exactly: drop",
+			rec:         mkRI(10, 10, 80),
+			target:      80,
+			wantDropped: true,
+		},
+		{
+			// Already over target: drop.
+			name:        "Existing exceeds target: drop",
+			rec:         mkRI(10, 10, 95),
+			target:      80,
+			wantDropped: true,
+		},
+		{
+			// Gap too small to justify even one RI:
+			// avg=2, existing=70%, target=80%, gap=0.10, n=floor(0.20)=0. Drop.
+			name:        "Gap too small for one RI: drop",
+			rec:         mkRI(5, 2, 70),
+			target:      80,
+			wantDropped: true,
+		},
+		{
+			// Near-target top-up: avg=10, existing=60%, target=70%, gap=0.10.
+			// n=floor(1.0)=1. Total cov = 60+10 = 70.
+			name:         "Small top-up to reach target",
+			rec:          mkRI(10, 10, 60),
+			target:       70,
+			wantCount:    1,
+			wantTotalCov: 70,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := ApplyTargetCoverage([]common.Recommendation{tt.rec}, tt.target)
+			if tt.wantDropped {
+				assert.Len(t, out, 0, "expected drop")
+				return
+			}
+			require.Len(t, out, 1)
+			assert.Equal(t, tt.wantCount, out[0].Count, "Count")
+			assert.InDelta(t, tt.wantTotalCov, out[0].ProjectedCoverage, 0.01, "ProjectedCoverage is TOTAL (existing + new)")
+		})
+	}
+}
+
 // TestApplyTargetCoverage_SP covers the SP sizing branch under under-buy
 // semantics: HourlyCommitment and EstimatedSavings scale by targetPct/100
 // regardless of AWS's projected utilization. CommitmentCost / OnDemandCost /

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -931,17 +931,17 @@ func TestApplyTargetCoverage_RI(t *testing.T) {
 		wantProjCovGTE float64 // we assert coverage >= this (handles the float clamping)
 	}{
 		{
-			// avg=8.5, target=95% → floor(8.5*0.95) = floor(8.075) = 8.
-			// Projected utilization = 8.5/8 = 106.25 → clamped to 100.
-			// Projected coverage = 8/8.5 = 94.1%, just under target.
-			name:         "RI: target 95 buys close to AWS rec (under-buy by floor)",
+			// avg=8.5, target=95% → ceil(8.5*0.95) = ceil(8.075) = 9.
+			// Projected utilization = 8.5/9 = 94.4. Coverage = 9/8.5 = 105.9
+			// clamped to 100.
+			name:         "RI: target 95 buys 9 (ceil rounds 8.075 up)",
 			rec:          mkRI(10, 8.5, 85),
 			target:       95,
-			wantCount:    8,
-			wantProjUtil: 100,
+			wantCount:    9,
+			wantProjUtil: 94.44,
 		},
 		{
-			// avg=10, target=50% → floor(10*0.5) = 5. Half of average usage
+			// avg=10, target=50% → ceil(10*0.5) = 5. Half of average usage
 			// is reserved; the other half spills to on-demand. Projected
 			// utilization = 10/5 = 200 → clamped to 100 (RIs always full).
 			// Projected coverage = 5/10 = 50, matches target.
@@ -952,12 +952,15 @@ func TestApplyTargetCoverage_RI(t *testing.T) {
 			wantProjUtil: 100, // 10/5 clamped
 		},
 		{
-			// avg=0.4, target=50% → floor(0.4*0.5) = 0 → drop with log.
-			// Target too low to support even one RI on this rec's average.
-			name:        "RI: target produces zero count → dropped",
-			rec:         mkRI(5, 0.4, 50),
-			target:      50,
-			wantDropped: true,
+			// avg=0.4, target=50% → ceil(0.4*0.5) = ceil(0.2) = 1.
+			// Tiny-pool case: ceil rounds up so a single fractional avg
+			// instance still gets one RI rather than the pool being dropped.
+			// Projected utilization = 0.4/1 = 40 (not clamped — below 100).
+			name:         "RI: tiny pool rounds up to 1 (ceil)",
+			rec:          mkRI(5, 0.4, 50),
+			target:       50,
+			wantCount:    1,
+			wantProjUtil: 40,
 		},
 		{
 			// avg=0 (no signal) → passed through unchanged, counted in skip summary.
@@ -968,13 +971,14 @@ func TestApplyTargetCoverage_RI(t *testing.T) {
 			wantProjUtil: 0, // never set in pass-through
 		},
 		{
-			// avg=4, target=80% → floor(4*0.8) = 3. Projected utilization =
-			// 4/3 = 133 → clamped to 100. Projected coverage = 3/4 = 75,
-			// just under target (floor's effect on small avg).
-			name:         "RI: target 80 under-buys (3 of 4 covered)",
+			// avg=4, target=80% → ceil(4*0.8) = ceil(3.2) = 4. Projected
+			// utilization = 4/4 = 100. Projected coverage = 4/4 = 100,
+			// over target by ceil's rounding; preferable to under-buying
+			// since target=80 expresses a floor on coverage, not a ceiling.
+			name:         "RI: target 80 covers 4 of 4 (ceil rounds 3.2 up)",
 			rec:          mkRI(5, 4, 80),
 			target:       80,
-			wantCount:    3,
+			wantCount:    4,
 			wantProjUtil: 100,
 		},
 	}
@@ -1021,13 +1025,14 @@ func TestApplyTargetCoverage_RI_CostScaling(t *testing.T) {
 		SavingsPercentage:           25,
 		AverageInstancesUsedPerHour: 8,
 	}
-	// target=80 → floor(8*0.8) = 6 (under-buy from rec.Count=10). Ratio = 0.6.
+	// target=80 → ceil(8*0.8) = ceil(6.4) = 7 (under-buy from rec.Count=10).
+	// Ratio = 0.7. All cost-bearing fields scale by this ratio.
 	out := ApplyTargetCoverage([]common.Recommendation{rec}, 80)
 	require.Len(t, out, 1)
-	assert.Equal(t, 6, out[0].Count)
-	assert.InDelta(t, 600.0, out[0].CommitmentCost, 0.001, "CommitmentCost scales by Count/rec.Count")
-	assert.InDelta(t, 1200.0, out[0].OnDemandCost, 0.001, "OnDemandCost scales by Count/rec.Count")
-	assert.InDelta(t, 300.0, out[0].EstimatedSavings, 0.001, "EstimatedSavings scales by Count/rec.Count")
+	assert.Equal(t, 7, out[0].Count)
+	assert.InDelta(t, 700.0, out[0].CommitmentCost, 0.001, "CommitmentCost scales by Count/rec.Count")
+	assert.InDelta(t, 1400.0, out[0].OnDemandCost, 0.001, "OnDemandCost scales by Count/rec.Count")
+	assert.InDelta(t, 350.0, out[0].EstimatedSavings, 0.001, "EstimatedSavings scales by Count/rec.Count")
 	assert.Equal(t, 25.0, out[0].SavingsPercentage, "SavingsPercentage is invariant under count scaling")
 }
 
@@ -1062,7 +1067,7 @@ func TestApplyTargetCoverage_RI_ExistingCoverage(t *testing.T) {
 	}{
 		{
 			// User's worked example: 20 demand, 10 existing covering 50%, target 80%.
-			// gap = (80-50)/100 = 0.30. n = floor(20*0.30) = 6.
+			// gap = 80-50 = 30 (in pct). n = ceil(20*0.30) = ceil(6.0) = 6.
 			// Total coverage = 50 + 6/20*100 = 80.
 			name:         "User example: 50% existing, 80% target on avg=20 -> buy 6",
 			rec:          mkRI(10, 20, 50),
@@ -1071,9 +1076,9 @@ func TestApplyTargetCoverage_RI_ExistingCoverage(t *testing.T) {
 			wantTotalCov: 80,
 		},
 		{
-			// existing=0% degenerates to old behavior.
-			// gap = 0.70. n = floor(10*0.70) = 7. Total cov = 0+70 = 70.
-			name:         "Zero existing: degenerates to floor(avg*target)",
+			// existing=0% so no subtraction.
+			// gap=70 (pct). n = ceil(10*0.70) = 7. Total cov = 0+70 = 70.
+			name:         "Zero existing: degenerates to ceil(avg*target)",
 			rec:          mkRI(10, 10, 0),
 			target:       70,
 			wantCount:    7,
@@ -1094,16 +1099,18 @@ func TestApplyTargetCoverage_RI_ExistingCoverage(t *testing.T) {
 			wantDropped: true,
 		},
 		{
-			// Gap too small to justify even one RI:
-			// avg=2, existing=70%, target=80%, gap=0.10, n=floor(0.20)=0. Drop.
-			name:        "Gap too small for one RI: drop",
-			rec:         mkRI(5, 2, 70),
-			target:      80,
-			wantDropped: true,
+			// avg=2, existing=70%, target=80%, gap=10 (pct), n=ceil(0.20)=1.
+			// Ceil keeps the rec alive even for tiny gaps. Total cov =
+			// 70 + 1/2*100 = 120 → clamped to 100 (over target by 20%).
+			name:         "Small gap rounds up to 1 RI",
+			rec:          mkRI(5, 2, 70),
+			target:       80,
+			wantCount:    1,
+			wantTotalCov: 100,
 		},
 		{
-			// Near-target top-up: avg=10, existing=60%, target=70%, gap=0.10.
-			// n=floor(1.0)=1. Total cov = 60+10 = 70.
+			// Near-target top-up: avg=10, existing=60%, target=70%, gap=10 (pct).
+			// n=ceil(1.0)=1. Total cov = 60+10 = 70.
 			name:         "Small top-up to reach target",
 			rec:          mkRI(10, 10, 60),
 			target:       70,
@@ -1199,9 +1206,9 @@ func TestApplySizing(t *testing.T) {
 		cfg := Config{TargetCoverage: 80, Coverage: 100}
 		out := applySizing([]common.Recommendation{ri}, cfg, cfg.Coverage)
 		require.Len(t, out, 1)
-		// Under-buy: floor(8*0.8) = 6. ProjectedUtilization = 8/6 = 133
-		// clamped to 100 (RIs always fully used when count < avg).
-		assert.Equal(t, 6, out[0].Count)
+		// Under-buy: ceil(8*0.8) = ceil(6.4) = 7. ProjectedUtilization =
+		// 8/7 = 114 clamped to 100 (RIs always fully used when count < avg).
+		assert.Equal(t, 7, out[0].Count)
 		assert.Equal(t, 100.0, out[0].ProjectedUtilization)
 	})
 
@@ -1218,10 +1225,10 @@ func TestApplySizing(t *testing.T) {
 
 // TestApplyTargetCoverage_RI_Target100 covers the target == 100 boundary
 // (issue #338 AC: "target == 100 → only purchases with perfectly-matched
-// existing usage"). At target=100 (ratio=1.0), floor(avg*1.0) = floor(avg) —
-// so a rec with avg < 1 drops, and a rec with avg >= 1 buys floor(avg).
-// Same counts as the original ceil-division version because target=100 is
-// the fixed point of both formulas.
+// existing usage"). At target=100 (ratio=1.0), ceil(avg*1.0) is ceil(avg) —
+// so any non-zero avg rounds up to at least 1 (ceil never drops a pool
+// with running demand). Fractional avg above an integer rounds up to the
+// next integer.
 func TestApplyTargetCoverage_RI_Target100(t *testing.T) {
 	mkRI := func(count int, avg float64) common.Recommendation {
 		return common.Recommendation{
@@ -1240,13 +1247,14 @@ func TestApplyTargetCoverage_RI_Target100(t *testing.T) {
 		wantDropped bool
 		wantCount   int
 	}{
-		// avg=0.999 → floor(0.999*1.0) = 0 → dropped (count is zero).
-		{name: "target 100, avg=0.999 → dropped", rec: mkRI(5, 0.999), wantDropped: true},
-		// avg=1.0 → floor(1.0*1.0) = 1 → buy 1. projected utilization = 100.
+		// avg=0.999 → ceil(0.999*1.0) = 1. Ceil ensures any non-zero pool
+		// gets a rec (matches AWS behaviour).
+		{name: "target 100, avg=0.999 → buy 1", rec: mkRI(5, 0.999), wantCount: 1},
+		// avg=1.0 → ceil(1.0*1.0) = 1 → buy 1. projected utilization = 100.
 		{name: "target 100, avg=1.0 → buy 1", rec: mkRI(5, 1.0), wantCount: 1},
-		// avg=8.7 → floor(8.7*1.0) = 8. projected utilization = 8.7/8 = 108.75 → clamped to 100.
-		{name: "target 100, avg=8.7 → buy 8 (clamped)", rec: mkRI(10, 8.7), wantCount: 8},
-		// avg=10.0 exactly → floor(10*1.0) = 10 (exact match). projected utilization = 100.
+		// avg=8.7 → ceil(8.7*1.0) = 9. Slightly over target but matches AWS rec.
+		{name: "target 100, avg=8.7 → buy 9 (ceil rounds up)", rec: mkRI(10, 8.7), wantCount: 9},
+		// avg=10.0 exactly → ceil(10*1.0) = 10 (exact integer). projected utilization = 100.
 		{name: "target 100, avg=10.0 → buy 10 (perfect match)", rec: mkRI(10, 10.0), wantCount: 10},
 	}
 

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -931,33 +931,34 @@ func TestApplyTargetCoverage_RI(t *testing.T) {
 		wantProjCovGTE float64 // we assert coverage >= this (handles the float clamping)
 	}{
 		{
-			// rec.Count=10, avg=8.5, target=95%, existing=0%.
-			// gap=95, remaining=100. n = floor(10 * 95/100) = floor(9.5) = 9.
-			// Projected util = 8.5/9 = 94.4.
-			name:         "RI: target 95 buys 9 (floor of 10*0.95)",
+			// avg=8.5, target=95%, existing=0%.
+			// gap=95. n = floor(8.5 * 95/100) = floor(8.075) = 8.
+			// Projected util = 8.5/8 = 106.25 → clamped to 100.
+			name:         "RI: target 95 buys 8 (floor of avg*0.95)",
 			rec:          mkRI(10, 8.5, 0),
 			target:       95,
-			wantCount:    9,
-			wantProjUtil: 94.44,
+			wantCount:    8,
+			wantProjUtil: 100,
 		},
 		{
-			// rec.Count=10, target=50%, existing=0%. n=floor(10*0.5)=5.
-			name:         "RI: target 50 covers half the AWS rec",
+			// avg=10, target=50%, existing=0%. n=floor(10*0.5)=5.
+			name:         "RI: target 50 buys half of avg demand",
 			rec:          mkRI(10, 10, 0),
 			target:       50,
 			wantCount:    5,
 			wantProjUtil: 100, // 10/5 clamped
 		},
 		{
-			// rec.Count=5, avg=0.4, target=50%, existing=0%.
-			// n = floor(5 * 50/100) = floor(2.5) = 2.
-			// Tiny pool still gets a rec since AWS sized it; use
-			// --min-pool-size upstream to filter tiny pools out by avg.
-			name:         "RI: tiny avg still buys per rec.Count scaling",
-			rec:          mkRI(5, 0.4, 0),
-			target:       50,
-			wantCount:    2,
-			wantProjUtil: 20, // 0.4/2 = 20% (not clamped, below 100)
+			// avg=0.4, target=50%, existing=0%.
+			// n = floor(0.4 * 50/100) = floor(0.2) = 0 → DROPPED.
+			// Tiny pools where avg×gap%<100 produce 0 RIs under the
+			// coverage-anchored formula. --min-pool-size upstream is the
+			// intended filter for these; the drop here is the fallback
+			// when the upstream filter wasn't applied.
+			name:        "RI: tiny avg below 1-RI threshold drops",
+			rec:         mkRI(5, 0.4, 0),
+			target:      50,
+			wantDropped: true,
 		},
 		{
 			// avg=0 (no signal) → passed through unchanged, counted in skip summary.
@@ -968,12 +969,12 @@ func TestApplyTargetCoverage_RI(t *testing.T) {
 			wantProjUtil: 0, // never set in pass-through
 		},
 		{
-			// rec.Count=5, avg=4, target=80%, existing=0%. n=floor(5*0.8)=4.
-			// Projected util = 4/4 = 100.
-			name:         "RI: target 80 buys 4 of 5 AWS-recommended",
+			// avg=4, target=80%, existing=0%. n=floor(4*0.8)=3.
+			// Projected util = 4/3 = 133% clamped to 100.
+			name:         "RI: target 80 buys floor(avg*0.8)",
 			rec:          mkRI(5, 4, 0),
 			target:       80,
-			wantCount:    4,
+			wantCount:    3,
 			wantProjUtil: 100,
 		},
 	}
@@ -1020,14 +1021,16 @@ func TestApplyTargetCoverage_RI_CostScaling(t *testing.T) {
 		SavingsPercentage:           25,
 		AverageInstancesUsedPerHour: 8,
 	}
-	// target=80, existing=0, rec.Count=10 → gap=80, remaining=100.
-	// n = floor(10 * 80/100) = 8. Ratio = 8/10 = 0.8.
+	// target=80, existing=0, avg=8 → gap=80.
+	// n = floor(8 * 80/100) = 6. Ratio = 6/10 = 0.6 (cost scaling still
+	// uses rec.Count to convert AWS's quoted cost-for-rec.Count into
+	// cost-for-nTarget).
 	out := ApplyTargetCoverage([]common.Recommendation{rec}, 80)
 	require.Len(t, out, 1)
-	assert.Equal(t, 8, out[0].Count)
-	assert.InDelta(t, 800.0, out[0].CommitmentCost, 0.001, "CommitmentCost scales by Count/rec.Count")
-	assert.InDelta(t, 1600.0, out[0].OnDemandCost, 0.001, "OnDemandCost scales by Count/rec.Count")
-	assert.InDelta(t, 400.0, out[0].EstimatedSavings, 0.001, "EstimatedSavings scales by Count/rec.Count")
+	assert.Equal(t, 6, out[0].Count)
+	assert.InDelta(t, 600.0, out[0].CommitmentCost, 0.001, "CommitmentCost scales by nTarget/rec.Count")
+	assert.InDelta(t, 1200.0, out[0].OnDemandCost, 0.001, "OnDemandCost scales by nTarget/rec.Count")
+	assert.InDelta(t, 300.0, out[0].EstimatedSavings, 0.001, "EstimatedSavings scales by nTarget/rec.Count")
 	assert.Equal(t, 25.0, out[0].SavingsPercentage, "SavingsPercentage is invariant under count scaling")
 }
 
@@ -1092,29 +1095,25 @@ func TestApplyTargetCoverage_RI_ExistingCoverage(t *testing.T) {
 			wantDropped: true,
 		},
 		{
-			// rec.Count=5, existing=70%, target=80%, avg=2.
-			// gap=10, remaining=30. n = floor(5 * 10/30) = floor(1.67) = 1.
-			// Total cov = 70 + 1/2*100 = 120 clamped to 100.
-			name:         "Small gap still buys 1 (rec.Count*ratio)",
-			rec:          mkRI(5, 2, 70),
-			target:       80,
-			wantCount:    1,
-			wantTotalCov: 100,
+			// avg=2, existing=70%, target=80%. gap=10.
+			// n = floor(2 * 10/100) = floor(0.2) = 0 → DROPPED.
+			// Small pool + thin gap: no integer buy can approximate the
+			// target. --min-pool-size upstream is the intended filter.
+			name:        "Small gap on tiny avg drops",
+			rec:         mkRI(5, 2, 70),
+			target:      80,
+			wantDropped: true,
 		},
 		{
-			// rec.Count=10, existing=60%, target=70%, avg=10.
-			// gap=10, remaining=40. n = floor(10 * 10/40) = floor(2.5) = 2.
-			// Total cov = 60 + 2/10*100 = 80, slightly over target — would
-			// be 1 if rec.Count matched the avg×remaining/100 baseline,
-			// but the test fixture sets rec.Count=10 which is larger than
-			// the implied "incremental to 100%" count of 4. In real CE
-			// data, rec.Count is per-account-correct, so the formula is
-			// trusting AWS over the avg+existing-derived count.
-			name:         "Small top-up: scales AWS rec.Count by gap ratio",
+			// avg=10, existing=60%, target=70%. gap=10.
+			// n = floor(10 * 10/100) = 1. Total cov = 60 + 1/10*100 = 70.
+			// Coverage-anchored: 1 RI exactly closes the 10-point gap
+			// because avg=10 and each RI is worth 10% of avg demand.
+			name:         "Small top-up: 1 RI exactly closes 10-pt gap on avg=10",
 			rec:          mkRI(10, 10, 60),
 			target:       70,
-			wantCount:    2,
-			wantTotalCov: 80,
+			wantCount:    1,
+			wantTotalCov: 70,
 		},
 	}
 
@@ -1205,9 +1204,9 @@ func TestApplySizing(t *testing.T) {
 		cfg := Config{TargetCoverage: 80, Coverage: 100}
 		out := applySizing([]common.Recommendation{ri}, cfg, cfg.Coverage)
 		require.Len(t, out, 1)
-		// rec.Count=10, target=80%, existing=0%, avg=8.
-		// n = floor(10 * 80/100) = 8. ProjectedUtilization = 8/8 = 100.
-		assert.Equal(t, 8, out[0].Count)
+		// avg=8, target=80%, existing=0%. gap=80.
+		// n = floor(8 * 80/100) = floor(6.4) = 6. ProjUtil = 8/6 = 133% → 100.
+		assert.Equal(t, 6, out[0].Count)
 		assert.Equal(t, 100.0, out[0].ProjectedUtilization)
 	})
 
@@ -1223,10 +1222,11 @@ func TestApplySizing(t *testing.T) {
 }
 
 // TestApplyTargetCoverage_RI_Target100 covers the target == 100 boundary.
-// With the rec.Count-based formula, target=100 (existing=0) always yields
-// n = floor(rec.Count * 100/100) = rec.Count — operators get AWS's exact
-// recommendation. Tiny-avg pools no longer drop on this branch; use
-// --min-pool-size to filter them upstream.
+// With the coverage-anchored formula, target=100 (existing=0) yields
+// n = floor(avg * 100/100) = floor(avg) — operators get a buy sized to
+// the pool's average concurrent demand, not AWS's rec.Count (which may
+// be sized to peak/ROI-curated). Pools where avg<1 drop; --min-pool-size
+// is the intended upstream filter.
 func TestApplyTargetCoverage_RI_Target100(t *testing.T) {
 	mkRI := func(count int, avg float64) common.Recommendation {
 		return common.Recommendation{
@@ -1245,12 +1245,14 @@ func TestApplyTargetCoverage_RI_Target100(t *testing.T) {
 		wantDropped bool
 		wantCount   int
 	}{
-		// rec.Count=5 → buy 5 regardless of avg.
-		{name: "target 100, rec.Count=5 → buy AWS rec exactly", rec: mkRI(5, 0.999), wantCount: 5},
-		{name: "target 100, rec.Count=5 avg=1 → buy 5", rec: mkRI(5, 1.0), wantCount: 5},
-		// rec.Count=10, target=100 → buy 10 (regardless of avg).
-		{name: "target 100, rec.Count=10 → buy AWS rec exactly", rec: mkRI(10, 8.7), wantCount: 10},
-		{name: "target 100, rec.Count=10 avg=10 → buy 10", rec: mkRI(10, 10.0), wantCount: 10},
+		// avg=0.999 → floor(0.999)=0 → drop.
+		{name: "target 100, avg=0.999 → drop (avg<1)", rec: mkRI(5, 0.999), wantDropped: true},
+		// avg=1.0 → buy 1 (matches avg demand).
+		{name: "target 100, avg=1 → buy 1", rec: mkRI(5, 1.0), wantCount: 1},
+		// avg=8.7 → floor(8.7) = 8.
+		{name: "target 100, avg=8.7 → buy floor(avg)=8", rec: mkRI(10, 8.7), wantCount: 8},
+		// avg=10 → buy 10 (avg=10 means 10 concurrent instances on average).
+		{name: "target 100, avg=10 → buy 10", rec: mkRI(10, 10.0), wantCount: 10},
 	}
 
 	for _, tt := range tests {

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -931,36 +931,32 @@ func TestApplyTargetCoverage_RI(t *testing.T) {
 		wantProjCovGTE float64 // we assert coverage >= this (handles the float clamping)
 	}{
 		{
-			// rec.Count=10, avg=8.5, target=95%.
-			// awsScaled = ceil(10*0.95) = 10. existingAware = ceil(8.5*0.95) = 9.
-			// max = 10. Projected util = 8.5/10 = 85.
-			name:         "RI: target 95 uses awsScaled floor (10 > 9)",
-			rec:          mkRI(10, 8.5, 85),
+			// avg=8.5, target=95%, existing=0% (no signal).
+			// gap=95, n=ceil(8.5*0.95) = ceil(8.075) = 9.
+			// Projected util = 8.5/9 = 94.4.
+			name:         "RI: target 95 buys 9 (ceil rounds 8.075 up)",
+			rec:          mkRI(10, 8.5, 0),
 			target:       95,
-			wantCount:    10,
-			wantProjUtil: 85.0,
+			wantCount:    9,
+			wantProjUtil: 94.44,
 		},
 		{
-			// rec.Count=10, avg=10, target=50%.
-			// awsScaled = ceil(10*0.5) = 5. existingAware = ceil(10*0.5) = 5.
-			// max = 5. Same count via either path.
-			name:         "RI: target 50 sizes to half AWS rec",
-			rec:          mkRI(10, 10, 90),
+			// avg=10, target=50%, existing=0%. gap=50. n=ceil(5)=5.
+			name:         "RI: target 50 under-buys to leave on-demand headroom",
+			rec:          mkRI(10, 10, 0),
 			target:       50,
 			wantCount:    5,
 			wantProjUtil: 100, // 10/5 clamped
 		},
 		{
-			// rec.Count=5, avg=0.4, target=50%.
-			// awsScaled = ceil(5*0.5) = 3. existingAware = ceil(0.4*0.5) = 1.
-			// max = 3. The AWS-scaled floor keeps the rec alive even on
-			// tiny-avg pools because the AWS rec list still recommends them.
-			// Projected util = 0.4/3 = 13.3 (under 100, no clamp).
-			name:         "RI: tiny pool gets awsScaled count, not just 1",
-			rec:          mkRI(5, 0.4, 50),
+			// avg=0.4, target=50%, existing=0%. gap=50. n=ceil(0.2)=1.
+			// Tiny-pool case: ceil keeps the rec alive at 1 RI rather than
+			// dropping. Projected util = 0.4/1 = 40 (under 100, no clamp).
+			name:         "RI: tiny pool rounds up to 1 (ceil)",
+			rec:          mkRI(5, 0.4, 0),
 			target:       50,
-			wantCount:    3,
-			wantProjUtil: 13.33,
+			wantCount:    1,
+			wantProjUtil: 40,
 		},
 		{
 			// avg=0 (no signal) → passed through unchanged, counted in skip summary.
@@ -971,14 +967,13 @@ func TestApplyTargetCoverage_RI(t *testing.T) {
 			wantProjUtil: 0, // never set in pass-through
 		},
 		{
-			// rec.Count=5, avg=4, target=80%.
-			// awsScaled = ceil(5*0.8) = 4. existingAware = ceil(4*0.8) = 4.
-			// max = 4.
-			name:         "RI: target 80 covers 4 of 5 AWS-recommended",
-			rec:          mkRI(5, 4, 80),
+			// avg=4, target=80%, existing=0%. gap=80. n=ceil(3.2)=4.
+			// Projected coverage = 4/4 = 100, over target by ceil's rounding.
+			name:         "RI: target 80 covers 4 of 4 (ceil rounds 3.2 up)",
+			rec:          mkRI(5, 4, 0),
 			target:       80,
 			wantCount:    4,
-			wantProjUtil: 100, // avg/n = 4/4 = 100
+			wantProjUtil: 100,
 		},
 	}
 
@@ -1024,14 +1019,14 @@ func TestApplyTargetCoverage_RI_CostScaling(t *testing.T) {
 		SavingsPercentage:           25,
 		AverageInstancesUsedPerHour: 8,
 	}
-	// target=80 → awsScaled = ceil(10*0.8) = 8. existingAware = ceil(8*0.8) = 7.
-	// max = 8. Ratio = 8/10 = 0.8. Cost-bearing fields scale by 0.8.
+	// target=80 → gap=80, n=ceil(8*0.8) = ceil(6.4) = 7 (rec.Count=10).
+	// Ratio = 7/10 = 0.7. Cost-bearing fields scale by 0.7.
 	out := ApplyTargetCoverage([]common.Recommendation{rec}, 80)
 	require.Len(t, out, 1)
-	assert.Equal(t, 8, out[0].Count)
-	assert.InDelta(t, 800.0, out[0].CommitmentCost, 0.001, "CommitmentCost scales by Count/rec.Count")
-	assert.InDelta(t, 1600.0, out[0].OnDemandCost, 0.001, "OnDemandCost scales by Count/rec.Count")
-	assert.InDelta(t, 400.0, out[0].EstimatedSavings, 0.001, "EstimatedSavings scales by Count/rec.Count")
+	assert.Equal(t, 7, out[0].Count)
+	assert.InDelta(t, 700.0, out[0].CommitmentCost, 0.001, "CommitmentCost scales by Count/rec.Count")
+	assert.InDelta(t, 1400.0, out[0].OnDemandCost, 0.001, "OnDemandCost scales by Count/rec.Count")
+	assert.InDelta(t, 350.0, out[0].EstimatedSavings, 0.001, "EstimatedSavings scales by Count/rec.Count")
 	assert.Equal(t, 25.0, out[0].SavingsPercentage, "SavingsPercentage is invariant under count scaling")
 }
 
@@ -1065,69 +1060,54 @@ func TestApplyTargetCoverage_RI_ExistingCoverage(t *testing.T) {
 		wantTotalCov float64 // ProjectedCoverage = existing + new contribution
 	}{
 		{
-			// User's worked example: rec.Count=10, avg=20, existing=50%, target=80%.
-			// awsScaled = ceil(10*0.8) = 8.
-			// existingAware = ceil(20*0.30) = 6.
-			// max = 8. AWS-scaled floor wins (the hybrid trade — slight
-			// over-target vs the strict 6-RI answer, in exchange for
-			// matching AWS's recommendation shape).
-			// Total cov = 50 + 8/20*100 = 90.
-			name:         "User example: hybrid uses awsScaled floor of 8",
+			// User's worked example: avg=20, existing=50%, target=80%.
+			// gap=30. n=ceil(20*0.30)=6. Total cov = 50 + 6/20*100 = 80.
+			name:         "User example: 50% existing, 80% target on avg=20 → buy 6",
 			rec:          mkRI(10, 20, 50),
 			target:       80,
-			wantCount:    8,
-			wantTotalCov: 90,
+			wantCount:    6,
+			wantTotalCov: 80,
 		},
 		{
-			// rec.Count=10, avg=10, existing=0%, target=70%.
-			// awsScaled = ceil(10*0.7) = 7. existingAware = ceil(10*0.7) = 7.
-			// max = 7. Both candidates agree when existing=0.
-			name:         "Zero existing: both candidates agree",
+			// existing=0%, target=70%, avg=10. gap=70. n=ceil(7)=7.
+			name:         "Zero existing: ceil(avg*target/100)",
 			rec:          mkRI(10, 10, 0),
 			target:       70,
 			wantCount:    7,
 			wantTotalCov: 70,
 		},
 		{
-			// rec.Count=10, avg=10, existing=80%, target=80%.
-			// awsScaled = ceil(10*0.8) = 8. existingAware = 0 (gap=0).
-			// max = 8. AWS still recommends so we still buy — hybrid keeps
-			// the rec alive (covers the RI-expiry case CE coverage doesn't
-			// see). Total cov = 80 + 8/10*100 = 160 clamped to 100.
-			name:         "Existing meets target: awsScaled floor still buys",
-			rec:          mkRI(10, 10, 80),
-			target:       80,
-			wantCount:    8,
-			wantTotalCov: 100,
+			// existing=80% meets target=80% → drop.
+			name:        "Existing meets target exactly: drop",
+			rec:         mkRI(10, 10, 80),
+			target:      80,
+			wantDropped: true,
 		},
 		{
-			// rec.Count=10, avg=10, existing=95%, target=80%.
-			// awsScaled = 8. existingAware = 0. max = 8.
-			name:         "Existing exceeds target: awsScaled floor still buys",
-			rec:          mkRI(10, 10, 95),
-			target:       80,
-			wantCount:    8,
-			wantTotalCov: 100,
+			// existing=95% exceeds target=80% → drop.
+			name:        "Existing exceeds target: drop",
+			rec:         mkRI(10, 10, 95),
+			target:      80,
+			wantDropped: true,
 		},
 		{
-			// rec.Count=5, avg=2, existing=70%, target=80%.
-			// awsScaled = ceil(5*0.8) = 4. existingAware = ceil(2*0.1) = 1.
-			// max = 4. Total cov = 70 + 4/2*100 = 270 clamped to 100.
-			name:         "Small gap: awsScaled floor of 4 wins over 1",
+			// avg=2, existing=70%, target=80%. gap=10. n=ceil(0.2)=1.
+			// Ceil keeps the rec alive even for tiny gaps. Total cov =
+			// 70 + 1/2*100 = 120 → clamped to 100.
+			name:         "Small gap rounds up to 1 RI",
 			rec:          mkRI(5, 2, 70),
 			target:       80,
-			wantCount:    4,
+			wantCount:    1,
 			wantTotalCov: 100,
 		},
 		{
-			// rec.Count=10, avg=10, existing=60%, target=70%.
-			// awsScaled = ceil(10*0.7) = 7. existingAware = ceil(10*0.1) = 1.
-			// max = 7. Total cov = 60 + 7/10*100 = 130 clamped to 100.
-			name:         "Small top-up: awsScaled floor of 7 wins over 1",
+			// avg=10, existing=60%, target=70%. gap=10. n=ceil(1.0)=1.
+			// Total cov = 60+10 = 70 (hits target exactly).
+			name:         "Small top-up to reach target",
 			rec:          mkRI(10, 10, 60),
 			target:       70,
-			wantCount:    7,
-			wantTotalCov: 100,
+			wantCount:    1,
+			wantTotalCov: 70,
 		},
 	}
 
@@ -1218,10 +1198,9 @@ func TestApplySizing(t *testing.T) {
 		cfg := Config{TargetCoverage: 80, Coverage: 100}
 		out := applySizing([]common.Recommendation{ri}, cfg, cfg.Coverage)
 		require.Len(t, out, 1)
-		// Hybrid: rec.Count=10, avg=8, target=80%.
-		// awsScaled = ceil(10*0.8) = 8. existingAware = ceil(8*0.8) = 7.
-		// max = 8. ProjectedUtilization = 8/8 = 100.
-		assert.Equal(t, 8, out[0].Count)
+		// avg=8, target=80%, existing=0%. gap=80. n=ceil(8*0.8)=ceil(6.4)=7.
+		// ProjectedUtilization = 8/7 = 114 clamped to 100.
+		assert.Equal(t, 7, out[0].Count)
 		assert.Equal(t, 100.0, out[0].ProjectedUtilization)
 	})
 
@@ -1237,10 +1216,9 @@ func TestApplySizing(t *testing.T) {
 }
 
 // TestApplyTargetCoverage_RI_Target100 covers the target == 100 boundary.
-// At target=100 (ratio=1.0), awsScaled = ceil(rec.Count*1.0) = rec.Count,
-// which becomes the floor — we always buy AWS's full recommended count.
-// The existingAware branch (ceil(avg*1.0)) only wins when avg > rec.Count,
-// which doesn't happen in practice (AWS sizes rec.Count >= avg).
+// At target=100 (and existing=0), ceil(avg*1.0) = ceil(avg) — any non-zero
+// avg rounds up to at least 1. Fractional avg above an integer rounds up
+// to the next integer.
 func TestApplyTargetCoverage_RI_Target100(t *testing.T) {
 	mkRI := func(count int, avg float64) common.Recommendation {
 		return common.Recommendation{
@@ -1259,14 +1237,14 @@ func TestApplyTargetCoverage_RI_Target100(t *testing.T) {
 		wantDropped bool
 		wantCount   int
 	}{
-		// rec.Count=5, avg=0.999. awsScaled=5, existingAware=1. max=5.
-		{name: "target 100, rec.Count=5 → awsScaled floor wins", rec: mkRI(5, 0.999), wantCount: 5},
-		// rec.Count=5, avg=1.0. awsScaled=5, existingAware=1. max=5.
-		{name: "target 100, avg=1 with rec.Count=5 → buy 5", rec: mkRI(5, 1.0), wantCount: 5},
-		// rec.Count=10, avg=8.7. awsScaled=10, existingAware=9. max=10.
-		{name: "target 100, rec.Count > avg → awsScaled wins", rec: mkRI(10, 8.7), wantCount: 10},
-		// rec.Count=10, avg=10. awsScaled=10, existingAware=10. max=10.
-		{name: "target 100, rec.Count == avg → match", rec: mkRI(10, 10.0), wantCount: 10},
+		// avg=0.999 → ceil(0.999) = 1.
+		{name: "target 100, avg=0.999 → buy 1", rec: mkRI(5, 0.999), wantCount: 1},
+		// avg=1.0 → ceil(1.0) = 1.
+		{name: "target 100, avg=1.0 → buy 1", rec: mkRI(5, 1.0), wantCount: 1},
+		// avg=8.7 → ceil(8.7) = 9. Slightly over target but matches AWS rec.
+		{name: "target 100, avg=8.7 → buy 9 (ceil rounds up)", rec: mkRI(10, 8.7), wantCount: 9},
+		// avg=10.0 exactly → ceil(10) = 10.
+		{name: "target 100, avg=10.0 → buy 10 (perfect match)", rec: mkRI(10, 10.0), wantCount: 10},
 	}
 
 	for _, tt := range tests {

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -1105,3 +1105,89 @@ func TestApplySizing(t *testing.T) {
 		assert.Equal(t, 0.0, out[0].ProjectedUtilization)
 	})
 }
+
+// TestApplyTargetUtilization_RI_Target100 covers the target == 100 boundary
+// (issue #338 AC: "target == 100 → only purchases with perfectly-matched
+// existing usage"). At target=100, floor(avg/1.0) = floor(avg) — so any rec
+// with avg < 1 drops, and a rec with avg >= 1 buys floor(avg) instances.
+func TestApplyTargetUtilization_RI_Target100(t *testing.T) {
+	mkRI := func(count int, avg float64) common.Recommendation {
+		return common.Recommendation{
+			Service:                     common.ServiceEC2,
+			Region:                      "us-east-1",
+			ResourceType:                "t3.medium",
+			Count:                       count,
+			CommitmentType:              common.CommitmentReservedInstance,
+			AverageInstancesUsedPerHour: avg,
+		}
+	}
+
+	tests := []struct {
+		name        string
+		rec         common.Recommendation
+		wantDropped bool
+		wantCount   int
+	}{
+		// avg=0.999 → floor(0.999/1.0) = 0 → dropped (target unreachable).
+		{name: "target 100, avg=0.999 → dropped", rec: mkRI(5, 0.999), wantDropped: true},
+		// avg=1.0 → floor(1.0/1.0) = 1 → buy 1. projected utilization = 100.
+		{name: "target 100, avg=1.0 → buy 1", rec: mkRI(5, 1.0), wantCount: 1},
+		// avg=8.7 → floor(8.7/1.0) = 8. projected utilization = 8.7/8 = 108.75 → clamped to 100.
+		{name: "target 100, avg=8.7 → buy 8 (clamped)", rec: mkRI(10, 8.7), wantCount: 8},
+		// avg=10.0 exactly → floor(10/1.0) = 10 (exact match). projected utilization = 100.
+		{name: "target 100, avg=10.0 → buy 10 (perfect match)", rec: mkRI(10, 10.0), wantCount: 10},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := ApplyTargetUtilization([]common.Recommendation{tt.rec}, 100)
+			if tt.wantDropped {
+				assert.Len(t, out, 0, "expected drop at target=100 for avg=%.3f", tt.rec.AverageInstancesUsedPerHour)
+				return
+			}
+			require.Len(t, out, 1)
+			assert.Equal(t, tt.wantCount, out[0].Count)
+		})
+	}
+}
+
+// TestApplyTargetUtilization_SP_NoSignalGuards covers the two SP no-signal
+// branches: RecommendedUtilization <= 0 (already covered by other tests) and
+// the new HourlyCommitment <= 0 guard (CE occasionally returns $0
+// placeholder recs).
+func TestApplyTargetUtilization_SP_NoSignalGuards(t *testing.T) {
+	t.Run("HourlyCommitment=0 with positive RecommendedUtilization → pass through unscaled", func(t *testing.T) {
+		rec := common.Recommendation{
+			Service:                common.ServiceSavingsPlansCompute,
+			CommitmentType:         common.CommitmentSavingsPlan,
+			EstimatedSavings:       1500,
+			RecommendedUtilization: 50,
+			Details:                &common.SavingsPlanDetails{HourlyCommitment: 0},
+		}
+		out := ApplyTargetUtilization([]common.Recommendation{rec}, 80)
+		require.Len(t, out, 1, "$0 SP rec should still be in output (pass-through)")
+		// Pass-through — projection fields must NOT be set, savings unchanged.
+		assert.Equal(t, 0.0, out[0].ProjectedUtilization, "ProjectedUtilization must NOT be set for $0-commitment pass-through")
+		assert.Equal(t, 1500.0, out[0].EstimatedSavings, "EstimatedSavings unchanged on pass-through")
+		assert.Equal(t, 0.0, out[0].Details.(*common.SavingsPlanDetails).HourlyCommitment, "HourlyCommitment unchanged")
+	})
+
+	t.Run("Details is wrong type → pass through unscaled, no projection metric set", func(t *testing.T) {
+		// Defensive case: SP rec with non-SP Details (a parser bug). The
+		// scaling can't proceed, and we MUST NOT set ProjectedUtilization
+		// to target% because the underlying cost fields aren't scaled —
+		// that would mislead the operator into thinking the rec was sized
+		// to the target when in fact it's the original unscaled commitment.
+		rec := common.Recommendation{
+			Service:                common.ServiceSavingsPlansCompute,
+			CommitmentType:         common.CommitmentSavingsPlan,
+			EstimatedSavings:       1500,
+			RecommendedUtilization: 50,
+			Details:                common.ComputeDetails{Platform: "Linux/UNIX"}, // wrong type
+		}
+		out := ApplyTargetUtilization([]common.Recommendation{rec}, 80)
+		require.Len(t, out, 1)
+		assert.Equal(t, 0.0, out[0].ProjectedUtilization, "must NOT set projection when scaling failed")
+		assert.Equal(t, 1500.0, out[0].EstimatedSavings, "EstimatedSavings must remain unscaled when scaling failed")
+	})
+}

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -931,33 +931,33 @@ func TestApplyTargetCoverage_RI(t *testing.T) {
 		wantProjCovGTE float64 // we assert coverage >= this (handles the float clamping)
 	}{
 		{
-			// avg=8.5, target=95%, existing=0%. gap=95.
-			// n = floor(8.5 * 0.95) = floor(8.075) = 8.
-			// Projected util = 8.5/8 = 106.25 clamped to 100.
-			// Projected coverage = 8/8.5 = 94.1%, just under target.
-			name:         "RI: target 95 buys 8 (floor rounds 8.075 down)",
+			// rec.Count=10, avg=8.5, target=95%, existing=0%.
+			// gap=95, remaining=100. n = floor(10 * 95/100) = floor(9.5) = 9.
+			// Projected util = 8.5/9 = 94.4.
+			name:         "RI: target 95 buys 9 (floor of 10*0.95)",
 			rec:          mkRI(10, 8.5, 0),
 			target:       95,
-			wantCount:    8,
-			wantProjUtil: 100,
+			wantCount:    9,
+			wantProjUtil: 94.44,
 		},
 		{
-			// avg=10, target=50%, existing=0%. gap=50. n=floor(5)=5.
-			name:         "RI: target 50 covers exactly half",
+			// rec.Count=10, target=50%, existing=0%. n=floor(10*0.5)=5.
+			name:         "RI: target 50 covers half the AWS rec",
 			rec:          mkRI(10, 10, 0),
 			target:       50,
 			wantCount:    5,
 			wantProjUtil: 100, // 10/5 clamped
 		},
 		{
-			// avg=0.4, target=50%, existing=0%. gap=50. n=floor(0.2)=0 → drop.
-			// Tiny-pool case: floor drops rather than over-covering. Operators
-			// who want these pools kept use --min-pool-size to filter
-			// upstream OR accept the on-demand spend.
-			name:        "RI: tiny pool drops (floor rounds down to 0)",
-			rec:         mkRI(5, 0.4, 0),
-			target:      50,
-			wantDropped: true,
+			// rec.Count=5, avg=0.4, target=50%, existing=0%.
+			// n = floor(5 * 50/100) = floor(2.5) = 2.
+			// Tiny pool still gets a rec since AWS sized it; use
+			// --min-pool-size upstream to filter tiny pools out by avg.
+			name:         "RI: tiny avg still buys per rec.Count scaling",
+			rec:          mkRI(5, 0.4, 0),
+			target:       50,
+			wantCount:    2,
+			wantProjUtil: 20, // 0.4/2 = 20% (not clamped, below 100)
 		},
 		{
 			// avg=0 (no signal) → passed through unchanged, counted in skip summary.
@@ -968,13 +968,13 @@ func TestApplyTargetCoverage_RI(t *testing.T) {
 			wantProjUtil: 0, // never set in pass-through
 		},
 		{
-			// avg=4, target=80%, existing=0%. gap=80. n=floor(3.2)=3.
-			// Projected coverage = 3/4 = 75, just under target (strict-target).
-			name:         "RI: target 80 covers 3 of 4 (floor rounds 3.2 down)",
+			// rec.Count=5, avg=4, target=80%, existing=0%. n=floor(5*0.8)=4.
+			// Projected util = 4/4 = 100.
+			name:         "RI: target 80 buys 4 of 5 AWS-recommended",
 			rec:          mkRI(5, 4, 0),
 			target:       80,
-			wantCount:    3,
-			wantProjUtil: 100, // 4/3 = 133 clamped
+			wantCount:    4,
+			wantProjUtil: 100,
 		},
 	}
 
@@ -1020,14 +1020,14 @@ func TestApplyTargetCoverage_RI_CostScaling(t *testing.T) {
 		SavingsPercentage:           25,
 		AverageInstancesUsedPerHour: 8,
 	}
-	// target=80 → gap=80, n=floor(8*0.8) = floor(6.4) = 6 (rec.Count=10).
-	// Ratio = 6/10 = 0.6. Cost-bearing fields scale by 0.6.
+	// target=80, existing=0, rec.Count=10 → gap=80, remaining=100.
+	// n = floor(10 * 80/100) = 8. Ratio = 8/10 = 0.8.
 	out := ApplyTargetCoverage([]common.Recommendation{rec}, 80)
 	require.Len(t, out, 1)
-	assert.Equal(t, 6, out[0].Count)
-	assert.InDelta(t, 600.0, out[0].CommitmentCost, 0.001, "CommitmentCost scales by Count/rec.Count")
-	assert.InDelta(t, 1200.0, out[0].OnDemandCost, 0.001, "OnDemandCost scales by Count/rec.Count")
-	assert.InDelta(t, 300.0, out[0].EstimatedSavings, 0.001, "EstimatedSavings scales by Count/rec.Count")
+	assert.Equal(t, 8, out[0].Count)
+	assert.InDelta(t, 800.0, out[0].CommitmentCost, 0.001, "CommitmentCost scales by Count/rec.Count")
+	assert.InDelta(t, 1600.0, out[0].OnDemandCost, 0.001, "OnDemandCost scales by Count/rec.Count")
+	assert.InDelta(t, 400.0, out[0].EstimatedSavings, 0.001, "EstimatedSavings scales by Count/rec.Count")
 	assert.Equal(t, 25.0, out[0].SavingsPercentage, "SavingsPercentage is invariant under count scaling")
 }
 
@@ -1092,21 +1092,29 @@ func TestApplyTargetCoverage_RI_ExistingCoverage(t *testing.T) {
 			wantDropped: true,
 		},
 		{
-			// avg=2, existing=70%, target=80%. gap=10. n=floor(0.2)=0 → drop.
-			// Strict-target: would over-shoot if we bought 1 RI, so drop.
-			name:        "Small gap rounds down to 0 → drop",
-			rec:         mkRI(5, 2, 70),
-			target:      80,
-			wantDropped: true,
+			// rec.Count=5, existing=70%, target=80%, avg=2.
+			// gap=10, remaining=30. n = floor(5 * 10/30) = floor(1.67) = 1.
+			// Total cov = 70 + 1/2*100 = 120 clamped to 100.
+			name:         "Small gap still buys 1 (rec.Count*ratio)",
+			rec:          mkRI(5, 2, 70),
+			target:       80,
+			wantCount:    1,
+			wantTotalCov: 100,
 		},
 		{
-			// avg=10, existing=60%, target=70%. gap=10. n=floor(1.0)=1.
-			// Total cov = 60+10 = 70 (hits target exactly).
-			name:         "Small top-up to reach target",
+			// rec.Count=10, existing=60%, target=70%, avg=10.
+			// gap=10, remaining=40. n = floor(10 * 10/40) = floor(2.5) = 2.
+			// Total cov = 60 + 2/10*100 = 80, slightly over target — would
+			// be 1 if rec.Count matched the avg×remaining/100 baseline,
+			// but the test fixture sets rec.Count=10 which is larger than
+			// the implied "incremental to 100%" count of 4. In real CE
+			// data, rec.Count is per-account-correct, so the formula is
+			// trusting AWS over the avg+existing-derived count.
+			name:         "Small top-up: scales AWS rec.Count by gap ratio",
 			rec:          mkRI(10, 10, 60),
 			target:       70,
-			wantCount:    1,
-			wantTotalCov: 70,
+			wantCount:    2,
+			wantTotalCov: 80,
 		},
 	}
 
@@ -1197,9 +1205,9 @@ func TestApplySizing(t *testing.T) {
 		cfg := Config{TargetCoverage: 80, Coverage: 100}
 		out := applySizing([]common.Recommendation{ri}, cfg, cfg.Coverage)
 		require.Len(t, out, 1)
-		// avg=8, target=80%, existing=0%. gap=80. n=floor(8*0.8)=floor(6.4)=6.
-		// ProjectedUtilization = 8/6 = 133 clamped to 100.
-		assert.Equal(t, 6, out[0].Count)
+		// rec.Count=10, target=80%, existing=0%, avg=8.
+		// n = floor(10 * 80/100) = 8. ProjectedUtilization = 8/8 = 100.
+		assert.Equal(t, 8, out[0].Count)
 		assert.Equal(t, 100.0, out[0].ProjectedUtilization)
 	})
 
@@ -1215,9 +1223,10 @@ func TestApplySizing(t *testing.T) {
 }
 
 // TestApplyTargetCoverage_RI_Target100 covers the target == 100 boundary.
-// At target=100 (and existing=0), floor(avg*1.0) = floor(avg) — fractional
-// avg rounds DOWN to the nearest integer. Pools with avg<1 drop entirely
-// (strict-target: don't over-cover even at 100%).
+// With the rec.Count-based formula, target=100 (existing=0) always yields
+// n = floor(rec.Count * 100/100) = rec.Count — operators get AWS's exact
+// recommendation. Tiny-avg pools no longer drop on this branch; use
+// --min-pool-size to filter them upstream.
 func TestApplyTargetCoverage_RI_Target100(t *testing.T) {
 	mkRI := func(count int, avg float64) common.Recommendation {
 		return common.Recommendation{
@@ -1236,15 +1245,12 @@ func TestApplyTargetCoverage_RI_Target100(t *testing.T) {
 		wantDropped bool
 		wantCount   int
 	}{
-		// avg=0.999 → floor(0.999) = 0 → drop. Use --min-pool-size to
-		// filter such pools out explicitly upstream.
-		{name: "target 100, avg=0.999 → dropped (floor rounds to 0)", rec: mkRI(5, 0.999), wantDropped: true},
-		// avg=1.0 → floor(1.0) = 1.
-		{name: "target 100, avg=1.0 → buy 1", rec: mkRI(5, 1.0), wantCount: 1},
-		// avg=8.7 → floor(8.7) = 8. Slightly under target (strict-target).
-		{name: "target 100, avg=8.7 → buy 8 (floor rounds down)", rec: mkRI(10, 8.7), wantCount: 8},
-		// avg=10.0 exactly → floor(10) = 10.
-		{name: "target 100, avg=10.0 → buy 10 (perfect match)", rec: mkRI(10, 10.0), wantCount: 10},
+		// rec.Count=5 → buy 5 regardless of avg.
+		{name: "target 100, rec.Count=5 → buy AWS rec exactly", rec: mkRI(5, 0.999), wantCount: 5},
+		{name: "target 100, rec.Count=5 avg=1 → buy 5", rec: mkRI(5, 1.0), wantCount: 5},
+		// rec.Count=10, target=100 → buy 10 (regardless of avg).
+		{name: "target 100, rec.Count=10 → buy AWS rec exactly", rec: mkRI(10, 8.7), wantCount: 10},
+		{name: "target 100, rec.Count=10 avg=10 → buy 10", rec: mkRI(10, 10.0), wantCount: 10},
 	}
 
 	for _, tt := range tests {

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -899,11 +899,13 @@ func TestAdjustRecommendationsForExisting_PartialCoverage(t *testing.T) {
 	mockClient.AssertExpectations(t)
 }
 
-// TestApplyTargetUtilization covers the RI sizing branch of issue #338's
-// --target-utilization flag. Confirms: floor (not ceil) selection so we
-// hit "utilization >= target", AWS-ceiling cap, drop-when-unreachable,
-// no-signal pass-through, and projected utilization/coverage outputs.
-func TestApplyTargetUtilization_RI(t *testing.T) {
+// TestApplyTargetCoverage covers the RI sizing branch of issue #338's
+// --target-coverage flag, now under-buy semantics: n = floor(avg*target).
+// Confirms: floor (not ceil) selection so coverage stays at-most target,
+// drop-when-target-too-low (avg*target < 1), no-signal pass-through, and
+// projected utilization (typically 100% since we under-buy) / coverage
+// (tracks target%) outputs.
+func TestApplyTargetCoverage_RI(t *testing.T) {
 	mkRI := func(count int, avg, recUtil float64) common.Recommendation {
 		return common.Recommendation{
 			Service:                     common.ServiceEC2,
@@ -929,26 +931,30 @@ func TestApplyTargetUtilization_RI(t *testing.T) {
 		wantProjCovGTE float64 // we assert coverage >= this (handles the float clamping)
 	}{
 		{
-			// avg=8.5, target=95% → floor(8.5/0.95) = floor(8.94) = 8.
-			// projected utilization = 8.5/8 = 106.25 → clamped to 100.
-			name:         "RI: target 95 hits cap with non-integer avg",
+			// avg=8.5, target=95% → floor(8.5*0.95) = floor(8.075) = 8.
+			// Projected utilization = 8.5/8 = 106.25 → clamped to 100.
+			// Projected coverage = 8/8.5 = 94.1%, just under target.
+			name:         "RI: target 95 buys close to AWS rec (under-buy by floor)",
 			rec:          mkRI(10, 8.5, 85),
 			target:       95,
 			wantCount:    8,
 			wantProjUtil: 100,
 		},
 		{
-			// avg=10, target=50% → floor(10/0.5) = 20. Capped at rec.Count=10
-			// (target too lenient). Cap log fires (not asserted here).
-			name:         "RI: target 50 hits AWS ceiling cap",
+			// avg=10, target=50% → floor(10*0.5) = 5. Half of average usage
+			// is reserved; the other half spills to on-demand. Projected
+			// utilization = 10/5 = 200 → clamped to 100 (RIs always full).
+			// Projected coverage = 5/10 = 50, matches target.
+			name:         "RI: target 50 under-buys to leave on-demand headroom",
 			rec:          mkRI(10, 10, 90),
 			target:       50,
-			wantCount:    10,
-			wantProjUtil: 100, // 10/10 = 100
+			wantCount:    5,
+			wantProjUtil: 100, // 10/5 clamped
 		},
 		{
-			// avg=0.4, target=50% → floor(0.4/0.5) = 0 → drop with log.
-			name:        "RI: target unreachable → dropped",
+			// avg=0.4, target=50% → floor(0.4*0.5) = 0 → drop with log.
+			// Target too low to support even one RI on this rec's average.
+			name:        "RI: target produces zero count → dropped",
 			rec:         mkRI(5, 0.4, 50),
 			target:      50,
 			wantDropped: true,
@@ -962,21 +968,21 @@ func TestApplyTargetUtilization_RI(t *testing.T) {
 			wantProjUtil: 0, // never set in pass-through
 		},
 		{
-			// avg=4, target=80% → floor(4/0.8) = 5. Capped at rec.Count=5
-			// (binding cap, no log fires because uncapped == cap).
-			// projected utilization = 4/5 = 80.
-			name:         "RI: target 80 hits target exactly",
+			// avg=4, target=80% → floor(4*0.8) = 3. Projected utilization =
+			// 4/3 = 133 → clamped to 100. Projected coverage = 3/4 = 75,
+			// just under target (floor's effect on small avg).
+			name:         "RI: target 80 under-buys (3 of 4 covered)",
 			rec:          mkRI(5, 4, 80),
 			target:       80,
-			wantCount:    5,
-			wantProjUtil: 80,
+			wantCount:    3,
+			wantProjUtil: 100,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			recs := []common.Recommendation{tt.rec}
-			out := ApplyTargetUtilization(recs, tt.target)
+			out := ApplyTargetCoverage(recs, tt.target)
 			if tt.wantDropped {
 				if len(out) != 0 {
 					t.Fatalf("expected drop; got %d recs", len(out))
@@ -999,11 +1005,11 @@ func TestApplyTargetUtilization_RI(t *testing.T) {
 	}
 }
 
-// TestApplyTargetUtilization_RI_CostScaling verifies cost fields are NOT
+// TestApplyTargetCoverage_RI_CostScaling verifies RI cost fields are NOT
 // scaled when the count is adjusted (matching ApplyCoverage's RI branch,
 // which also leaves cost fields untouched). Divergence would silently
 // mis-cost the dry-run output relative to the coverage path.
-func TestApplyTargetUtilization_RI_CostScaling(t *testing.T) {
+func TestApplyTargetCoverage_RI_CostScaling(t *testing.T) {
 	rec := common.Recommendation{
 		Service:                     common.ServiceEC2,
 		Count:                       10,
@@ -1013,21 +1019,21 @@ func TestApplyTargetUtilization_RI_CostScaling(t *testing.T) {
 		EstimatedSavings:            500,
 		AverageInstancesUsedPerHour: 8,
 	}
-	// target=80 → floor(8/0.8) = 10 = rec.Count (no scaling). Cost fields
-	// must match the input exactly.
-	out := ApplyTargetUtilization([]common.Recommendation{rec}, 80)
+	// target=80 → floor(8*0.8) = 6 (under-buy from rec.Count=10). Cost
+	// fields must match the input exactly; only Count changes.
+	out := ApplyTargetCoverage([]common.Recommendation{rec}, 80)
 	require.Len(t, out, 1)
-	assert.Equal(t, 10, out[0].Count)
+	assert.Equal(t, 6, out[0].Count)
 	assert.Equal(t, 1000.0, out[0].CommitmentCost, "CommitmentCost should be untouched by RI branch")
 	assert.Equal(t, 2000.0, out[0].OnDemandCost, "OnDemandCost should be untouched by RI branch")
 	assert.Equal(t, 500.0, out[0].EstimatedSavings, "EstimatedSavings should be untouched by RI branch")
 }
 
-// TestApplyTargetUtilization_SP covers the SP sizing branch. SP sizing
-// scales only HourlyCommitment (inside SavingsPlanDetails) and
-// EstimatedSavings — matching exactly what ApplyCoverage scales for SPs.
-// CommitmentCost / OnDemandCost / SavingsPercentage must NOT change.
-func TestApplyTargetUtilization_SP(t *testing.T) {
+// TestApplyTargetCoverage_SP covers the SP sizing branch under under-buy
+// semantics: HourlyCommitment and EstimatedSavings scale by targetPct/100
+// regardless of AWS's projected utilization. CommitmentCost / OnDemandCost /
+// SavingsPercentage must NOT change.
+func TestApplyTargetCoverage_SP(t *testing.T) {
 	mkSP := func(recUtil float64) common.Recommendation {
 		return common.Recommendation{
 			Service:                common.ServiceSavingsPlansCompute,
@@ -1041,34 +1047,38 @@ func TestApplyTargetUtilization_SP(t *testing.T) {
 		}
 	}
 
-	t.Run("AWS already above target — no scaling", func(t *testing.T) {
-		out := ApplyTargetUtilization([]common.Recommendation{mkSP(95)}, 80)
+	t.Run("AWS above target — still scales by target (under-buy)", func(t *testing.T) {
+		// RecUtil=95, target=80. Even though AWS projects above target, the
+		// flag's intent is "leave 20% headroom", so commitment shrinks to
+		// 80% of AWS rec. HourlyCommitment: 2.0 * 0.80 = 1.6, savings: 1500
+		// * 0.80 = 1200. Projected util = 95/0.80 = 118.75 clamped to 100.
+		out := ApplyTargetCoverage([]common.Recommendation{mkSP(95)}, 80)
 		require.Len(t, out, 1)
-		assert.Equal(t, 2.0, out[0].Details.(*common.SavingsPlanDetails).HourlyCommitment)
-		assert.Equal(t, 1500.0, out[0].EstimatedSavings)
-		assert.Equal(t, 95.0, out[0].ProjectedUtilization)
+		assert.InDelta(t, 1.6, out[0].Details.(*common.SavingsPlanDetails).HourlyCommitment, 0.001)
+		assert.InDelta(t, 1200.0, out[0].EstimatedSavings, 0.001)
+		assert.InDelta(t, 100.0, out[0].ProjectedUtilization, 0.001, "RecUtil/ratio = 95/0.80 = 118.75 clamps to 100")
 		assert.Equal(t, 0.0, out[0].ProjectedCoverage, "SPs intentionally leave ProjectedCoverage at zero")
 	})
 
-	t.Run("AWS below target — scale down", func(t *testing.T) {
-		// RecUtil=50, target=80 → ratio = 50/80 = 0.625.
-		// HourlyCommitment: 2.0 * 0.625 = 1.25
-		// EstimatedSavings: 1500 * 0.625 = 937.5
-		out := ApplyTargetUtilization([]common.Recommendation{mkSP(50)}, 80)
+	t.Run("AWS below target — scale down by target (under-buy)", func(t *testing.T) {
+		// RecUtil=50, target=80. Commitment shrinks to 80% of AWS rec.
+		// HourlyCommitment: 2.0 * 0.80 = 1.6, savings: 1500 * 0.80 = 1200.
+		// Projected util = 50/0.80 = 62.5 (no clamp needed).
+		out := ApplyTargetCoverage([]common.Recommendation{mkSP(50)}, 80)
 		require.Len(t, out, 1)
 		details := out[0].Details.(*common.SavingsPlanDetails)
-		assert.InDelta(t, 1.25, details.HourlyCommitment, 0.001)
-		assert.InDelta(t, 937.5, out[0].EstimatedSavings, 0.001)
+		assert.InDelta(t, 1.6, details.HourlyCommitment, 0.001)
+		assert.InDelta(t, 1200.0, out[0].EstimatedSavings, 0.001)
 		// CommitmentCost / OnDemandCost / SavingsPercentage MUST be unchanged.
 		assert.Equal(t, 1000.0, out[0].CommitmentCost, "CommitmentCost must not scale on SP branch (matches ApplyCoverage)")
 		assert.Equal(t, 5000.0, out[0].OnDemandCost, "OnDemandCost must not scale on SP branch (matches ApplyCoverage)")
 		assert.Equal(t, 30.0, out[0].SavingsPercentage, "SavingsPercentage must not scale on SP branch")
-		assert.Equal(t, 80.0, out[0].ProjectedUtilization)
+		assert.InDelta(t, 62.5, out[0].ProjectedUtilization, 0.001, "RecUtil/ratio = 50/0.80 = 62.5")
 		assert.Equal(t, 0.0, out[0].ProjectedCoverage)
 	})
 
 	t.Run("no signal → passed through unchanged", func(t *testing.T) {
-		out := ApplyTargetUtilization([]common.Recommendation{mkSP(0)}, 80)
+		out := ApplyTargetCoverage([]common.Recommendation{mkSP(0)}, 80)
 		require.Len(t, out, 1)
 		// Original recommendation values intact.
 		assert.Equal(t, 2.0, out[0].Details.(*common.SavingsPlanDetails).HourlyCommitment)
@@ -1078,7 +1088,7 @@ func TestApplyTargetUtilization_SP(t *testing.T) {
 }
 
 // TestApplySizing checks the routing helper picks the right sizer based
-// on cfg.TargetUtilization being >0 vs ==0.
+// on cfg.TargetCoverage being >0 vs ==0.
 func TestApplySizing(t *testing.T) {
 	ri := common.Recommendation{
 		Service:                     common.ServiceEC2,
@@ -1087,16 +1097,18 @@ func TestApplySizing(t *testing.T) {
 		AverageInstancesUsedPerHour: 8,
 	}
 
-	t.Run("TargetUtilization > 0 → ApplyTargetUtilization", func(t *testing.T) {
-		cfg := Config{TargetUtilization: 80, Coverage: 100}
+	t.Run("TargetCoverage > 0 → ApplyTargetCoverage", func(t *testing.T) {
+		cfg := Config{TargetCoverage: 80, Coverage: 100}
 		out := applySizing([]common.Recommendation{ri}, cfg, cfg.Coverage)
 		require.Len(t, out, 1)
-		// floor(8/0.8)=10, capped at rec.Count=10. ProjectedUtilization set.
-		assert.Equal(t, 80.0, out[0].ProjectedUtilization)
+		// Under-buy: floor(8*0.8) = 6. ProjectedUtilization = 8/6 = 133
+		// clamped to 100 (RIs always fully used when count < avg).
+		assert.Equal(t, 6, out[0].Count)
+		assert.Equal(t, 100.0, out[0].ProjectedUtilization)
 	})
 
-	t.Run("TargetUtilization == 0 → ApplyCoverage", func(t *testing.T) {
-		cfg := Config{TargetUtilization: 0, Coverage: 50}
+	t.Run("TargetCoverage == 0 → ApplyCoverage", func(t *testing.T) {
+		cfg := Config{TargetCoverage: 0, Coverage: 50}
 		out := applySizing([]common.Recommendation{ri}, cfg, cfg.Coverage)
 		require.Len(t, out, 1)
 		// ApplyCoverage(50) on count=10 → 5. ProjectedUtilization NOT set
@@ -1106,11 +1118,13 @@ func TestApplySizing(t *testing.T) {
 	})
 }
 
-// TestApplyTargetUtilization_RI_Target100 covers the target == 100 boundary
+// TestApplyTargetCoverage_RI_Target100 covers the target == 100 boundary
 // (issue #338 AC: "target == 100 → only purchases with perfectly-matched
-// existing usage"). At target=100, floor(avg/1.0) = floor(avg) — so any rec
-// with avg < 1 drops, and a rec with avg >= 1 buys floor(avg) instances.
-func TestApplyTargetUtilization_RI_Target100(t *testing.T) {
+// existing usage"). At target=100 (ratio=1.0), floor(avg*1.0) = floor(avg) —
+// so a rec with avg < 1 drops, and a rec with avg >= 1 buys floor(avg).
+// Same counts as the original ceil-division version because target=100 is
+// the fixed point of both formulas.
+func TestApplyTargetCoverage_RI_Target100(t *testing.T) {
 	mkRI := func(count int, avg float64) common.Recommendation {
 		return common.Recommendation{
 			Service:                     common.ServiceEC2,
@@ -1128,19 +1142,19 @@ func TestApplyTargetUtilization_RI_Target100(t *testing.T) {
 		wantDropped bool
 		wantCount   int
 	}{
-		// avg=0.999 → floor(0.999/1.0) = 0 → dropped (target unreachable).
+		// avg=0.999 → floor(0.999*1.0) = 0 → dropped (count is zero).
 		{name: "target 100, avg=0.999 → dropped", rec: mkRI(5, 0.999), wantDropped: true},
-		// avg=1.0 → floor(1.0/1.0) = 1 → buy 1. projected utilization = 100.
+		// avg=1.0 → floor(1.0*1.0) = 1 → buy 1. projected utilization = 100.
 		{name: "target 100, avg=1.0 → buy 1", rec: mkRI(5, 1.0), wantCount: 1},
-		// avg=8.7 → floor(8.7/1.0) = 8. projected utilization = 8.7/8 = 108.75 → clamped to 100.
+		// avg=8.7 → floor(8.7*1.0) = 8. projected utilization = 8.7/8 = 108.75 → clamped to 100.
 		{name: "target 100, avg=8.7 → buy 8 (clamped)", rec: mkRI(10, 8.7), wantCount: 8},
-		// avg=10.0 exactly → floor(10/1.0) = 10 (exact match). projected utilization = 100.
+		// avg=10.0 exactly → floor(10*1.0) = 10 (exact match). projected utilization = 100.
 		{name: "target 100, avg=10.0 → buy 10 (perfect match)", rec: mkRI(10, 10.0), wantCount: 10},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			out := ApplyTargetUtilization([]common.Recommendation{tt.rec}, 100)
+			out := ApplyTargetCoverage([]common.Recommendation{tt.rec}, 100)
 			if tt.wantDropped {
 				assert.Len(t, out, 0, "expected drop at target=100 for avg=%.3f", tt.rec.AverageInstancesUsedPerHour)
 				return
@@ -1151,11 +1165,11 @@ func TestApplyTargetUtilization_RI_Target100(t *testing.T) {
 	}
 }
 
-// TestApplyTargetUtilization_SP_NoSignalGuards covers the two SP no-signal
+// TestApplyTargetCoverage_SP_NoSignalGuards covers the two SP no-signal
 // branches: RecommendedUtilization <= 0 (already covered by other tests) and
 // the new HourlyCommitment <= 0 guard (CE occasionally returns $0
 // placeholder recs).
-func TestApplyTargetUtilization_SP_NoSignalGuards(t *testing.T) {
+func TestApplyTargetCoverage_SP_NoSignalGuards(t *testing.T) {
 	t.Run("HourlyCommitment=0 with positive RecommendedUtilization → pass through unscaled", func(t *testing.T) {
 		rec := common.Recommendation{
 			Service:                common.ServiceSavingsPlansCompute,
@@ -1164,7 +1178,7 @@ func TestApplyTargetUtilization_SP_NoSignalGuards(t *testing.T) {
 			RecommendedUtilization: 50,
 			Details:                &common.SavingsPlanDetails{HourlyCommitment: 0},
 		}
-		out := ApplyTargetUtilization([]common.Recommendation{rec}, 80)
+		out := ApplyTargetCoverage([]common.Recommendation{rec}, 80)
 		require.Len(t, out, 1, "$0 SP rec should still be in output (pass-through)")
 		// Pass-through — projection fields must NOT be set, savings unchanged.
 		assert.Equal(t, 0.0, out[0].ProjectedUtilization, "ProjectedUtilization must NOT be set for $0-commitment pass-through")
@@ -1185,7 +1199,7 @@ func TestApplyTargetUtilization_SP_NoSignalGuards(t *testing.T) {
 			RecommendedUtilization: 50,
 			Details:                common.ComputeDetails{Platform: "Linux/UNIX"}, // wrong type
 		}
-		out := ApplyTargetUtilization([]common.Recommendation{rec}, 80)
+		out := ApplyTargetCoverage([]common.Recommendation{rec}, 80)
 		require.Len(t, out, 1)
 		assert.Equal(t, 0.0, out[0].ProjectedUtilization, "must NOT set projection when scaling failed")
 		assert.Equal(t, 1500.0, out[0].EstimatedSavings, "EstimatedSavings must remain unscaled when scaling failed")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -74,6 +74,12 @@ type Config struct {
 	MinSavingsPct      float64
 	MaxBreakEvenMonths int
 	MinCount           int
+	// RebuyWindowDays, when > 0, treats existing RIs whose remaining term
+	// is at most this many days as already uncovered, so --target-coverage
+	// recommends replacements before they expire. Zero (default) keeps the
+	// strict per-pool subtraction — existing coverage is fully trusted
+	// regardless of when it expires.
+	RebuyWindowDays int
 }
 
 func main() {
@@ -137,6 +143,10 @@ func init() {
 	rootCmd.Flags().Float64Var(&toolCfg.MinSavingsPct, "min-savings-pct", 0, "Minimum savings percentage to include a recommendation (0 = no filter)")
 	rootCmd.Flags().IntVar(&toolCfg.MaxBreakEvenMonths, "max-break-even-months", 0, "Maximum break-even period in months (0 = no filter)")
 	rootCmd.Flags().IntVar(&toolCfg.MinCount, "min-count", 0, "Minimum instance count to include a recommendation (0 = no filter)")
+	rootCmd.Flags().IntVar(&toolCfg.RebuyWindowDays, "rebuy-window-days", 0,
+		"When >0, treat existing RIs expiring within this many days as already "+
+			"uncovered, so --target-coverage sizes recommendations to replace them "+
+			"before they expire. Default 0 = trust existing coverage fully.")
 }
 
 // Package-level Config that cobra flags bind to

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -33,10 +33,15 @@ const (
 
 // Config holds all configuration for the RI helper tool
 type Config struct {
-	Providers              []string
-	Regions                []string
-	Services               []string
-	Coverage               float64
+	Providers []string
+	Regions   []string
+	Services  []string
+	Coverage  float64
+	// TargetUtilization, when > 0, switches sizing from coverage-% to
+	// "size the purchase so projected post-purchase utilization stays >=
+	// this %". Mutually exclusive with --coverage (target wins, with an
+	// info log). See cmd/helpers.go: ApplyTargetUtilization.
+	TargetUtilization      float64
 	ActualPurchase         bool
 	CSVOutput              string
 	CSVInput               string
@@ -92,6 +97,10 @@ func init() {
 	rootCmd.Flags().StringSliceVarP(&toolCfg.Services, "services", "s", []string{"rds"}, "Services to process (rds, elasticache, ec2, opensearch, redshift, memorydb, savingsplans)")
 	rootCmd.Flags().BoolVar(&toolCfg.AllServices, "all-services", false, "Process all supported services")
 	rootCmd.Flags().Float64VarP(&toolCfg.Coverage, "coverage", "c", 80.0, "Percentage of recommendations to purchase (0-100)")
+	rootCmd.Flags().Float64VarP(&toolCfg.TargetUtilization, "target-utilization", "u", 0,
+		"Target post-purchase utilization % (0-100). When >0, sizes recommendations "+
+			"so projected utilization stays >= target — higher target = fewer commitments "+
+			"bought (stricter waste ceiling). Overrides --coverage. Default 0 = disabled.")
 	rootCmd.Flags().BoolVar(&toolCfg.ActualPurchase, "purchase", false, "Actually purchase RIs instead of just printing the data")
 	rootCmd.Flags().StringVarP(&toolCfg.CSVOutput, "output", "o", "", "Output CSV file path (if not specified, auto-generates filename)")
 	rootCmd.Flags().StringVarP(&toolCfg.CSVInput, "input-csv", "i", "", "Input CSV file with recommendations to purchase")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -37,11 +37,13 @@ type Config struct {
 	Regions   []string
 	Services  []string
 	Coverage  float64
-	// TargetUtilization, when > 0, switches sizing from coverage-% to
-	// "size the purchase so projected post-purchase utilization stays >=
-	// this %". Mutually exclusive with --coverage (target wins, with an
-	// info log). See cmd/helpers.go: ApplyTargetUtilization.
-	TargetUtilization      float64
+	// TargetCoverage, when > 0, switches sizing from --coverage's
+	// rec.Count-scaling to under-buy against historical hourly usage:
+	// each rec is sized to floor(avg * TargetCoverage/100), leaving
+	// (100-TargetCoverage)% of historical demand on-demand. Mutually
+	// exclusive with --coverage (target wins, with an info log). See
+	// cmd/helpers.go: ApplyTargetCoverage.
+	TargetCoverage         float64
 	ActualPurchase         bool
 	CSVOutput              string
 	CSVInput               string
@@ -97,10 +99,11 @@ func init() {
 	rootCmd.Flags().StringSliceVarP(&toolCfg.Services, "services", "s", []string{"rds"}, "Services to process (rds, elasticache, ec2, opensearch, redshift, memorydb, savingsplans)")
 	rootCmd.Flags().BoolVar(&toolCfg.AllServices, "all-services", false, "Process all supported services")
 	rootCmd.Flags().Float64VarP(&toolCfg.Coverage, "coverage", "c", 80.0, "Percentage of recommendations to purchase (0-100)")
-	rootCmd.Flags().Float64VarP(&toolCfg.TargetUtilization, "target-utilization", "u", 0,
-		"Target post-purchase utilization % (0-100). When >0, sizes recommendations "+
-			"so projected utilization stays >= target — higher target = fewer commitments "+
-			"bought (stricter waste ceiling). Overrides --coverage. Default 0 = disabled.")
+	rootCmd.Flags().Float64VarP(&toolCfg.TargetCoverage, "target-coverage", "u", 0,
+		"Target % (0-100) of historical avg-hourly usage to cover with commitments. "+
+			"When >0, sizes each rec to floor(avg * target/100) so projected coverage "+
+			"approximates target and projected utilization stays near 100%, leaving "+
+			"(100-target)% on-demand headroom. Overrides --coverage. Default 0 = disabled.")
 	rootCmd.Flags().BoolVar(&toolCfg.ActualPurchase, "purchase", false, "Actually purchase RIs instead of just printing the data")
 	rootCmd.Flags().StringVarP(&toolCfg.CSVOutput, "output", "o", "", "Output CSV file path (if not specified, auto-generates filename)")
 	rootCmd.Flags().StringVarP(&toolCfg.CSVInput, "input-csv", "i", "", "Input CSV file with recommendations to purchase")
@@ -248,12 +251,12 @@ func createServiceClient(service common.ServiceType, cfg aws.Config) provider.Se
 }
 
 // effectiveSizingPct returns the sizing % actually applied to recommendations:
-// cfg.TargetUtilization when set (>0), else cfg.Coverage. Use this when
+// cfg.TargetCoverage when set (>0), else cfg.Coverage. Use this when
 // emitting human-facing labels (purchase IDs, audit-log fields) so the label
 // reflects the value that drove the sizing, not the unused default.
 func effectiveSizingPct(cfg Config) float64 {
-	if cfg.TargetUtilization > 0 {
-		return cfg.TargetUtilization
+	if cfg.TargetCoverage > 0 {
+		return cfg.TargetCoverage
 	}
 	return cfg.Coverage
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -80,6 +80,13 @@ type Config struct {
 	// strict per-pool subtraction — existing coverage is fully trusted
 	// regardless of when it expires.
 	RebuyWindowDays int
+	// MinPoolSize, when > 0, drops RI recommendations for pools whose
+	// AverageInstancesUsedPerHour is below this threshold. Used to avoid
+	// the integer-arithmetic over-cover problem on tiny pools (avg < 5
+	// can't approximate target=80% without buying enough RIs to hit
+	// 100% coverage). Zero (default) keeps all pools. SPs and recs
+	// without a per-hour signal pass through unfiltered.
+	MinPoolSize float64
 }
 
 func main() {
@@ -147,6 +154,11 @@ func init() {
 		"When >0, treat existing RIs expiring within this many days as already "+
 			"uncovered, so --target-coverage sizes recommendations to replace them "+
 			"before they expire. Default 0 = trust existing coverage fully.")
+	rootCmd.Flags().Float64Var(&toolCfg.MinPoolSize, "min-pool-size", 0,
+		"When >0, drop RI recommendations for pools with AverageInstancesUsedPerHour "+
+			"below this threshold. Useful with --target-coverage to skip tiny pools "+
+			"that integer arithmetic forces above target (e.g. avg=1 cannot hit 80%%). "+
+			"Default 0 = no filter.")
 }
 
 // Package-level Config that cobra flags bind to

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -247,8 +247,22 @@ func createServiceClient(service common.ServiceType, cfg aws.Config) provider.Se
 	}
 }
 
-// generatePurchaseID creates a descriptive purchase ID with UUID for uniqueness
-func generatePurchaseID(rec common.Recommendation, region string, _ int, isDryRun bool, coverage float64) string {
+// effectiveSizingPct returns the sizing % actually applied to recommendations:
+// cfg.TargetUtilization when set (>0), else cfg.Coverage. Use this when
+// emitting human-facing labels (purchase IDs, audit-log fields) so the label
+// reflects the value that drove the sizing, not the unused default.
+func effectiveSizingPct(cfg Config) float64 {
+	if cfg.TargetUtilization > 0 {
+		return cfg.TargetUtilization
+	}
+	return cfg.Coverage
+}
+
+// generatePurchaseID creates a descriptive purchase ID with UUID for uniqueness.
+// sizingPct is the percentage that actually drove the sizing decision (see
+// effectiveSizingPct); it appears in the ID as e.g. "80pct" purely for human
+// readability and audit traceability.
+func generatePurchaseID(rec common.Recommendation, region string, _ int, isDryRun bool, sizingPct float64) string {
 	// Generate a short UUID suffix (first 8 characters) for uniqueness
 	uuidSuffix := uuid.New().String()[:8]
 	timestamp := time.Now().Format("20060102-150405")
@@ -277,7 +291,7 @@ func generatePurchaseID(rec common.Recommendation, region string, _ int, isDryRu
 
 	// Add account name if available
 	accountName := sanitizeAccountName(rec.AccountName)
-	coveragePct := fmt.Sprintf("%.0fpct", coverage)
+	coveragePct := fmt.Sprintf("%.0fpct", sizingPct)
 	if accountName != "" {
 		if engine != "" {
 			return fmt.Sprintf("%s-%s-%s-%s-%s-%s-%dx-%s-%s-%s",

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -636,7 +636,7 @@ func TestGeneratePurchaseIDCoverageVariations(t *testing.T) {
 	}
 }
 
-// TestEffectiveSizingPct locks the rule that target-utilization wins over
+// TestEffectiveSizingPct locks the rule that target-coverage wins over
 // coverage when both are configured. Without this, dry-run purchase IDs (and
 // any other audit label that calls effectiveSizingPct) print the unused
 // default Coverage=80 instead of the actual target value the user passed.
@@ -649,9 +649,9 @@ func TestEffectiveSizingPct(t *testing.T) {
 	}{
 		{"target unset, coverage default", Config{Coverage: 80}, 80},
 		{"target unset, coverage custom", Config{Coverage: 50}, 50},
-		{"target set, coverage default ignored", Config{TargetUtilization: 70, Coverage: 80}, 70},
-		{"target set, coverage explicit ignored", Config{TargetUtilization: 95, Coverage: 30}, 95},
-		{"target zero falls back to coverage", Config{TargetUtilization: 0, Coverage: 60}, 60},
+		{"target set, coverage default ignored", Config{TargetCoverage: 70, Coverage: 80}, 70},
+		{"target set, coverage explicit ignored", Config{TargetCoverage: 95, Coverage: 30}, 95},
+		{"target zero falls back to coverage", Config{TargetCoverage: 0, Coverage: 60}, 60},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -636,6 +636,30 @@ func TestGeneratePurchaseIDCoverageVariations(t *testing.T) {
 	}
 }
 
+// TestEffectiveSizingPct locks the rule that target-utilization wins over
+// coverage when both are configured. Without this, dry-run purchase IDs (and
+// any other audit label that calls effectiveSizingPct) print the unused
+// default Coverage=80 instead of the actual target value the user passed.
+// Regression guard for the Aurora-target / RDS-target CLI dry-run runs.
+func TestEffectiveSizingPct(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+		want float64
+	}{
+		{"target unset, coverage default", Config{Coverage: 80}, 80},
+		{"target unset, coverage custom", Config{Coverage: 50}, 50},
+		{"target set, coverage default ignored", Config{TargetUtilization: 70, Coverage: 80}, 70},
+		{"target set, coverage explicit ignored", Config{TargetUtilization: 95, Coverage: 30}, 95},
+		{"target zero falls back to coverage", Config{TargetUtilization: 0, Coverage: 60}, 60},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, effectiveSizingPct(tt.cfg))
+		})
+	}
+}
+
 func TestParseServicesWithEmptyAndNil(t *testing.T) {
 	// Empty slice
 	result := parseServices([]string{})

--- a/cmd/multi_service.go
+++ b/cmd/multi_service.go
@@ -14,10 +14,43 @@ import (
 	"github.com/LeanerCloud/CUDly/pkg/provider"
 	"github.com/LeanerCloud/CUDly/pkg/scorer"
 	awsprovider "github.com/LeanerCloud/CUDly/providers/aws"
+	"github.com/LeanerCloud/CUDly/providers/aws/recommendations"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/google/uuid"
 )
+
+// existingCoverageLookbackDays is the historical window we ask CE to
+// summarise existing-RI coverage over for --target-coverage sizing.
+// 30 days matches CE's UI default and the GetRIUtilization caller.
+const existingCoverageLookbackDays = 30
+
+// fetchExistingCoverage retrieves the existing-RI coverage map from Cost
+// Explorer so --target-coverage sizing can subtract what's already owned in
+// each pool. Best-effort: a transient CE failure logs a warning and returns
+// an empty map, which the sizing path treats as "no signal" — recs sized
+// against avg without subtracting existing commitments (the old behavior).
+// Skipping the fetch entirely when --target-coverage is not in play avoids a
+// needless CE call (and its $0.01 charge) for users on the --coverage path.
+func fetchExistingCoverage(ctx context.Context, recClient provider.RecommendationsClient, cfg Config) recommendations.PoolCoverageMap {
+	if cfg.TargetCoverage <= 0 {
+		return nil
+	}
+	adapter, ok := recClient.(*awsprovider.RecommendationsClientAdapter)
+	if !ok {
+		// Non-AWS provider: feature not wired up. Sizing degenerates to
+		// the no-existing-commitments path.
+		return nil
+	}
+	AppLogger.Printf("\n🔎 Fetching existing-RI coverage from Cost Explorer (lookback %d days)...\n", existingCoverageLookbackDays)
+	cov, err := adapter.GetRICoverageMap(ctx, existingCoverageLookbackDays)
+	if err != nil {
+		AppLogger.Printf("  ⚠️  Could not fetch existing-RI coverage (%v); sizing will assume zero existing coverage\n", err)
+		return nil
+	}
+	AppLogger.Printf("  ✅ Fetched coverage for %d (region, instance-type) pools\n", len(cov))
+	return cov
+}
 
 // shutdownRequested is set to true when SIGINT is received during a purchase run.
 var shutdownRequested atomic.Bool
@@ -63,9 +96,16 @@ func runToolMultiService(ctx context.Context, cfg Config) {
 	recClient := awsprovider.NewRecommendationsClient(awsCfg)
 	engineData := fetchEngineVersionData(ctx, cfg)
 
+	// Fetch existing-RI coverage so --target-coverage can subtract what
+	// the user already owns. Best-effort: a failure here logs a warning
+	// and continues with an empty map, which makes sizing degenerate to
+	// the no-existing-commitments path (matches behavior when no recs
+	// are matched in the map).
+	coverageMap := fetchExistingCoverage(ctx, recClient, cfg)
+
 	// Phase 1: collect all recommendations without purchasing.
 	AppLogger.Printf("\n📥 Fetching recommendations from all services...\n")
-	allRecs := fetchAllRecs(ctx, awsCfg, recClient, accountCache, servicesToProcess, engineData, cfg)
+	allRecs := fetchAllRecs(ctx, awsCfg, recClient, accountCache, servicesToProcess, engineData, cfg, coverageMap)
 
 	// Phase 2: score and display.
 	scoredResult := scoreAndDisplay(allRecs, cfg)
@@ -387,10 +427,13 @@ func processService(ctx context.Context, awsCfg aws.Config, recClient provider.R
 	serviceResults := make([]common.PurchaseResult, 0)
 
 	for i, region := range regionsToProcess {
+		// Legacy single-service entry point — no coverage map is fetched here,
+		// so sizing falls back to the no-existing-commitments formula. The new
+		// path (runToolMultiService) fetches coverage once and threads it through.
 		regionResult := processRegionRecommendations(
 			ctx, awsCfg, recClient, accountCache,
 			service, region, i+1, len(regionsToProcess),
-			engineData, isDryRun, cfg,
+			engineData, isDryRun, cfg, nil,
 		)
 		serviceRecs = append(serviceRecs, regionResult.recommendations...)
 		serviceResults = append(serviceResults, regionResult.results...)

--- a/cmd/multi_service.go
+++ b/cmd/multi_service.go
@@ -29,10 +29,14 @@ const existingCoverageLookbackDays = 30
 // Explorer so --target-coverage sizing can subtract what's already owned in
 // each pool. Best-effort: a transient CE failure logs a warning and returns
 // an empty map, which the sizing path treats as "no signal" — recs sized
-// against avg without subtracting existing commitments (the old behavior).
-// Skipping the fetch entirely when --target-coverage is not in play avoids a
-// needless CE call (and its $0.01 charge) for users on the --coverage path.
-func fetchExistingCoverage(ctx context.Context, recClient provider.RecommendationsClient, cfg Config) recommendations.PoolCoverageMap {
+// without subtracting existing commitments. Skipping the fetch entirely
+// when --target-coverage is not in play avoids the per-region CE charges
+// for users on the --coverage path.
+//
+// Coverage is fetched per-region per-account so CE's org-wide aggregate
+// doesn't bleed one account's coverage into another in multi-account orgs.
+// Regions come from cfg.Regions if set, otherwise from EC2 DescribeRegions.
+func fetchExistingCoverage(ctx context.Context, awsCfg aws.Config, recClient provider.RecommendationsClient, cfg Config) recommendations.PoolCoverageMap {
 	if cfg.TargetCoverage <= 0 {
 		return nil
 	}
@@ -42,13 +46,22 @@ func fetchExistingCoverage(ctx context.Context, recClient provider.Recommendatio
 		// the no-existing-commitments path.
 		return nil
 	}
-	AppLogger.Printf("\n🔎 Fetching existing-RI coverage from Cost Explorer (lookback %d days)...\n", existingCoverageLookbackDays)
-	cov, err := adapter.GetRICoverageMap(ctx, existingCoverageLookbackDays)
+	regions := cfg.Regions
+	if len(regions) == 0 {
+		allRegions, err := getAllAWSRegions(ctx, awsCfg)
+		if err != nil {
+			AppLogger.Printf("  ⚠️  Could not list AWS regions for coverage fetch (%v); skipping existing-coverage subtraction\n", err)
+			return nil
+		}
+		regions = allRegions
+	}
+	AppLogger.Printf("\n🔎 Fetching existing-RI coverage from Cost Explorer per-account across %d regions (lookback %d days)...\n", len(regions), existingCoverageLookbackDays)
+	cov, err := adapter.GetRICoverageMap(ctx, existingCoverageLookbackDays, regions)
 	if err != nil {
 		AppLogger.Printf("  ⚠️  Could not fetch existing-RI coverage (%v); sizing will assume zero existing coverage\n", err)
 		return nil
 	}
-	AppLogger.Printf("  ✅ Fetched coverage for %d (region, instance-type) pools\n", len(cov))
+	AppLogger.Printf("  ✅ Fetched coverage for %d (region, instance-type, engine, account) entries\n", len(cov))
 	return cov
 }
 
@@ -101,7 +114,7 @@ func runToolMultiService(ctx context.Context, cfg Config) {
 	// and continues with an empty map, which makes sizing degenerate to
 	// the no-existing-commitments path (matches behavior when no recs
 	// are matched in the map).
-	coverageMap := fetchExistingCoverage(ctx, recClient, cfg)
+	coverageMap := fetchExistingCoverage(ctx, awsCfg, recClient, cfg)
 
 	// Phase 1: collect all recommendations without purchasing.
 	AppLogger.Printf("\n📥 Fetching recommendations from all services...\n")

--- a/cmd/multi_service.go
+++ b/cmd/multi_service.go
@@ -343,15 +343,15 @@ func filterAndAdjustRecommendations(recommendations []common.Recommendation, csv
 		AppLogger.Printf("🔍 After filters: %d recommendations (filtered out %d)\n", len(recommendations), originalCount-len(recommendations))
 	}
 
-	// Apply sizing — target-utilization if set, otherwise coverage.
+	// Apply sizing — target-coverage if set, otherwise coverage.
 	// Coverage 100% is a no-op (early-returned inside ApplyCoverage), but
-	// --target-utilization always applies even at coverage 100%, so the
-	// CSV-path short-circuit is conditional on TargetUtilization == 0.
-	if cfg.TargetUtilization > 0 || csvModeCoverage < 100 {
+	// --target-coverage always applies even at coverage 100%, so the
+	// CSV-path short-circuit is conditional on TargetCoverage == 0.
+	if cfg.TargetCoverage > 0 || csvModeCoverage < 100 {
 		beforeSize := len(recommendations)
 		recommendations = applySizing(recommendations, cfg, csvModeCoverage)
-		if cfg.TargetUtilization > 0 {
-			AppLogger.Printf("🎯 Applying %.1f%% target-utilization: %d recommendations selected (from %d)\n", cfg.TargetUtilization, len(recommendations), beforeSize)
+		if cfg.TargetCoverage > 0 {
+			AppLogger.Printf("🎯 Applying %.1f%% target-coverage: %d recommendations selected (from %d)\n", cfg.TargetCoverage, len(recommendations), beforeSize)
 		} else {
 			AppLogger.Printf("📈 Applying %.1f%% coverage: %d recommendations selected (from %d)\n", csvModeCoverage, len(recommendations), beforeSize)
 		}

--- a/cmd/multi_service.go
+++ b/cmd/multi_service.go
@@ -343,11 +343,18 @@ func filterAndAdjustRecommendations(recommendations []common.Recommendation, csv
 		AppLogger.Printf("🔍 After filters: %d recommendations (filtered out %d)\n", len(recommendations), originalCount-len(recommendations))
 	}
 
-	// Apply coverage if not 100%
-	if csvModeCoverage < 100 {
-		beforeCoverage := len(recommendations)
-		recommendations = applyCommonCoverage(recommendations, csvModeCoverage)
-		AppLogger.Printf("📈 Applying %.1f%% coverage: %d recommendations selected (from %d)\n", csvModeCoverage, len(recommendations), beforeCoverage)
+	// Apply sizing — target-utilization if set, otherwise coverage.
+	// Coverage 100% is a no-op (early-returned inside ApplyCoverage), but
+	// --target-utilization always applies even at coverage 100%, so the
+	// CSV-path short-circuit is conditional on TargetUtilization == 0.
+	if cfg.TargetUtilization > 0 || csvModeCoverage < 100 {
+		beforeSize := len(recommendations)
+		recommendations = applySizing(recommendations, cfg, csvModeCoverage)
+		if cfg.TargetUtilization > 0 {
+			AppLogger.Printf("🎯 Applying %.1f%% target-utilization: %d recommendations selected (from %d)\n", cfg.TargetUtilization, len(recommendations), beforeSize)
+		} else {
+			AppLogger.Printf("📈 Applying %.1f%% coverage: %d recommendations selected (from %d)\n", csvModeCoverage, len(recommendations), beforeSize)
+		}
 	}
 
 	// Apply count override if specified

--- a/cmd/multi_service_csv.go
+++ b/cmd/multi_service_csv.go
@@ -167,17 +167,15 @@ func writeMultiServiceCSVReport(results []common.PurchaseResult, filepath string
 	defer writer.Flush()
 
 	// Write header. RecommendedCount shows AWS's pre-sizing count alongside
-	// Count (the post-sizing value); UpfrontPayment shows the upfront we'd
-	// actually pay for Count instances (rec.CommitmentCost is AWS's upfront
-	// for RecommendedCount, so we pro-rate at render time — ApplyCoverage
-	// and ApplyTargetCoverage deliberately do not mutate the cost fields).
-	// ProjectedCoverage shows where --target-coverage landed. All three new
-	// columns render blank when zero so users on the straight --coverage
-	// path don't see noise. ProjectedUtilization and RecommendedUtilization
-	// are NOT emitted because under under-buy sizing both land at ~100% on
-	// every row, which adds noise without information; the underlying fields
-	// stay on the Recommendation struct for internal use (SP no-signal
-	// guard, etc.).
+	// Count (the post-sizing value); UpfrontPayment is rec.CommitmentCost,
+	// which ApplyCoverage / ApplyTargetCoverage now scale at sizing time so
+	// the value already reflects the sized purchase. ProjectedCoverage shows
+	// where --target-coverage landed. All three new columns render blank
+	// when zero so users on the straight --coverage path don't see noise.
+	// ProjectedUtilization and RecommendedUtilization are NOT emitted because
+	// under under-buy sizing both land at ~100% on every row, which adds
+	// noise without information; the underlying fields stay on the
+	// Recommendation struct for internal use (SP no-signal guard, etc.).
 	header := []string{
 		"Service", "Region", "ResourceType", "Count", "RecommendedCount",
 		"Account", "AccountName", "Term", "PaymentOption",
@@ -207,7 +205,7 @@ func writeMultiServiceCSVReport(results []common.PurchaseResult, filepath string
 			rec.AccountName,
 			rec.Term,
 			rec.PaymentOption,
-			formatUpfrontForSizedCount(rec),
+			formatCurrencyOrBlank(rec.CommitmentCost),
 			fmt.Sprintf("%.2f", rec.EstimatedSavings),
 			r.CommitmentID,
 			fmt.Sprintf("%t", r.Success),
@@ -234,24 +232,14 @@ func formatIntOrBlank(v int) string {
 	return fmt.Sprintf("%d", v)
 }
 
-// formatUpfrontForSizedCount renders the upfront payment scaled to the
-// post-sizing Count. rec.CommitmentCost holds AWS's upfront for the
-// pre-sizing RecommendedCount; --coverage and --target-coverage shrink
-// Count without touching CommitmentCost, so rendering CommitmentCost
-// directly would over-state the upfront whenever Count < RecommendedCount.
-// Pro-rate by Count/RecommendedCount for RIs (RecommendedCount > 0). For
-// SPs (RecommendedCount == 0) emit CommitmentCost as-is — SP under-buy
-// sizing scales HourlyCommitment / EstimatedSavings but leaves the upfront
-// untouched, a pre-existing inconsistency tracked separately.
-func formatUpfrontForSizedCount(rec common.Recommendation) string {
-	if rec.CommitmentCost == 0 {
+// formatCurrencyOrBlank renders a currency value as "%.2f" when non-zero,
+// "" otherwise. Used for UpfrontPayment so a no-upfront / unknown-upfront
+// rec renders as a blank cell rather than "$0.00".
+func formatCurrencyOrBlank(v float64) string {
+	if v == 0 {
 		return ""
 	}
-	if rec.RecommendedCount > 0 && rec.Count != rec.RecommendedCount {
-		scaled := rec.CommitmentCost * float64(rec.Count) / float64(rec.RecommendedCount)
-		return fmt.Sprintf("%.2f", scaled)
-	}
-	return fmt.Sprintf("%.2f", rec.CommitmentCost)
+	return fmt.Sprintf("%.2f", v)
 }
 
 // formatPercentOrBlank renders a % value as "%.1f" when non-zero, "" otherwise.

--- a/cmd/multi_service_csv.go
+++ b/cmd/multi_service_csv.go
@@ -167,7 +167,7 @@ func writeMultiServiceCSVReport(results []common.PurchaseResult, filepath string
 	defer writer.Flush()
 
 	// Write header. ProjectedUtilization, ProjectedCoverage, and
-	// RecommendedUtilization appended for --target-utilization (#338);
+	// RecommendedUtilization appended for --target-coverage (#338);
 	// they print blank when zero so users on the coverage path don't see
 	// noise.
 	header := []string{
@@ -217,7 +217,7 @@ func writeMultiServiceCSVReport(results []common.PurchaseResult, filepath string
 // formatPercentOrBlank renders a % value as "%.1f" when non-zero, "" otherwise.
 // Zero means "unknown / not applicable" — we don't want "0.0" in cells where
 // the metric simply wasn't computed (e.g. ProjectedCoverage for SP rows, or
-// any utilization field when --target-utilization wasn't used).
+// any utilization field when --target-coverage wasn't used).
 func formatPercentOrBlank(v float64) string {
 	if v == 0 {
 		return ""

--- a/cmd/multi_service_csv.go
+++ b/cmd/multi_service_csv.go
@@ -166,15 +166,17 @@ func writeMultiServiceCSVReport(results []common.PurchaseResult, filepath string
 	writer := csv.NewWriter(file)
 	defer writer.Flush()
 
-	// Write header. ProjectedUtilization, ProjectedCoverage, and
-	// RecommendedUtilization appended for --target-coverage (#338);
-	// they print blank when zero so users on the coverage path don't see
-	// noise.
+	// Write header. ProjectedCoverage appended for --target-coverage (#338);
+	// it prints blank when zero so users on the coverage path don't see
+	// noise. ProjectedUtilization and RecommendedUtilization are NOT emitted
+	// because under under-buy sizing both land at ~100% on every row, which
+	// adds noise without information; the underlying fields stay on the
+	// Recommendation struct for internal use (SP no-signal guard, etc.).
 	header := []string{
 		"Service", "Region", "ResourceType", "Count", "Account", "AccountName",
 		"Term", "PaymentOption", "EstimatedSavings", "CommitmentID",
 		"Success", "Error", "Timestamp",
-		"ProjectedUtilization", "ProjectedCoverage", "RecommendedUtilization",
+		"ProjectedCoverage",
 	}
 	if err := writer.Write(header); err != nil {
 		return fmt.Errorf("failed to write CSV header: %w", err)
@@ -202,9 +204,7 @@ func writeMultiServiceCSVReport(results []common.PurchaseResult, filepath string
 			fmt.Sprintf("%t", r.Success),
 			errStr,
 			r.Timestamp.Format(time.RFC3339),
-			formatPercentOrBlank(rec.ProjectedUtilization),
 			formatPercentOrBlank(rec.ProjectedCoverage),
-			formatPercentOrBlank(rec.RecommendedUtilization),
 		}
 		if err := writer.Write(row); err != nil {
 			return fmt.Errorf("failed to write CSV row: %w", err)

--- a/cmd/multi_service_csv.go
+++ b/cmd/multi_service_csv.go
@@ -166,16 +166,18 @@ func writeMultiServiceCSVReport(results []common.PurchaseResult, filepath string
 	writer := csv.NewWriter(file)
 	defer writer.Flush()
 
-	// Write header. ProjectedCoverage appended for --target-coverage (#338);
-	// it prints blank when zero so users on the coverage path don't see
-	// noise. ProjectedUtilization and RecommendedUtilization are NOT emitted
-	// because under under-buy sizing both land at ~100% on every row, which
-	// adds noise without information; the underlying fields stay on the
-	// Recommendation struct for internal use (SP no-signal guard, etc.).
+	// Write header. RecommendedCount shows AWS's pre-sizing count alongside
+	// Count (the post-sizing value); ProjectedCoverage shows where
+	// --target-coverage landed. Both render blank when zero so users on the
+	// straight --coverage path don't see noise. ProjectedUtilization and
+	// RecommendedUtilization are NOT emitted because under under-buy sizing
+	// both land at ~100% on every row, which adds noise without information;
+	// the underlying fields stay on the Recommendation struct for internal
+	// use (SP no-signal guard, etc.).
 	header := []string{
-		"Service", "Region", "ResourceType", "Count", "Account", "AccountName",
-		"Term", "PaymentOption", "EstimatedSavings", "CommitmentID",
-		"Success", "Error", "Timestamp",
+		"Service", "Region", "ResourceType", "Count", "RecommendedCount",
+		"Account", "AccountName", "Term", "PaymentOption", "EstimatedSavings",
+		"CommitmentID", "Success", "Error", "Timestamp",
 		"ProjectedCoverage",
 	}
 	if err := writer.Write(header); err != nil {
@@ -195,6 +197,7 @@ func writeMultiServiceCSVReport(results []common.PurchaseResult, filepath string
 			rec.Region,
 			rec.ResourceType,
 			fmt.Sprintf("%d", rec.Count),
+			formatIntOrBlank(rec.RecommendedCount),
 			rec.Account,
 			rec.AccountName,
 			rec.Term,
@@ -212,6 +215,17 @@ func writeMultiServiceCSVReport(results []common.PurchaseResult, filepath string
 	}
 
 	return nil
+}
+
+// formatIntOrBlank renders an int as its decimal string when non-zero, ""
+// otherwise. SP recommendations leave RecommendedCount at zero (SPs are
+// dollar-denominated, not count-denominated), so blanking matches the
+// "0 = unknown / not applicable" convention used elsewhere in the CSV.
+func formatIntOrBlank(v int) string {
+	if v == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%d", v)
 }
 
 // formatPercentOrBlank renders a % value as "%.1f" when non-zero, "" otherwise.

--- a/cmd/multi_service_csv.go
+++ b/cmd/multi_service_csv.go
@@ -180,7 +180,9 @@ func writeMultiServiceCSVReport(results []common.PurchaseResult, filepath string
 	// stay on the Recommendation struct for internal use (SP no-signal
 	// guard, etc.).
 	header := []string{
-		"Service", "Region", "ResourceType", "Engine", "Count", "RecommendedCount",
+		"Service", "Region", "ResourceType", "Engine",
+		"Instances", "CoveredInstances",
+		"Count", "RecommendedCount",
 		"Account", "AccountName", "Term", "PaymentOption",
 		"UpfrontPayment", "EstimatedSavings",
 		"CommitmentID", "Success", "Error", "Timestamp",
@@ -203,6 +205,8 @@ func writeMultiServiceCSVReport(results []common.PurchaseResult, filepath string
 			rec.Region,
 			rec.ResourceType,
 			extractEngine(rec),
+			formatAvgInstancesOrBlank(rec.AverageInstancesUsedPerHour),
+			formatCoveredInstancesOrBlank(rec),
 			fmt.Sprintf("%d", rec.Count),
 			formatIntOrBlank(rec.RecommendedCount),
 			rec.Account,
@@ -240,14 +244,31 @@ func formatIntOrBlank(v int) string {
 // extractEngine returns the engine / platform string for a recommendation's
 // polymorphic Details: Engine for RDS / ElastiCache (DatabaseDetails,
 // CacheDetails), Platform for EC2 (ComputeDetails), empty for SP and other
-// commitment types that don't carry an engine field. Matches the dispatch
-// in generatePurchaseID so the CSV column and the dry-run ID never disagree.
+// commitment types that don't carry an engine field.
+//
+// Both value and pointer Details are accepted because the parser stores
+// *DatabaseDetails / *CacheDetails / *ComputeDetails while the CSV-loader
+// path constructs the value forms; the dispatch in generatePurchaseID does
+// the same trick. Without the pointer cases the column silently blanks
+// every row coming from the live parser path.
 func extractEngine(rec common.Recommendation) string {
 	switch details := rec.Details.(type) {
+	case *common.DatabaseDetails:
+		if details != nil {
+			return details.Engine
+		}
 	case common.DatabaseDetails:
 		return details.Engine
+	case *common.CacheDetails:
+		if details != nil {
+			return details.Engine
+		}
 	case common.CacheDetails:
 		return details.Engine
+	case *common.ComputeDetails:
+		if details != nil {
+			return details.Platform
+		}
 	case common.ComputeDetails:
 		return details.Platform
 	}
@@ -262,6 +283,30 @@ func formatCurrencyOrBlank(v float64) string {
 		return ""
 	}
 	return fmt.Sprintf("%.2f", v)
+}
+
+// formatAvgInstancesOrBlank renders the average instances-per-hour signal
+// (AverageInstancesUsedPerHour from CE) with one decimal so operators can
+// see the pool's running demand without losing the fractional precision
+// CE returns. Blank when zero, matching the "0 = no signal" convention.
+func formatAvgInstancesOrBlank(v float64) string {
+	if v == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%.1f", v)
+}
+
+// formatCoveredInstancesOrBlank renders the instances in the pool already
+// covered by existing commitments: avg × existing_coverage / 100. Useful
+// next to Instances so operators can read "you have X running, Y are
+// already covered, this rec adds N more" without doing the arithmetic.
+// Blank when either signal is zero (we can't compute a meaningful value).
+func formatCoveredInstancesOrBlank(rec common.Recommendation) string {
+	if rec.AverageInstancesUsedPerHour <= 0 || rec.ExistingCoveragePct <= 0 {
+		return ""
+	}
+	covered := rec.AverageInstancesUsedPerHour * rec.ExistingCoveragePct / 100.0
+	return fmt.Sprintf("%.1f", covered)
 }
 
 // formatPercentOrBlank renders a % value as "%.1f" when non-zero, "" otherwise.

--- a/cmd/multi_service_csv.go
+++ b/cmd/multi_service_csv.go
@@ -185,7 +185,7 @@ func writeMultiServiceCSVReport(results []common.PurchaseResult, filepath string
 		"Instances", "CoveredInstances",
 		"Count", "NormalizedUnits", "RecommendedCount",
 		"Account", "AccountName", "Term", "PaymentOption",
-		"UpfrontPayment", "EstimatedSavings",
+		"UpfrontPayment", "RecurringMonthlyCost", "EstimatedSavings",
 		"CommitmentID", "Success", "Error", "Timestamp",
 		"ExistingCoverage", "ProjectedCoverage",
 	}
@@ -218,6 +218,7 @@ func writeMultiServiceCSVReport(results []common.PurchaseResult, filepath string
 			rec.Term,
 			rec.PaymentOption,
 			formatCurrencyOrBlank(rec.CommitmentCost),
+			formatRecurringMonthlyOrBlank(rec.RecurringMonthlyCost),
 			fmt.Sprintf("%.2f", rec.EstimatedSavings),
 			r.CommitmentID,
 			fmt.Sprintf("%t", r.Success),
@@ -327,6 +328,23 @@ func extractEngine(rec common.Recommendation) string {
 		return details.Platform
 	}
 	return ""
+}
+
+// formatRecurringMonthlyOrBlank renders rec.RecurringMonthlyCost (the
+// per-month fee on top of any upfront payment, populated by the AWS
+// parser when CE returns RecurringStandardMonthlyCost). Distinguishes
+// "no recurring fee" (all-upfront RIs, where the pointer is set to
+// zero) from "unknown" (pointer is nil because CE didn't return the
+// field): zero renders as "0.00", nil renders as blank.
+//
+// Operators on partial-upfront / no-upfront plans need this to compute
+// total cost (upfront + monthly × 36); without it the CSV only shows
+// the upfront portion and over-states ROI.
+func formatRecurringMonthlyOrBlank(p *float64) string {
+	if p == nil {
+		return ""
+	}
+	return fmt.Sprintf("%.2f", *p)
 }
 
 // formatCurrencyOrBlank renders a currency value as "%.2f" when non-zero,

--- a/cmd/multi_service_csv.go
+++ b/cmd/multi_service_csv.go
@@ -180,7 +180,7 @@ func writeMultiServiceCSVReport(results []common.PurchaseResult, filepath string
 	// stay on the Recommendation struct for internal use (SP no-signal
 	// guard, etc.).
 	header := []string{
-		"Service", "Region", "ResourceType", "Engine",
+		"Service", "Region", "ResourceType", "Engine", "Deployment",
 		"Instances", "CoveredInstances",
 		"Count", "RecommendedCount",
 		"Account", "AccountName", "Term", "PaymentOption",
@@ -205,6 +205,7 @@ func writeMultiServiceCSVReport(results []common.PurchaseResult, filepath string
 			rec.Region,
 			rec.ResourceType,
 			extractEngine(rec),
+			extractDeployment(rec),
 			formatAvgInstancesOrBlank(rec.AverageInstancesUsedPerHour),
 			formatCoveredInstancesOrBlank(rec),
 			fmt.Sprintf("%d", rec.Count),
@@ -239,6 +240,27 @@ func formatIntOrBlank(v int) string {
 		return ""
 	}
 	return fmt.Sprintf("%d", v)
+}
+
+// extractDeployment returns the RDS deployment-option string
+// ("single-az" / "multi-az") for an RDS recommendation, empty for any
+// service that doesn't carry a deployment dimension. Critical for RDS
+// price verification: Multi-AZ list prices are roughly 2x Single-AZ, so
+// operators need to see the deployment alongside the upfront figure to
+// confirm a $X upfront row is for the deployment they expect.
+//
+// Both value and pointer Details are accepted to mirror extractEngine
+// (parser path stores pointers; CSV-loader path constructs values).
+func extractDeployment(rec common.Recommendation) string {
+	switch details := rec.Details.(type) {
+	case *common.DatabaseDetails:
+		if details != nil {
+			return details.AZConfig
+		}
+	case common.DatabaseDetails:
+		return details.AZConfig
+	}
+	return ""
 }
 
 // extractEngine returns the engine / platform string for a recommendation's

--- a/cmd/multi_service_csv.go
+++ b/cmd/multi_service_csv.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/LeanerCloud/CUDly/pkg/common"
+	"github.com/LeanerCloud/CUDly/providers/aws/recommendations"
 )
 
 // determineCSVCoverage determines the coverage percentage to use for CSV mode
@@ -180,9 +181,9 @@ func writeMultiServiceCSVReport(results []common.PurchaseResult, filepath string
 	// stay on the Recommendation struct for internal use (SP no-signal
 	// guard, etc.).
 	header := []string{
-		"Service", "Region", "ResourceType", "Engine", "Deployment",
+		"Service", "Region", "ResourceType", "Family", "Engine", "Deployment",
 		"Instances", "CoveredInstances",
-		"Count", "RecommendedCount",
+		"Count", "NormalizedUnits", "RecommendedCount",
 		"Account", "AccountName", "Term", "PaymentOption",
 		"UpfrontPayment", "EstimatedSavings",
 		"CommitmentID", "Success", "Error", "Timestamp",
@@ -204,11 +205,13 @@ func writeMultiServiceCSVReport(results []common.PurchaseResult, filepath string
 			string(rec.Service),
 			rec.Region,
 			rec.ResourceType,
+			extractRDSFamily(rec),
 			extractEngine(rec),
 			extractDeployment(rec),
 			formatAvgInstancesOrBlank(rec.AverageInstancesUsedPerHour),
 			formatCoveredInstancesOrBlank(rec),
 			fmt.Sprintf("%d", rec.Count),
+			formatNormalizedUnitsOrBlank(rec),
 			formatIntOrBlank(rec.RecommendedCount),
 			rec.Account,
 			rec.AccountName,
@@ -240,6 +243,35 @@ func formatIntOrBlank(v int) string {
 		return ""
 	}
 	return fmt.Sprintf("%d", v)
+}
+
+// extractRDSFamily returns the RDS instance-family prefix (e.g.
+// "db.r7g") for an RDS recommendation, empty for any service whose
+// instance type doesn't follow the RDS three-part naming. Useful for
+// grouping rows in the CSV by family-NU bucket so operators can see at
+// a glance which recs belong to the same size-flex family.
+func extractRDSFamily(rec common.Recommendation) string {
+	if rec.Service != common.ServiceRDS && rec.Service != common.ServiceRelationalDB {
+		return ""
+	}
+	return recommendations.RDSFamilyFromType(rec.ResourceType)
+}
+
+// formatNormalizedUnitsOrBlank renders the per-rec NU contribution
+// (rec.Count × NU(size)) for RDS rows: e.g. 15 × db.r7g.large = 60 NU.
+// Surfaces the size-flex math AWS rec API uses to bundle family demand
+// into a single rec at one size — without this column, operators have
+// to compute NU by hand to verify the bundling. Renders blank for
+// non-RDS rows and for sizes not in the standard NU scale.
+func formatNormalizedUnitsOrBlank(rec common.Recommendation) string {
+	if rec.Service != common.ServiceRDS && rec.Service != common.ServiceRelationalDB {
+		return ""
+	}
+	nu := recommendations.RDSInstanceNUFromType(rec.ResourceType)
+	if nu == 0 || rec.Count == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%g", float64(rec.Count)*nu)
 }
 
 // extractDeployment returns the RDS deployment-option string

--- a/cmd/multi_service_csv.go
+++ b/cmd/multi_service_csv.go
@@ -167,16 +167,21 @@ func writeMultiServiceCSVReport(results []common.PurchaseResult, filepath string
 	defer writer.Flush()
 
 	// Write header. RecommendedCount shows AWS's pre-sizing count alongside
-	// Count (the post-sizing value); ProjectedCoverage shows where
-	// --target-coverage landed. Both render blank when zero so users on the
-	// straight --coverage path don't see noise. ProjectedUtilization and
-	// RecommendedUtilization are NOT emitted because under under-buy sizing
-	// both land at ~100% on every row, which adds noise without information;
-	// the underlying fields stay on the Recommendation struct for internal
-	// use (SP no-signal guard, etc.).
+	// Count (the post-sizing value); UpfrontPayment shows the upfront we'd
+	// actually pay for Count instances (rec.CommitmentCost is AWS's upfront
+	// for RecommendedCount, so we pro-rate at render time — ApplyCoverage
+	// and ApplyTargetCoverage deliberately do not mutate the cost fields).
+	// ProjectedCoverage shows where --target-coverage landed. All three new
+	// columns render blank when zero so users on the straight --coverage
+	// path don't see noise. ProjectedUtilization and RecommendedUtilization
+	// are NOT emitted because under under-buy sizing both land at ~100% on
+	// every row, which adds noise without information; the underlying fields
+	// stay on the Recommendation struct for internal use (SP no-signal
+	// guard, etc.).
 	header := []string{
 		"Service", "Region", "ResourceType", "Count", "RecommendedCount",
-		"Account", "AccountName", "Term", "PaymentOption", "EstimatedSavings",
+		"Account", "AccountName", "Term", "PaymentOption",
+		"UpfrontPayment", "EstimatedSavings",
 		"CommitmentID", "Success", "Error", "Timestamp",
 		"ProjectedCoverage",
 	}
@@ -202,6 +207,7 @@ func writeMultiServiceCSVReport(results []common.PurchaseResult, filepath string
 			rec.AccountName,
 			rec.Term,
 			rec.PaymentOption,
+			formatUpfrontForSizedCount(rec),
 			fmt.Sprintf("%.2f", rec.EstimatedSavings),
 			r.CommitmentID,
 			fmt.Sprintf("%t", r.Success),
@@ -226,6 +232,26 @@ func formatIntOrBlank(v int) string {
 		return ""
 	}
 	return fmt.Sprintf("%d", v)
+}
+
+// formatUpfrontForSizedCount renders the upfront payment scaled to the
+// post-sizing Count. rec.CommitmentCost holds AWS's upfront for the
+// pre-sizing RecommendedCount; --coverage and --target-coverage shrink
+// Count without touching CommitmentCost, so rendering CommitmentCost
+// directly would over-state the upfront whenever Count < RecommendedCount.
+// Pro-rate by Count/RecommendedCount for RIs (RecommendedCount > 0). For
+// SPs (RecommendedCount == 0) emit CommitmentCost as-is — SP under-buy
+// sizing scales HourlyCommitment / EstimatedSavings but leaves the upfront
+// untouched, a pre-existing inconsistency tracked separately.
+func formatUpfrontForSizedCount(rec common.Recommendation) string {
+	if rec.CommitmentCost == 0 {
+		return ""
+	}
+	if rec.RecommendedCount > 0 && rec.Count != rec.RecommendedCount {
+		scaled := rec.CommitmentCost * float64(rec.Count) / float64(rec.RecommendedCount)
+		return fmt.Sprintf("%.2f", scaled)
+	}
+	return fmt.Sprintf("%.2f", rec.CommitmentCost)
 }
 
 // formatPercentOrBlank renders a % value as "%.1f" when non-zero, "" otherwise.

--- a/cmd/multi_service_csv.go
+++ b/cmd/multi_service_csv.go
@@ -169,19 +169,22 @@ func writeMultiServiceCSVReport(results []common.PurchaseResult, filepath string
 	// Write header. RecommendedCount shows AWS's pre-sizing count alongside
 	// Count (the post-sizing value); UpfrontPayment is rec.CommitmentCost,
 	// which ApplyCoverage / ApplyTargetCoverage now scale at sizing time so
-	// the value already reflects the sized purchase. ProjectedCoverage shows
-	// where --target-coverage landed. All three new columns render blank
-	// when zero so users on the straight --coverage path don't see noise.
-	// ProjectedUtilization and RecommendedUtilization are NOT emitted because
-	// under under-buy sizing both land at ~100% on every row, which adds
-	// noise without information; the underlying fields stay on the
-	// Recommendation struct for internal use (SP no-signal guard, etc.).
+	// the value already reflects the sized purchase. ExistingCoverage shows
+	// the % of demand already covered by commitments in the same pool (from
+	// CE GetReservationCoverage); ProjectedCoverage shows where the purchase
+	// landed (total coverage after adding the new RIs). All four optional
+	// columns render blank when zero so users on the straight --coverage
+	// path don't see noise. ProjectedUtilization and RecommendedUtilization
+	// are NOT emitted because under under-buy sizing both land at ~100% on
+	// every row, which adds noise without information; the underlying fields
+	// stay on the Recommendation struct for internal use (SP no-signal
+	// guard, etc.).
 	header := []string{
 		"Service", "Region", "ResourceType", "Count", "RecommendedCount",
 		"Account", "AccountName", "Term", "PaymentOption",
 		"UpfrontPayment", "EstimatedSavings",
 		"CommitmentID", "Success", "Error", "Timestamp",
-		"ProjectedCoverage",
+		"ExistingCoverage", "ProjectedCoverage",
 	}
 	if err := writer.Write(header); err != nil {
 		return fmt.Errorf("failed to write CSV header: %w", err)
@@ -211,6 +214,7 @@ func writeMultiServiceCSVReport(results []common.PurchaseResult, filepath string
 			fmt.Sprintf("%t", r.Success),
 			errStr,
 			r.Timestamp.Format(time.RFC3339),
+			formatPercentOrBlank(rec.ExistingCoveragePct),
 			formatPercentOrBlank(rec.ProjectedCoverage),
 		}
 		if err := writer.Write(row); err != nil {

--- a/cmd/multi_service_csv.go
+++ b/cmd/multi_service_csv.go
@@ -166,11 +166,15 @@ func writeMultiServiceCSVReport(results []common.PurchaseResult, filepath string
 	writer := csv.NewWriter(file)
 	defer writer.Flush()
 
-	// Write header
+	// Write header. ProjectedUtilization, ProjectedCoverage, and
+	// RecommendedUtilization appended for --target-utilization (#338);
+	// they print blank when zero so users on the coverage path don't see
+	// noise.
 	header := []string{
 		"Service", "Region", "ResourceType", "Count", "Account", "AccountName",
 		"Term", "PaymentOption", "EstimatedSavings", "CommitmentID",
 		"Success", "Error", "Timestamp",
+		"ProjectedUtilization", "ProjectedCoverage", "RecommendedUtilization",
 	}
 	if err := writer.Write(header); err != nil {
 		return fmt.Errorf("failed to write CSV header: %w", err)
@@ -198,6 +202,9 @@ func writeMultiServiceCSVReport(results []common.PurchaseResult, filepath string
 			fmt.Sprintf("%t", r.Success),
 			errStr,
 			r.Timestamp.Format(time.RFC3339),
+			formatPercentOrBlank(rec.ProjectedUtilization),
+			formatPercentOrBlank(rec.ProjectedCoverage),
+			formatPercentOrBlank(rec.RecommendedUtilization),
 		}
 		if err := writer.Write(row); err != nil {
 			return fmt.Errorf("failed to write CSV row: %w", err)
@@ -205,4 +212,15 @@ func writeMultiServiceCSVReport(results []common.PurchaseResult, filepath string
 	}
 
 	return nil
+}
+
+// formatPercentOrBlank renders a % value as "%.1f" when non-zero, "" otherwise.
+// Zero means "unknown / not applicable" — we don't want "0.0" in cells where
+// the metric simply wasn't computed (e.g. ProjectedCoverage for SP rows, or
+// any utilization field when --target-utilization wasn't used).
+func formatPercentOrBlank(v float64) string {
+	if v == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%.1f", v)
 }

--- a/cmd/multi_service_csv.go
+++ b/cmd/multi_service_csv.go
@@ -180,7 +180,7 @@ func writeMultiServiceCSVReport(results []common.PurchaseResult, filepath string
 	// stay on the Recommendation struct for internal use (SP no-signal
 	// guard, etc.).
 	header := []string{
-		"Service", "Region", "ResourceType", "Count", "RecommendedCount",
+		"Service", "Region", "ResourceType", "Engine", "Count", "RecommendedCount",
 		"Account", "AccountName", "Term", "PaymentOption",
 		"UpfrontPayment", "EstimatedSavings",
 		"CommitmentID", "Success", "Error", "Timestamp",
@@ -202,6 +202,7 @@ func writeMultiServiceCSVReport(results []common.PurchaseResult, filepath string
 			string(rec.Service),
 			rec.Region,
 			rec.ResourceType,
+			extractEngine(rec),
 			fmt.Sprintf("%d", rec.Count),
 			formatIntOrBlank(rec.RecommendedCount),
 			rec.Account,
@@ -234,6 +235,23 @@ func formatIntOrBlank(v int) string {
 		return ""
 	}
 	return fmt.Sprintf("%d", v)
+}
+
+// extractEngine returns the engine / platform string for a recommendation's
+// polymorphic Details: Engine for RDS / ElastiCache (DatabaseDetails,
+// CacheDetails), Platform for EC2 (ComputeDetails), empty for SP and other
+// commitment types that don't carry an engine field. Matches the dispatch
+// in generatePurchaseID so the CSV column and the dry-run ID never disagree.
+func extractEngine(rec common.Recommendation) string {
+	switch details := rec.Details.(type) {
+	case common.DatabaseDetails:
+		return details.Engine
+	case common.CacheDetails:
+		return details.Engine
+	case common.ComputeDetails:
+		return details.Platform
+	}
+	return ""
 }
 
 // formatCurrencyOrBlank renders a currency value as "%.2f" when non-zero,

--- a/cmd/multi_service_csv.go
+++ b/cmd/multi_service_csv.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"sort"
 	"time"
 
 	"github.com/LeanerCloud/CUDly/pkg/common"
@@ -193,8 +194,18 @@ func writeMultiServiceCSVReport(results []common.PurchaseResult, filepath string
 		return fmt.Errorf("failed to write CSV header: %w", err)
 	}
 
-	// Write data rows
-	for _, r := range results {
+	// Sort by upfront DESC so the biggest-dollar decisions surface at
+	// the top of the file rather than wherever AWS rec API happened to
+	// return them. Operators reading top-down see the rows that matter
+	// most for budget review first. Copy the slice so the caller's
+	// ordering isn't mutated (some callers iterate results twice).
+	sorted := make([]common.PurchaseResult, len(results))
+	copy(sorted, results)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		return sorted[i].Recommendation.CommitmentCost > sorted[j].Recommendation.CommitmentCost
+	})
+
+	for _, r := range sorted {
 		rec := r.Recommendation
 		errStr := ""
 		if r.Error != nil {
@@ -232,7 +243,57 @@ func writeMultiServiceCSVReport(results []common.PurchaseResult, filepath string
 		}
 	}
 
+	// TOTAL row aggregates the sum-able fields (Count, NormalizedUnits,
+	// UpfrontPayment, RecurringMonthlyCost, EstimatedSavings) so operators
+	// don't have to recompute in a spreadsheet. The "TOTAL" label lands in
+	// the Service column for easy spotting; columns that don't aggregate
+	// meaningfully (per-rec identifiers, timestamps, %) stay blank.
+	if len(sorted) > 0 {
+		totalRow := buildTotalRow(sorted)
+		if err := writer.Write(totalRow); err != nil {
+			return fmt.Errorf("failed to write CSV total row: %w", err)
+		}
+	}
+
 	return nil
+}
+
+// buildTotalRow sums the count + currency columns across results and
+// returns a row aligned to the same header order as writeCSVRowsOrdered.
+// Non-summable cells (per-rec identifiers, percentages, timestamps) are
+// blank; the "TOTAL" label lands in Service so the row reads as a
+// summary at first glance.
+func buildTotalRow(results []common.PurchaseResult) []string {
+	var totalCount int
+	var totalNU, totalUpfront, totalRecurring, totalSavings float64
+	hasRecurring := false
+	for _, r := range results {
+		totalCount += r.Recommendation.Count
+		totalNU += float64(r.Recommendation.Count) * recommendations.RDSInstanceNUFromType(r.Recommendation.ResourceType)
+		totalUpfront += r.Recommendation.CommitmentCost
+		totalSavings += r.Recommendation.EstimatedSavings
+		if r.Recommendation.RecurringMonthlyCost != nil {
+			totalRecurring += *r.Recommendation.RecurringMonthlyCost
+			hasRecurring = true
+		}
+	}
+	recurringCell := ""
+	if hasRecurring {
+		recurringCell = fmt.Sprintf("%.2f", totalRecurring)
+	}
+	nuCell := ""
+	if totalNU > 0 {
+		nuCell = fmt.Sprintf("%g", totalNU)
+	}
+	return []string{
+		"TOTAL", "", "", "", "", "", // Service through Deployment
+		"", "", // Instances, CoveredInstances
+		fmt.Sprintf("%d", totalCount), nuCell, "", // Count, NormalizedUnits, RecommendedCount
+		"", "", "", "", // Account, AccountName, Term, PaymentOption
+		fmt.Sprintf("%.2f", totalUpfront), recurringCell, fmt.Sprintf("%.2f", totalSavings),
+		"", "", "", "", // CommitmentID, Success, Error, Timestamp
+		"", "", // ExistingCoverage, ProjectedCoverage
+	}
 }
 
 // formatIntOrBlank renders an int as its decimal string when non-zero, ""

--- a/cmd/multi_service_csv.go
+++ b/cmd/multi_service_csv.go
@@ -224,7 +224,7 @@ func writeMultiServiceCSVReport(results []common.PurchaseResult, filepath string
 			fmt.Sprintf("%t", r.Success),
 			errStr,
 			r.Timestamp.Format(time.RFC3339),
-			formatPercentOrBlank(rec.ExistingCoveragePct),
+			formatExistingCoverage(rec),
 			formatPercentOrBlank(rec.ProjectedCoverage),
 		}
 		if err := writer.Write(row); err != nil {
@@ -328,6 +328,26 @@ func extractEngine(rec common.Recommendation) string {
 		return details.Platform
 	}
 	return ""
+}
+
+// formatExistingCoverage renders the existing-RI coverage cell with
+// three distinct states:
+//   - "n/a" when CE returned no data for the rec's pool (rec parser was
+//     able to surface a recommendation from some other signal but CE's
+//     coverage view doesn't see the pool yet — e.g. recently-launched
+//     instances within CUDly's run window but outside CE's lookback)
+//   - "0.0" when CE confirms the pool exists but has zero RI coverage
+//     (the legitimate "buy for uncovered demand" case)
+//   - "X.X" with one decimal for any non-zero coverage percentage
+//
+// Previously both the no-data and the genuine-zero cases rendered as a
+// blank cell, conflating "we don't know" with "definitely zero" and
+// making it impossible to spot pools where the CE signal was missing.
+func formatExistingCoverage(rec common.Recommendation) string {
+	if !rec.ExistingCoverageKnown {
+		return "n/a"
+	}
+	return fmt.Sprintf("%.1f", rec.ExistingCoveragePct)
 }
 
 // formatRecurringMonthlyOrBlank renders rec.RecurringMonthlyCost (the

--- a/cmd/multi_service_csv_test.go
+++ b/cmd/multi_service_csv_test.go
@@ -205,8 +205,9 @@ func TestWriteMultiServiceCSVReport_CoverageColumn(t *testing.T) {
 				Service:                common.ServiceEC2,
 				Region:                 "us-east-1",
 				ResourceType:           "t3.medium",
-				Count:                  7,  // post-sizing
-				RecommendedCount:       10, // AWS pre-sizing
+				Count:                  7,    // post-sizing
+				RecommendedCount:       10,   // AWS pre-sizing
+				CommitmentCost:         1000, // AWS upfront for 10 RIs; pro-rates to 700 for 7.
 				Term:                   "1yr",
 				ProjectedUtilization:   95.0,
 				ProjectedCoverage:      87.5,
@@ -217,7 +218,8 @@ func TestWriteMultiServiceCSVReport_CoverageColumn(t *testing.T) {
 		{
 			// All sizing-related fields zero — ProjectedCoverage and
 			// RecommendedCount cells should both be blank (SP rec or a
-			// pre-target rec that never went through sizing).
+			// pre-target rec that never went through sizing). UpfrontPayment
+			// is also blank when CommitmentCost is zero.
 			Recommendation: common.Recommendation{
 				Service:      common.ServiceEC2,
 				Region:       "us-east-1",
@@ -236,10 +238,11 @@ func TestWriteMultiServiceCSVReport_CoverageColumn(t *testing.T) {
 	require.NoError(t, err)
 	csvText := string(content)
 
-	// Header contains ProjectedCoverage and RecommendedCount but NOT the
-	// always-100% utilization siblings.
+	// Header contains ProjectedCoverage, RecommendedCount and UpfrontPayment
+	// but NOT the always-100% utilization siblings.
 	assert.Contains(t, csvText, "ProjectedCoverage")
 	assert.Contains(t, csvText, "RecommendedCount")
+	assert.Contains(t, csvText, "UpfrontPayment")
 	assert.NotContains(t, csvText, "ProjectedUtilization", "column was removed; it's ~100% on every under-buy row")
 	assert.NotContains(t, csvText, "RecommendedUtilization", "column was removed; it's ~99-100% on every row")
 
@@ -251,28 +254,70 @@ func TestWriteMultiServiceCSVReport_CoverageColumn(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, rows, 3) // header + 2 data rows
 	header := rows[0]
-	idxProjCov := -1
-	idxRecCount := -1
+	idxProjCov, idxRecCount, idxUpfront := -1, -1, -1
 	for i, h := range header {
 		switch h {
 		case "ProjectedCoverage":
 			idxProjCov = i
 		case "RecommendedCount":
 			idxRecCount = i
+		case "UpfrontPayment":
+			idxUpfront = i
 		}
 	}
 	require.NotEqual(t, -1, idxProjCov, "ProjectedCoverage column not found")
 	require.NotEqual(t, -1, idxRecCount, "RecommendedCount column not found")
+	require.NotEqual(t, -1, idxUpfront, "UpfrontPayment column not found")
 
-	// Populated row: RecommendedCount=10 renders as "10", ProjectedCoverage=87.5 as "87.5".
+	// Populated row: RecommendedCount=10 renders as "10", UpfrontPayment
+	// pro-rates 1000 * 7/10 = 700.00, ProjectedCoverage=87.5 renders.
 	populatedRow := rows[1]
 	assert.Equal(t, "10", populatedRow[idxRecCount], "RecommendedCount should render as decimal")
+	assert.Equal(t, "700.00", populatedRow[idxUpfront], "UpfrontPayment should pro-rate CommitmentCost by Count/RecommendedCount")
 	assert.Equal(t, "87.5", populatedRow[idxProjCov])
 
-	// Zero-fields row: both cells blank.
+	// Zero-fields row: all three cells blank.
 	zeroRow := rows[2]
 	assert.Equal(t, "", zeroRow[idxProjCov], "zero ProjectedCoverage should be blank")
 	assert.Equal(t, "", zeroRow[idxRecCount], "zero RecommendedCount should be blank (SP rec or pre-sizing)")
+	assert.Equal(t, "", zeroRow[idxUpfront], "zero CommitmentCost should leave UpfrontPayment blank")
+}
+
+// TestFormatUpfrontForSizedCount locks the three branches: pro-rate when
+// Count != RecommendedCount, no scaling when they match, and pass-through
+// for SP recs (RecommendedCount == 0).
+func TestFormatUpfrontForSizedCount(t *testing.T) {
+	tests := []struct {
+		name string
+		rec  common.Recommendation
+		want string
+	}{
+		{
+			name: "RI under-buy pro-rates upfront",
+			rec:  common.Recommendation{Count: 7, RecommendedCount: 10, CommitmentCost: 1000},
+			want: "700.00",
+		},
+		{
+			name: "RI sized at AWS rec emits CommitmentCost as-is",
+			rec:  common.Recommendation{Count: 10, RecommendedCount: 10, CommitmentCost: 1000},
+			want: "1000.00",
+		},
+		{
+			name: "SP (RecommendedCount=0) emits CommitmentCost as-is",
+			rec:  common.Recommendation{Count: 1, RecommendedCount: 0, CommitmentCost: 1234.56},
+			want: "1234.56",
+		},
+		{
+			name: "zero CommitmentCost blanks the cell",
+			rec:  common.Recommendation{Count: 5, RecommendedCount: 10, CommitmentCost: 0},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, formatUpfrontForSizedCount(tt.rec))
+		})
+	}
 }
 
 // Tests for loadRecommendationsFromCSV function

--- a/cmd/multi_service_csv_test.go
+++ b/cmd/multi_service_csv_test.go
@@ -189,11 +189,12 @@ func TestWriteMultiServiceCSVReport(t *testing.T) {
 }
 
 // TestWriteMultiServiceCSVReport_CoverageColumn confirms the ProjectedCoverage
-// column added for --target-coverage (#338) is emitted with the "blank-when-zero"
-// formatting (matches the "0 = unknown" convention shared with the JSON-level
-// omitempty tags). The sibling ProjectedUtilization and RecommendedUtilization
-// fields are intentionally NOT emitted to CSV (both land at ~100% on every
-// under-buy row, so they add noise without information).
+// and RecommendedCount columns added for --target-coverage (#338) are emitted
+// with the "blank-when-zero" formatting (matches the "0 = unknown" convention
+// shared with the JSON-level omitempty tags). The sibling ProjectedUtilization
+// and RecommendedUtilization fields are intentionally NOT emitted to CSV
+// (both land at ~100% on every under-buy row, so they add noise without
+// information).
 func TestWriteMultiServiceCSVReport_CoverageColumn(t *testing.T) {
 	tmpDir := t.TempDir()
 	filepath := tmpDir + "/util.csv"
@@ -204,7 +205,8 @@ func TestWriteMultiServiceCSVReport_CoverageColumn(t *testing.T) {
 				Service:                common.ServiceEC2,
 				Region:                 "us-east-1",
 				ResourceType:           "t3.medium",
-				Count:                  10,
+				Count:                  7,  // post-sizing
+				RecommendedCount:       10, // AWS pre-sizing
 				Term:                   "1yr",
 				ProjectedUtilization:   95.0,
 				ProjectedCoverage:      87.5,
@@ -213,7 +215,9 @@ func TestWriteMultiServiceCSVReport_CoverageColumn(t *testing.T) {
 			Success: true,
 		},
 		{
-			// All utilization fields zero — ProjectedCoverage cell should be blank.
+			// All sizing-related fields zero — ProjectedCoverage and
+			// RecommendedCount cells should both be blank (SP rec or a
+			// pre-target rec that never went through sizing).
 			Recommendation: common.Recommendation{
 				Service:      common.ServiceEC2,
 				Region:       "us-east-1",
@@ -232,30 +236,43 @@ func TestWriteMultiServiceCSVReport_CoverageColumn(t *testing.T) {
 	require.NoError(t, err)
 	csvText := string(content)
 
-	// Header contains ProjectedCoverage but NOT the always-100% siblings.
+	// Header contains ProjectedCoverage and RecommendedCount but NOT the
+	// always-100% utilization siblings.
 	assert.Contains(t, csvText, "ProjectedCoverage")
+	assert.Contains(t, csvText, "RecommendedCount")
 	assert.NotContains(t, csvText, "ProjectedUtilization", "column was removed; it's ~100% on every under-buy row")
 	assert.NotContains(t, csvText, "RecommendedUtilization", "column was removed; it's ~99-100% on every row")
 
-	// First data row (populated rec) has the coverage value formatted.
+	// First data row (populated rec) has the coverage and AWS-count values.
 	assert.Contains(t, csvText, "87.5", "ProjectedCoverage should render with one decimal")
 
-	// Second data row (zero coverage) must end with an empty cell.
 	r := csv.NewReader(strings.NewReader(csvText))
 	rows, err := r.ReadAll()
 	require.NoError(t, err)
 	require.Len(t, rows, 3) // header + 2 data rows
 	header := rows[0]
 	idxProjCov := -1
+	idxRecCount := -1
 	for i, h := range header {
-		if h == "ProjectedCoverage" {
+		switch h {
+		case "ProjectedCoverage":
 			idxProjCov = i
-			break
+		case "RecommendedCount":
+			idxRecCount = i
 		}
 	}
 	require.NotEqual(t, -1, idxProjCov, "ProjectedCoverage column not found")
+	require.NotEqual(t, -1, idxRecCount, "RecommendedCount column not found")
+
+	// Populated row: RecommendedCount=10 renders as "10", ProjectedCoverage=87.5 as "87.5".
+	populatedRow := rows[1]
+	assert.Equal(t, "10", populatedRow[idxRecCount], "RecommendedCount should render as decimal")
+	assert.Equal(t, "87.5", populatedRow[idxProjCov])
+
+	// Zero-fields row: both cells blank.
 	zeroRow := rows[2]
 	assert.Equal(t, "", zeroRow[idxProjCov], "zero ProjectedCoverage should be blank")
+	assert.Equal(t, "", zeroRow[idxRecCount], "zero RecommendedCount should be blank (SP rec or pre-sizing)")
 }
 
 // Tests for loadRecommendationsFromCSV function

--- a/cmd/multi_service_csv_test.go
+++ b/cmd/multi_service_csv_test.go
@@ -315,6 +315,34 @@ func TestWriteMultiServiceCSVReport_CoverageColumn(t *testing.T) {
 	assert.Equal(t, "", zeroRow[idxCovered], "missing avg or existing_cov should leave CoveredInstances blank")
 }
 
+// TestExtractDeployment covers the deployment-extraction helper used by
+// the RDS row in the CSV. Single-AZ / Multi-AZ is critical context for
+// pricing verification (Multi-AZ list price is ~2x Single-AZ) so the
+// column should land for every RDS rec regardless of which Details form
+// the upstream path used.
+func TestExtractDeployment(t *testing.T) {
+	tests := []struct {
+		name string
+		rec  common.Recommendation
+		want string
+	}{
+		{"*DatabaseDetails Single-AZ", common.Recommendation{Details: &common.DatabaseDetails{AZConfig: "single-az"}}, "single-az"},
+		{"*DatabaseDetails Multi-AZ", common.Recommendation{Details: &common.DatabaseDetails{AZConfig: "multi-az"}}, "multi-az"},
+		{"DatabaseDetails (value) Multi-AZ", common.Recommendation{Details: common.DatabaseDetails{AZConfig: "multi-az"}}, "multi-az"},
+		{"DatabaseDetails empty AZConfig", common.Recommendation{Details: &common.DatabaseDetails{Engine: "mysql"}}, ""},
+		// Non-RDS Details → blank (column is RDS-only data).
+		{"CacheDetails -> empty", common.Recommendation{Details: &common.CacheDetails{Engine: "redis"}}, ""},
+		{"ComputeDetails -> empty", common.Recommendation{Details: &common.ComputeDetails{Platform: "Linux/UNIX"}}, ""},
+		{"nil Details -> empty", common.Recommendation{}, ""},
+		{"nil *DatabaseDetails -> empty", common.Recommendation{Details: (*common.DatabaseDetails)(nil)}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, extractDeployment(tt.rec))
+		})
+	}
+}
+
 // TestExtractEngine covers the four cases the helper dispatches on:
 // DatabaseDetails (RDS engine), CacheDetails (ElastiCache engine),
 // ComputeDetails (EC2 platform), and unset/other Details (blank).

--- a/cmd/multi_service_csv_test.go
+++ b/cmd/multi_service_csv_test.go
@@ -213,6 +213,7 @@ func TestWriteMultiServiceCSVReport_CoverageColumn(t *testing.T) {
 				ProjectedCoverage:      87.5,
 				ExistingCoveragePct:    20.0,
 				RecommendedUtilization: 80.0,
+				Details:                common.ComputeDetails{Platform: "Linux/UNIX"},
 			},
 			Success: true,
 		},
@@ -220,7 +221,8 @@ func TestWriteMultiServiceCSVReport_CoverageColumn(t *testing.T) {
 			// All sizing-related fields zero — ProjectedCoverage and
 			// RecommendedCount cells should both be blank (SP rec or a
 			// pre-target rec that never went through sizing). UpfrontPayment
-			// is also blank when CommitmentCost is zero.
+			// is also blank when CommitmentCost is zero. No Details either,
+			// so the Engine column is blank.
 			Recommendation: common.Recommendation{
 				Service:      common.ServiceEC2,
 				Region:       "us-east-1",
@@ -256,7 +258,7 @@ func TestWriteMultiServiceCSVReport_CoverageColumn(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, rows, 3) // header + 2 data rows
 	header := rows[0]
-	idxProjCov, idxRecCount, idxUpfront, idxExisting := -1, -1, -1, -1
+	idxProjCov, idxRecCount, idxUpfront, idxExisting, idxEngine := -1, -1, -1, -1, -1
 	for i, h := range header {
 		switch h {
 		case "ProjectedCoverage":
@@ -267,28 +269,56 @@ func TestWriteMultiServiceCSVReport_CoverageColumn(t *testing.T) {
 			idxUpfront = i
 		case "ExistingCoverage":
 			idxExisting = i
+		case "Engine":
+			idxEngine = i
 		}
 	}
 	require.NotEqual(t, -1, idxProjCov, "ProjectedCoverage column not found")
 	require.NotEqual(t, -1, idxRecCount, "RecommendedCount column not found")
 	require.NotEqual(t, -1, idxUpfront, "UpfrontPayment column not found")
 	require.NotEqual(t, -1, idxExisting, "ExistingCoverage column not found")
+	require.NotEqual(t, -1, idxEngine, "Engine column not found")
 
 	// Populated row: RecommendedCount=10 renders as "10", UpfrontPayment
 	// emits CommitmentCost as-is (sizing already scaled it; see
-	// ApplyTargetCoverage), ProjectedCoverage=87.5 renders, ExistingCoverage=20.0.
+	// ApplyTargetCoverage), ProjectedCoverage=87.5 renders, ExistingCoverage=20.0,
+	// Engine pulled from ComputeDetails.Platform.
 	populatedRow := rows[1]
 	assert.Equal(t, "10", populatedRow[idxRecCount], "RecommendedCount should render as decimal")
 	assert.Equal(t, "700.00", populatedRow[idxUpfront], "UpfrontPayment should render rec.CommitmentCost as-is")
 	assert.Equal(t, "87.5", populatedRow[idxProjCov])
 	assert.Equal(t, "20.0", populatedRow[idxExisting], "ExistingCoverage should render with one decimal")
+	assert.Equal(t, "Linux/UNIX", populatedRow[idxEngine], "Engine should pull from ComputeDetails.Platform")
 
-	// Zero-fields row: all four optional cells blank.
+	// Zero-fields row: optional cells blank, Engine blank when Details is nil.
 	zeroRow := rows[2]
 	assert.Equal(t, "", zeroRow[idxProjCov], "zero ProjectedCoverage should be blank")
 	assert.Equal(t, "", zeroRow[idxRecCount], "zero RecommendedCount should be blank (SP rec or pre-sizing)")
 	assert.Equal(t, "", zeroRow[idxUpfront], "zero CommitmentCost should leave UpfrontPayment blank")
 	assert.Equal(t, "", zeroRow[idxExisting], "zero ExistingCoverage should be blank")
+	assert.Equal(t, "", zeroRow[idxEngine], "missing Details should leave Engine blank")
+}
+
+// TestExtractEngine covers the four cases the helper dispatches on:
+// DatabaseDetails (RDS engine), CacheDetails (ElastiCache engine),
+// ComputeDetails (EC2 platform), and unset/other Details (blank).
+func TestExtractEngine(t *testing.T) {
+	tests := []struct {
+		name string
+		rec  common.Recommendation
+		want string
+	}{
+		{"DatabaseDetails -> Engine", common.Recommendation{Details: common.DatabaseDetails{Engine: "aurora-postgresql"}}, "aurora-postgresql"},
+		{"CacheDetails -> Engine", common.Recommendation{Details: common.CacheDetails{Engine: "redis"}}, "redis"},
+		{"ComputeDetails -> Platform", common.Recommendation{Details: common.ComputeDetails{Platform: "Linux/UNIX"}}, "Linux/UNIX"},
+		{"nil Details -> empty", common.Recommendation{}, ""},
+		{"SavingsPlanDetails -> empty", common.Recommendation{Details: &common.SavingsPlanDetails{HourlyCommitment: 1.0}}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, extractEngine(tt.rec))
+		})
+	}
 }
 
 // TestFormatCurrencyOrBlank locks the blank-when-zero behaviour for the

--- a/cmd/multi_service_csv_test.go
+++ b/cmd/multi_service_csv_test.go
@@ -261,7 +261,14 @@ func TestWriteMultiServiceCSVReport_CoverageColumn(t *testing.T) {
 	r := csv.NewReader(strings.NewReader(csvText))
 	rows, err := r.ReadAll()
 	require.NoError(t, err)
-	require.Len(t, rows, 3) // header + 2 data rows
+	// Header + 2 data rows + 1 TOTAL row.
+	require.Len(t, rows, 4)
+	// TOTAL row sits at the bottom with "TOTAL" in the Service column and
+	// summed Count / UpfrontPayment / EstimatedSavings.
+	totalRow := rows[3]
+	assert.Equal(t, "TOTAL", totalRow[0], "TOTAL label lands in Service column")
+	// Data rows are sorted by UpfrontPayment DESC; populated rec ($700)
+	// comes before the empty rec ($0).
 	header := rows[0]
 	idxProjCov, idxRecCount, idxUpfront, idxExisting := -1, -1, -1, -1
 	idxEngine, idxInstances, idxCovered := -1, -1, -1
@@ -317,6 +324,69 @@ func TestWriteMultiServiceCSVReport_CoverageColumn(t *testing.T) {
 	assert.Equal(t, "", zeroRow[idxEngine], "missing Details should leave Engine blank")
 	assert.Equal(t, "", zeroRow[idxInstances], "zero avg should leave Instances blank")
 	assert.Equal(t, "", zeroRow[idxCovered], "missing avg or existing_cov should leave CoveredInstances blank")
+}
+
+// TestWriteMultiServiceCSVReport_SortAndTotal confirms data rows are
+// sorted by UpfrontPayment DESC and that a TOTAL summary row lands at
+// the bottom with the column sums. Operators reading the file top-down
+// want the biggest-dollar decisions surfaced first; the TOTAL row
+// removes the need to copy-paste columns into a spreadsheet to add
+// them up.
+func TestWriteMultiServiceCSVReport_SortAndTotal(t *testing.T) {
+	tmpDir := t.TempDir()
+	fp := tmpDir + "/sort-total.csv"
+
+	// Three recs: $5K, $20K, $1K upfront. After DESC sort the order
+	// should be 20K, 5K, 1K.
+	results := []common.PurchaseResult{
+		{Recommendation: common.Recommendation{Service: "rds", ResourceType: "db.r6g.large", Count: 5, CommitmentCost: 5000, EstimatedSavings: 500}},
+		{Recommendation: common.Recommendation{Service: "rds", ResourceType: "db.r6g.2xlarge", Count: 2, CommitmentCost: 20000, EstimatedSavings: 1500}},
+		{Recommendation: common.Recommendation{Service: "rds", ResourceType: "db.t4g.medium", Count: 4, CommitmentCost: 1000, EstimatedSavings: 80}},
+	}
+	require.NoError(t, writeMultiServiceCSVReport(results, fp))
+	content, err := os.ReadFile(fp)
+	require.NoError(t, err)
+
+	r := csv.NewReader(strings.NewReader(string(content)))
+	rows, err := r.ReadAll()
+	require.NoError(t, err)
+	require.Len(t, rows, 5) // header + 3 data + TOTAL
+
+	// Find UpfrontPayment column index.
+	header := rows[0]
+	idxUpfront := -1
+	idxCount := -1
+	idxService := -1
+	idxNU := -1
+	idxSavings := -1
+	for i, h := range header {
+		switch h {
+		case "UpfrontPayment":
+			idxUpfront = i
+		case "Count":
+			idxCount = i
+		case "Service":
+			idxService = i
+		case "NormalizedUnits":
+			idxNU = i
+		case "EstimatedSavings":
+			idxSavings = i
+		}
+	}
+
+	// Sort order: $20K, $5K, $1K.
+	assert.Equal(t, "20000.00", rows[1][idxUpfront], "row 1 has the largest upfront")
+	assert.Equal(t, "5000.00", rows[2][idxUpfront])
+	assert.Equal(t, "1000.00", rows[3][idxUpfront])
+
+	// TOTAL row aggregates: count=11, upfront=$26K, savings=$2,080.
+	// NU = 5×4 + 2×16 + 4×2 = 20 + 32 + 8 = 60.
+	totalRow := rows[4]
+	assert.Equal(t, "TOTAL", totalRow[idxService])
+	assert.Equal(t, "11", totalRow[idxCount])
+	assert.Equal(t, "60", totalRow[idxNU])
+	assert.Equal(t, "26000.00", totalRow[idxUpfront])
+	assert.Equal(t, "2080.00", totalRow[idxSavings])
 }
 
 // TestFormatExistingCoverage locks the three-state rendering:

--- a/cmd/multi_service_csv_test.go
+++ b/cmd/multi_service_csv_test.go
@@ -211,6 +211,7 @@ func TestWriteMultiServiceCSVReport_CoverageColumn(t *testing.T) {
 				Term:                   "1yr",
 				ProjectedUtilization:   95.0,
 				ProjectedCoverage:      87.5,
+				ExistingCoveragePct:    20.0,
 				RecommendedUtilization: 80.0,
 			},
 			Success: true,
@@ -238,9 +239,10 @@ func TestWriteMultiServiceCSVReport_CoverageColumn(t *testing.T) {
 	require.NoError(t, err)
 	csvText := string(content)
 
-	// Header contains ProjectedCoverage, RecommendedCount and UpfrontPayment
-	// but NOT the always-100% utilization siblings.
+	// Header contains ProjectedCoverage, ExistingCoverage, RecommendedCount,
+	// and UpfrontPayment but NOT the always-100% utilization siblings.
 	assert.Contains(t, csvText, "ProjectedCoverage")
+	assert.Contains(t, csvText, "ExistingCoverage")
 	assert.Contains(t, csvText, "RecommendedCount")
 	assert.Contains(t, csvText, "UpfrontPayment")
 	assert.NotContains(t, csvText, "ProjectedUtilization", "column was removed; it's ~100% on every under-buy row")
@@ -254,7 +256,7 @@ func TestWriteMultiServiceCSVReport_CoverageColumn(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, rows, 3) // header + 2 data rows
 	header := rows[0]
-	idxProjCov, idxRecCount, idxUpfront := -1, -1, -1
+	idxProjCov, idxRecCount, idxUpfront, idxExisting := -1, -1, -1, -1
 	for i, h := range header {
 		switch h {
 		case "ProjectedCoverage":
@@ -263,25 +265,30 @@ func TestWriteMultiServiceCSVReport_CoverageColumn(t *testing.T) {
 			idxRecCount = i
 		case "UpfrontPayment":
 			idxUpfront = i
+		case "ExistingCoverage":
+			idxExisting = i
 		}
 	}
 	require.NotEqual(t, -1, idxProjCov, "ProjectedCoverage column not found")
 	require.NotEqual(t, -1, idxRecCount, "RecommendedCount column not found")
 	require.NotEqual(t, -1, idxUpfront, "UpfrontPayment column not found")
+	require.NotEqual(t, -1, idxExisting, "ExistingCoverage column not found")
 
 	// Populated row: RecommendedCount=10 renders as "10", UpfrontPayment
 	// emits CommitmentCost as-is (sizing already scaled it; see
-	// ApplyTargetCoverage), ProjectedCoverage=87.5 renders.
+	// ApplyTargetCoverage), ProjectedCoverage=87.5 renders, ExistingCoverage=20.0.
 	populatedRow := rows[1]
 	assert.Equal(t, "10", populatedRow[idxRecCount], "RecommendedCount should render as decimal")
 	assert.Equal(t, "700.00", populatedRow[idxUpfront], "UpfrontPayment should render rec.CommitmentCost as-is")
 	assert.Equal(t, "87.5", populatedRow[idxProjCov])
+	assert.Equal(t, "20.0", populatedRow[idxExisting], "ExistingCoverage should render with one decimal")
 
-	// Zero-fields row: all three cells blank.
+	// Zero-fields row: all four optional cells blank.
 	zeroRow := rows[2]
 	assert.Equal(t, "", zeroRow[idxProjCov], "zero ProjectedCoverage should be blank")
 	assert.Equal(t, "", zeroRow[idxRecCount], "zero RecommendedCount should be blank (SP rec or pre-sizing)")
 	assert.Equal(t, "", zeroRow[idxUpfront], "zero CommitmentCost should leave UpfrontPayment blank")
+	assert.Equal(t, "", zeroRow[idxExisting], "zero ExistingCoverage should be blank")
 }
 
 // TestFormatCurrencyOrBlank locks the blank-when-zero behaviour for the

--- a/cmd/multi_service_csv_test.go
+++ b/cmd/multi_service_csv_test.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"encoding/csv"
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -184,6 +186,82 @@ func TestWriteMultiServiceCSVReport(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestWriteMultiServiceCSVReport_UtilizationColumns confirms the three
+// utilization-related columns added for issue #338 are emitted with the
+// right "blank-when-zero" formatting (matches the "0 = unknown" convention
+// shared with the JSON-level omitempty tags).
+func TestWriteMultiServiceCSVReport_UtilizationColumns(t *testing.T) {
+	tmpDir := t.TempDir()
+	filepath := tmpDir + "/util.csv"
+
+	results := []common.PurchaseResult{
+		{
+			Recommendation: common.Recommendation{
+				Service:                common.ServiceEC2,
+				Region:                 "us-east-1",
+				ResourceType:           "t3.medium",
+				Count:                  10,
+				Term:                   "1yr",
+				ProjectedUtilization:   95.0,
+				ProjectedCoverage:      87.5,
+				RecommendedUtilization: 80.0,
+			},
+			Success: true,
+		},
+		{
+			// All three utilization fields zero — should render as blank cells.
+			Recommendation: common.Recommendation{
+				Service:      common.ServiceEC2,
+				Region:       "us-east-1",
+				ResourceType: "m5.large",
+				Count:        5,
+				Term:         "1yr",
+			},
+			Success: true,
+		},
+	}
+
+	err := writeMultiServiceCSVReport(results, filepath)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath)
+	require.NoError(t, err)
+	csvText := string(content)
+
+	// Header contains the new columns.
+	assert.Contains(t, csvText, "ProjectedUtilization")
+	assert.Contains(t, csvText, "ProjectedCoverage")
+	assert.Contains(t, csvText, "RecommendedUtilization")
+
+	// First data row (populated rec) has formatted values.
+	assert.Contains(t, csvText, "95.0", "ProjectedUtilization should render with one decimal")
+	assert.Contains(t, csvText, "87.5", "ProjectedCoverage should render with one decimal")
+	assert.Contains(t, csvText, "80.0", "RecommendedUtilization should render with one decimal")
+
+	// Second data row (zero values) must end with empty cells for the three
+	// utilization columns: "...,t3-no-util...,,," — assert by counting the
+	// number of trailing commas before the newline. Parse with the stdlib
+	// csv reader to avoid string-matching fragility.
+	r := csv.NewReader(strings.NewReader(csvText))
+	rows, err := r.ReadAll()
+	require.NoError(t, err)
+	require.Len(t, rows, 3) // header + 2 data rows
+	// Find the 3 trailing utilization columns by index from the header.
+	header := rows[0]
+	idxProjUtil := -1
+	for i, h := range header {
+		if h == "ProjectedUtilization" {
+			idxProjUtil = i
+			break
+		}
+	}
+	require.NotEqual(t, -1, idxProjUtil, "ProjectedUtilization column not found")
+	zeroRow := rows[2]
+	assert.Equal(t, "", zeroRow[idxProjUtil], "zero ProjectedUtilization should be blank")
+	assert.Equal(t, "", zeroRow[idxProjUtil+1], "zero ProjectedCoverage should be blank")
+	assert.Equal(t, "", zeroRow[idxProjUtil+2], "zero RecommendedUtilization should be blank")
 }
 
 // Tests for loadRecommendationsFromCSV function

--- a/cmd/multi_service_csv_test.go
+++ b/cmd/multi_service_csv_test.go
@@ -188,11 +188,13 @@ func TestWriteMultiServiceCSVReport(t *testing.T) {
 	}
 }
 
-// TestWriteMultiServiceCSVReport_UtilizationColumns confirms the three
-// utilization-related columns added for issue #338 are emitted with the
-// right "blank-when-zero" formatting (matches the "0 = unknown" convention
-// shared with the JSON-level omitempty tags).
-func TestWriteMultiServiceCSVReport_UtilizationColumns(t *testing.T) {
+// TestWriteMultiServiceCSVReport_CoverageColumn confirms the ProjectedCoverage
+// column added for --target-coverage (#338) is emitted with the "blank-when-zero"
+// formatting (matches the "0 = unknown" convention shared with the JSON-level
+// omitempty tags). The sibling ProjectedUtilization and RecommendedUtilization
+// fields are intentionally NOT emitted to CSV (both land at ~100% on every
+// under-buy row, so they add noise without information).
+func TestWriteMultiServiceCSVReport_CoverageColumn(t *testing.T) {
 	tmpDir := t.TempDir()
 	filepath := tmpDir + "/util.csv"
 
@@ -211,7 +213,7 @@ func TestWriteMultiServiceCSVReport_UtilizationColumns(t *testing.T) {
 			Success: true,
 		},
 		{
-			// All three utilization fields zero — should render as blank cells.
+			// All utilization fields zero — ProjectedCoverage cell should be blank.
 			Recommendation: common.Recommendation{
 				Service:      common.ServiceEC2,
 				Region:       "us-east-1",
@@ -230,38 +232,30 @@ func TestWriteMultiServiceCSVReport_UtilizationColumns(t *testing.T) {
 	require.NoError(t, err)
 	csvText := string(content)
 
-	// Header contains the new columns.
-	assert.Contains(t, csvText, "ProjectedUtilization")
+	// Header contains ProjectedCoverage but NOT the always-100% siblings.
 	assert.Contains(t, csvText, "ProjectedCoverage")
-	assert.Contains(t, csvText, "RecommendedUtilization")
+	assert.NotContains(t, csvText, "ProjectedUtilization", "column was removed; it's ~100% on every under-buy row")
+	assert.NotContains(t, csvText, "RecommendedUtilization", "column was removed; it's ~99-100% on every row")
 
-	// First data row (populated rec) has formatted values.
-	assert.Contains(t, csvText, "95.0", "ProjectedUtilization should render with one decimal")
+	// First data row (populated rec) has the coverage value formatted.
 	assert.Contains(t, csvText, "87.5", "ProjectedCoverage should render with one decimal")
-	assert.Contains(t, csvText, "80.0", "RecommendedUtilization should render with one decimal")
 
-	// Second data row (zero values) must end with empty cells for the three
-	// utilization columns: "...,t3-no-util...,,," — assert by counting the
-	// number of trailing commas before the newline. Parse with the stdlib
-	// csv reader to avoid string-matching fragility.
+	// Second data row (zero coverage) must end with an empty cell.
 	r := csv.NewReader(strings.NewReader(csvText))
 	rows, err := r.ReadAll()
 	require.NoError(t, err)
 	require.Len(t, rows, 3) // header + 2 data rows
-	// Find the 3 trailing utilization columns by index from the header.
 	header := rows[0]
-	idxProjUtil := -1
+	idxProjCov := -1
 	for i, h := range header {
-		if h == "ProjectedUtilization" {
-			idxProjUtil = i
+		if h == "ProjectedCoverage" {
+			idxProjCov = i
 			break
 		}
 	}
-	require.NotEqual(t, -1, idxProjUtil, "ProjectedUtilization column not found")
+	require.NotEqual(t, -1, idxProjCov, "ProjectedCoverage column not found")
 	zeroRow := rows[2]
-	assert.Equal(t, "", zeroRow[idxProjUtil], "zero ProjectedUtilization should be blank")
-	assert.Equal(t, "", zeroRow[idxProjUtil+1], "zero ProjectedCoverage should be blank")
-	assert.Equal(t, "", zeroRow[idxProjUtil+2], "zero RecommendedUtilization should be blank")
+	assert.Equal(t, "", zeroRow[idxProjCov], "zero ProjectedCoverage should be blank")
 }
 
 // Tests for loadRecommendationsFromCSV function

--- a/cmd/multi_service_csv_test.go
+++ b/cmd/multi_service_csv_test.go
@@ -315,6 +315,59 @@ func TestWriteMultiServiceCSVReport_CoverageColumn(t *testing.T) {
 	assert.Equal(t, "", zeroRow[idxCovered], "missing avg or existing_cov should leave CoveredInstances blank")
 }
 
+// TestExtractRDSFamily covers the family-prefix extraction used by the
+// CSV writer to group rows by size-flex family.
+func TestExtractRDSFamily(t *testing.T) {
+	tests := []struct {
+		name string
+		rec  common.Recommendation
+		want string
+	}{
+		{"RDS db.r7g.large", common.Recommendation{Service: common.ServiceRDS, ResourceType: "db.r7g.large"}, "db.r7g"},
+		{"RDS db.t4g.medium", common.Recommendation{Service: common.ServiceRDS, ResourceType: "db.t4g.medium"}, "db.t4g"},
+		{"RelationalDB alias", common.Recommendation{Service: common.ServiceRelationalDB, ResourceType: "db.m5.xlarge"}, "db.m5"},
+		// Non-RDS services blank even when ResourceType looks RDS-shaped.
+		{"EC2 ignored", common.Recommendation{Service: common.ServiceEC2, ResourceType: "m5.large"}, ""},
+		{"ElastiCache ignored", common.Recommendation{Service: common.ServiceElastiCache, ResourceType: "cache.t3.micro"}, ""},
+		// Malformed RDS type.
+		{"RDS bare type", common.Recommendation{Service: common.ServiceRDS, ResourceType: "db.r7g"}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, extractRDSFamily(tt.rec))
+		})
+	}
+}
+
+// TestFormatNormalizedUnitsOrBlank confirms NU values land for RDS rows
+// with known sizes and stay blank for non-RDS / zero-count / unknown-size
+// inputs, matching the "0/empty = unknown" convention used elsewhere.
+func TestFormatNormalizedUnitsOrBlank(t *testing.T) {
+	tests := []struct {
+		name string
+		rec  common.Recommendation
+		want string
+	}{
+		// 15 × db.r7g.large = 15 × 4 NU = 60 NU
+		{"r7g.large × 15", common.Recommendation{Service: common.ServiceRDS, ResourceType: "db.r7g.large", Count: 15}, "60"},
+		// 3 × db.t4g.medium = 3 × 2 NU = 6 NU
+		{"t4g.medium × 3", common.Recommendation{Service: common.ServiceRDS, ResourceType: "db.t4g.medium", Count: 3}, "6"},
+		// Fractional NU survives via %g (db.t4g.micro = 0.5 NU)
+		{"t4g.micro × 3", common.Recommendation{Service: common.ServiceRDS, ResourceType: "db.t4g.micro", Count: 3}, "1.5"},
+		// Non-RDS service → blank
+		{"EC2 row blank", common.Recommendation{Service: common.ServiceEC2, ResourceType: "m5.large", Count: 5}, ""},
+		// Zero count → blank
+		{"zero count blank", common.Recommendation{Service: common.ServiceRDS, ResourceType: "db.r7g.large", Count: 0}, ""},
+		// Unknown size → blank
+		{"unknown size blank", common.Recommendation{Service: common.ServiceRDS, ResourceType: "db.r7g.bogus", Count: 5}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, formatNormalizedUnitsOrBlank(tt.rec))
+		})
+	}
+}
+
 // TestExtractDeployment covers the deployment-extraction helper used by
 // the RDS row in the CSV. Single-AZ / Multi-AZ is critical context for
 // pricing verification (Multi-AZ list price is ~2x Single-AZ) so the

--- a/cmd/multi_service_csv_test.go
+++ b/cmd/multi_service_csv_test.go
@@ -202,18 +202,22 @@ func TestWriteMultiServiceCSVReport_CoverageColumn(t *testing.T) {
 	results := []common.PurchaseResult{
 		{
 			Recommendation: common.Recommendation{
-				Service:                common.ServiceEC2,
-				Region:                 "us-east-1",
-				ResourceType:           "t3.medium",
-				Count:                  7,   // post-sizing
-				RecommendedCount:       10,  // AWS pre-sizing
-				CommitmentCost:         700, // already scaled at sizing time
-				Term:                   "1yr",
-				ProjectedUtilization:   95.0,
-				ProjectedCoverage:      87.5,
-				ExistingCoveragePct:    20.0,
-				RecommendedUtilization: 80.0,
-				Details:                common.ComputeDetails{Platform: "Linux/UNIX"},
+				Service:                     common.ServiceEC2,
+				Region:                      "us-east-1",
+				ResourceType:                "t3.medium",
+				Count:                       7,   // post-sizing
+				RecommendedCount:            10,  // AWS pre-sizing
+				CommitmentCost:              700, // already scaled at sizing time
+				Term:                        "1yr",
+				ProjectedUtilization:        95.0,
+				ProjectedCoverage:           87.5,
+				ExistingCoveragePct:         20.0,
+				RecommendedUtilization:      80.0,
+				AverageInstancesUsedPerHour: 10.0,
+				// Pointer form matches the live parser (parser_services.go
+				// stores &common.ComputeDetails{...}); extractEngine must
+				// handle both pointer and value Details.
+				Details: &common.ComputeDetails{Platform: "Linux/UNIX"},
 			},
 			Success: true,
 		},
@@ -258,7 +262,8 @@ func TestWriteMultiServiceCSVReport_CoverageColumn(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, rows, 3) // header + 2 data rows
 	header := rows[0]
-	idxProjCov, idxRecCount, idxUpfront, idxExisting, idxEngine := -1, -1, -1, -1, -1
+	idxProjCov, idxRecCount, idxUpfront, idxExisting := -1, -1, -1, -1
+	idxEngine, idxInstances, idxCovered := -1, -1, -1
 	for i, h := range header {
 		switch h {
 		case "ProjectedCoverage":
@@ -271,6 +276,10 @@ func TestWriteMultiServiceCSVReport_CoverageColumn(t *testing.T) {
 			idxExisting = i
 		case "Engine":
 			idxEngine = i
+		case "Instances":
+			idxInstances = i
+		case "CoveredInstances":
+			idxCovered = i
 		}
 	}
 	require.NotEqual(t, -1, idxProjCov, "ProjectedCoverage column not found")
@@ -278,17 +287,22 @@ func TestWriteMultiServiceCSVReport_CoverageColumn(t *testing.T) {
 	require.NotEqual(t, -1, idxUpfront, "UpfrontPayment column not found")
 	require.NotEqual(t, -1, idxExisting, "ExistingCoverage column not found")
 	require.NotEqual(t, -1, idxEngine, "Engine column not found")
+	require.NotEqual(t, -1, idxInstances, "Instances column not found")
+	require.NotEqual(t, -1, idxCovered, "CoveredInstances column not found")
 
 	// Populated row: RecommendedCount=10 renders as "10", UpfrontPayment
 	// emits CommitmentCost as-is (sizing already scaled it; see
 	// ApplyTargetCoverage), ProjectedCoverage=87.5 renders, ExistingCoverage=20.0,
-	// Engine pulled from ComputeDetails.Platform.
+	// Engine pulled from *ComputeDetails.Platform. Instances = avg = 10.0.
+	// CoveredInstances = 10.0 × 20% = 2.0.
 	populatedRow := rows[1]
 	assert.Equal(t, "10", populatedRow[idxRecCount], "RecommendedCount should render as decimal")
 	assert.Equal(t, "700.00", populatedRow[idxUpfront], "UpfrontPayment should render rec.CommitmentCost as-is")
 	assert.Equal(t, "87.5", populatedRow[idxProjCov])
 	assert.Equal(t, "20.0", populatedRow[idxExisting], "ExistingCoverage should render with one decimal")
-	assert.Equal(t, "Linux/UNIX", populatedRow[idxEngine], "Engine should pull from ComputeDetails.Platform")
+	assert.Equal(t, "Linux/UNIX", populatedRow[idxEngine], "Engine should pull from *ComputeDetails.Platform")
+	assert.Equal(t, "10.0", populatedRow[idxInstances], "Instances should render avg with one decimal")
+	assert.Equal(t, "2.0", populatedRow[idxCovered], "CoveredInstances = avg * existing_cov / 100")
 
 	// Zero-fields row: optional cells blank, Engine blank when Details is nil.
 	zeroRow := rows[2]
@@ -297,6 +311,8 @@ func TestWriteMultiServiceCSVReport_CoverageColumn(t *testing.T) {
 	assert.Equal(t, "", zeroRow[idxUpfront], "zero CommitmentCost should leave UpfrontPayment blank")
 	assert.Equal(t, "", zeroRow[idxExisting], "zero ExistingCoverage should be blank")
 	assert.Equal(t, "", zeroRow[idxEngine], "missing Details should leave Engine blank")
+	assert.Equal(t, "", zeroRow[idxInstances], "zero avg should leave Instances blank")
+	assert.Equal(t, "", zeroRow[idxCovered], "missing avg or existing_cov should leave CoveredInstances blank")
 }
 
 // TestExtractEngine covers the four cases the helper dispatches on:
@@ -308,11 +324,18 @@ func TestExtractEngine(t *testing.T) {
 		rec  common.Recommendation
 		want string
 	}{
-		{"DatabaseDetails -> Engine", common.Recommendation{Details: common.DatabaseDetails{Engine: "aurora-postgresql"}}, "aurora-postgresql"},
-		{"CacheDetails -> Engine", common.Recommendation{Details: common.CacheDetails{Engine: "redis"}}, "redis"},
-		{"ComputeDetails -> Platform", common.Recommendation{Details: common.ComputeDetails{Platform: "Linux/UNIX"}}, "Linux/UNIX"},
+		// Pointer forms — what the live parser actually emits.
+		{"*DatabaseDetails -> Engine", common.Recommendation{Details: &common.DatabaseDetails{Engine: "aurora-postgresql"}}, "aurora-postgresql"},
+		{"*CacheDetails -> Engine", common.Recommendation{Details: &common.CacheDetails{Engine: "redis"}}, "redis"},
+		{"*ComputeDetails -> Platform", common.Recommendation{Details: &common.ComputeDetails{Platform: "Linux/UNIX"}}, "Linux/UNIX"},
+		// Value forms — what the CSV-loader path constructs.
+		{"DatabaseDetails (value) -> Engine", common.Recommendation{Details: common.DatabaseDetails{Engine: "mysql"}}, "mysql"},
+		{"CacheDetails (value) -> Engine", common.Recommendation{Details: common.CacheDetails{Engine: "memcached"}}, "memcached"},
+		{"ComputeDetails (value) -> Platform", common.Recommendation{Details: common.ComputeDetails{Platform: "Windows"}}, "Windows"},
+		// Fallbacks.
 		{"nil Details -> empty", common.Recommendation{}, ""},
 		{"SavingsPlanDetails -> empty", common.Recommendation{Details: &common.SavingsPlanDetails{HourlyCommitment: 1.0}}, ""},
+		{"nil *DatabaseDetails -> empty", common.Recommendation{Details: (*common.DatabaseDetails)(nil)}, ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/multi_service_csv_test.go
+++ b/cmd/multi_service_csv_test.go
@@ -205,9 +205,9 @@ func TestWriteMultiServiceCSVReport_CoverageColumn(t *testing.T) {
 				Service:                common.ServiceEC2,
 				Region:                 "us-east-1",
 				ResourceType:           "t3.medium",
-				Count:                  7,    // post-sizing
-				RecommendedCount:       10,   // AWS pre-sizing
-				CommitmentCost:         1000, // AWS upfront for 10 RIs; pro-rates to 700 for 7.
+				Count:                  7,   // post-sizing
+				RecommendedCount:       10,  // AWS pre-sizing
+				CommitmentCost:         700, // already scaled at sizing time
 				Term:                   "1yr",
 				ProjectedUtilization:   95.0,
 				ProjectedCoverage:      87.5,
@@ -270,10 +270,11 @@ func TestWriteMultiServiceCSVReport_CoverageColumn(t *testing.T) {
 	require.NotEqual(t, -1, idxUpfront, "UpfrontPayment column not found")
 
 	// Populated row: RecommendedCount=10 renders as "10", UpfrontPayment
-	// pro-rates 1000 * 7/10 = 700.00, ProjectedCoverage=87.5 renders.
+	// emits CommitmentCost as-is (sizing already scaled it; see
+	// ApplyTargetCoverage), ProjectedCoverage=87.5 renders.
 	populatedRow := rows[1]
 	assert.Equal(t, "10", populatedRow[idxRecCount], "RecommendedCount should render as decimal")
-	assert.Equal(t, "700.00", populatedRow[idxUpfront], "UpfrontPayment should pro-rate CommitmentCost by Count/RecommendedCount")
+	assert.Equal(t, "700.00", populatedRow[idxUpfront], "UpfrontPayment should render rec.CommitmentCost as-is")
 	assert.Equal(t, "87.5", populatedRow[idxProjCov])
 
 	// Zero-fields row: all three cells blank.
@@ -283,39 +284,23 @@ func TestWriteMultiServiceCSVReport_CoverageColumn(t *testing.T) {
 	assert.Equal(t, "", zeroRow[idxUpfront], "zero CommitmentCost should leave UpfrontPayment blank")
 }
 
-// TestFormatUpfrontForSizedCount locks the three branches: pro-rate when
-// Count != RecommendedCount, no scaling when they match, and pass-through
-// for SP recs (RecommendedCount == 0).
-func TestFormatUpfrontForSizedCount(t *testing.T) {
+// TestFormatCurrencyOrBlank locks the blank-when-zero behaviour for the
+// UpfrontPayment column. Non-zero renders with two decimals; zero renders
+// as an empty cell so users can distinguish "no upfront due" from "actual
+// $0 upfront", consistent with the rest of the optional CSV columns.
+func TestFormatCurrencyOrBlank(t *testing.T) {
 	tests := []struct {
 		name string
-		rec  common.Recommendation
+		in   float64
 		want string
 	}{
-		{
-			name: "RI under-buy pro-rates upfront",
-			rec:  common.Recommendation{Count: 7, RecommendedCount: 10, CommitmentCost: 1000},
-			want: "700.00",
-		},
-		{
-			name: "RI sized at AWS rec emits CommitmentCost as-is",
-			rec:  common.Recommendation{Count: 10, RecommendedCount: 10, CommitmentCost: 1000},
-			want: "1000.00",
-		},
-		{
-			name: "SP (RecommendedCount=0) emits CommitmentCost as-is",
-			rec:  common.Recommendation{Count: 1, RecommendedCount: 0, CommitmentCost: 1234.56},
-			want: "1234.56",
-		},
-		{
-			name: "zero CommitmentCost blanks the cell",
-			rec:  common.Recommendation{Count: 5, RecommendedCount: 10, CommitmentCost: 0},
-			want: "",
-		},
+		{"non-zero renders with two decimals", 1234.56, "1234.56"},
+		{"integer value gets .00", 700, "700.00"},
+		{"zero blanks the cell", 0, ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, formatUpfrontForSizedCount(tt.rec))
+			assert.Equal(t, tt.want, formatCurrencyOrBlank(tt.in))
 		})
 	}
 }

--- a/cmd/multi_service_csv_test.go
+++ b/cmd/multi_service_csv_test.go
@@ -212,6 +212,7 @@ func TestWriteMultiServiceCSVReport_CoverageColumn(t *testing.T) {
 				ProjectedUtilization:        95.0,
 				ProjectedCoverage:           87.5,
 				ExistingCoveragePct:         20.0,
+				ExistingCoverageKnown:       true,
 				RecommendedUtilization:      80.0,
 				AverageInstancesUsedPerHour: 10.0,
 				// Pointer form matches the live parser (parser_services.go
@@ -305,14 +306,43 @@ func TestWriteMultiServiceCSVReport_CoverageColumn(t *testing.T) {
 	assert.Equal(t, "2.0", populatedRow[idxCovered], "CoveredInstances = avg * existing_cov / 100")
 
 	// Zero-fields row: optional cells blank, Engine blank when Details is nil.
+	// ExistingCoverage shows "n/a" because ExistingCoverageKnown wasn't set:
+	// CE had no data for this pool (distinct from "0% covered", which would
+	// be ExistingCoverageKnown=true, Pct=0 rendering as "0.0").
 	zeroRow := rows[2]
 	assert.Equal(t, "", zeroRow[idxProjCov], "zero ProjectedCoverage should be blank")
 	assert.Equal(t, "", zeroRow[idxRecCount], "zero RecommendedCount should be blank (SP rec or pre-sizing)")
 	assert.Equal(t, "", zeroRow[idxUpfront], "zero CommitmentCost should leave UpfrontPayment blank")
-	assert.Equal(t, "", zeroRow[idxExisting], "zero ExistingCoverage should be blank")
+	assert.Equal(t, "n/a", zeroRow[idxExisting], "ExistingCoverage should render n/a when CE had no signal")
 	assert.Equal(t, "", zeroRow[idxEngine], "missing Details should leave Engine blank")
 	assert.Equal(t, "", zeroRow[idxInstances], "zero avg should leave Instances blank")
 	assert.Equal(t, "", zeroRow[idxCovered], "missing avg or existing_cov should leave CoveredInstances blank")
+}
+
+// TestFormatExistingCoverage locks the three-state rendering:
+//   - ExistingCoverageKnown=false → "n/a" (CE has no data for this pool)
+//   - ExistingCoverageKnown=true, Pct=0 → "0.0" (CE confirms zero coverage)
+//   - ExistingCoverageKnown=true, Pct>0 → formatted with one decimal
+//
+// Critical for operators interpreting the column: a blank or zero cell
+// previously meant either "CE was queried but returned 0%" or "CE
+// returned nothing", with no way to tell which.
+func TestFormatExistingCoverage(t *testing.T) {
+	tests := []struct {
+		name string
+		rec  common.Recommendation
+		want string
+	}{
+		{"unknown (CE no data)", common.Recommendation{}, "n/a"},
+		{"known zero coverage", common.Recommendation{ExistingCoverageKnown: true}, "0.0"},
+		{"known partial coverage", common.Recommendation{ExistingCoverageKnown: true, ExistingCoveragePct: 37.74}, "37.7"},
+		{"known full coverage", common.Recommendation{ExistingCoverageKnown: true, ExistingCoveragePct: 100.0}, "100.0"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, formatExistingCoverage(tt.rec))
+		})
+	}
 }
 
 // TestFormatRecurringMonthlyOrBlank locks the nil-vs-zero distinction:

--- a/cmd/multi_service_csv_test.go
+++ b/cmd/multi_service_csv_test.go
@@ -315,6 +315,30 @@ func TestWriteMultiServiceCSVReport_CoverageColumn(t *testing.T) {
 	assert.Equal(t, "", zeroRow[idxCovered], "missing avg or existing_cov should leave CoveredInstances blank")
 }
 
+// TestFormatRecurringMonthlyOrBlank locks the nil-vs-zero distinction:
+// nil pointer (AWS API didn't return RecurringStandardMonthlyCost)
+// renders as blank, zero value (genuinely no monthly fee, e.g.
+// all-upfront RIs) renders as "0.00". Operators need to tell "we don't
+// know" apart from "definitely zero" to compute total cost correctly.
+func TestFormatRecurringMonthlyOrBlank(t *testing.T) {
+	zero := 0.0
+	twenty := 20.5
+	tests := []struct {
+		name string
+		in   *float64
+		want string
+	}{
+		{"nil → blank (unknown)", nil, ""},
+		{"zero pointer → 0.00 (definitely zero)", &zero, "0.00"},
+		{"non-zero → formatted", &twenty, "20.50"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, formatRecurringMonthlyOrBlank(tt.in))
+		})
+	}
+}
+
 // TestExtractRDSFamily covers the family-prefix extraction used by the
 // CSV writer to group rows by size-flex family.
 func TestExtractRDSFamily(t *testing.T) {

--- a/cmd/multi_service_filters.go
+++ b/cmd/multi_service_filters.go
@@ -22,7 +22,10 @@ func applyFilters(recs []common.Recommendation, cfg Config, instanceVersions map
 	return filtered
 }
 
-// processRecommendation applies all filters to a recommendation and returns the adjusted recommendation and whether to include it
+// processRecommendation applies all filters to a recommendation and returns
+// the adjusted recommendation and whether to include it. The flat
+// boolean-filter checks are delegated to passesDimensionFilters to keep
+// this function under gocyclo's complexity threshold.
 func processRecommendation(rec common.Recommendation, cfg Config, instanceVersions map[string][]InstanceEngineVersion, versionInfo map[string]MajorEngineVersionInfo, currentRegion string) (common.Recommendation, bool) {
 	// Filter to only recommendations for the current region being processed
 	// This prevents duplicating recommendations across all regions
@@ -31,20 +34,7 @@ func processRecommendation(rec common.Recommendation, cfg Config, instanceVersio
 		return rec, false
 	}
 
-	// Apply basic filters
-	if !shouldIncludeRegion(rec.Region, cfg) {
-		return rec, false
-	}
-
-	if !shouldIncludeInstanceType(rec.ResourceType, cfg) {
-		return rec, false
-	}
-
-	if !shouldIncludeEngine(rec, cfg) {
-		return rec, false
-	}
-
-	if !shouldIncludeAccount(rec.AccountName, cfg) {
+	if !passesDimensionFilters(rec, cfg) {
 		return rec, false
 	}
 
@@ -58,6 +48,52 @@ func processRecommendation(rec common.Recommendation, cfg Config, instanceVersio
 	}
 
 	return rec, true
+}
+
+// passesDimensionFilters runs the stateless include/exclude checks on
+// region, instance type, engine, account, and pool size. Returns false on
+// the first failing filter. Split out of processRecommendation to keep
+// each function's cyclomatic complexity under the gocyclo limit; the
+// dimension filters here are pure functions of rec + cfg with no side
+// effects.
+func passesDimensionFilters(rec common.Recommendation, cfg Config) bool {
+	if !shouldIncludeRegion(rec.Region, cfg) {
+		return false
+	}
+	if !shouldIncludeInstanceType(rec.ResourceType, cfg) {
+		return false
+	}
+	if !shouldIncludeEngine(rec, cfg) {
+		return false
+	}
+	if !shouldIncludeAccount(rec.AccountName, cfg) {
+		return false
+	}
+	if !shouldIncludePoolSize(rec, cfg) {
+		return false
+	}
+	return true
+}
+
+// shouldIncludePoolSize filters out RI recommendations for pools whose
+// AverageInstancesUsedPerHour is below cfg.MinPoolSize. The purpose is to
+// drop tiny pools where integer-arithmetic sizing forces 100% coverage
+// regardless of --target-coverage (e.g. avg=1 with target=80% → floor(0.8)=0
+// drops, ceil(0.8)=1 over-covers). Setting --min-pool-size=2 keeps pools
+// where target can be meaningfully approximated.
+//
+// Pass-through cases: filter disabled (MinPoolSize<=0), or rec has no
+// per-hour signal (avg<=0 — SPs and recs CE didn't return usage for).
+// Those pools aren't sized via the per-hour formula so the filter doesn't
+// apply to them.
+func shouldIncludePoolSize(rec common.Recommendation, cfg Config) bool {
+	if cfg.MinPoolSize <= 0 {
+		return true
+	}
+	if rec.AverageInstancesUsedPerHour <= 0 {
+		return true
+	}
+	return rec.AverageInstancesUsedPerHour >= cfg.MinPoolSize
 }
 
 // shouldIncludeRegion checks if a region should be included based on filters

--- a/cmd/multi_service_helpers.go
+++ b/cmd/multi_service_helpers.go
@@ -483,9 +483,22 @@ func applyCoverageAndOverrides(recs []common.Recommendation, cfg Config, coverag
 			AppLogger.Printf("  ⏰ Treating %d recs as partially uncovered (RIs expiring within %d days)\n", n, cfg.RebuyWindowDays)
 		}
 	}
-	filteredRecs := applySizing(recs, cfg, cfg.Coverage)
+	// Family-NU sizing for RDS recs: AWS rec API already bundles size-flex
+	// demand within a family into one rec at one size, so per-pool sizing
+	// under-buys. Run the family-NU pass first (RDS only, target-coverage
+	// mode only); non-RDS recs flow through the per-pool path unchanged.
+	// When TargetCoverage isn't set (legacy --coverage path) the per-pool
+	// flow handles everything as before.
+	var sizedRDS []common.Recommendation
+	rest := recs
 	if cfg.TargetCoverage > 0 {
-		AppLogger.Printf("  🎯 Applying %.1f%% target-coverage: %d recommendations selected\n", cfg.TargetCoverage, len(filteredRecs))
+		sizedRDS, rest = recommendations.ApplyFamilyNUSizingRDS(recs, coverageMap, cfg.TargetCoverage)
+	}
+	filteredRecs := applySizing(rest, cfg, cfg.Coverage)
+	filteredRecs = append(filteredRecs, sizedRDS...)
+	if cfg.TargetCoverage > 0 {
+		AppLogger.Printf("  🎯 Applying %.1f%% target-coverage: %d recommendations selected (%d via family-NU, %d via per-pool)\n",
+			cfg.TargetCoverage, len(filteredRecs), len(sizedRDS), len(filteredRecs)-len(sizedRDS))
 	} else {
 		AppLogger.Printf("  📈 Applying %.1f%% coverage: %d recommendations selected\n", cfg.Coverage, len(filteredRecs))
 	}

--- a/cmd/multi_service_helpers.go
+++ b/cmd/multi_service_helpers.go
@@ -458,11 +458,16 @@ func applyRegionFilters(
 	return recs
 }
 
-// applyCoverageAndOverrides applies coverage percentage and count overrides
+// applyCoverageAndOverrides applies sizing (coverage % or target-utilization)
+// and count overrides. Sizing mode is selected by cfg.TargetUtilization: > 0
+// routes to ApplyTargetUtilization; otherwise the legacy ApplyCoverage path.
 func applyCoverageAndOverrides(recs []common.Recommendation, cfg Config) []common.Recommendation {
-	// Apply coverage
-	filteredRecs := applyCommonCoverage(recs, cfg.Coverage)
-	AppLogger.Printf("  📈 Applying %.1f%% coverage: %d recommendations selected\n", cfg.Coverage, len(filteredRecs))
+	filteredRecs := applySizing(recs, cfg, cfg.Coverage)
+	if cfg.TargetUtilization > 0 {
+		AppLogger.Printf("  🎯 Applying %.1f%% target-utilization: %d recommendations selected\n", cfg.TargetUtilization, len(filteredRecs))
+	} else {
+		AppLogger.Printf("  📈 Applying %.1f%% coverage: %d recommendations selected\n", cfg.Coverage, len(filteredRecs))
+	}
 
 	// Apply count override if specified
 	if cfg.OverrideCount > 0 {

--- a/cmd/multi_service_helpers.go
+++ b/cmd/multi_service_helpers.go
@@ -458,13 +458,13 @@ func applyRegionFilters(
 	return recs
 }
 
-// applyCoverageAndOverrides applies sizing (coverage % or target-utilization)
-// and count overrides. Sizing mode is selected by cfg.TargetUtilization: > 0
-// routes to ApplyTargetUtilization; otherwise the legacy ApplyCoverage path.
+// applyCoverageAndOverrides applies sizing (coverage % or target-coverage)
+// and count overrides. Sizing mode is selected by cfg.TargetCoverage: > 0
+// routes to ApplyTargetCoverage; otherwise the legacy ApplyCoverage path.
 func applyCoverageAndOverrides(recs []common.Recommendation, cfg Config) []common.Recommendation {
 	filteredRecs := applySizing(recs, cfg, cfg.Coverage)
-	if cfg.TargetUtilization > 0 {
-		AppLogger.Printf("  🎯 Applying %.1f%% target-utilization: %d recommendations selected\n", cfg.TargetUtilization, len(filteredRecs))
+	if cfg.TargetCoverage > 0 {
+		AppLogger.Printf("  🎯 Applying %.1f%% target-coverage: %d recommendations selected\n", cfg.TargetCoverage, len(filteredRecs))
 	} else {
 		AppLogger.Printf("  📈 Applying %.1f%% coverage: %d recommendations selected\n", cfg.Coverage, len(filteredRecs))
 	}

--- a/cmd/multi_service_helpers.go
+++ b/cmd/multi_service_helpers.go
@@ -205,7 +205,7 @@ func createDryRunResult(rec common.Recommendation, region string, index int, cfg
 	return common.PurchaseResult{
 		Recommendation: rec,
 		Success:        true,
-		CommitmentID:   generatePurchaseID(rec, region, index, true, cfg.Coverage),
+		CommitmentID:   generatePurchaseID(rec, region, index, true, effectiveSizingPct(cfg)),
 		DryRun:         true,
 		Timestamp:      time.Now(),
 	}
@@ -218,7 +218,7 @@ func createCancelledResults(recs []common.Recommendation, region string, cfg Con
 		results[k] = common.PurchaseResult{
 			Recommendation: recs[k],
 			Success:        false,
-			CommitmentID:   generatePurchaseID(recs[k], region, k+1, false, cfg.Coverage),
+			CommitmentID:   generatePurchaseID(recs[k], region, k+1, false, effectiveSizingPct(cfg)),
 			Error:          fmt.Errorf("purchase cancelled by user"),
 			Timestamp:      time.Now(),
 		}
@@ -236,7 +236,7 @@ func executePurchase(ctx context.Context, rec common.Recommendation, region stri
 		result.Error = err
 	}
 	if result.CommitmentID == "" {
-		result.CommitmentID = generatePurchaseID(rec, region, index, false, cfg.Coverage)
+		result.CommitmentID = generatePurchaseID(rec, region, index, false, effectiveSizingPct(cfg))
 	}
 	return result
 }

--- a/cmd/multi_service_helpers.go
+++ b/cmd/multi_service_helpers.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/LeanerCloud/CUDly/pkg/common"
 	"github.com/LeanerCloud/CUDly/pkg/provider"
+	"github.com/LeanerCloud/CUDly/providers/aws/recommendations"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
 )
@@ -346,6 +347,7 @@ func processRegionRecommendations(
 	engineData engineVersionData,
 	isDryRun bool,
 	cfg Config,
+	coverageMap recommendations.PoolCoverageMap,
 ) regionRecommendations {
 	result := regionRecommendations{
 		recommendations: make([]common.Recommendation, 0),
@@ -374,7 +376,7 @@ func processRegionRecommendations(
 	}
 
 	// Apply coverage and overrides
-	filteredRecs := applyCoverageAndOverrides(recs, cfg)
+	filteredRecs := applyCoverageAndOverrides(recs, cfg, coverageMap)
 
 	result.recommendations = filteredRecs
 
@@ -461,7 +463,12 @@ func applyRegionFilters(
 // applyCoverageAndOverrides applies sizing (coverage % or target-coverage)
 // and count overrides. Sizing mode is selected by cfg.TargetCoverage: > 0
 // routes to ApplyTargetCoverage; otherwise the legacy ApplyCoverage path.
-func applyCoverageAndOverrides(recs []common.Recommendation, cfg Config) []common.Recommendation {
+// coverageMap (when non-nil) populates Recommendation.ExistingCoveragePct
+// before sizing so the under-buy formula can subtract pool coverage already
+// owned. Nil map = no-op; recs keep their default zero values and the
+// sizing path falls back to the no-existing-commitments formula.
+func applyCoverageAndOverrides(recs []common.Recommendation, cfg Config, coverageMap recommendations.PoolCoverageMap) []common.Recommendation {
+	recommendations.ApplyCoverageMapToRecommendations(recs, coverageMap)
 	filteredRecs := applySizing(recs, cfg, cfg.Coverage)
 	if cfg.TargetCoverage > 0 {
 		AppLogger.Printf("  🎯 Applying %.1f%% target-coverage: %d recommendations selected\n", cfg.TargetCoverage, len(filteredRecs))
@@ -514,6 +521,8 @@ func checkDuplicatesAndApplyLimit(
 
 // fetchAndFilterRegionRecs fetches, filters, applies coverage, and deduplicates
 // recommendations for a single service+region. No purchases are made.
+// coverageMap (when non-nil) feeds existing-pool coverage into the sizing
+// step for --target-coverage.
 func fetchAndFilterRegionRecs(
 	ctx context.Context,
 	awsCfg aws.Config,
@@ -524,6 +533,7 @@ func fetchAndFilterRegionRecs(
 	regionIndex, totalRegions int,
 	engineData engineVersionData,
 	cfg Config,
+	coverageMap recommendations.PoolCoverageMap,
 ) []common.Recommendation {
 	AppLogger.Printf("\n  📍 [%d/%d] Region: %s\n", regionIndex, totalRegions, region)
 
@@ -541,7 +551,7 @@ func fetchAndFilterRegionRecs(
 		return nil
 	}
 
-	recs = applyCoverageAndOverrides(recs, cfg)
+	recs = applyCoverageAndOverrides(recs, cfg, coverageMap)
 
 	// Deduplication: skip recs matching recently-purchased commitments
 	regionalCfg := awsCfg.Copy()
@@ -554,7 +564,10 @@ func fetchAndFilterRegionRecs(
 	return recs
 }
 
-// fetchAllRecs collects recommendations from all services and regions without purchasing.
+// fetchAllRecs collects recommendations from all services and regions without
+// purchasing. coverageMap (when non-nil) populates Recommendation.ExistingCoveragePct
+// on each rec before sizing, so --target-coverage can subtract what's already
+// owned in the same pool.
 func fetchAllRecs(
 	ctx context.Context,
 	awsCfg aws.Config,
@@ -563,6 +576,7 @@ func fetchAllRecs(
 	servicesToProcess []common.ServiceType,
 	engineData engineVersionData,
 	cfg Config,
+	coverageMap recommendations.PoolCoverageMap,
 ) []common.Recommendation {
 	all := make([]common.Recommendation, 0)
 	for _, service := range servicesToProcess {
@@ -576,7 +590,7 @@ func fetchAllRecs(
 			continue
 		}
 		for i, region := range regions {
-			recs := fetchAndFilterRegionRecs(ctx, awsCfg, recClient, accountCache, service, region, i+1, len(regions), engineData, cfg)
+			recs := fetchAndFilterRegionRecs(ctx, awsCfg, recClient, accountCache, service, region, i+1, len(regions), engineData, cfg, coverageMap)
 			all = append(all, recs...)
 		}
 	}

--- a/cmd/multi_service_helpers.go
+++ b/cmd/multi_service_helpers.go
@@ -375,8 +375,11 @@ func processRegionRecommendations(
 		return result
 	}
 
-	// Apply coverage and overrides
-	filteredRecs := applyCoverageAndOverrides(recs, cfg, coverageMap)
+	// Apply coverage and overrides. This legacy path (test-only) doesn't
+	// fetch expiring commitments — expiry-aware sizing only runs via the
+	// main pipeline in fetchAndFilterRegionRecs, which has access to the
+	// regional service client at the right moment.
+	filteredRecs := applyCoverageAndOverrides(recs, cfg, coverageMap, nil)
 
 	result.recommendations = filteredRecs
 
@@ -467,8 +470,19 @@ func applyRegionFilters(
 // before sizing so the under-buy formula can subtract pool coverage already
 // owned. Nil map = no-op; recs keep their default zero values and the
 // sizing path falls back to the no-existing-commitments formula.
-func applyCoverageAndOverrides(recs []common.Recommendation, cfg Config, coverageMap recommendations.PoolCoverageMap) []common.Recommendation {
+//
+// expiringCommitments (when non-empty and cfg.RebuyWindowDays > 0) reduces
+// ExistingCoveragePct further by the share of pool demand attributable to
+// RIs expiring within the window, so --target-coverage recommends
+// replacements before the cliff. Doesn't run if either input is empty.
+func applyCoverageAndOverrides(recs []common.Recommendation, cfg Config, coverageMap recommendations.PoolCoverageMap, expiringCommitments []common.Commitment) []common.Recommendation {
 	recommendations.ApplyCoverageMapToRecommendations(recs, coverageMap)
+	if cfg.RebuyWindowDays > 0 && len(expiringCommitments) > 0 {
+		n := recommendations.AdjustExistingCoverageForExpiringCommitments(recs, expiringCommitments, cfg.RebuyWindowDays)
+		if n > 0 {
+			AppLogger.Printf("  ⏰ Treating %d recs as partially uncovered (RIs expiring within %d days)\n", n, cfg.RebuyWindowDays)
+		}
+	}
 	filteredRecs := applySizing(recs, cfg, cfg.Coverage)
 	if cfg.TargetCoverage > 0 {
 		AppLogger.Printf("  🎯 Applying %.1f%% target-coverage: %d recommendations selected\n", cfg.TargetCoverage, len(filteredRecs))
@@ -551,12 +565,29 @@ func fetchAndFilterRegionRecs(
 		return nil
 	}
 
-	recs = applyCoverageAndOverrides(recs, cfg, coverageMap)
-
-	// Deduplication: skip recs matching recently-purchased commitments
+	// Build the regional service client once and reuse for both expiry-aware
+	// coverage adjustment and the downstream duplicate check.
 	regionalCfg := awsCfg.Copy()
 	regionalCfg.Region = region
 	serviceClient := createServiceClient(service, regionalCfg)
+
+	// Fetch existing commitments up front when --rebuy-window-days is set so
+	// the sizing step can deduct expiring RIs from ExistingCoveragePct.
+	// Best-effort: a failure here logs and continues; expiry adjustment
+	// becomes a no-op for this region.
+	var expiringCommitments []common.Commitment
+	if cfg.RebuyWindowDays > 0 && serviceClient != nil {
+		commits, err := serviceClient.GetExistingCommitments(ctx)
+		if err != nil {
+			AppLogger.Printf("  ⚠️  Could not fetch existing commitments for expiry check: %v\n", err)
+		} else {
+			expiringCommitments = commits
+		}
+	}
+
+	recs = applyCoverageAndOverrides(recs, cfg, coverageMap, expiringCommitments)
+
+	// Deduplication: skip recs matching recently-purchased commitments.
 	if serviceClient != nil {
 		recs = checkDuplicatesAndApplyLimit(ctx, recs, serviceClient, cfg)
 	}

--- a/cmd/validators.go
+++ b/cmd/validators.go
@@ -42,7 +42,7 @@ func validateNumericRanges(cmd *cobra.Command) error {
 		return fmt.Errorf("coverage percentage must be between 0 and 100, got: %.2f", toolCfg.Coverage)
 	}
 
-	if err := validateTargetUtilization(cmd); err != nil {
+	if err := validateTargetCoverage(cmd); err != nil {
 		return err
 	}
 
@@ -67,22 +67,22 @@ func validateNumericRanges(cmd *cobra.Command) error {
 	return nil
 }
 
-// validateTargetUtilization validates the --target-utilization range and
+// validateTargetCoverage validates the --target-coverage range and
 // emits an info-log when it is set alongside an explicitly-overridden
 // --coverage (target wins). Split out of validateNumericRanges to keep
 // the parent under gocyclo's complexity threshold.
-func validateTargetUtilization(cmd *cobra.Command) error {
-	if toolCfg.TargetUtilization < 0 || toolCfg.TargetUtilization > 100 {
-		return fmt.Errorf("target-utilization percentage must be between 0 and 100, got: %.2f", toolCfg.TargetUtilization)
+func validateTargetCoverage(cmd *cobra.Command) error {
+	if toolCfg.TargetCoverage < 0 || toolCfg.TargetCoverage > 100 {
+		return fmt.Errorf("target-coverage percentage must be between 0 and 100, got: %.2f", toolCfg.TargetCoverage)
 	}
 
-	// Info-log when both flags are explicitly set — target-utilization wins.
+	// Info-log when both flags are explicitly set — target-coverage wins.
 	// Detect "user explicitly set --coverage" via cobra's Changed() rather than
 	// comparing to the default value, so a user who happens to set --coverage 80
 	// (which equals the default) still sees the notice.
-	if toolCfg.TargetUtilization > 0 && cmd != nil && cmd.Flags().Changed("coverage") {
-		log.Printf("--target-utilization=%.1f set; --coverage=%.1f is being ignored (target-utilization sizing supersedes coverage sizing)",
-			toolCfg.TargetUtilization, toolCfg.Coverage)
+	if toolCfg.TargetCoverage > 0 && cmd != nil && cmd.Flags().Changed("coverage") {
+		log.Printf("--target-coverage=%.1f set; --coverage=%.1f is being ignored (target-coverage sizing supersedes coverage sizing)",
+			toolCfg.TargetCoverage, toolCfg.Coverage)
 	}
 	return nil
 }

--- a/cmd/validators.go
+++ b/cmd/validators.go
@@ -13,7 +13,7 @@ import (
 
 // validateFlags performs validation on command line flags before execution
 func validateFlags(cmd *cobra.Command, args []string) error {
-	if err := validateNumericRanges(); err != nil {
+	if err := validateNumericRanges(cmd); err != nil {
 		return err
 	}
 
@@ -32,11 +32,18 @@ func validateFlags(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// validateNumericRanges validates all numeric configuration values
-func validateNumericRanges() error {
+// validateNumericRanges validates all numeric configuration values.
+// cmd is used to detect explicitly-set flags via cobra's Changed(); pass
+// nil if no flag-source-detection is required (e.g. unit-test paths that
+// only need the numeric bounds checks).
+func validateNumericRanges(cmd *cobra.Command) error {
 	// Validate coverage percentage
 	if toolCfg.Coverage < 0 || toolCfg.Coverage > 100 {
 		return fmt.Errorf("coverage percentage must be between 0 and 100, got: %.2f", toolCfg.Coverage)
+	}
+
+	if err := validateTargetUtilization(cmd); err != nil {
+		return err
 	}
 
 	// Validate max instances
@@ -57,6 +64,26 @@ func validateNumericRanges() error {
 		return fmt.Errorf("override-count (%d) exceeds reasonable limit of %d", toolCfg.OverrideCount, MaxReasonableInstances)
 	}
 
+	return nil
+}
+
+// validateTargetUtilization validates the --target-utilization range and
+// emits an info-log when it is set alongside an explicitly-overridden
+// --coverage (target wins). Split out of validateNumericRanges to keep
+// the parent under gocyclo's complexity threshold.
+func validateTargetUtilization(cmd *cobra.Command) error {
+	if toolCfg.TargetUtilization < 0 || toolCfg.TargetUtilization > 100 {
+		return fmt.Errorf("target-utilization percentage must be between 0 and 100, got: %.2f", toolCfg.TargetUtilization)
+	}
+
+	// Info-log when both flags are explicitly set — target-utilization wins.
+	// Detect "user explicitly set --coverage" via cobra's Changed() rather than
+	// comparing to the default value, so a user who happens to set --coverage 80
+	// (which equals the default) still sees the notice.
+	if toolCfg.TargetUtilization > 0 && cmd != nil && cmd.Flags().Changed("coverage") {
+		log.Printf("--target-utilization=%.1f set; --coverage=%.1f is being ignored (target-utilization sizing supersedes coverage sizing)",
+			toolCfg.TargetUtilization, toolCfg.Coverage)
+	}
 	return nil
 }
 

--- a/cmd/validators_test.go
+++ b/cmd/validators_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/LeanerCloud/CUDly/pkg/common"
+	"github.com/spf13/cobra"
 )
 
 func TestValidateNumericRanges(t *testing.T) {
@@ -415,11 +416,12 @@ func TestValidateNoConflicts(t *testing.T) {
 // Note: TestValidateInstanceTypes and TestValidateFlags already exist in main_test.go
 
 // TestValidateTargetCoverage covers the --target-coverage range check
-// and the "both flags explicitly set" info-log gate. The log itself isn't
-// asserted (log goes to stderr via log.Printf and capturing it from this
-// package's tests is more friction than value); we verify the validator
-// does not error in the "both set" case and does error on out-of-range
-// values.
+// and the "both flags explicitly set" info-log gate. Range cases pass nil
+// cmd (the explicit-flag detection is irrelevant for them); the "both set"
+// case constructs a real cobra command and marks --coverage as explicitly
+// set so the Changed("coverage") branch actually fires. The log line
+// itself isn't asserted (log.Printf goes to stderr and capturing it from
+// this package is more friction than value).
 func TestValidateTargetCoverage(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -427,6 +429,10 @@ func TestValidateTargetCoverage(t *testing.T) {
 		coverage  float64
 		wantErr   bool
 		errSubstr string
+		// useCobraCmd controls whether the test builds a real cobra command
+		// with --coverage marked as Changed, exercising the precedence-log
+		// gate. False keeps the nil-cmd shortcut for pure range checks.
+		useCobraCmd bool
 	}{
 		{name: "disabled (zero) is valid", target: 0, coverage: 80, wantErr: false},
 		{name: "min boundary valid", target: 0.0001, coverage: 80, wantErr: false},
@@ -441,16 +447,32 @@ func TestValidateTargetCoverage(t *testing.T) {
 			errSubstr: "target-coverage percentage must be between 0 and 100",
 		},
 		{
-			// Both flags valid — should not error. The info-log is fired but
-			// not asserted (out-of-band stderr write).
-			name: "target + coverage both set, both valid", target: 95, coverage: 50, wantErr: false,
+			// Both flags explicitly set — the precedence info-log fires;
+			// validation still passes. useCobraCmd builds a real command so
+			// Changed("coverage") returns true; without this the branch is
+			// effectively dead code in the test.
+			name:        "target + coverage both set, both valid",
+			target:      95,
+			coverage:    50,
+			wantErr:     false,
+			useCobraCmd: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			toolCfg = Config{Coverage: tt.coverage, TargetCoverage: tt.target}
-			err := validateNumericRanges(nil)
+			var cmd *cobra.Command
+			if tt.useCobraCmd {
+				cmd = &cobra.Command{Use: "test"}
+				// Default doesn't matter — the Set call below marks the flag
+				// as Changed, which is what validateTargetCoverage checks.
+				cmd.Flags().Float64("coverage", 80, "")
+				if err := cmd.Flags().Set("coverage", "50"); err != nil {
+					t.Fatalf("failed to mark coverage flag as Changed: %v", err)
+				}
+			}
+			err := validateNumericRanges(cmd)
 			if tt.wantErr {
 				if err == nil {
 					t.Errorf("validateNumericRanges() expected error containing %q, got nil", tt.errSubstr)

--- a/cmd/validators_test.go
+++ b/cmd/validators_test.go
@@ -89,7 +89,7 @@ func TestValidateNumericRanges(t *testing.T) {
 
 			// Execute (nil cmd — these tests only exercise the numeric
 			// bounds checks; the flag-source-detection branch is covered
-			// by TestValidateTargetUtilization below).
+			// by TestValidateTargetCoverage below).
 			err := validateNumericRanges(nil)
 
 			// Verify
@@ -414,13 +414,13 @@ func TestValidateNoConflicts(t *testing.T) {
 
 // Note: TestValidateInstanceTypes and TestValidateFlags already exist in main_test.go
 
-// TestValidateTargetUtilization covers the --target-utilization range check
+// TestValidateTargetCoverage covers the --target-coverage range check
 // and the "both flags explicitly set" info-log gate. The log itself isn't
 // asserted (log goes to stderr via log.Printf and capturing it from this
 // package's tests is more friction than value); we verify the validator
 // does not error in the "both set" case and does error on out-of-range
 // values.
-func TestValidateTargetUtilization(t *testing.T) {
+func TestValidateTargetCoverage(t *testing.T) {
 	tests := []struct {
 		name      string
 		target    float64
@@ -434,11 +434,11 @@ func TestValidateTargetUtilization(t *testing.T) {
 		{name: "mid-range valid", target: 95, coverage: 80, wantErr: false},
 		{
 			name: "negative target rejected", target: -0.5, coverage: 80, wantErr: true,
-			errSubstr: "target-utilization percentage must be between 0 and 100",
+			errSubstr: "target-coverage percentage must be between 0 and 100",
 		},
 		{
 			name: "above 100 rejected", target: 100.01, coverage: 80, wantErr: true,
-			errSubstr: "target-utilization percentage must be between 0 and 100",
+			errSubstr: "target-coverage percentage must be between 0 and 100",
 		},
 		{
 			// Both flags valid — should not error. The info-log is fired but
@@ -449,7 +449,7 @@ func TestValidateTargetUtilization(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			toolCfg = Config{Coverage: tt.coverage, TargetUtilization: tt.target}
+			toolCfg = Config{Coverage: tt.coverage, TargetCoverage: tt.target}
 			err := validateNumericRanges(nil)
 			if tt.wantErr {
 				if err == nil {

--- a/cmd/validators_test.go
+++ b/cmd/validators_test.go
@@ -87,8 +87,10 @@ func TestValidateNumericRanges(t *testing.T) {
 			toolCfg = Config{}
 			tt.setupFunc()
 
-			// Execute
-			err := validateNumericRanges()
+			// Execute (nil cmd — these tests only exercise the numeric
+			// bounds checks; the flag-source-detection branch is covered
+			// by TestValidateTargetUtilization below).
+			err := validateNumericRanges(nil)
 
 			// Verify
 			if tt.wantErr {
@@ -411,3 +413,53 @@ func TestValidateNoConflicts(t *testing.T) {
 }
 
 // Note: TestValidateInstanceTypes and TestValidateFlags already exist in main_test.go
+
+// TestValidateTargetUtilization covers the --target-utilization range check
+// and the "both flags explicitly set" info-log gate. The log itself isn't
+// asserted (log goes to stderr via log.Printf and capturing it from this
+// package's tests is more friction than value); we verify the validator
+// does not error in the "both set" case and does error on out-of-range
+// values.
+func TestValidateTargetUtilization(t *testing.T) {
+	tests := []struct {
+		name      string
+		target    float64
+		coverage  float64
+		wantErr   bool
+		errSubstr string
+	}{
+		{name: "disabled (zero) is valid", target: 0, coverage: 80, wantErr: false},
+		{name: "min boundary valid", target: 0.0001, coverage: 80, wantErr: false},
+		{name: "max boundary valid", target: 100, coverage: 80, wantErr: false},
+		{name: "mid-range valid", target: 95, coverage: 80, wantErr: false},
+		{
+			name: "negative target rejected", target: -0.5, coverage: 80, wantErr: true,
+			errSubstr: "target-utilization percentage must be between 0 and 100",
+		},
+		{
+			name: "above 100 rejected", target: 100.01, coverage: 80, wantErr: true,
+			errSubstr: "target-utilization percentage must be between 0 and 100",
+		},
+		{
+			// Both flags valid — should not error. The info-log is fired but
+			// not asserted (out-of-band stderr write).
+			name: "target + coverage both set, both valid", target: 95, coverage: 50, wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			toolCfg = Config{Coverage: tt.coverage, TargetUtilization: tt.target}
+			err := validateNumericRanges(nil)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("validateNumericRanges() expected error containing %q, got nil", tt.errSubstr)
+				} else if tt.errSubstr != "" && !strings.Contains(err.Error(), tt.errSubstr) {
+					t.Errorf("validateNumericRanges() error = %v, want substring %q", err, tt.errSubstr)
+				}
+			} else if err != nil {
+				t.Errorf("validateNumericRanges() unexpected error = %v", err)
+			}
+		})
+	}
+}

--- a/internal/reporter/reporter.go
+++ b/internal/reporter/reporter.go
@@ -82,6 +82,10 @@ func RenderExcluded(result scorer.ScoredResult) string {
 
 // RenderSummary returns a one-paragraph summary: total estimated savings and cost for
 // passed recommendations, plus count of filtered recommendations with a reason breakdown.
+//
+// EstimatedSavings is monthly: sourced from AWS's EstimatedMonthlySavingsAmount
+// (see providers/aws/recommendations/parser_ri.go). CommitmentCost is the
+// upfront portion (one-time), so the two figures are NOT on the same timescale.
 func RenderSummary(result scorer.ScoredResult) string {
 	var totalSavings, totalCost float64
 	for _, rec := range result.Passed {
@@ -90,7 +94,7 @@ func RenderSummary(result scorer.ScoredResult) string {
 	}
 
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "Passed: %d recommendations — estimated savings $%.2f/yr, commitment cost $%.2f\n",
+	fmt.Fprintf(&sb, "Passed: %d recommendations — estimated savings $%.2f/mo, upfront commitment $%.2f\n",
 		len(result.Passed), totalSavings, totalCost)
 
 	if len(result.Filtered) > 0 {

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -172,8 +172,12 @@ type Recommendation struct {
 	// RecommendedUtilization is "what AWS projects for the full recommendation"
 	// (%). ProjectedUtilization / ProjectedCoverage are populated by the sizing
 	// step after we pick our own quantity.
+	// RecommendedCount is AWS's pre-sizing count (mirrors Count before
+	// ApplyCoverage / ApplyTargetCoverage mutates Count); zero for SPs since
+	// the SP commitment is dollar-denominated rather than count-denominated.
 	AverageInstancesUsedPerHour float64 `json:"average_instances_used_per_hour,omitempty" csv:"AverageInstancesUsedPerHour"`
 	RecommendedUtilization      float64 `json:"recommended_utilization,omitempty" csv:"RecommendedUtilization"`
+	RecommendedCount            int     `json:"recommended_count,omitempty" csv:"RecommendedCount"`
 	ProjectedUtilization        float64 `json:"projected_utilization,omitempty" csv:"ProjectedUtilization"`
 	ProjectedCoverage           float64 `json:"projected_coverage,omitempty" csv:"ProjectedCoverage"`
 

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -255,7 +255,16 @@ func NormalizeSource(s string) (string, error) {
 	}
 }
 
-// Commitment represents an existing commitment (RI/SP/CUD/etc)
+// Commitment represents an existing commitment (RI/SP/CUD/etc).
+//
+// Deployment is RDS-specific (Multi-AZ vs Single-AZ); it stays empty for
+// services that don't have a deployment dimension (EC2, ElastiCache,
+// etc). When populated, it carries the same vocabulary as
+// DatabaseDetails.AZConfig on Recommendation ("single-az" / "multi-az")
+// so pool-key matching can collapse both sides via normaliseDeployment
+// in the recommendations package. Without this field, RDS expiry
+// adjustments would silently miss because Recommendation lookup keys
+// are deployment-aware while commitment keys defaulted to empty.
 type Commitment struct {
 	Provider       ProviderType   `json:"provider"`
 	Account        string         `json:"account"`
@@ -264,7 +273,8 @@ type Commitment struct {
 	Service        ServiceType    `json:"service"`
 	Region         string         `json:"region"`
 	ResourceType   string         `json:"resource_type"`
-	Engine         string         `json:"engine,omitempty"` // Database engine for RDS/ElastiCache (e.g., "mysql", "aurora-postgresql")
+	Engine         string         `json:"engine,omitempty"`     // Database engine for RDS/ElastiCache (e.g., "mysql", "aurora-postgresql")
+	Deployment     string         `json:"deployment,omitempty"` // RDS Multi-AZ vs Single-AZ; empty for non-RDS
 	Count          int            `json:"count"`
 	StartDate      time.Time      `json:"start_date"`
 	EndDate        time.Time      `json:"end_date"`

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -207,6 +207,24 @@ type ServiceDetails interface {
 	GetDetailDescription() string
 }
 
+// ScaleRecommendationCosts multiplies all cost-bearing fields of rec by
+// ratio and returns the result. RecurringMonthlyCost is allocated as a
+// new pointer when present so callers don't mutate the upstream rec's
+// pointer target. Used by sizing paths (ApplyCoverage, ApplyTargetCoverage,
+// family-NU) to keep Count and cost in sync when a recommendation is
+// sized down (or up) from AWS's proposal — without this helper the same
+// four-field scaling pattern was duplicated at every sizing site.
+func ScaleRecommendationCosts(rec Recommendation, ratio float64) Recommendation {
+	rec.CommitmentCost *= ratio
+	rec.OnDemandCost *= ratio
+	rec.EstimatedSavings *= ratio
+	if rec.RecurringMonthlyCost != nil {
+		scaled := *rec.RecurringMonthlyCost * ratio
+		rec.RecurringMonthlyCost = &scaled
+	}
+	return rec
+}
+
 // PurchaseResult represents the outcome of a commitment purchase
 type PurchaseResult struct {
 	Recommendation Recommendation `json:"recommendation"`

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -167,7 +167,7 @@ type Recommendation struct {
 	BreakEvenMonths float64 `json:"break_even_months,omitempty" csv:"BreakEvenMonths"`
 
 	// Utilization signals — populated by cloud parsers when the API exposes them.
-	// Used by --target-utilization sizing (see cmd/helpers.go: ApplyTargetUtilization).
+	// Used by --target-coverage sizing (see cmd/helpers.go: ApplyTargetCoverage).
 	// AverageInstancesUsedPerHour is RI-only (zero for SPs and other commitment types).
 	// RecommendedUtilization is "what AWS projects for the full recommendation"
 	// (%). ProjectedUtilization / ProjectedCoverage are populated by the sizing

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -175,9 +175,15 @@ type Recommendation struct {
 	// RecommendedCount is AWS's pre-sizing count (mirrors Count before
 	// ApplyCoverage / ApplyTargetCoverage mutates Count); zero for SPs since
 	// the SP commitment is dollar-denominated rather than count-denominated.
+	// ExistingCoveragePct is the share of demand already covered by existing
+	// commitments in the same pool (from CE GetReservationCoverage /
+	// GetSavingsPlansCoverage). Zero = "no signal" (CE returned nothing for
+	// this pool, or the fetch step wasn't run); sizing then degenerates to
+	// the no-existing-commitments path. See cmd/helpers.go.
 	AverageInstancesUsedPerHour float64 `json:"average_instances_used_per_hour,omitempty" csv:"AverageInstancesUsedPerHour"`
 	RecommendedUtilization      float64 `json:"recommended_utilization,omitempty" csv:"RecommendedUtilization"`
 	RecommendedCount            int     `json:"recommended_count,omitempty" csv:"RecommendedCount"`
+	ExistingCoveragePct         float64 `json:"existing_coverage_pct,omitempty" csv:"ExistingCoveragePct"`
 	ProjectedUtilization        float64 `json:"projected_utilization,omitempty" csv:"ProjectedUtilization"`
 	ProjectedCoverage           float64 `json:"projected_coverage,omitempty" csv:"ProjectedCoverage"`
 

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -166,6 +166,17 @@ type Recommendation struct {
 	// Break-even in months (populated by cloud parsers where available; used by scorer filter)
 	BreakEvenMonths float64 `json:"break_even_months,omitempty" csv:"BreakEvenMonths"`
 
+	// Utilization signals — populated by cloud parsers when the API exposes them.
+	// Used by --target-utilization sizing (see cmd/helpers.go: ApplyTargetUtilization).
+	// AverageInstancesUsedPerHour is RI-only (zero for SPs and other commitment types).
+	// RecommendedUtilization is "what AWS projects for the full recommendation"
+	// (%). ProjectedUtilization / ProjectedCoverage are populated by the sizing
+	// step after we pick our own quantity.
+	AverageInstancesUsedPerHour float64 `json:"average_instances_used_per_hour,omitempty" csv:"AverageInstancesUsedPerHour"`
+	RecommendedUtilization      float64 `json:"recommended_utilization,omitempty" csv:"RecommendedUtilization"`
+	ProjectedUtilization        float64 `json:"projected_utilization,omitempty" csv:"ProjectedUtilization"`
+	ProjectedCoverage           float64 `json:"projected_coverage,omitempty" csv:"ProjectedCoverage"`
+
 	// RawRecommendation holds the original cloud API response bytes for audit/debugging.
 	// omitempty ensures nil is absent from JSON (not written as null).
 	RawRecommendation json.RawMessage `json:"raw_recommendation,omitempty" csv:"-"`

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -184,8 +184,17 @@ type Recommendation struct {
 	RecommendedUtilization      float64 `json:"recommended_utilization,omitempty" csv:"RecommendedUtilization"`
 	RecommendedCount            int     `json:"recommended_count,omitempty" csv:"RecommendedCount"`
 	ExistingCoveragePct         float64 `json:"existing_coverage_pct,omitempty" csv:"ExistingCoveragePct"`
-	ProjectedUtilization        float64 `json:"projected_utilization,omitempty" csv:"ProjectedUtilization"`
-	ProjectedCoverage           float64 `json:"projected_coverage,omitempty" csv:"ProjectedCoverage"`
+	// ExistingCoverageKnown distinguishes "CE returned a value for this
+	// pool" (Known=true, Pct possibly 0.0 meaning the pool has running
+	// instances but no RI coverage yet) from "CE has no data for this
+	// pool" (Known=false, Pct=0.0 by default). Set by
+	// ApplyCoverageMapToRecommendations whenever a pool lookup hits, and
+	// by family-NU sizing when a family-level existing% lands on the rec.
+	// CSV writers use this to render "n/a" for unknown vs "0.0" for
+	// genuine zero-coverage pools.
+	ExistingCoverageKnown bool    `json:"existing_coverage_known,omitempty" csv:"-"`
+	ProjectedUtilization  float64 `json:"projected_utilization,omitempty" csv:"ProjectedUtilization"`
+	ProjectedCoverage     float64 `json:"projected_coverage,omitempty" csv:"ProjectedCoverage"`
 
 	// RawRecommendation holds the original cloud API response bytes for audit/debugging.
 	// omitempty ensures nil is absent from JSON (not written as null).

--- a/providers/aws/recommendations/client.go
+++ b/providers/aws/recommendations/client.go
@@ -20,6 +20,7 @@ type CostExplorerAPI interface {
 	GetReservationPurchaseRecommendation(ctx context.Context, params *costexplorer.GetReservationPurchaseRecommendationInput, optFns ...func(*costexplorer.Options)) (*costexplorer.GetReservationPurchaseRecommendationOutput, error)
 	GetSavingsPlansPurchaseRecommendation(ctx context.Context, params *costexplorer.GetSavingsPlansPurchaseRecommendationInput, optFns ...func(*costexplorer.Options)) (*costexplorer.GetSavingsPlansPurchaseRecommendationOutput, error)
 	GetReservationUtilization(ctx context.Context, params *costexplorer.GetReservationUtilizationInput, optFns ...func(*costexplorer.Options)) (*costexplorer.GetReservationUtilizationOutput, error)
+	GetReservationCoverage(ctx context.Context, params *costexplorer.GetReservationCoverageInput, optFns ...func(*costexplorer.Options)) (*costexplorer.GetReservationCoverageOutput, error)
 }
 
 // Client wraps the AWS Cost Explorer client for RI recommendations

--- a/providers/aws/recommendations/client_test.go
+++ b/providers/aws/recommendations/client_test.go
@@ -47,6 +47,10 @@ func (m *mockCostExplorerAPI) GetReservationUtilization(ctx context.Context, par
 	return &costexplorer.GetReservationUtilizationOutput{}, nil
 }
 
+func (m *mockCostExplorerAPI) GetReservationCoverage(ctx context.Context, params *costexplorer.GetReservationCoverageInput, optFns ...func(*costexplorer.Options)) (*costexplorer.GetReservationCoverageOutput, error) {
+	return &costexplorer.GetReservationCoverageOutput{}, nil
+}
+
 func TestNewClient(t *testing.T) {
 	cfg := aws.Config{
 		Region: "us-west-2",

--- a/providers/aws/recommendations/coverage.go
+++ b/providers/aws/recommendations/coverage.go
@@ -13,6 +13,21 @@ import (
 	"github.com/LeanerCloud/CUDly/pkg/common"
 )
 
+// coverageServiceFilters lists the Cost Explorer service-dimension values
+// we issue GetReservationCoverage against. CE returns only EC2 coverage when
+// no SERVICE filter is set, so any account that runs RDS/ElastiCache/
+// OpenSearch/Redshift RIs needs a per-service call. The service strings here
+// match CE's canonical dimension values (case-sensitive); the comments
+// indicate which CUDly internal common.ServiceType they correspond to.
+var coverageServiceFilters = []string{
+	"Amazon Elastic Compute Cloud - Compute", // EC2
+	"Amazon Relational Database Service",     // RDS (incl. Aurora)
+	"Amazon ElastiCache",                     // ElastiCache
+	"Amazon OpenSearch Service",              // OpenSearch
+	"Amazon Redshift",                        // Redshift
+	"Amazon MemoryDB",                        // MemoryDB
+}
+
 // PoolCoverageMap maps "region:instance_type" (lowercase) to the share of
 // historical demand already covered by existing reservations in that pool,
 // expressed as a 0-100 percentage. Used by --target-coverage sizing to
@@ -47,34 +62,60 @@ func (c *Client) GetRICoverageMap(ctx context.Context, lookbackDays int) (PoolCo
 	}
 	end := time.Now().UTC()
 	start := end.AddDate(0, 0, -lookbackDays)
+	startStr := start.Format("2006-01-02")
+	endStr := end.Format("2006-01-02")
 
+	out := make(PoolCoverageMap)
+	for _, service := range coverageServiceFilters {
+		if err := c.fetchCoverageForService(ctx, startStr, endStr, service, out); err != nil {
+			return nil, fmt.Errorf("fetching coverage for service %q: %w", service, err)
+		}
+	}
+	return out, nil
+}
+
+// fetchCoverageForService runs the paged GetReservationCoverage loop for a
+// single SERVICE dimension value and writes the (region, instance_type) →
+// HoursPercentage entries into out. Split per-service because CE returns
+// only EC2 coverage when no SERVICE filter is set, so a single
+// no-filter call hides RDS/ElastiCache/etc. coverage entirely.
+func (c *Client) fetchCoverageForService(ctx context.Context, startStr, endStr, service string, out PoolCoverageMap) error {
 	input := &costexplorer.GetReservationCoverageInput{
 		TimePeriod: &types.DateInterval{
-			Start: aws.String(start.Format("2006-01-02")),
-			End:   aws.String(end.Format("2006-01-02")),
+			Start: aws.String(startStr),
+			End:   aws.String(endStr),
 		},
 		GroupBy: []types.GroupDefinition{
 			{Type: types.GroupDefinitionTypeDimension, Key: aws.String("REGION")},
 			{Type: types.GroupDefinitionTypeDimension, Key: aws.String("INSTANCE_TYPE")},
 		},
-		Metrics: []string{"HoursPercentage"},
+		Filter: &types.Expression{
+			Dimensions: &types.DimensionValues{
+				Key:    types.DimensionService,
+				Values: []string{service},
+			},
+		},
+		// "Hour" tells CE to include the Hour coverage block in the response;
+		// CoverageHoursPercentage inside that block is what we actually parse.
+		// HoursPercentage isn't a valid Metrics value (CE rejects it with
+		// ValidationException) — Metrics names the block, the percentage
+		// field is computed and included automatically.
+		Metrics: []string{"Hour"},
 	}
 
-	out := make(PoolCoverageMap)
 	var token *string
 	for {
 		input.NextPageToken = token
 		result, err := c.fetchCoveragePage(ctx, input)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		accumulateCoverageGroups(out, result.CoveragesByTime)
 		if result.NextPageToken == nil || *result.NextPageToken == "" {
-			break
+			return nil
 		}
 		token = result.NextPageToken
 	}
-	return out, nil
 }
 
 // fetchCoveragePage calls the Cost Explorer API with rate-limit retry.
@@ -105,8 +146,7 @@ func (c *Client) fetchCoveragePage(ctx context.Context, input *costexplorer.GetR
 func accumulateCoverageGroups(out PoolCoverageMap, byTime []types.CoverageByTime) {
 	for _, period := range byTime {
 		for _, group := range period.Groups {
-			region := strings.ToLower(group.Attributes["REGION"])
-			instType := strings.ToLower(group.Attributes["INSTANCE_TYPE"])
+			region, instType := extractGroupPoolKey(group.Attributes)
 			if region == "" || instType == "" {
 				continue
 			}
@@ -118,6 +158,24 @@ func accumulateCoverageGroups(out PoolCoverageMap, byTime []types.CoverageByTime
 			out[poolKey(region, instType)] = pct
 		}
 	}
+}
+
+// extractGroupPoolKey reads the REGION and INSTANCE_TYPE values from CE's
+// Attributes map. CE sends keys in camelCase (e.g. "region", "instanceType")
+// even though the GroupBy input expects SCREAMING_SNAKE_CASE
+// ("REGION", "INSTANCE_TYPE"); normalise both sides by stripping underscores
+// and lower-casing before comparing. Returns ("", "") when either dimension
+// is missing — caller skips those groups.
+func extractGroupPoolKey(attrs map[string]string) (region, instanceType string) {
+	for k, v := range attrs {
+		switch strings.ToLower(strings.ReplaceAll(k, "_", "")) {
+		case "region":
+			region = strings.ToLower(v)
+		case "instancetype":
+			instanceType = strings.ToLower(v)
+		}
+	}
+	return region, instanceType
 }
 
 // ApplyCoverageMapToRecommendations sets ExistingCoveragePct on each rec

--- a/providers/aws/recommendations/coverage.go
+++ b/providers/aws/recommendations/coverage.go
@@ -452,6 +452,7 @@ func ApplyCoverageMapToRecommendations(recs []common.Recommendation, coverage Po
 			continue
 		}
 		recs[i].ExistingCoveragePct = cov.Pct
+		recs[i].ExistingCoverageKnown = true
 		if cov.AvgInstancesPerHour <= 0 {
 			// No org-wide avg signal — leave rec.avg as-is (rec API's
 			// per-account number is the only signal we have for sizing).

--- a/providers/aws/recommendations/coverage.go
+++ b/providers/aws/recommendations/coverage.go
@@ -1,0 +1,140 @@
+package recommendations
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/costexplorer"
+	"github.com/aws/aws-sdk-go-v2/service/costexplorer/types"
+
+	"github.com/LeanerCloud/CUDly/pkg/common"
+)
+
+// PoolCoverageMap maps "region:instance_type" (lowercase) to the share of
+// historical demand already covered by existing reservations in that pool,
+// expressed as a 0-100 percentage. Used by --target-coverage sizing to
+// subtract existing commitments from the under-buy formula.
+type PoolCoverageMap map[string]float64
+
+// poolKey returns the canonical lookup key for a (region, instance_type)
+// pair. Both inputs are lower-cased so callers don't have to normalise
+// case at every site.
+func poolKey(region, instanceType string) string {
+	return strings.ToLower(region) + ":" + strings.ToLower(instanceType)
+}
+
+// GetRICoverageMap fetches existing-RI coverage % over the last lookbackDays
+// days, returning a map keyed by "region:instance_type". Operators wiring
+// the result back onto Recommendation.ExistingCoveragePct should call
+// ApplyCoverageMapToRecommendations rather than walking the map manually.
+//
+// CE's GetReservationCoverage accepts at most 2 GroupBy dimensions, so we
+// pick REGION + INSTANCE_TYPE as the dominant per-pool dimensions across
+// EC2, RDS, ElastiCache and OpenSearch RIs. Finer dimensions (OS, tenancy
+// for EC2; engine, multi-AZ for RDS) are aggregated together — imprecise
+// for mixed pools but the API doesn't let us slice finer in one call.
+//
+// Missing pools (no existing commitment in the pool) are omitted from the
+// map; ApplyCoverageMapToRecommendations leaves ExistingCoveragePct at zero
+// for those recs, which the sizing path treats as "no signal" and falls
+// back to the no-existing-commitments formula.
+func (c *Client) GetRICoverageMap(ctx context.Context, lookbackDays int) (PoolCoverageMap, error) {
+	if lookbackDays <= 0 {
+		lookbackDays = 30
+	}
+	end := time.Now().UTC()
+	start := end.AddDate(0, 0, -lookbackDays)
+
+	input := &costexplorer.GetReservationCoverageInput{
+		TimePeriod: &types.DateInterval{
+			Start: aws.String(start.Format("2006-01-02")),
+			End:   aws.String(end.Format("2006-01-02")),
+		},
+		GroupBy: []types.GroupDefinition{
+			{Type: types.GroupDefinitionTypeDimension, Key: aws.String("REGION")},
+			{Type: types.GroupDefinitionTypeDimension, Key: aws.String("INSTANCE_TYPE")},
+		},
+		Metrics: []string{"HoursPercentage"},
+	}
+
+	out := make(PoolCoverageMap)
+	var token *string
+	for {
+		input.NextPageToken = token
+		result, err := c.fetchCoveragePage(ctx, input)
+		if err != nil {
+			return nil, err
+		}
+		accumulateCoverageGroups(out, result.CoveragesByTime)
+		if result.NextPageToken == nil || *result.NextPageToken == "" {
+			break
+		}
+		token = result.NextPageToken
+	}
+	return out, nil
+}
+
+// fetchCoveragePage calls the Cost Explorer API with rate-limit retry.
+// Mirrors fetchUtilizationPage so the two paths fail and back off the
+// same way.
+func (c *Client) fetchCoveragePage(ctx context.Context, input *costexplorer.GetReservationCoverageInput) (*costexplorer.GetReservationCoverageOutput, error) {
+	c.rateLimiter.Reset()
+	for {
+		if waitErr := c.rateLimiter.Wait(ctx); waitErr != nil {
+			return nil, fmt.Errorf("rate limiter wait failed: %w", waitErr)
+		}
+		result, err := c.costExplorerClient.GetReservationCoverage(ctx, input)
+		if !c.rateLimiter.ShouldRetry(err) {
+			if err != nil {
+				return nil, fmt.Errorf("failed to get reservation coverage: %w", err)
+			}
+			return result, nil
+		}
+	}
+}
+
+// accumulateCoverageGroups walks a page of CE coverage responses and writes
+// the (region, instance_type) → HoursPercentage entries into out. Later
+// pages overwrite earlier ones for the same key — CE returns one group per
+// (region, instance_type) per time period, so collisions only happen across
+// time periods and we keep the latest value (sufficient as a single-figure
+// summary; finer time-series analysis is out of scope here).
+func accumulateCoverageGroups(out PoolCoverageMap, byTime []types.CoverageByTime) {
+	for _, period := range byTime {
+		for _, group := range period.Groups {
+			region := strings.ToLower(group.Attributes["REGION"])
+			instType := strings.ToLower(group.Attributes["INSTANCE_TYPE"])
+			if region == "" || instType == "" {
+				continue
+			}
+			if group.Coverage == nil || group.Coverage.CoverageHours == nil ||
+				group.Coverage.CoverageHours.CoverageHoursPercentage == nil {
+				continue
+			}
+			pct := parseFloat(aws.ToString(group.Coverage.CoverageHours.CoverageHoursPercentage))
+			out[poolKey(region, instType)] = pct
+		}
+	}
+}
+
+// ApplyCoverageMapToRecommendations sets ExistingCoveragePct on each rec
+// whose (region, ResourceType) appears in the map. Recs without a match
+// stay at zero, which the sizing path treats as "no signal" and falls
+// back to the no-existing-commitments formula.
+//
+// Mutates recs in place to mirror the way the sizing pipeline already
+// hands recs around by value within each loop iteration.
+func ApplyCoverageMapToRecommendations(recs []common.Recommendation, coverage PoolCoverageMap) {
+	if len(coverage) == 0 {
+		return
+	}
+	for i := range recs {
+		key := poolKey(recs[i].Region, recs[i].ResourceType)
+		if pct, ok := coverage[key]; ok {
+			recs[i].ExistingCoveragePct = pct
+		}
+	}
+}

--- a/providers/aws/recommendations/coverage.go
+++ b/providers/aws/recommendations/coverage.go
@@ -19,19 +19,44 @@ import (
 // OpenSearch/Redshift RIs needs a per-service call. The service strings here
 // match CE's canonical dimension values (case-sensitive); the comments
 // indicate which CUDly internal common.ServiceType they correspond to.
+//
+// RDS gets special handling further down — same instance type often runs
+// multiple engines in the same region, and CE GroupBy is limited to two
+// dimensions, so we fan out across engines via the DATABASE_ENGINE filter
+// instead of the GroupBy.
 var coverageServiceFilters = []string{
 	"Amazon Elastic Compute Cloud - Compute", // EC2
-	"Amazon Relational Database Service",     // RDS (incl. Aurora)
 	"Amazon ElastiCache",                     // ElastiCache
 	"Amazon OpenSearch Service",              // OpenSearch
 	"Amazon Redshift",                        // Redshift
 	"Amazon MemoryDB",                        // MemoryDB
 }
 
-// PoolCoverageMap maps "region:instance_type" (lowercase) to the share of
-// historical demand already covered by existing reservations in that pool,
-// expressed as a 0-100 percentage. Used by --target-coverage sizing to
-// subtract existing commitments from the under-buy formula.
+// rdsCoverageEngines enumerates CE's DATABASE_ENGINE dimension values for
+// RDS recommendations. CUDly's parser normalises engine names to lowercase
+// shorthand (e.g. "aurora-postgresql") for rec.Details.Engine; CE expects
+// the human-readable form here (e.g. "Aurora PostgreSQL"). The
+// rdsEngineKeyFromCE / rdsEngineKeyFromRec helpers normalise both sides to
+// the same lookup key.
+var rdsCoverageEngines = []string{
+	"MySQL",
+	"PostgreSQL",
+	"MariaDB",
+	"Oracle",
+	"SQL Server",
+	"Aurora MySQL",
+	"Aurora PostgreSQL",
+}
+
+const rdsServiceFilter = "Amazon Relational Database Service"
+
+// PoolCoverageMap maps a pool key to the share of historical demand already
+// covered by existing reservations in that pool, expressed as a 0-100
+// percentage. Used by --target-coverage sizing to subtract existing
+// commitments from the under-buy formula. Non-RDS keys are
+// "region:instance_type"; RDS keys are "region:instance_type:engine"
+// because the same instance type often runs different engines in the same
+// region and their existing-RI coverage doesn't bleed across.
 type PoolCoverageMap map[string]float64
 
 // poolKey returns the canonical lookup key for a (region, instance_type)
@@ -39,6 +64,28 @@ type PoolCoverageMap map[string]float64
 // case at every site.
 func poolKey(region, instanceType string) string {
 	return strings.ToLower(region) + ":" + strings.ToLower(instanceType)
+}
+
+// rdsPoolKey returns the engine-aware lookup key for an RDS pool. CE's
+// DATABASE_ENGINE dimension uses human-readable strings ("Aurora MySQL"),
+// while CUDly's parser stores the shorthand on rec.Details.Engine
+// ("aurora-mysql"). Both forms normalise to the same lookup key here so
+// the producer (per-engine fetcher) and consumer (apply helper) agree.
+func rdsPoolKey(region, instanceType, engine string) string {
+	return strings.ToLower(region) + ":" + strings.ToLower(instanceType) + ":" + normaliseRDSEngine(engine)
+}
+
+// normaliseRDSEngine canonicalises an engine string from either CE's
+// "Aurora MySQL" form or the parser's "aurora-mysql" form to a single
+// lowercase no-spaces representation ("auroramysql"). Strips spaces and
+// hyphens so both producer and consumer of the coverage map collapse to
+// the same key.
+func normaliseRDSEngine(engine string) string {
+	s := strings.ToLower(engine)
+	s = strings.ReplaceAll(s, " ", "")
+	s = strings.ReplaceAll(s, "-", "")
+	s = strings.ReplaceAll(s, "_", "")
+	return s
 }
 
 // GetRICoverageMap fetches existing-RI coverage % over the last lookbackDays
@@ -71,7 +118,62 @@ func (c *Client) GetRICoverageMap(ctx context.Context, lookbackDays int) (PoolCo
 			return nil, fmt.Errorf("fetching coverage for service %q: %w", service, err)
 		}
 	}
+	// RDS fans out per engine because mixed-engine pools (same instance type,
+	// different DB engines) aren't separable via the 2-dimension GroupBy. See
+	// coverageServiceFilters block-comment for the rationale.
+	for _, engine := range rdsCoverageEngines {
+		if err := c.fetchCoverageForRDSEngine(ctx, startStr, endStr, engine, out); err != nil {
+			return nil, fmt.Errorf("fetching coverage for RDS engine %q: %w", engine, err)
+		}
+	}
 	return out, nil
+}
+
+// fetchCoverageForRDSEngine runs the paged GetReservationCoverage loop for
+// RDS recommendations filtered to a single DATABASE_ENGINE. Writes entries
+// keyed by "region:instance_type:engine" so the apply helper can look up
+// per-engine coverage instead of the per-pool aggregate that
+// fetchCoverageForService would produce. Solves the cross-engine bleed:
+// without it, a db.r7g.large in eu-west-2 with heavy Aurora coverage looks
+// 83%-covered even though MySQL recs in the same pool have 0% coverage.
+func (c *Client) fetchCoverageForRDSEngine(ctx context.Context, startStr, endStr, engine string, out PoolCoverageMap) error {
+	input := &costexplorer.GetReservationCoverageInput{
+		TimePeriod: &types.DateInterval{
+			Start: aws.String(startStr),
+			End:   aws.String(endStr),
+		},
+		GroupBy: []types.GroupDefinition{
+			{Type: types.GroupDefinitionTypeDimension, Key: aws.String("REGION")},
+			{Type: types.GroupDefinitionTypeDimension, Key: aws.String("INSTANCE_TYPE")},
+		},
+		Filter: &types.Expression{
+			And: []types.Expression{
+				{Dimensions: &types.DimensionValues{
+					Key:    types.DimensionService,
+					Values: []string{rdsServiceFilter},
+				}},
+				{Dimensions: &types.DimensionValues{
+					Key:    types.DimensionDatabaseEngine,
+					Values: []string{engine},
+				}},
+			},
+		},
+		Metrics: []string{"Hour"},
+	}
+
+	var token *string
+	for {
+		input.NextPageToken = token
+		result, err := c.fetchCoveragePage(ctx, input)
+		if err != nil {
+			return err
+		}
+		accumulateRDSEngineGroups(out, result.CoveragesByTime, engine)
+		if result.NextPageToken == nil || *result.NextPageToken == "" {
+			return nil
+		}
+		token = result.NextPageToken
+	}
 }
 
 // fetchCoverageForService runs the paged GetReservationCoverage loop for a
@@ -160,6 +262,28 @@ func accumulateCoverageGroups(out PoolCoverageMap, byTime []types.CoverageByTime
 	}
 }
 
+// accumulateRDSEngineGroups is the RDS variant of accumulateCoverageGroups
+// that writes engine-aware keys. The engine arg is the CE-side
+// DATABASE_ENGINE filter value that produced this page; we encode it into
+// each key via rdsPoolKey so the apply helper can disambiguate
+// same-instance-type pools running different engines.
+func accumulateRDSEngineGroups(out PoolCoverageMap, byTime []types.CoverageByTime, engine string) {
+	for _, period := range byTime {
+		for _, group := range period.Groups {
+			region, instType := extractGroupPoolKey(group.Attributes)
+			if region == "" || instType == "" {
+				continue
+			}
+			if group.Coverage == nil || group.Coverage.CoverageHours == nil ||
+				group.Coverage.CoverageHours.CoverageHoursPercentage == nil {
+				continue
+			}
+			pct := parseFloat(aws.ToString(group.Coverage.CoverageHours.CoverageHoursPercentage))
+			out[rdsPoolKey(region, instType, engine)] = pct
+		}
+	}
+}
+
 // extractGroupPoolKey reads the REGION and INSTANCE_TYPE values from CE's
 // Attributes map. CE sends keys in camelCase (e.g. "region", "instanceType")
 // even though the GroupBy input expects SCREAMING_SNAKE_CASE
@@ -179,9 +303,12 @@ func extractGroupPoolKey(attrs map[string]string) (region, instanceType string) 
 }
 
 // ApplyCoverageMapToRecommendations sets ExistingCoveragePct on each rec
-// whose (region, ResourceType) appears in the map. Recs without a match
-// stay at zero, which the sizing path treats as "no signal" and falls
-// back to the no-existing-commitments formula.
+// whose pool key appears in the map. Pool key shape depends on service:
+// RDS recs (DatabaseDetails carrying an engine) look up by
+// "region:instance_type:engine"; other services look up by
+// "region:instance_type". Recs without a match stay at zero, which the
+// sizing path treats as "no signal" and falls back to the
+// no-existing-commitments formula.
 //
 // Mutates recs in place to mirror the way the sizing pipeline already
 // hands recs around by value within each loop iteration.
@@ -190,9 +317,36 @@ func ApplyCoverageMapToRecommendations(recs []common.Recommendation, coverage Po
 		return
 	}
 	for i := range recs {
-		key := poolKey(recs[i].Region, recs[i].ResourceType)
+		key := lookupPoolKey(recs[i])
 		if pct, ok := coverage[key]; ok {
 			recs[i].ExistingCoveragePct = pct
 		}
 	}
+}
+
+// lookupPoolKey returns the pool key for a recommendation. RDS uses the
+// engine-aware form so the per-engine fetcher's keys match. Other services
+// fall back to the simpler region:instance_type form.
+func lookupPoolKey(rec common.Recommendation) string {
+	if engine := rdsEngineFromRec(rec); engine != "" {
+		return rdsPoolKey(rec.Region, rec.ResourceType, engine)
+	}
+	return poolKey(rec.Region, rec.ResourceType)
+}
+
+// rdsEngineFromRec extracts the RDS engine string from a recommendation's
+// polymorphic Details, returning "" when the rec isn't an RDS rec or the
+// engine isn't populated. Handles both pointer and value forms of
+// DatabaseDetails because the live parser uses pointers and the CSV
+// loader uses values.
+func rdsEngineFromRec(rec common.Recommendation) string {
+	switch details := rec.Details.(type) {
+	case *common.DatabaseDetails:
+		if details != nil {
+			return details.Engine
+		}
+	case common.DatabaseDetails:
+		return details.Engine
+	}
+	return ""
 }

--- a/providers/aws/recommendations/coverage.go
+++ b/providers/aws/recommendations/coverage.go
@@ -59,11 +59,12 @@ const rdsServiceFilter = "Amazon Relational Database Service"
 // region and their existing-RI coverage doesn't bleed across.
 type PoolCoverageMap map[string]float64
 
-// poolKey returns the canonical lookup key for a (region, instance_type)
-// pair. Both inputs are lower-cased so callers don't have to normalise
-// case at every site.
-func poolKey(region, instanceType string) string {
-	return strings.ToLower(region) + ":" + strings.ToLower(instanceType)
+// poolKey returns the canonical non-RDS lookup key for a
+// (region, instance_type, account) tuple. All inputs are lower-cased so
+// callers don't have to normalise case at every site. Account is the
+// AWS-side 12-digit linked-account ID (kept as-is — it's already digits).
+func poolKey(region, instanceType, account string) string {
+	return strings.ToLower(region) + ":" + strings.ToLower(instanceType) + ":" + account
 }
 
 // rdsPoolKey returns the engine-aware lookup key for an RDS pool. CE's
@@ -71,8 +72,10 @@ func poolKey(region, instanceType string) string {
 // while CUDly's parser stores the shorthand on rec.Details.Engine
 // ("aurora-mysql"). Both forms normalise to the same lookup key here so
 // the producer (per-engine fetcher) and consumer (apply helper) agree.
-func rdsPoolKey(region, instanceType, engine string) string {
-	return strings.ToLower(region) + ":" + strings.ToLower(instanceType) + ":" + normaliseRDSEngine(engine)
+// Account is the AWS-side linked-account ID, mirroring the LINKED_ACCOUNT
+// dimension we group by in CE.
+func rdsPoolKey(region, instanceType, engine, account string) string {
+	return strings.ToLower(region) + ":" + strings.ToLower(instanceType) + ":" + normaliseRDSEngine(engine) + ":" + account
 }
 
 // normaliseRDSEngine canonicalises an engine string from either CE's
@@ -103,7 +106,7 @@ func normaliseRDSEngine(engine string) string {
 // map; ApplyCoverageMapToRecommendations leaves ExistingCoveragePct at zero
 // for those recs, which the sizing path treats as "no signal" and falls
 // back to the no-existing-commitments formula.
-func (c *Client) GetRICoverageMap(ctx context.Context, lookbackDays int) (PoolCoverageMap, error) {
+func (c *Client) GetRICoverageMap(ctx context.Context, lookbackDays int, regions []string) (PoolCoverageMap, error) {
 	if lookbackDays <= 0 {
 		lookbackDays = 30
 	}
@@ -113,37 +116,47 @@ func (c *Client) GetRICoverageMap(ctx context.Context, lookbackDays int) (PoolCo
 	endStr := end.Format("2006-01-02")
 
 	out := make(PoolCoverageMap)
-	for _, service := range coverageServiceFilters {
-		if err := c.fetchCoverageForService(ctx, startStr, endStr, service, out); err != nil {
-			return nil, fmt.Errorf("fetching coverage for service %q: %w", service, err)
+	// CE's GroupBy is capped at two dimensions. We group by LINKED_ACCOUNT
+	// + INSTANCE_TYPE and push REGION into the Filter so coverage comes
+	// back per linked account in the region we're scanning. Without this
+	// per-account split, CE's org-wide aggregate would average a heavily-
+	// covered account's coverage into accounts with zero existing RIs in
+	// the same pool — see #338 design discussion.
+	//
+	// Cost: one CE call per (service, region) for non-RDS; one CE call per
+	// (engine, region) for RDS. For shift-prd's 5 services × ~23 regions +
+	// 7 engines × 23 regions ≈ 270 calls (~$2.70/run). Empty regions
+	// return quickly so the bound is loose in practice.
+	for _, region := range regions {
+		for _, service := range coverageServiceFilters {
+			if err := c.fetchCoverageForServiceRegion(ctx, startStr, endStr, service, region, out); err != nil {
+				return nil, fmt.Errorf("fetching coverage for service %q region %q: %w", service, region, err)
+			}
 		}
-	}
-	// RDS fans out per engine because mixed-engine pools (same instance type,
-	// different DB engines) aren't separable via the 2-dimension GroupBy. See
-	// coverageServiceFilters block-comment for the rationale.
-	for _, engine := range rdsCoverageEngines {
-		if err := c.fetchCoverageForRDSEngine(ctx, startStr, endStr, engine, out); err != nil {
-			return nil, fmt.Errorf("fetching coverage for RDS engine %q: %w", engine, err)
+		for _, engine := range rdsCoverageEngines {
+			if err := c.fetchCoverageForRDSEngineRegion(ctx, startStr, endStr, engine, region, out); err != nil {
+				return nil, fmt.Errorf("fetching coverage for RDS engine %q region %q: %w", engine, region, err)
+			}
 		}
 	}
 	return out, nil
 }
 
-// fetchCoverageForRDSEngine runs the paged GetReservationCoverage loop for
-// RDS recommendations filtered to a single DATABASE_ENGINE. Writes entries
-// keyed by "region:instance_type:engine" so the apply helper can look up
-// per-engine coverage instead of the per-pool aggregate that
-// fetchCoverageForService would produce. Solves the cross-engine bleed:
-// without it, a db.r7g.large in eu-west-2 with heavy Aurora coverage looks
-// 83%-covered even though MySQL recs in the same pool have 0% coverage.
-func (c *Client) fetchCoverageForRDSEngine(ctx context.Context, startStr, endStr, engine string, out PoolCoverageMap) error {
+// fetchCoverageForRDSEngineRegion runs the paged GetReservationCoverage
+// loop for one (RDS engine, region) tuple. Writes entries keyed by
+// "region:instance_type:engine:account" so the apply helper looks up
+// per-engine per-account coverage. This solves both the cross-engine
+// bleed (db.r7g.large with heavy Aurora coverage looking covered for
+// MySQL too) and the cross-account bleed (one account's full coverage
+// dragging up the org-wide average against accounts with zero coverage).
+func (c *Client) fetchCoverageForRDSEngineRegion(ctx context.Context, startStr, endStr, engine, region string, out PoolCoverageMap) error {
 	input := &costexplorer.GetReservationCoverageInput{
 		TimePeriod: &types.DateInterval{
 			Start: aws.String(startStr),
 			End:   aws.String(endStr),
 		},
 		GroupBy: []types.GroupDefinition{
-			{Type: types.GroupDefinitionTypeDimension, Key: aws.String("REGION")},
+			{Type: types.GroupDefinitionTypeDimension, Key: aws.String("LINKED_ACCOUNT")},
 			{Type: types.GroupDefinitionTypeDimension, Key: aws.String("INSTANCE_TYPE")},
 		},
 		Filter: &types.Expression{
@@ -156,6 +169,10 @@ func (c *Client) fetchCoverageForRDSEngine(ctx context.Context, startStr, endStr
 					Key:    types.DimensionDatabaseEngine,
 					Values: []string{engine},
 				}},
+				{Dimensions: &types.DimensionValues{
+					Key:    types.DimensionRegion,
+					Values: []string{region},
+				}},
 			},
 		},
 		Metrics: []string{"Hour"},
@@ -168,7 +185,7 @@ func (c *Client) fetchCoverageForRDSEngine(ctx context.Context, startStr, endStr
 		if err != nil {
 			return err
 		}
-		accumulateRDSEngineGroups(out, result.CoveragesByTime, engine)
+		accumulateRDSEngineAccountGroups(out, result.CoveragesByTime, engine, region)
 		if result.NextPageToken == nil || *result.NextPageToken == "" {
 			return nil
 		}
@@ -176,32 +193,38 @@ func (c *Client) fetchCoverageForRDSEngine(ctx context.Context, startStr, endStr
 	}
 }
 
-// fetchCoverageForService runs the paged GetReservationCoverage loop for a
-// single SERVICE dimension value and writes the (region, instance_type) →
-// HoursPercentage entries into out. Split per-service because CE returns
-// only EC2 coverage when no SERVICE filter is set, so a single
-// no-filter call hides RDS/ElastiCache/etc. coverage entirely.
-func (c *Client) fetchCoverageForService(ctx context.Context, startStr, endStr, service string, out PoolCoverageMap) error {
+// fetchCoverageForServiceRegion runs the paged GetReservationCoverage loop
+// for one (non-RDS service, region) tuple. Writes entries keyed by
+// "region:instance_type:account". Same per-account split as the RDS path,
+// without the engine dimension (non-RDS services don't have it).
+//
+// "Hour" tells CE to include the Hour coverage block in the response;
+// CoverageHoursPercentage inside that block is what we actually parse.
+// HoursPercentage isn't a valid Metrics value (CE rejects it with
+// ValidationException) — Metrics names the block, the percentage field
+// is computed and included automatically.
+func (c *Client) fetchCoverageForServiceRegion(ctx context.Context, startStr, endStr, service, region string, out PoolCoverageMap) error {
 	input := &costexplorer.GetReservationCoverageInput{
 		TimePeriod: &types.DateInterval{
 			Start: aws.String(startStr),
 			End:   aws.String(endStr),
 		},
 		GroupBy: []types.GroupDefinition{
-			{Type: types.GroupDefinitionTypeDimension, Key: aws.String("REGION")},
+			{Type: types.GroupDefinitionTypeDimension, Key: aws.String("LINKED_ACCOUNT")},
 			{Type: types.GroupDefinitionTypeDimension, Key: aws.String("INSTANCE_TYPE")},
 		},
 		Filter: &types.Expression{
-			Dimensions: &types.DimensionValues{
-				Key:    types.DimensionService,
-				Values: []string{service},
+			And: []types.Expression{
+				{Dimensions: &types.DimensionValues{
+					Key:    types.DimensionService,
+					Values: []string{service},
+				}},
+				{Dimensions: &types.DimensionValues{
+					Key:    types.DimensionRegion,
+					Values: []string{region},
+				}},
 			},
 		},
-		// "Hour" tells CE to include the Hour coverage block in the response;
-		// CoverageHoursPercentage inside that block is what we actually parse.
-		// HoursPercentage isn't a valid Metrics value (CE rejects it with
-		// ValidationException) — Metrics names the block, the percentage
-		// field is computed and included automatically.
 		Metrics: []string{"Hour"},
 	}
 
@@ -212,7 +235,7 @@ func (c *Client) fetchCoverageForService(ctx context.Context, startStr, endStr, 
 		if err != nil {
 			return err
 		}
-		accumulateCoverageGroups(out, result.CoveragesByTime)
+		accumulateAccountGroups(out, result.CoveragesByTime, region)
 		if result.NextPageToken == nil || *result.NextPageToken == "" {
 			return nil
 		}
@@ -239,17 +262,15 @@ func (c *Client) fetchCoveragePage(ctx context.Context, input *costexplorer.GetR
 	}
 }
 
-// accumulateCoverageGroups walks a page of CE coverage responses and writes
-// the (region, instance_type) → HoursPercentage entries into out. Later
-// pages overwrite earlier ones for the same key — CE returns one group per
-// (region, instance_type) per time period, so collisions only happen across
-// time periods and we keep the latest value (sufficient as a single-figure
-// summary; finer time-series analysis is out of scope here).
-func accumulateCoverageGroups(out PoolCoverageMap, byTime []types.CoverageByTime) {
+// accumulateAccountGroups walks a page of CE coverage responses grouped by
+// LINKED_ACCOUNT + INSTANCE_TYPE and writes (region, instance_type, account)
+// → HoursPercentage entries into out. The region arg comes from the caller
+// (we filter by region; CE doesn't echo it back in the group attributes).
+func accumulateAccountGroups(out PoolCoverageMap, byTime []types.CoverageByTime, region string) {
 	for _, period := range byTime {
 		for _, group := range period.Groups {
-			region, instType := extractGroupPoolKey(group.Attributes)
-			if region == "" || instType == "" {
+			account, instType := extractGroupAccountInstanceType(group.Attributes)
+			if account == "" || instType == "" {
 				continue
 			}
 			if group.Coverage == nil || group.Coverage.CoverageHours == nil ||
@@ -257,21 +278,19 @@ func accumulateCoverageGroups(out PoolCoverageMap, byTime []types.CoverageByTime
 				continue
 			}
 			pct := parseFloat(aws.ToString(group.Coverage.CoverageHours.CoverageHoursPercentage))
-			out[poolKey(region, instType)] = pct
+			out[poolKey(region, instType, account)] = pct
 		}
 	}
 }
 
-// accumulateRDSEngineGroups is the RDS variant of accumulateCoverageGroups
-// that writes engine-aware keys. The engine arg is the CE-side
-// DATABASE_ENGINE filter value that produced this page; we encode it into
-// each key via rdsPoolKey so the apply helper can disambiguate
-// same-instance-type pools running different engines.
-func accumulateRDSEngineGroups(out PoolCoverageMap, byTime []types.CoverageByTime, engine string) {
+// accumulateRDSEngineAccountGroups is the RDS variant of accumulateAccountGroups
+// that writes engine-aware keys. The engine and region args come from the
+// caller (both are in the Filter, not the GroupBy).
+func accumulateRDSEngineAccountGroups(out PoolCoverageMap, byTime []types.CoverageByTime, engine, region string) {
 	for _, period := range byTime {
 		for _, group := range period.Groups {
-			region, instType := extractGroupPoolKey(group.Attributes)
-			if region == "" || instType == "" {
+			account, instType := extractGroupAccountInstanceType(group.Attributes)
+			if account == "" || instType == "" {
 				continue
 			}
 			if group.Coverage == nil || group.Coverage.CoverageHours == nil ||
@@ -279,27 +298,27 @@ func accumulateRDSEngineGroups(out PoolCoverageMap, byTime []types.CoverageByTim
 				continue
 			}
 			pct := parseFloat(aws.ToString(group.Coverage.CoverageHours.CoverageHoursPercentage))
-			out[rdsPoolKey(region, instType, engine)] = pct
+			out[rdsPoolKey(region, instType, engine, account)] = pct
 		}
 	}
 }
 
-// extractGroupPoolKey reads the REGION and INSTANCE_TYPE values from CE's
-// Attributes map. CE sends keys in camelCase (e.g. "region", "instanceType")
-// even though the GroupBy input expects SCREAMING_SNAKE_CASE
-// ("REGION", "INSTANCE_TYPE"); normalise both sides by stripping underscores
-// and lower-casing before comparing. Returns ("", "") when either dimension
-// is missing — caller skips those groups.
-func extractGroupPoolKey(attrs map[string]string) (region, instanceType string) {
+// extractGroupAccountInstanceType reads the LINKED_ACCOUNT and INSTANCE_TYPE
+// values from CE's Attributes map. CE sends keys in camelCase ("account" /
+// "instanceType") even though the GroupBy input expects SCREAMING_SNAKE_CASE
+// ("LINKED_ACCOUNT" / "INSTANCE_TYPE"); normalise both sides by stripping
+// underscores and lower-casing before comparing. Returns ("", "") when
+// either dimension is missing — caller skips those groups.
+func extractGroupAccountInstanceType(attrs map[string]string) (account, instanceType string) {
 	for k, v := range attrs {
 		switch strings.ToLower(strings.ReplaceAll(k, "_", "")) {
-		case "region":
-			region = strings.ToLower(v)
+		case "account", "linkedaccount":
+			account = v // 12-digit AWS account ID, case-insensitive but already digits
 		case "instancetype":
 			instanceType = strings.ToLower(v)
 		}
 	}
-	return region, instanceType
+	return account, instanceType
 }
 
 // ApplyCoverageMapToRecommendations sets ExistingCoveragePct on each rec
@@ -325,13 +344,14 @@ func ApplyCoverageMapToRecommendations(recs []common.Recommendation, coverage Po
 }
 
 // lookupPoolKey returns the pool key for a recommendation. RDS uses the
-// engine-aware form so the per-engine fetcher's keys match. Other services
-// fall back to the simpler region:instance_type form.
+// engine-aware form; non-RDS uses the simpler form. Both include the
+// linked-account ID so the per-account fetcher's keys match — without
+// this, CE's org-wide aggregate would bleed across accounts.
 func lookupPoolKey(rec common.Recommendation) string {
 	if engine := rdsEngineFromRec(rec); engine != "" {
-		return rdsPoolKey(rec.Region, rec.ResourceType, engine)
+		return rdsPoolKey(rec.Region, rec.ResourceType, engine, rec.Account)
 	}
-	return poolKey(rec.Region, rec.ResourceType)
+	return poolKey(rec.Region, rec.ResourceType, rec.Account)
 }
 
 // rdsEngineFromRec extracts the RDS engine string from a recommendation's

--- a/providers/aws/recommendations/coverage.go
+++ b/providers/aws/recommendations/coverage.go
@@ -204,62 +204,32 @@ func (c *Client) GetRICoverageMap(ctx context.Context, lookbackDays int, regions
 	return out, nil
 }
 
-// fetchCoverageForRDSEngineRegion runs the paged GetReservationCoverage
-// loop for one (RDS engine, region) tuple. Writes entries keyed by
+// fetchCoverageForRDSEngineRegion fetches coverage for one (RDS engine,
+// region) tuple. Writes entries keyed by
 // "region:instance_type:engine:deployment" so the apply helper looks up
 // per-engine per-deployment coverage. This solves both the cross-engine
 // bleed (db.r7g.large with heavy Aurora coverage looking covered for
-// MySQL too) and the cross-deployment bleed (a Single-AZ RI being credited
-// against Multi-AZ demand).
+// MySQL too) and the cross-deployment bleed (a Single-AZ RI being
+// credited against Multi-AZ demand).
 func (c *Client) fetchCoverageForRDSEngineRegion(ctx context.Context, startStr, endStr string, windowHours float64, engine, region string, out PoolCoverageMap) error {
 	input := &costexplorer.GetReservationCoverageInput{
-		TimePeriod: &types.DateInterval{
-			Start: aws.String(startStr),
-			End:   aws.String(endStr),
-		},
+		TimePeriod: &types.DateInterval{Start: aws.String(startStr), End: aws.String(endStr)},
 		GroupBy: []types.GroupDefinition{
 			{Type: types.GroupDefinitionTypeDimension, Key: aws.String(string(types.DimensionInstanceType))},
 			{Type: types.GroupDefinitionTypeDimension, Key: aws.String(string(types.DimensionDeploymentOption))},
 		},
-		Filter: &types.Expression{
-			And: []types.Expression{
-				{Dimensions: &types.DimensionValues{
-					Key:    types.DimensionService,
-					Values: []string{rdsServiceFilter},
-				}},
-				{Dimensions: &types.DimensionValues{
-					Key:    types.DimensionDatabaseEngine,
-					Values: []string{engine},
-				}},
-				{Dimensions: &types.DimensionValues{
-					Key:    types.DimensionRegion,
-					Values: []string{region},
-				}},
-			},
-		},
+		Filter:  rdsEngineRegionFilter(engine, region),
 		Metrics: []string{"Hour"},
 	}
-
-	var token *string
-	for {
-		input.NextPageToken = token
-		result, err := c.fetchCoveragePage(ctx, input)
-		if err != nil {
-			return err
-		}
-		accumulateRDSEngineGroups(out, result.CoveragesByTime, engine, region, windowHours)
-		if result.NextPageToken == nil || *result.NextPageToken == "" {
-			return nil
-		}
-		token = result.NextPageToken
-	}
+	return c.fetchCoveragePaged(ctx, input, func(instType, deployment string, cov PoolCoverage) {
+		out[rdsPoolKey(region, instType, engine, deployment)] = cov
+	}, windowHours)
 }
 
-// fetchCoverageForServiceRegion runs the paged GetReservationCoverage loop
-// for one (non-RDS service, region) tuple. Writes entries keyed by
-// "region:instance_type". Non-RDS services don't have an engine or
-// deployment-option split worth tracking the way RDS does, so we group by
-// INSTANCE_TYPE alone.
+// fetchCoverageForServiceRegion fetches coverage for one (non-RDS
+// service, region) tuple. Writes entries keyed by "region:instance_type"
+// — non-RDS services don't have an engine or deployment split worth
+// tracking the way RDS does, so we group by INSTANCE_TYPE alone.
 //
 // "Hour" tells CE to include the Hour coverage block in the response;
 // CoverageHoursPercentage + TotalRunningHours inside that block are what
@@ -268,28 +238,29 @@ func (c *Client) fetchCoverageForRDSEngineRegion(ctx context.Context, startStr, 
 // percentage / hours fields are computed and included automatically.
 func (c *Client) fetchCoverageForServiceRegion(ctx context.Context, startStr, endStr string, windowHours float64, service, region string, out PoolCoverageMap) error {
 	input := &costexplorer.GetReservationCoverageInput{
-		TimePeriod: &types.DateInterval{
-			Start: aws.String(startStr),
-			End:   aws.String(endStr),
-		},
+		TimePeriod: &types.DateInterval{Start: aws.String(startStr), End: aws.String(endStr)},
 		GroupBy: []types.GroupDefinition{
 			{Type: types.GroupDefinitionTypeDimension, Key: aws.String(string(types.DimensionInstanceType))},
 		},
-		Filter: &types.Expression{
-			And: []types.Expression{
-				{Dimensions: &types.DimensionValues{
-					Key:    types.DimensionService,
-					Values: []string{service},
-				}},
-				{Dimensions: &types.DimensionValues{
-					Key:    types.DimensionRegion,
-					Values: []string{region},
-				}},
-			},
-		},
+		Filter:  serviceRegionFilter(service, region),
 		Metrics: []string{"Hour"},
 	}
+	return c.fetchCoveragePaged(ctx, input, func(instType, _ string, cov PoolCoverage) {
+		out[poolKey(region, instType)] = cov
+	}, windowHours)
+}
 
+// fetchCoveragePaged runs the paginated GetReservationCoverage loop and
+// invokes record on each group with a non-empty INSTANCE_TYPE and a
+// valid Coverage block. The keyed-write logic is callsite-specific
+// (RDS keys carry engine + deployment, non-RDS keys don't), so record
+// closes over the key shape the caller wants.
+func (c *Client) fetchCoveragePaged(
+	ctx context.Context,
+	input *costexplorer.GetReservationCoverageInput,
+	record func(instType, deployment string, cov PoolCoverage),
+	windowHours float64,
+) error {
 	var token *string
 	for {
 		input.NextPageToken = token
@@ -297,11 +268,49 @@ func (c *Client) fetchCoverageForServiceRegion(ctx context.Context, startStr, en
 		if err != nil {
 			return err
 		}
-		accumulateGroups(out, result.CoveragesByTime, region, windowHours)
+		for _, period := range result.CoveragesByTime {
+			for _, group := range period.Groups {
+				instType, deployment := extractGroupAttributes(group.Attributes)
+				if instType == "" {
+					continue
+				}
+				cov, ok := poolCoverageFromGroup(group, windowHours)
+				if !ok {
+					continue
+				}
+				record(instType, deployment, cov)
+			}
+		}
 		if result.NextPageToken == nil || *result.NextPageToken == "" {
 			return nil
 		}
 		token = result.NextPageToken
+	}
+}
+
+// rdsEngineRegionFilter builds the CE Filter expression scoping a
+// GetReservationCoverage call to a single (RDS engine, region) tuple.
+// Extracted so the fetch path doesn't bury the filter shape inside the
+// input struct literal.
+func rdsEngineRegionFilter(engine, region string) *types.Expression {
+	return &types.Expression{
+		And: []types.Expression{
+			{Dimensions: &types.DimensionValues{Key: types.DimensionService, Values: []string{rdsServiceFilter}}},
+			{Dimensions: &types.DimensionValues{Key: types.DimensionDatabaseEngine, Values: []string{engine}}},
+			{Dimensions: &types.DimensionValues{Key: types.DimensionRegion, Values: []string{region}}},
+		},
+	}
+}
+
+// serviceRegionFilter builds the CE Filter expression scoping a
+// GetReservationCoverage call to a single (service, region) tuple
+// (non-RDS variant: no DATABASE_ENGINE dimension).
+func serviceRegionFilter(service, region string) *types.Expression {
+	return &types.Expression{
+		And: []types.Expression{
+			{Dimensions: &types.DimensionValues{Key: types.DimensionService, Values: []string{service}}},
+			{Dimensions: &types.DimensionValues{Key: types.DimensionRegion, Values: []string{region}}},
+		},
 	}
 }
 
@@ -341,46 +350,6 @@ func poolCoverageFromGroup(group types.ReservationCoverageGroup, windowHours flo
 		avg = parseFloat(aws.ToString(group.Coverage.CoverageHours.TotalRunningHours)) / windowHours
 	}
 	return PoolCoverage{Pct: pct, AvgInstancesPerHour: avg}, true
-}
-
-// accumulateGroups walks a page of CE coverage responses grouped by
-// INSTANCE_TYPE and writes (region, instance_type) → PoolCoverage entries
-// into out. The region arg comes from the caller (we filter by region; CE
-// doesn't echo it back in the group attributes).
-func accumulateGroups(out PoolCoverageMap, byTime []types.CoverageByTime, region string, windowHours float64) {
-	for _, period := range byTime {
-		for _, group := range period.Groups {
-			instType, _ := extractGroupAttributes(group.Attributes)
-			if instType == "" {
-				continue
-			}
-			cov, ok := poolCoverageFromGroup(group, windowHours)
-			if !ok {
-				continue
-			}
-			out[poolKey(region, instType)] = cov
-		}
-	}
-}
-
-// accumulateRDSEngineGroups is the RDS variant of accumulateGroups that writes
-// engine + deployment-aware keys. The engine and region args come from the
-// caller (both are in the Filter, not the GroupBy); deployment comes from
-// the group attributes.
-func accumulateRDSEngineGroups(out PoolCoverageMap, byTime []types.CoverageByTime, engine, region string, windowHours float64) {
-	for _, period := range byTime {
-		for _, group := range period.Groups {
-			instType, deployment := extractGroupAttributes(group.Attributes)
-			if instType == "" {
-				continue
-			}
-			cov, ok := poolCoverageFromGroup(group, windowHours)
-			if !ok {
-				continue
-			}
-			out[rdsPoolKey(region, instType, engine, deployment)] = cov
-		}
-	}
 }
 
 // extractGroupAttributes reads INSTANCE_TYPE and DEPLOYMENT_OPTION values

--- a/providers/aws/recommendations/coverage.go
+++ b/providers/aws/recommendations/coverage.go
@@ -17,13 +17,13 @@ import (
 // we issue GetReservationCoverage against. CE returns only EC2 coverage when
 // no SERVICE filter is set, so any account that runs RDS/ElastiCache/
 // OpenSearch/Redshift RIs needs a per-service call. The service strings here
-// match CE's canonical dimension values (case-sensitive); the comments
-// indicate which CUDly internal common.ServiceType they correspond to.
+// match CE's canonical dimension values (case-sensitive).
 //
-// RDS gets special handling further down — same instance type often runs
-// multiple engines in the same region, and CE GroupBy is limited to two
-// dimensions, so we fan out across engines via the DATABASE_ENGINE filter
-// instead of the GroupBy.
+// RDS gets special handling — same instance type often runs multiple engines
+// in the same region, and the AWS console coverage report further splits each
+// engine row by deployment option (Single-AZ vs Multi-AZ), so we fan out
+// across engines via the DATABASE_ENGINE filter and pull DEPLOYMENT_OPTION
+// into the GroupBy alongside INSTANCE_TYPE.
 var coverageServiceFilters = []string{
 	"Amazon Elastic Compute Cloud - Compute", // EC2
 	"Amazon ElastiCache",                     // ElastiCache
@@ -35,9 +35,8 @@ var coverageServiceFilters = []string{
 // rdsCoverageEngines enumerates CE's DATABASE_ENGINE dimension values for
 // RDS recommendations. CUDly's parser normalises engine names to lowercase
 // shorthand (e.g. "aurora-postgresql") for rec.Details.Engine; CE expects
-// the human-readable form here (e.g. "Aurora PostgreSQL"). The
-// rdsEngineKeyFromCE / rdsEngineKeyFromRec helpers normalise both sides to
-// the same lookup key.
+// the human-readable form here (e.g. "Aurora PostgreSQL"). normaliseRDSEngine
+// canonicalises both sides to the same lookup key.
 var rdsCoverageEngines = []string{
 	"MySQL",
 	"PostgreSQL",
@@ -50,62 +49,131 @@ var rdsCoverageEngines = []string{
 
 const rdsServiceFilter = "Amazon Relational Database Service"
 
-// PoolCoverageMap maps a pool key to the share of historical demand already
-// covered by existing reservations in that pool, expressed as a 0-100
-// percentage. Used by --target-coverage sizing to subtract existing
-// commitments from the under-buy formula. Non-RDS keys are
-// "region:instance_type"; RDS keys are "region:instance_type:engine"
-// because the same instance type often runs different engines in the same
-// region and their existing-RI coverage doesn't bleed across.
-type PoolCoverageMap map[string]float64
-
-// poolKey returns the canonical non-RDS lookup key for a
-// (region, instance_type, account) tuple. All inputs are lower-cased so
-// callers don't have to normalise case at every site. Account is the
-// AWS-side 12-digit linked-account ID (kept as-is — it's already digits).
-func poolKey(region, instanceType, account string) string {
-	return strings.ToLower(region) + ":" + strings.ToLower(instanceType) + ":" + account
+// PoolCoverage captures the two CE coverage signals we use downstream: the
+// share of historical demand already covered by existing reservations
+// (Pct, 0-100) and the average concurrent-instances figure derived from
+// TotalRunningHours over the lookback window (AvgInstancesPerHour).
+//
+// AvgInstancesPerHour matches the "Total running hours / window hours"
+// figure shown in the AWS console reservations-coverage report; it's what
+// --target-coverage sizing now anchors on (linear in avg × gap%) so a
+// pool's CUDly buy lines up with the same math operators see in the
+// console CSV. Zero means CE returned no running hours for the pool over
+// the window — sizing then falls back to rec.AverageInstancesUsedPerHour
+// from the rec parser (per-account signal from
+// GetReservationPurchaseRecommendation).
+type PoolCoverage struct {
+	Pct                 float64
+	AvgInstancesPerHour float64
 }
 
-// rdsPoolKey returns the engine-aware lookup key for an RDS pool. CE's
-// DATABASE_ENGINE dimension uses human-readable strings ("Aurora MySQL"),
-// while CUDly's parser stores the shorthand on rec.Details.Engine
-// ("aurora-mysql"). Both forms normalise to the same lookup key here so
-// the producer (per-engine fetcher) and consumer (apply helper) agree.
-// Account is the AWS-side linked-account ID, mirroring the LINKED_ACCOUNT
-// dimension we group by in CE.
-func rdsPoolKey(region, instanceType, engine, account string) string {
-	return strings.ToLower(region) + ":" + strings.ToLower(instanceType) + ":" + normaliseRDSEngine(engine) + ":" + account
+// PoolCoverageMap maps a pool key to the (pct, avg) pair for that pool.
+// Used by --target-coverage sizing to subtract existing commitments from
+// the under-buy formula and to size linearly off the org-wide demand.
+// Keys are org-wide (no account dimension) to match the AWS console's
+// reservations-coverage report: non-RDS keys are "region:instance_type";
+// RDS keys are "region:instance_type:engine:deployment" so Single-AZ vs
+// Multi-AZ pools stay distinct (a Single-AZ RI cannot cover a Multi-AZ
+// instance).
+type PoolCoverageMap map[string]PoolCoverage
+
+// poolKey returns the canonical non-RDS lookup key for a (region,
+// instance_type) tuple. Both inputs are lower-cased so callers don't have
+// to normalise case at every site.
+func poolKey(region, instanceType string) string {
+	return strings.ToLower(region) + ":" + strings.ToLower(instanceType)
+}
+
+// rdsPoolKey returns the engine + deployment-aware lookup key for an RDS
+// pool. CE's DATABASE_ENGINE dimension uses human-readable strings
+// ("Aurora MySQL"), while CUDly's parser stores the shorthand on
+// rec.Details.Engine ("aurora-mysql"). DEPLOYMENT_OPTION ("Single-AZ" /
+// "Multi-AZ") similarly maps to the parser's AZConfig ("single-az" /
+// "multi-az"). Both sides normalise to the same lookup key here so the
+// producer (per-engine fetcher) and consumer (apply helper) agree.
+func rdsPoolKey(region, instanceType, engine, deployment string) string {
+	return strings.ToLower(region) + ":" +
+		strings.ToLower(instanceType) + ":" +
+		normaliseRDSEngine(engine) + ":" +
+		normaliseDeployment(deployment)
 }
 
 // normaliseRDSEngine canonicalises an engine string from either CE's
-// "Aurora MySQL" form or the parser's "aurora-mysql" form to a single
-// lowercase no-spaces representation ("auroramysql"). Strips spaces and
-// hyphens so both producer and consumer of the coverage map collapse to
-// the same key.
+// display form ("Aurora MySQL", "PostgreSQL", "SQL Server") or the
+// shorter forms returned by RDS APIs ("aurora-mysql", "postgres",
+// "sqlserver-ee", "oracle-se2") to a single lowercase no-spaces
+// representation. Strips spaces / hyphens / underscores AND collapses
+// well-known short-form aliases plus edition suffixes so both producer
+// (per-engine CE fetcher seeded from rdsCoverageEngines) and consumer
+// (apply helper reading rec.Details.Engine) land on the same key
+// regardless of which API surfaced the engine string.
+//
+// Specifically:
+//   - "postgres" collapses to "postgresql" (the bare RDS engine slug
+//     vs the CE display form).
+//   - "sqlserver-ee" / "sqlserver-se" / "sqlserver-ex" / "sqlserver-web"
+//     all collapse to "sqlserver" (CE returns the bare display form
+//     "SQL Server" while RDS Describe* APIs return edition-suffixed
+//     slugs).
+//   - "oracle-ee" / "oracle-se" / "oracle-se1" / "oracle-se2" collapse
+//     to "oracle".
+//
+// Without the alias collapse, a rec whose parser saw "postgres" (or an
+// Oracle/SQL-Server edition slug) would miss the coverage entry the
+// per-engine fetcher wrote under the display-form key, silently
+// dropping ExistingCoveragePct to zero and over-buying for that pool.
 func normaliseRDSEngine(engine string) string {
 	s := strings.ToLower(engine)
 	s = strings.ReplaceAll(s, " ", "")
 	s = strings.ReplaceAll(s, "-", "")
 	s = strings.ReplaceAll(s, "_", "")
+	if s == "postgres" {
+		return "postgresql"
+	}
+	for _, family := range []string{"sqlserver", "oracle"} {
+		if strings.HasPrefix(s, family) {
+			return family
+		}
+	}
 	return s
 }
 
-// GetRICoverageMap fetches existing-RI coverage % over the last lookbackDays
-// days, returning a map keyed by "region:instance_type". Operators wiring
-// the result back onto Recommendation.ExistingCoveragePct should call
-// ApplyCoverageMapToRecommendations rather than walking the map manually.
+// normaliseDeployment canonicalises a deployment-option string from either
+// CE's "Single-AZ" / "Multi-AZ" form or the parser's "single-az" /
+// "multi-az" form to a single lowercase no-spaces representation. The
+// "Multi-AZ (readable standbys)" variant collapses to a distinct value
+// ("multiazreadablestandbys") since it's a distinct RI scope.
 //
-// CE's GetReservationCoverage accepts at most 2 GroupBy dimensions, so we
-// pick REGION + INSTANCE_TYPE as the dominant per-pool dimensions across
-// EC2, RDS, ElastiCache and OpenSearch RIs. Finer dimensions (OS, tenancy
-// for EC2; engine, multi-AZ for RDS) are aggregated together — imprecise
-// for mixed pools but the API doesn't let us slice finer in one call.
+// An empty input yields "" (not "unknown") so missing-deployment recs
+// produce a deterministic miss in the lookup map rather than colliding
+// with a real bucket.
+func normaliseDeployment(deployment string) string {
+	s := strings.ToLower(deployment)
+	s = strings.ReplaceAll(s, " ", "")
+	s = strings.ReplaceAll(s, "-", "")
+	s = strings.ReplaceAll(s, "_", "")
+	s = strings.ReplaceAll(s, "(", "")
+	s = strings.ReplaceAll(s, ")", "")
+	return s
+}
+
+// GetRICoverageMap fetches existing-RI coverage % and avg-running-instances
+// over the last lookbackDays days, returning a map keyed by org-wide pool
+// (no account dimension — matches the AWS console reservations-coverage
+// report). Operators wiring the result back onto Recommendations should
+// call ApplyCoverageMapToRecommendations rather than walking the map
+// manually.
 //
-// Missing pools (no existing commitment in the pool) are omitted from the
-// map; ApplyCoverageMapToRecommendations leaves ExistingCoveragePct at zero
-// for those recs, which the sizing path treats as "no signal" and falls
-// back to the no-existing-commitments formula.
+// Non-RDS calls group by INSTANCE_TYPE alone (REGION + SERVICE in the
+// Filter). RDS calls group by INSTANCE_TYPE + DEPLOYMENT_OPTION (REGION +
+// SERVICE + DATABASE_ENGINE in the Filter) so the resulting keys split
+// Single-AZ vs Multi-AZ pools, which have separate RI scopes.
+//
+// Missing pools (no demand in the pool over the window) are omitted from
+// the map; ApplyCoverageMapToRecommendations leaves
+// rec.ExistingCoveragePct at zero for those recs, which the sizing path
+// treats as "no signal" and falls back to the no-existing-commitments
+// formula.
 func (c *Client) GetRICoverageMap(ctx context.Context, lookbackDays int, regions []string) (PoolCoverageMap, error) {
 	if lookbackDays <= 0 {
 		lookbackDays = 30
@@ -114,27 +182,21 @@ func (c *Client) GetRICoverageMap(ctx context.Context, lookbackDays int, regions
 	start := end.AddDate(0, 0, -lookbackDays)
 	startStr := start.Format("2006-01-02")
 	endStr := end.Format("2006-01-02")
+	windowHours := float64(lookbackDays * 24)
 
 	out := make(PoolCoverageMap)
-	// CE's GroupBy is capped at two dimensions. We group by LINKED_ACCOUNT
-	// + INSTANCE_TYPE and push REGION into the Filter so coverage comes
-	// back per linked account in the region we're scanning. Without this
-	// per-account split, CE's org-wide aggregate would average a heavily-
-	// covered account's coverage into accounts with zero existing RIs in
-	// the same pool — see #338 design discussion.
-	//
 	// Cost: one CE call per (service, region) for non-RDS; one CE call per
-	// (engine, region) for RDS. For shift-prd's 5 services × ~23 regions +
-	// 7 engines × 23 regions ≈ 270 calls (~$2.70/run). Empty regions
-	// return quickly so the bound is loose in practice.
+	// (engine, region) for RDS. For a 5-service × 23-region survey + 7
+	// engines × 23 regions ≈ 270 calls (~$2.70/run). Empty regions return
+	// quickly so the bound is loose in practice.
 	for _, region := range regions {
 		for _, service := range coverageServiceFilters {
-			if err := c.fetchCoverageForServiceRegion(ctx, startStr, endStr, service, region, out); err != nil {
+			if err := c.fetchCoverageForServiceRegion(ctx, startStr, endStr, windowHours, service, region, out); err != nil {
 				return nil, fmt.Errorf("fetching coverage for service %q region %q: %w", service, region, err)
 			}
 		}
 		for _, engine := range rdsCoverageEngines {
-			if err := c.fetchCoverageForRDSEngineRegion(ctx, startStr, endStr, engine, region, out); err != nil {
+			if err := c.fetchCoverageForRDSEngineRegion(ctx, startStr, endStr, windowHours, engine, region, out); err != nil {
 				return nil, fmt.Errorf("fetching coverage for RDS engine %q region %q: %w", engine, region, err)
 			}
 		}
@@ -144,20 +206,20 @@ func (c *Client) GetRICoverageMap(ctx context.Context, lookbackDays int, regions
 
 // fetchCoverageForRDSEngineRegion runs the paged GetReservationCoverage
 // loop for one (RDS engine, region) tuple. Writes entries keyed by
-// "region:instance_type:engine:account" so the apply helper looks up
-// per-engine per-account coverage. This solves both the cross-engine
+// "region:instance_type:engine:deployment" so the apply helper looks up
+// per-engine per-deployment coverage. This solves both the cross-engine
 // bleed (db.r7g.large with heavy Aurora coverage looking covered for
-// MySQL too) and the cross-account bleed (one account's full coverage
-// dragging up the org-wide average against accounts with zero coverage).
-func (c *Client) fetchCoverageForRDSEngineRegion(ctx context.Context, startStr, endStr, engine, region string, out PoolCoverageMap) error {
+// MySQL too) and the cross-deployment bleed (a Single-AZ RI being credited
+// against Multi-AZ demand).
+func (c *Client) fetchCoverageForRDSEngineRegion(ctx context.Context, startStr, endStr string, windowHours float64, engine, region string, out PoolCoverageMap) error {
 	input := &costexplorer.GetReservationCoverageInput{
 		TimePeriod: &types.DateInterval{
 			Start: aws.String(startStr),
 			End:   aws.String(endStr),
 		},
 		GroupBy: []types.GroupDefinition{
-			{Type: types.GroupDefinitionTypeDimension, Key: aws.String("LINKED_ACCOUNT")},
-			{Type: types.GroupDefinitionTypeDimension, Key: aws.String("INSTANCE_TYPE")},
+			{Type: types.GroupDefinitionTypeDimension, Key: aws.String(string(types.DimensionInstanceType))},
+			{Type: types.GroupDefinitionTypeDimension, Key: aws.String(string(types.DimensionDeploymentOption))},
 		},
 		Filter: &types.Expression{
 			And: []types.Expression{
@@ -185,7 +247,7 @@ func (c *Client) fetchCoverageForRDSEngineRegion(ctx context.Context, startStr, 
 		if err != nil {
 			return err
 		}
-		accumulateRDSEngineAccountGroups(out, result.CoveragesByTime, engine, region)
+		accumulateRDSEngineGroups(out, result.CoveragesByTime, engine, region, windowHours)
 		if result.NextPageToken == nil || *result.NextPageToken == "" {
 			return nil
 		}
@@ -195,23 +257,23 @@ func (c *Client) fetchCoverageForRDSEngineRegion(ctx context.Context, startStr, 
 
 // fetchCoverageForServiceRegion runs the paged GetReservationCoverage loop
 // for one (non-RDS service, region) tuple. Writes entries keyed by
-// "region:instance_type:account". Same per-account split as the RDS path,
-// without the engine dimension (non-RDS services don't have it).
+// "region:instance_type". Non-RDS services don't have an engine or
+// deployment-option split worth tracking the way RDS does, so we group by
+// INSTANCE_TYPE alone.
 //
 // "Hour" tells CE to include the Hour coverage block in the response;
-// CoverageHoursPercentage inside that block is what we actually parse.
-// HoursPercentage isn't a valid Metrics value (CE rejects it with
-// ValidationException) — Metrics names the block, the percentage field
-// is computed and included automatically.
-func (c *Client) fetchCoverageForServiceRegion(ctx context.Context, startStr, endStr, service, region string, out PoolCoverageMap) error {
+// CoverageHoursPercentage + TotalRunningHours inside that block are what
+// we actually parse. HoursPercentage isn't a valid Metrics value (CE
+// rejects it with ValidationException) — Metrics names the block, the
+// percentage / hours fields are computed and included automatically.
+func (c *Client) fetchCoverageForServiceRegion(ctx context.Context, startStr, endStr string, windowHours float64, service, region string, out PoolCoverageMap) error {
 	input := &costexplorer.GetReservationCoverageInput{
 		TimePeriod: &types.DateInterval{
 			Start: aws.String(startStr),
 			End:   aws.String(endStr),
 		},
 		GroupBy: []types.GroupDefinition{
-			{Type: types.GroupDefinitionTypeDimension, Key: aws.String("LINKED_ACCOUNT")},
-			{Type: types.GroupDefinitionTypeDimension, Key: aws.String("INSTANCE_TYPE")},
+			{Type: types.GroupDefinitionTypeDimension, Key: aws.String(string(types.DimensionInstanceType))},
 		},
 		Filter: &types.Expression{
 			And: []types.Expression{
@@ -235,7 +297,7 @@ func (c *Client) fetchCoverageForServiceRegion(ctx context.Context, startStr, en
 		if err != nil {
 			return err
 		}
-		accumulateAccountGroups(out, result.CoveragesByTime, region)
+		accumulateGroups(out, result.CoveragesByTime, region, windowHours)
 		if result.NextPageToken == nil || *result.NextPageToken == "" {
 			return nil
 		}
@@ -262,72 +324,106 @@ func (c *Client) fetchCoveragePage(ctx context.Context, input *costexplorer.GetR
 	}
 }
 
-// accumulateAccountGroups walks a page of CE coverage responses grouped by
-// LINKED_ACCOUNT + INSTANCE_TYPE and writes (region, instance_type, account)
-// → HoursPercentage entries into out. The region arg comes from the caller
-// (we filter by region; CE doesn't echo it back in the group attributes).
-func accumulateAccountGroups(out PoolCoverageMap, byTime []types.CoverageByTime, region string) {
+// poolCoverageFromGroup pulls the (pct, avg) pair from a CE response
+// group's CoverageHours block. Returns (zero-value, false) when the block
+// is absent or missing the percentage field — caller drops the group.
+// AvgInstancesPerHour = TotalRunningHours / windowHours, matching the AWS
+// console's "instances over the lookback window" view. windowHours is
+// 24 * lookbackDays from the GetRICoverageMap caller.
+func poolCoverageFromGroup(group types.ReservationCoverageGroup, windowHours float64) (PoolCoverage, bool) {
+	if group.Coverage == nil || group.Coverage.CoverageHours == nil ||
+		group.Coverage.CoverageHours.CoverageHoursPercentage == nil {
+		return PoolCoverage{}, false
+	}
+	pct := parseFloat(aws.ToString(group.Coverage.CoverageHours.CoverageHoursPercentage))
+	var avg float64
+	if windowHours > 0 && group.Coverage.CoverageHours.TotalRunningHours != nil {
+		avg = parseFloat(aws.ToString(group.Coverage.CoverageHours.TotalRunningHours)) / windowHours
+	}
+	return PoolCoverage{Pct: pct, AvgInstancesPerHour: avg}, true
+}
+
+// accumulateGroups walks a page of CE coverage responses grouped by
+// INSTANCE_TYPE and writes (region, instance_type) → PoolCoverage entries
+// into out. The region arg comes from the caller (we filter by region; CE
+// doesn't echo it back in the group attributes).
+func accumulateGroups(out PoolCoverageMap, byTime []types.CoverageByTime, region string, windowHours float64) {
 	for _, period := range byTime {
 		for _, group := range period.Groups {
-			account, instType := extractGroupAccountInstanceType(group.Attributes)
-			if account == "" || instType == "" {
+			instType, _ := extractGroupAttributes(group.Attributes)
+			if instType == "" {
 				continue
 			}
-			if group.Coverage == nil || group.Coverage.CoverageHours == nil ||
-				group.Coverage.CoverageHours.CoverageHoursPercentage == nil {
+			cov, ok := poolCoverageFromGroup(group, windowHours)
+			if !ok {
 				continue
 			}
-			pct := parseFloat(aws.ToString(group.Coverage.CoverageHours.CoverageHoursPercentage))
-			out[poolKey(region, instType, account)] = pct
+			out[poolKey(region, instType)] = cov
 		}
 	}
 }
 
-// accumulateRDSEngineAccountGroups is the RDS variant of accumulateAccountGroups
-// that writes engine-aware keys. The engine and region args come from the
-// caller (both are in the Filter, not the GroupBy).
-func accumulateRDSEngineAccountGroups(out PoolCoverageMap, byTime []types.CoverageByTime, engine, region string) {
+// accumulateRDSEngineGroups is the RDS variant of accumulateGroups that writes
+// engine + deployment-aware keys. The engine and region args come from the
+// caller (both are in the Filter, not the GroupBy); deployment comes from
+// the group attributes.
+func accumulateRDSEngineGroups(out PoolCoverageMap, byTime []types.CoverageByTime, engine, region string, windowHours float64) {
 	for _, period := range byTime {
 		for _, group := range period.Groups {
-			account, instType := extractGroupAccountInstanceType(group.Attributes)
-			if account == "" || instType == "" {
+			instType, deployment := extractGroupAttributes(group.Attributes)
+			if instType == "" {
 				continue
 			}
-			if group.Coverage == nil || group.Coverage.CoverageHours == nil ||
-				group.Coverage.CoverageHours.CoverageHoursPercentage == nil {
+			cov, ok := poolCoverageFromGroup(group, windowHours)
+			if !ok {
 				continue
 			}
-			pct := parseFloat(aws.ToString(group.Coverage.CoverageHours.CoverageHoursPercentage))
-			out[rdsPoolKey(region, instType, engine, account)] = pct
+			out[rdsPoolKey(region, instType, engine, deployment)] = cov
 		}
 	}
 }
 
-// extractGroupAccountInstanceType reads the LINKED_ACCOUNT and INSTANCE_TYPE
-// values from CE's Attributes map. CE sends keys in camelCase ("account" /
-// "instanceType") even though the GroupBy input expects SCREAMING_SNAKE_CASE
-// ("LINKED_ACCOUNT" / "INSTANCE_TYPE"); normalise both sides by stripping
-// underscores and lower-casing before comparing. Returns ("", "") when
-// either dimension is missing — caller skips those groups.
-func extractGroupAccountInstanceType(attrs map[string]string) (account, instanceType string) {
+// extractGroupAttributes reads INSTANCE_TYPE and DEPLOYMENT_OPTION values
+// from CE's Attributes map. CE sends keys in camelCase ("instanceType",
+// "deploymentOption") even though the GroupBy input expects
+// SCREAMING_SNAKE_CASE ("INSTANCE_TYPE", "DEPLOYMENT_OPTION"); normalise
+// both sides by stripping underscores and lower-casing before comparing.
+// Returns empty strings for absent dimensions — the deployment slot is
+// optional (non-RDS callers don't group by it and won't pass it through).
+func extractGroupAttributes(attrs map[string]string) (instanceType, deployment string) {
 	for k, v := range attrs {
 		switch strings.ToLower(strings.ReplaceAll(k, "_", "")) {
-		case "account", "linkedaccount":
-			account = v // 12-digit AWS account ID, case-insensitive but already digits
 		case "instancetype":
 			instanceType = strings.ToLower(v)
+		case "deploymentoption":
+			deployment = v
 		}
 	}
-	return account, instanceType
+	return instanceType, deployment
 }
 
 // ApplyCoverageMapToRecommendations sets ExistingCoveragePct on each rec
-// whose pool key appears in the map. Pool key shape depends on service:
-// RDS recs (DatabaseDetails carrying an engine) look up by
-// "region:instance_type:engine"; other services look up by
-// "region:instance_type". Recs without a match stay at zero, which the
-// sizing path treats as "no signal" and falls back to the
-// no-existing-commitments formula.
+// whose pool key appears in the map, and rebalances each rec's
+// AverageInstancesUsedPerHour so that the per-pool sum across recs equals
+// the coverage map's org-wide AvgInstancesPerHour for the pool. Pool key
+// shape depends on service: RDS recs (DatabaseDetails carrying an engine
+// + AZConfig) look up by "region:instance_type:engine:deployment"; other
+// services look up by "region:instance_type". Recs without a match stay
+// at zero, which the sizing path treats as "no signal" and falls back to
+// the no-existing-commitments formula.
+//
+// Why rebalance instead of just trusting per-rec avgs: AWS's
+// GetReservationPurchaseRecommendation returns one rec per (pool, account)
+// where it sees demand worth recommending. When AWS rec API only returns
+// per-account avgs that sum to less than what CE coverage reports
+// org-wide for the same pool (some linked accounts in the pool aren't
+// surfaced as recs), per-rec sizing under-buys for the pool as a whole.
+// Rebalancing scales each rec's avg by (cov.avg / sum-of-rec-avgs-in-pool)
+// so the sized per-rec purchases sum to what the coverage CSV's gap math
+// implies. When AWS rec API already matches coverage, the scale factor is
+// ~1.0 and behaviour is unchanged. When multiple recs have zero avg
+// (no per-account signal at all), the coverage avg is split evenly across
+// them so the total still lines up.
 //
 // Mutates recs in place to mirror the way the sizing pipeline already
 // hands recs around by value within each loop iteration.
@@ -335,38 +431,75 @@ func ApplyCoverageMapToRecommendations(recs []common.Recommendation, coverage Po
 	if len(coverage) == 0 {
 		return
 	}
+	// First pass: index recs by pool key and sum per-account avgs so we
+	// can compute the scaling factor needed to land the per-pool total on
+	// the coverage's org-wide avg.
+	poolIdx := make(map[string][]int)
+	poolAvgSum := make(map[string]float64)
 	for i := range recs {
 		key := lookupPoolKey(recs[i])
-		if pct, ok := coverage[key]; ok {
-			recs[i].ExistingCoveragePct = pct
+		poolIdx[key] = append(poolIdx[key], i)
+		if recs[i].AverageInstancesUsedPerHour > 0 {
+			poolAvgSum[key] += recs[i].AverageInstancesUsedPerHour
+		}
+	}
+	// Second pass: set ExistingCoveragePct + scale AverageInstancesUsedPerHour
+	// per rec so the pool's recs sum to cov.AvgInstancesPerHour.
+	for i := range recs {
+		key := lookupPoolKey(recs[i])
+		cov, ok := coverage[key]
+		if !ok {
+			continue
+		}
+		recs[i].ExistingCoveragePct = cov.Pct
+		if cov.AvgInstancesPerHour <= 0 {
+			// No org-wide avg signal — leave rec.avg as-is (rec API's
+			// per-account number is the only signal we have for sizing).
+			continue
+		}
+		if recSum := poolAvgSum[key]; recSum > 0 {
+			// Scale this rec's per-account avg by its proportional share
+			// of the org-wide avg. When AWS rec API's per-account total
+			// matches CE coverage, scale ≈ 1 (no-op). When AWS rec API
+			// under-counts (some accounts not surfaced), scale > 1 and
+			// each rec's sized buy grows proportionally so the per-pool
+			// sum lands on the coverage figure.
+			recs[i].AverageInstancesUsedPerHour *= cov.AvgInstancesPerHour / recSum
+		} else {
+			// Every rec in this pool came back with zero avg — split the
+			// coverage's avg evenly across them. Equal distribution is
+			// the only fair choice when there's no per-account signal to
+			// weight by.
+			recs[i].AverageInstancesUsedPerHour = cov.AvgInstancesPerHour / float64(len(poolIdx[key]))
 		}
 	}
 }
 
 // lookupPoolKey returns the pool key for a recommendation. RDS uses the
-// engine-aware form; non-RDS uses the simpler form. Both include the
-// linked-account ID so the per-account fetcher's keys match — without
-// this, CE's org-wide aggregate would bleed across accounts.
+// engine + deployment-aware form; non-RDS uses the region+type form. Keys
+// are org-wide (no account dimension) so the same pool seen from any
+// linked account looks up the same coverage entry — matches the AWS
+// console reservations-coverage report.
 func lookupPoolKey(rec common.Recommendation) string {
-	if engine := rdsEngineFromRec(rec); engine != "" {
-		return rdsPoolKey(rec.Region, rec.ResourceType, engine, rec.Account)
+	if engine, deployment := rdsEngineDeploymentFromRec(rec); engine != "" {
+		return rdsPoolKey(rec.Region, rec.ResourceType, engine, deployment)
 	}
-	return poolKey(rec.Region, rec.ResourceType, rec.Account)
+	return poolKey(rec.Region, rec.ResourceType)
 }
 
-// rdsEngineFromRec extracts the RDS engine string from a recommendation's
-// polymorphic Details, returning "" when the rec isn't an RDS rec or the
-// engine isn't populated. Handles both pointer and value forms of
+// rdsEngineDeploymentFromRec extracts the RDS engine and deployment
+// strings from a recommendation's polymorphic Details, returning ("", "")
+// when the rec isn't an RDS rec. Handles both pointer and value forms of
 // DatabaseDetails because the live parser uses pointers and the CSV
 // loader uses values.
-func rdsEngineFromRec(rec common.Recommendation) string {
+func rdsEngineDeploymentFromRec(rec common.Recommendation) (engine, deployment string) {
 	switch details := rec.Details.(type) {
 	case *common.DatabaseDetails:
 		if details != nil {
-			return details.Engine
+			return details.Engine, details.AZConfig
 		}
 	case common.DatabaseDetails:
-		return details.Engine
+		return details.Engine, details.AZConfig
 	}
-	return ""
+	return "", ""
 }

--- a/providers/aws/recommendations/coverage_test.go
+++ b/providers/aws/recommendations/coverage_test.go
@@ -30,10 +30,12 @@ func (m *mockCoverageCE) GetReservationCoverage(ctx context.Context, params *cos
 	return m.coverageOutput, nil
 }
 
-// TestGetRICoverageMap_GroupsByRegionAndInstanceType confirms a single-page
-// CE response is parsed into the expected pool-keyed map and that absent
+// TestGetRICoverageMap_GroupsByInstanceType confirms a single-page CE
+// response is parsed into the expected pool-keyed map and that absent
 // attribute keys are skipped rather than producing zero-valued entries.
-func TestGetRICoverageMap_GroupsByAccountAndInstanceType(t *testing.T) {
+// Coverage is org-wide (no account dimension) — matches the AWS console
+// reservations-coverage report shape.
+func TestGetRICoverageMap_GroupsByInstanceType(t *testing.T) {
 	mock := &mockCoverageCE{
 		coverageOutput: &costexplorer.GetReservationCoverageOutput{
 			CoveragesByTime: []types.CoverageByTime{
@@ -41,12 +43,13 @@ func TestGetRICoverageMap_GroupsByAccountAndInstanceType(t *testing.T) {
 					Groups: []types.ReservationCoverageGroup{
 						{
 							Attributes: map[string]string{
-								"account":      "test-account-a",
 								"instanceType": "db.r6g.large",
 							},
 							Coverage: &types.Coverage{
 								CoverageHours: &types.CoverageHours{
 									CoverageHoursPercentage: aws.String("50.0"),
+									// 720h in a 30-day window = avg 1 instance.
+									TotalRunningHours: aws.String("720"),
 								},
 							},
 						},
@@ -55,18 +58,19 @@ func TestGetRICoverageMap_GroupsByAccountAndInstanceType(t *testing.T) {
 							// camelCase keys in practice but the parser tolerates
 							// either form.
 							Attributes: map[string]string{
-								"LINKED_ACCOUNT": "test-account-b",
-								"INSTANCE_TYPE":  "db.r6g.large",
+								"INSTANCE_TYPE": "db.m5.xlarge",
 							},
 							Coverage: &types.Coverage{
 								CoverageHours: &types.CoverageHours{
 									CoverageHoursPercentage: aws.String("33.7"),
+									// 7200h in a 30-day window = avg 10 instances.
+									TotalRunningHours: aws.String("7200"),
 								},
 							},
 						},
 						{
 							// Missing INSTANCE_TYPE attribute → skipped.
-							Attributes: map[string]string{"account": "test-account-a"},
+							Attributes: map[string]string{},
 							Coverage: &types.Coverage{
 								CoverageHours: &types.CoverageHours{
 									CoverageHoursPercentage: aws.String("99.9"),
@@ -88,12 +92,16 @@ func TestGetRICoverageMap_GroupsByAccountAndInstanceType(t *testing.T) {
 	wantCalls := len(regions) * (len(coverageServiceFilters) + len(rdsCoverageEngines))
 	assert.Equal(t, wantCalls, mock.coverageCalls, "one CE call per (region, service|engine) combo")
 
-	// Account test-account-a in us-east-1 + db.r6g.large = 50%. The mock
-	// returns the same canned response for every call, so the per-region
-	// loop writes the same key on every iteration — last write wins.
-	assert.InDelta(t, 50.0, got[poolKey("eu-west-2", "db.r6g.large", "test-account-a")], 0.001)
-	assert.InDelta(t, 33.7, got[poolKey("eu-west-2", "db.r6g.large", "test-account-b")], 0.001, "SCREAMING_SNAKE_CASE attribute keys tolerated")
-	_, hasMissing := got[poolKey("us-east-1", "", "test-account-a")]
+	// us-east-1 + db.r6g.large = 50% / avg 1. The mock returns the same
+	// canned response for every call, so the per-region loop writes the
+	// same key on every iteration — last write wins.
+	r6gLarge := got[poolKey("eu-west-2", "db.r6g.large")]
+	assert.InDelta(t, 50.0, r6gLarge.Pct, 0.001)
+	assert.InDelta(t, 1.0, r6gLarge.AvgInstancesPerHour, 0.001, "TotalRunningHours / window hours = avg concurrent instances")
+	m5xLarge := got[poolKey("eu-west-2", "db.m5.xlarge")]
+	assert.InDelta(t, 33.7, m5xLarge.Pct, 0.001, "SCREAMING_SNAKE_CASE attribute keys tolerated")
+	assert.InDelta(t, 10.0, m5xLarge.AvgInstancesPerHour, 0.001, "avg parsed regardless of attribute-key casing")
+	_, hasMissing := got[poolKey("us-east-1", "")]
 	assert.False(t, hasMissing, "groups missing INSTANCE_TYPE should be skipped, not emit empty keys")
 }
 
@@ -110,21 +118,19 @@ func TestGetRICoverageMap_LookbackDefault(t *testing.T) {
 	assert.Equal(t, wantCalls, mock.coverageCalls)
 }
 
-// TestApplyCoverageMapToRecommendations covers the per-account matching:
-// recs look up by (region, instance_type, [engine], account) so accounts
-// with zero existing coverage don't see another account's coverage bled
-// in via the org-wide aggregate.
+// TestApplyCoverageMapToRecommendations covers the org-wide pool matching:
+// recs look up by (region, instance_type, [engine, deployment]) so any
+// linked account in the org sees the same coverage % for the same pool
+// (matches AWS console aggregation).
 func TestApplyCoverageMapToRecommendations(t *testing.T) {
-	const acctA = "test-account-a"
-	const acctB = "test-account-b"
 	recs := []common.Recommendation{
-		{Region: "us-east-1", ResourceType: "db.r6g.large", Account: acctA},
-		{Region: "eu-west-2", ResourceType: "db.r6g.large", Account: acctB},
-		{Region: "us-east-1", ResourceType: "db.m5.large", Account: acctA}, // no match
+		{Region: "us-east-1", ResourceType: "db.r6g.large", Account: "acct-a"},
+		{Region: "eu-west-2", ResourceType: "db.r6g.large", Account: "acct-b"},
+		{Region: "us-east-1", ResourceType: "db.m5.large", Account: "acct-a"}, // no match
 	}
 	coverage := PoolCoverageMap{
-		poolKey("us-east-1", "db.r6g.large", acctA): 50.0,
-		poolKey("eu-west-2", "db.r6g.large", acctB): 33.7,
+		poolKey("us-east-1", "db.r6g.large"): {Pct: 50.0},
+		poolKey("eu-west-2", "db.r6g.large"): {Pct: 33.7},
 	}
 
 	ApplyCoverageMapToRecommendations(recs, coverage)
@@ -135,7 +141,7 @@ func TestApplyCoverageMapToRecommendations(t *testing.T) {
 
 	t.Run("empty map is a no-op", func(t *testing.T) {
 		recs := []common.Recommendation{
-			{Region: "us-east-1", ResourceType: "db.r6g.large", Account: acctA, ExistingCoveragePct: 42},
+			{Region: "us-east-1", ResourceType: "db.r6g.large", ExistingCoveragePct: 42},
 		}
 		ApplyCoverageMapToRecommendations(recs, nil)
 		assert.Equal(t, 42.0, recs[0].ExistingCoveragePct, "nil map must leave existing values untouched")
@@ -144,69 +150,166 @@ func TestApplyCoverageMapToRecommendations(t *testing.T) {
 	t.Run("case-insensitive matching for region/instance", func(t *testing.T) {
 		// Recommendations carry mixed-case region/type strings; the lookup
 		// must normalise both sides via poolKey.
-		recs := []common.Recommendation{{Region: "US-EAST-1", ResourceType: "DB.R6G.LARGE", Account: acctA}}
-		cov := PoolCoverageMap{poolKey("us-east-1", "db.r6g.large", acctA): 75.0}
+		recs := []common.Recommendation{{Region: "US-EAST-1", ResourceType: "DB.R6G.LARGE"}}
+		cov := PoolCoverageMap{poolKey("us-east-1", "db.r6g.large"): {Pct: 75.0}}
 		ApplyCoverageMapToRecommendations(recs, cov)
 		assert.InDelta(t, 75.0, recs[0].ExistingCoveragePct, 0.001)
 	})
 
-	t.Run("different accounts in same pool see different coverage", func(t *testing.T) {
-		// Production has 80% covered, staging has 0% — same pool dimensions
-		// otherwise. Without the per-account split this would average to ~40%
-		// for both. The per-account lookup keeps them distinct.
+	t.Run("all accounts in same pool see the same coverage", func(t *testing.T) {
+		// Pools are now org-wide: prod and staging running the same
+		// instance type / engine / deployment in the same region see the
+		// same coverage % (matches AWS console aggregation across linked
+		// accounts). Whoever buys the RI covers the org-wide pool.
 		recs := []common.Recommendation{
 			{
 				Service:      common.ServiceRDS,
 				Region:       "us-east-1",
 				ResourceType: "db.t4g.medium",
 				Account:      "prod-account",
-				Details:      &common.DatabaseDetails{Engine: "aurora-mysql"},
+				Details:      &common.DatabaseDetails{Engine: "aurora-mysql", AZConfig: "single-az"},
 			},
 			{
 				Service:      common.ServiceRDS,
 				Region:       "us-east-1",
 				ResourceType: "db.t4g.medium",
 				Account:      "staging-account",
-				Details:      &common.DatabaseDetails{Engine: "aurora-mysql"},
+				Details:      &common.DatabaseDetails{Engine: "aurora-mysql", AZConfig: "single-az"},
 			},
 		}
 		cov := PoolCoverageMap{
-			rdsPoolKey("us-east-1", "db.t4g.medium", "Aurora MySQL", "prod-account"):    80.0,
-			rdsPoolKey("us-east-1", "db.t4g.medium", "Aurora MySQL", "staging-account"): 0.0,
+			rdsPoolKey("us-east-1", "db.t4g.medium", "Aurora MySQL", "Single-AZ"): {Pct: 55.0},
 		}
 		ApplyCoverageMapToRecommendations(recs, cov)
-		assert.InDelta(t, 80.0, recs[0].ExistingCoveragePct, 0.001, "prod sees its own 80% coverage")
-		assert.Equal(t, 0.0, recs[1].ExistingCoveragePct, "staging sees 0%, not the prod-bled average")
+		assert.InDelta(t, 55.0, recs[0].ExistingCoveragePct, 0.001, "prod sees the org-wide 55% coverage")
+		assert.InDelta(t, 55.0, recs[1].ExistingCoveragePct, 0.001, "staging sees the same org-wide 55% coverage")
 	})
 
-	t.Run("RDS recs look up with engine-aware key per account", func(t *testing.T) {
-		// Same region + instance type + account, different engines —
-		// the per-engine fetcher writes one entry per engine and the
-		// lookup must pick the right one. CE-side ("Aurora MySQL") and
-		// parser-side ("aurora-mysql") forms collapse to the same key.
+	t.Run("avg-per-pool rebalances to coverage's org-wide signal", func(t *testing.T) {
+		// Single-rec-per-pool case: rec.avg is replaced with cov.avg via
+		// scale = cov.avg / rec.avg. Whatever AWS rec API surfaced as the
+		// per-account avg is replaced with the coverage's org-wide avg so
+		// downstream sizing buys the right number for the whole pool.
+		recs := []common.Recommendation{
+			// rec[0]: no per-account avg; coverage provides one → recs[0].avg = cov.avg
+			{Region: "us-east-1", ResourceType: "m5.large"},
+			// rec[1]: per-account avg present; coverage's larger avg now overrides
+			{Region: "us-east-1", ResourceType: "m5.xlarge", AverageInstancesUsedPerHour: 5.0},
+		}
+		cov := PoolCoverageMap{
+			poolKey("us-east-1", "m5.large"):  {Pct: 50.0, AvgInstancesPerHour: 10.0},
+			poolKey("us-east-1", "m5.xlarge"): {Pct: 30.0, AvgInstancesPerHour: 99.0},
+		}
+		ApplyCoverageMapToRecommendations(recs, cov)
+		assert.InDelta(t, 10.0, recs[0].AverageInstancesUsedPerHour, 0.001, "no-signal rec gets coverage's org-wide avg")
+		assert.InDelta(t, 99.0, recs[1].AverageInstancesUsedPerHour, 0.001, "single rec in pool: avg replaced with coverage's org-wide avg (scale=99/5)")
+	})
+
+	t.Run("avg-per-pool splits proportionally across multiple recs", func(t *testing.T) {
+		// Two per-account recs in the same pool with avgs 24.4 and 23.2;
+		// CE coverage reports org-wide avg of 210 for the pool (other
+		// accounts not surfaced by AWS rec API). Each rec gets scaled by
+		// 210 / (24.4+23.2) ≈ 4.412 so the per-pool sum hits 210, which
+		// is what the AWS console coverage CSV would target.
+		recs := []common.Recommendation{
+			{
+				Service:                     common.ServiceRDS,
+				Region:                      "us-east-1",
+				ResourceType:                "db.t4g.medium",
+				Account:                     "production",
+				Details:                     &common.DatabaseDetails{Engine: "aurora-mysql", AZConfig: "single-az"},
+				AverageInstancesUsedPerHour: 24.4,
+			},
+			{
+				Service:                     common.ServiceRDS,
+				Region:                      "us-east-1",
+				ResourceType:                "db.t4g.medium",
+				Account:                     "staging",
+				Details:                     &common.DatabaseDetails{Engine: "aurora-mysql", AZConfig: "single-az"},
+				AverageInstancesUsedPerHour: 23.2,
+			},
+		}
+		cov := PoolCoverageMap{
+			rdsPoolKey("us-east-1", "db.t4g.medium", "Aurora MySQL", "Single-AZ"): {
+				Pct: 55.0, AvgInstancesPerHour: 210.0,
+			},
+		}
+		ApplyCoverageMapToRecommendations(recs, cov)
+		// Per-rec scaled avgs sum to the coverage's org-wide avg.
+		sum := recs[0].AverageInstancesUsedPerHour + recs[1].AverageInstancesUsedPerHour
+		assert.InDelta(t, 210.0, sum, 0.001, "scaled per-rec avgs sum to coverage's org-wide avg")
+		// Proportions preserved: prod (24.4 / 47.6 = 51.3%) of the org total.
+		assert.InDelta(t, 210.0*24.4/47.6, recs[0].AverageInstancesUsedPerHour, 0.001, "prod gets its proportional share of org-wide avg")
+		assert.InDelta(t, 210.0*23.2/47.6, recs[1].AverageInstancesUsedPerHour, 0.001, "staging gets its proportional share of org-wide avg")
+	})
+
+	t.Run("avg-per-pool splits evenly when every rec has zero avg", func(t *testing.T) {
+		// Two recs in same pool, both with zero per-account avg signal.
+		// No per-rec proportion to preserve; coverage's avg splits evenly.
+		recs := []common.Recommendation{
+			{Region: "us-east-1", ResourceType: "m5.large", Account: "a"},
+			{Region: "us-east-1", ResourceType: "m5.large", Account: "b"},
+		}
+		cov := PoolCoverageMap{
+			poolKey("us-east-1", "m5.large"): {Pct: 50.0, AvgInstancesPerHour: 10.0},
+		}
+		ApplyCoverageMapToRecommendations(recs, cov)
+		assert.InDelta(t, 5.0, recs[0].AverageInstancesUsedPerHour, 0.001, "even split across zero-signal recs in same pool")
+		assert.InDelta(t, 5.0, recs[1].AverageInstancesUsedPerHour, 0.001, "even split across zero-signal recs in same pool")
+	})
+
+	t.Run("avg-per-pool leaves rec.avg untouched when coverage has no avg signal", func(t *testing.T) {
+		// Coverage entry exists (sets ExistingCoveragePct) but has no avg
+		// signal (e.g., TotalRunningHours absent from CE response). The
+		// per-account avg is the only signal — leave it alone.
+		recs := []common.Recommendation{
+			{Region: "us-east-1", ResourceType: "m5.large", AverageInstancesUsedPerHour: 7.5},
+		}
+		cov := PoolCoverageMap{
+			poolKey("us-east-1", "m5.large"): {Pct: 50.0, AvgInstancesPerHour: 0},
+		}
+		ApplyCoverageMapToRecommendations(recs, cov)
+		assert.InDelta(t, 50.0, recs[0].ExistingCoveragePct, 0.001)
+		assert.InDelta(t, 7.5, recs[0].AverageInstancesUsedPerHour, 0.001, "no coverage avg signal → leave rec avg as-is")
+	})
+
+	t.Run("RDS recs look up with engine + deployment-aware key", func(t *testing.T) {
+		// Same region + instance type, different engines and deployments —
+		// the per-engine fetcher writes one entry per (engine, deployment)
+		// and the lookup must pick the right one. CE-side ("Aurora MySQL",
+		// "Single-AZ") and parser-side ("aurora-mysql", "single-az") forms
+		// collapse to the same key.
 		recs := []common.Recommendation{
 			{
 				Service:      common.ServiceRDS,
 				Region:       "eu-west-2",
 				ResourceType: "db.r6g.large",
-				Account:      acctA,
-				Details:      &common.DatabaseDetails{Engine: "aurora-mysql"},
+				Details:      &common.DatabaseDetails{Engine: "aurora-mysql", AZConfig: "single-az"},
 			},
 			{
 				Service:      common.ServiceRDS,
 				Region:       "eu-west-2",
 				ResourceType: "db.r6g.large",
-				Account:      acctA,
-				Details:      &common.DatabaseDetails{Engine: "mysql"},
+				Details:      &common.DatabaseDetails{Engine: "mysql", AZConfig: "multi-az"},
+			},
+			{
+				// Same engine as rec[0] but Multi-AZ — a different pool
+				// scope (a Single-AZ RI can't cover Multi-AZ demand).
+				Service:      common.ServiceRDS,
+				Region:       "eu-west-2",
+				ResourceType: "db.r6g.large",
+				Details:      &common.DatabaseDetails{Engine: "aurora-mysql", AZConfig: "multi-az"},
 			},
 		}
 		cov := PoolCoverageMap{
-			rdsPoolKey("eu-west-2", "db.r6g.large", "Aurora MySQL", acctA): 98.5,
-			rdsPoolKey("eu-west-2", "db.r6g.large", "MySQL", acctA):        0.0,
+			rdsPoolKey("eu-west-2", "db.r6g.large", "Aurora MySQL", "Single-AZ"): {Pct: 98.5},
+			rdsPoolKey("eu-west-2", "db.r6g.large", "MySQL", "Multi-AZ"):         {Pct: 0.0},
+			rdsPoolKey("eu-west-2", "db.r6g.large", "Aurora MySQL", "Multi-AZ"):  {Pct: 12.0},
 		}
 		ApplyCoverageMapToRecommendations(recs, cov)
-		assert.InDelta(t, 98.5, recs[0].ExistingCoveragePct, 0.001, "aurora-mysql rec picks up Aurora MySQL coverage")
-		assert.Equal(t, 0.0, recs[1].ExistingCoveragePct, "MySQL rec sees only MySQL coverage, not Aurora's")
+		assert.InDelta(t, 98.5, recs[0].ExistingCoveragePct, 0.001, "aurora-mysql single-az rec picks up its own coverage")
+		assert.Equal(t, 0.0, recs[1].ExistingCoveragePct, "mysql multi-az rec sees only its own coverage")
+		assert.InDelta(t, 12.0, recs[2].ExistingCoveragePct, 0.001, "aurora-mysql multi-az is a distinct pool from single-az")
 	})
 }
 
@@ -225,7 +328,25 @@ func TestNormaliseRDSEngine(t *testing.T) {
 		// Parser-side strings (lowercase, hyphenated).
 		"aurora-mysql":      "auroramysql",
 		"aurora-postgresql": "aurorapostgresql",
-		"postgres":          "postgres",
+		// "postgres" is the bare RDS engine slug that DescribeDBInstances
+		// returns; CE coverage emits keys under "postgresql" (the display
+		// form). Collapse so both sides land on the same lookup key.
+		"postgres":   "postgresql",
+		"POSTGRES":   "postgresql",
+		"postgresql": "postgresql",
+		// SQL Server edition slugs (Express / Web / Standard / Enterprise)
+		// collapse to the bare family; CE coverage emits keys under
+		// "sqlserver" (from the "SQL Server" display form already covered
+		// in the CE-side block above).
+		"sqlserver-ee":  "sqlserver",
+		"sqlserver-se":  "sqlserver",
+		"sqlserver-ex":  "sqlserver",
+		"sqlserver-web": "sqlserver",
+		// Oracle edition slugs collapse to the bare family too.
+		"oracle-ee":  "oracle",
+		"oracle-se":  "oracle",
+		"oracle-se1": "oracle",
+		"oracle-se2": "oracle",
 		// Edge cases.
 		"":      "",
 		"MYSQL": "mysql",
@@ -233,6 +354,26 @@ func TestNormaliseRDSEngine(t *testing.T) {
 	for in, want := range cases {
 		t.Run(in, func(t *testing.T) {
 			assert.Equal(t, want, normaliseRDSEngine(in))
+		})
+	}
+}
+
+// TestNormaliseDeployment locks deployment-option canonicalisation. CE
+// returns "Single-AZ" / "Multi-AZ" / "Multi-AZ (readable standbys)" while
+// the parser stores "single-az" / "multi-az"; both forms must collapse to
+// the same lookup key.
+func TestNormaliseDeployment(t *testing.T) {
+	cases := map[string]string{
+		"Single-AZ":                    "singleaz",
+		"single-az":                    "singleaz",
+		"Multi-AZ":                     "multiaz",
+		"multi-az":                     "multiaz",
+		"Multi-AZ (readable standbys)": "multiazreadablestandbys",
+		"":                             "",
+	}
+	for in, want := range cases {
+		t.Run(in, func(t *testing.T) {
+			assert.Equal(t, want, normaliseDeployment(in))
 		})
 	}
 }

--- a/providers/aws/recommendations/coverage_test.go
+++ b/providers/aws/recommendations/coverage_test.go
@@ -83,7 +83,12 @@ func TestGetRICoverageMap_GroupsByRegionAndInstanceType(t *testing.T) {
 
 	got, err := client.GetRICoverageMap(context.Background(), 30)
 	require.NoError(t, err)
-	assert.Equal(t, 1, mock.coverageCalls, "should make exactly one CE call for a single-page response")
+	// One call per non-RDS service in coverageServiceFilters (EC2,
+	// ElastiCache, OpenSearch, Redshift, MemoryDB = 5) + one per RDS
+	// engine in rdsCoverageEngines (MySQL/PostgreSQL/MariaDB/Oracle/
+	// SQL Server/Aurora MySQL/Aurora PostgreSQL = 7) = 12 single-page calls.
+	wantCalls := len(coverageServiceFilters) + len(rdsCoverageEngines)
+	assert.Equal(t, wantCalls, mock.coverageCalls, "one CE call per (service|RDS engine) filter combo")
 
 	assert.InDelta(t, 50.0, got[poolKey("us-east-1", "db.r6g.large")], 0.001)
 	assert.InDelta(t, 33.7, got[poolKey("eu-west-2", "db.r6g.large")], 0.001, "REGION attribute should be lowercased")
@@ -99,7 +104,8 @@ func TestGetRICoverageMap_LookbackDefault(t *testing.T) {
 
 	_, err := client.GetRICoverageMap(context.Background(), 0)
 	require.NoError(t, err)
-	assert.Equal(t, 1, mock.coverageCalls)
+	wantCalls := len(coverageServiceFilters) + len(rdsCoverageEngines)
+	assert.Equal(t, wantCalls, mock.coverageCalls)
 }
 
 // TestApplyCoverageMapToRecommendations covers the three cases: matched
@@ -137,4 +143,60 @@ func TestApplyCoverageMapToRecommendations(t *testing.T) {
 		ApplyCoverageMapToRecommendations(recs, cov)
 		assert.InDelta(t, 75.0, recs[0].ExistingCoveragePct, 0.001)
 	})
+
+	t.Run("RDS recs look up with engine-aware key", func(t *testing.T) {
+		// Same region + instance type, different engines, different
+		// existing coverage — the per-engine fetcher writes one entry per
+		// engine and the lookup must pick the right one. CE-side ("Aurora
+		// MySQL") and parser-side ("aurora-mysql") forms must collapse to
+		// the same key via normaliseRDSEngine.
+		recs := []common.Recommendation{
+			{
+				Service:      common.ServiceRDS,
+				Region:       "eu-west-2",
+				ResourceType: "db.r6g.large",
+				Details:      &common.DatabaseDetails{Engine: "aurora-mysql"},
+			},
+			{
+				Service:      common.ServiceRDS,
+				Region:       "eu-west-2",
+				ResourceType: "db.r6g.large",
+				Details:      &common.DatabaseDetails{Engine: "mysql"},
+			},
+		}
+		cov := PoolCoverageMap{
+			rdsPoolKey("eu-west-2", "db.r6g.large", "Aurora MySQL"): 98.5,
+			rdsPoolKey("eu-west-2", "db.r6g.large", "MySQL"):        0.0,
+		}
+		ApplyCoverageMapToRecommendations(recs, cov)
+		assert.InDelta(t, 98.5, recs[0].ExistingCoveragePct, 0.001, "aurora-mysql rec picks up Aurora MySQL coverage")
+		assert.Equal(t, 0.0, recs[1].ExistingCoveragePct, "MySQL rec sees only MySQL coverage, not Aurora's")
+	})
+}
+
+// TestNormaliseRDSEngine locks the canonicalisation of CE-side and
+// parser-side engine strings to the same lookup key. Without this both
+// producer (per-engine fetcher) and consumer (apply helper) would write
+// or read differently and miss the lookup entirely.
+func TestNormaliseRDSEngine(t *testing.T) {
+	cases := map[string]string{
+		// CE-side strings (human readable, mixed case, spaces).
+		"Aurora MySQL":      "auroramysql",
+		"Aurora PostgreSQL": "aurorapostgresql",
+		"MySQL":             "mysql",
+		"PostgreSQL":        "postgresql",
+		"SQL Server":        "sqlserver",
+		// Parser-side strings (lowercase, hyphenated).
+		"aurora-mysql":      "auroramysql",
+		"aurora-postgresql": "aurorapostgresql",
+		"postgres":          "postgres",
+		// Edge cases.
+		"":      "",
+		"MYSQL": "mysql",
+	}
+	for in, want := range cases {
+		t.Run(in, func(t *testing.T) {
+			assert.Equal(t, want, normaliseRDSEngine(in))
+		})
+	}
 }

--- a/providers/aws/recommendations/coverage_test.go
+++ b/providers/aws/recommendations/coverage_test.go
@@ -1,0 +1,137 @@
+package recommendations
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/costexplorer"
+	"github.com/aws/aws-sdk-go-v2/service/costexplorer/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LeanerCloud/CUDly/pkg/common"
+)
+
+// mockCoverageCE extends the test mock with a configurable GetReservationCoverage
+// response so the coverage path can be exercised without hitting AWS.
+type mockCoverageCE struct {
+	mockCostExplorerAPI
+	coverageOutput *costexplorer.GetReservationCoverageOutput
+	coverageError  error
+	coverageCalls  int
+}
+
+func (m *mockCoverageCE) GetReservationCoverage(ctx context.Context, params *costexplorer.GetReservationCoverageInput, optFns ...func(*costexplorer.Options)) (*costexplorer.GetReservationCoverageOutput, error) {
+	m.coverageCalls++
+	if m.coverageError != nil {
+		return nil, m.coverageError
+	}
+	return m.coverageOutput, nil
+}
+
+// TestGetRICoverageMap_GroupsByRegionAndInstanceType confirms a single-page
+// CE response is parsed into the expected pool-keyed map and that absent
+// attribute keys are skipped rather than producing zero-valued entries.
+func TestGetRICoverageMap_GroupsByRegionAndInstanceType(t *testing.T) {
+	mock := &mockCoverageCE{
+		coverageOutput: &costexplorer.GetReservationCoverageOutput{
+			CoveragesByTime: []types.CoverageByTime{
+				{
+					Groups: []types.ReservationCoverageGroup{
+						{
+							Attributes: map[string]string{
+								"REGION":        "us-east-1",
+								"INSTANCE_TYPE": "db.r6g.large",
+							},
+							Coverage: &types.Coverage{
+								CoverageHours: &types.CoverageHours{
+									CoverageHoursPercentage: aws.String("50.0"),
+								},
+							},
+						},
+						{
+							// Mixed-case region from CE should normalise to lowercase.
+							Attributes: map[string]string{
+								"REGION":        "EU-WEST-2",
+								"INSTANCE_TYPE": "db.r6g.large",
+							},
+							Coverage: &types.Coverage{
+								CoverageHours: &types.CoverageHours{
+									CoverageHoursPercentage: aws.String("33.7"),
+								},
+							},
+						},
+						{
+							// Missing INSTANCE_TYPE attribute → skipped.
+							Attributes: map[string]string{"REGION": "us-east-1"},
+							Coverage: &types.Coverage{
+								CoverageHours: &types.CoverageHours{
+									CoverageHoursPercentage: aws.String("99.9"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	client := NewClientWithAPI(mock, "us-east-1")
+
+	got, err := client.GetRICoverageMap(context.Background(), 30)
+	require.NoError(t, err)
+	assert.Equal(t, 1, mock.coverageCalls, "should make exactly one CE call for a single-page response")
+
+	assert.InDelta(t, 50.0, got[poolKey("us-east-1", "db.r6g.large")], 0.001)
+	assert.InDelta(t, 33.7, got[poolKey("eu-west-2", "db.r6g.large")], 0.001, "REGION attribute should be lowercased")
+	_, hasMissing := got[poolKey("us-east-1", "")]
+	assert.False(t, hasMissing, "groups missing INSTANCE_TYPE should be skipped, not emit empty keys")
+}
+
+// TestGetRICoverageMap_LookbackDefault confirms that a non-positive lookback
+// substitutes the 30-day default (matches GetRIUtilization's behaviour).
+func TestGetRICoverageMap_LookbackDefault(t *testing.T) {
+	mock := &mockCoverageCE{coverageOutput: &costexplorer.GetReservationCoverageOutput{}}
+	client := NewClientWithAPI(mock, "us-east-1")
+
+	_, err := client.GetRICoverageMap(context.Background(), 0)
+	require.NoError(t, err)
+	assert.Equal(t, 1, mock.coverageCalls)
+}
+
+// TestApplyCoverageMapToRecommendations covers the three cases: matched
+// (sets the field), unmatched (leaves zero), and empty map (no-op).
+func TestApplyCoverageMapToRecommendations(t *testing.T) {
+	recs := []common.Recommendation{
+		{Region: "us-east-1", ResourceType: "db.r6g.large"},
+		{Region: "eu-west-2", ResourceType: "db.r6g.large"},
+		{Region: "us-east-1", ResourceType: "db.m5.large"}, // no match
+	}
+	coverage := PoolCoverageMap{
+		"us-east-1:db.r6g.large": 50.0,
+		"eu-west-2:db.r6g.large": 33.7,
+	}
+
+	ApplyCoverageMapToRecommendations(recs, coverage)
+
+	assert.InDelta(t, 50.0, recs[0].ExistingCoveragePct, 0.001)
+	assert.InDelta(t, 33.7, recs[1].ExistingCoveragePct, 0.001)
+	assert.Equal(t, 0.0, recs[2].ExistingCoveragePct, "unmatched pool should leave field at zero (no signal)")
+
+	t.Run("empty map is a no-op", func(t *testing.T) {
+		recs := []common.Recommendation{
+			{Region: "us-east-1", ResourceType: "db.r6g.large", ExistingCoveragePct: 42},
+		}
+		ApplyCoverageMapToRecommendations(recs, nil)
+		assert.Equal(t, 42.0, recs[0].ExistingCoveragePct, "nil map must leave existing values untouched")
+	})
+
+	t.Run("case-insensitive matching", func(t *testing.T) {
+		// Recommendations carry mixed-case region/type strings; the lookup
+		// must normalise both sides via poolKey.
+		recs := []common.Recommendation{{Region: "US-EAST-1", ResourceType: "DB.R6G.LARGE"}}
+		cov := PoolCoverageMap{"us-east-1:db.r6g.large": 75.0}
+		ApplyCoverageMapToRecommendations(recs, cov)
+		assert.InDelta(t, 75.0, recs[0].ExistingCoveragePct, 0.001)
+	})
+}

--- a/providers/aws/recommendations/coverage_test.go
+++ b/providers/aws/recommendations/coverage_test.go
@@ -136,8 +136,11 @@ func TestApplyCoverageMapToRecommendations(t *testing.T) {
 	ApplyCoverageMapToRecommendations(recs, coverage)
 
 	assert.InDelta(t, 50.0, recs[0].ExistingCoveragePct, 0.001)
+	assert.True(t, recs[0].ExistingCoverageKnown, "matched pool sets Known=true")
 	assert.InDelta(t, 33.7, recs[1].ExistingCoveragePct, 0.001)
+	assert.True(t, recs[1].ExistingCoverageKnown, "matched pool sets Known=true")
 	assert.Equal(t, 0.0, recs[2].ExistingCoveragePct, "unmatched pool should leave field at zero (no signal)")
+	assert.False(t, recs[2].ExistingCoverageKnown, "unmatched pool leaves Known=false so CSV renders n/a")
 
 	t.Run("empty map is a no-op", func(t *testing.T) {
 		recs := []common.Recommendation{

--- a/providers/aws/recommendations/coverage_test.go
+++ b/providers/aws/recommendations/coverage_test.go
@@ -33,7 +33,7 @@ func (m *mockCoverageCE) GetReservationCoverage(ctx context.Context, params *cos
 // TestGetRICoverageMap_GroupsByRegionAndInstanceType confirms a single-page
 // CE response is parsed into the expected pool-keyed map and that absent
 // attribute keys are skipped rather than producing zero-valued entries.
-func TestGetRICoverageMap_GroupsByRegionAndInstanceType(t *testing.T) {
+func TestGetRICoverageMap_GroupsByAccountAndInstanceType(t *testing.T) {
 	mock := &mockCoverageCE{
 		coverageOutput: &costexplorer.GetReservationCoverageOutput{
 			CoveragesByTime: []types.CoverageByTime{
@@ -41,7 +41,7 @@ func TestGetRICoverageMap_GroupsByRegionAndInstanceType(t *testing.T) {
 					Groups: []types.ReservationCoverageGroup{
 						{
 							Attributes: map[string]string{
-								"region":       "us-east-1",
+								"account":      "test-account-a",
 								"instanceType": "db.r6g.large",
 							},
 							Coverage: &types.Coverage{
@@ -51,13 +51,12 @@ func TestGetRICoverageMap_GroupsByRegionAndInstanceType(t *testing.T) {
 							},
 						},
 						{
-							// Mixed-case region from CE should normalise to lowercase.
-							// Also exercises the SCREAMING_SNAKE_CASE fallback path:
-							// CE returns camelCase keys in practice but our parser
-							// tolerates either form.
+							// SCREAMING_SNAKE_CASE fallback path: CE returns
+							// camelCase keys in practice but the parser tolerates
+							// either form.
 							Attributes: map[string]string{
-								"REGION":        "EU-WEST-2",
-								"INSTANCE_TYPE": "db.r6g.large",
+								"LINKED_ACCOUNT": "test-account-b",
+								"INSTANCE_TYPE":  "db.r6g.large",
 							},
 							Coverage: &types.Coverage{
 								CoverageHours: &types.CoverageHours{
@@ -67,7 +66,7 @@ func TestGetRICoverageMap_GroupsByRegionAndInstanceType(t *testing.T) {
 						},
 						{
 							// Missing INSTANCE_TYPE attribute → skipped.
-							Attributes: map[string]string{"REGION": "us-east-1"},
+							Attributes: map[string]string{"account": "test-account-a"},
 							Coverage: &types.Coverage{
 								CoverageHours: &types.CoverageHours{
 									CoverageHoursPercentage: aws.String("99.9"),
@@ -81,18 +80,20 @@ func TestGetRICoverageMap_GroupsByRegionAndInstanceType(t *testing.T) {
 	}
 	client := NewClientWithAPI(mock, "us-east-1")
 
-	got, err := client.GetRICoverageMap(context.Background(), 30)
+	regions := []string{"us-east-1", "eu-west-2"}
+	got, err := client.GetRICoverageMap(context.Background(), 30, regions)
 	require.NoError(t, err)
-	// One call per non-RDS service in coverageServiceFilters (EC2,
-	// ElastiCache, OpenSearch, Redshift, MemoryDB = 5) + one per RDS
-	// engine in rdsCoverageEngines (MySQL/PostgreSQL/MariaDB/Oracle/
-	// SQL Server/Aurora MySQL/Aurora PostgreSQL = 7) = 12 single-page calls.
-	wantCalls := len(coverageServiceFilters) + len(rdsCoverageEngines)
-	assert.Equal(t, wantCalls, mock.coverageCalls, "one CE call per (service|RDS engine) filter combo")
+	// One call per (region, service) for non-RDS + one per (region, RDS engine).
+	// Total = len(regions) × (len(coverageServiceFilters) + len(rdsCoverageEngines)).
+	wantCalls := len(regions) * (len(coverageServiceFilters) + len(rdsCoverageEngines))
+	assert.Equal(t, wantCalls, mock.coverageCalls, "one CE call per (region, service|engine) combo")
 
-	assert.InDelta(t, 50.0, got[poolKey("us-east-1", "db.r6g.large")], 0.001)
-	assert.InDelta(t, 33.7, got[poolKey("eu-west-2", "db.r6g.large")], 0.001, "REGION attribute should be lowercased")
-	_, hasMissing := got[poolKey("us-east-1", "")]
+	// Account test-account-a in us-east-1 + db.r6g.large = 50%. The mock
+	// returns the same canned response for every call, so the per-region
+	// loop writes the same key on every iteration — last write wins.
+	assert.InDelta(t, 50.0, got[poolKey("eu-west-2", "db.r6g.large", "test-account-a")], 0.001)
+	assert.InDelta(t, 33.7, got[poolKey("eu-west-2", "db.r6g.large", "test-account-b")], 0.001, "SCREAMING_SNAKE_CASE attribute keys tolerated")
+	_, hasMissing := got[poolKey("us-east-1", "", "test-account-a")]
 	assert.False(t, hasMissing, "groups missing INSTANCE_TYPE should be skipped, not emit empty keys")
 }
 
@@ -102,23 +103,28 @@ func TestGetRICoverageMap_LookbackDefault(t *testing.T) {
 	mock := &mockCoverageCE{coverageOutput: &costexplorer.GetReservationCoverageOutput{}}
 	client := NewClientWithAPI(mock, "us-east-1")
 
-	_, err := client.GetRICoverageMap(context.Background(), 0)
+	regions := []string{"us-east-1"}
+	_, err := client.GetRICoverageMap(context.Background(), 0, regions)
 	require.NoError(t, err)
-	wantCalls := len(coverageServiceFilters) + len(rdsCoverageEngines)
+	wantCalls := len(regions) * (len(coverageServiceFilters) + len(rdsCoverageEngines))
 	assert.Equal(t, wantCalls, mock.coverageCalls)
 }
 
-// TestApplyCoverageMapToRecommendations covers the three cases: matched
-// (sets the field), unmatched (leaves zero), and empty map (no-op).
+// TestApplyCoverageMapToRecommendations covers the per-account matching:
+// recs look up by (region, instance_type, [engine], account) so accounts
+// with zero existing coverage don't see another account's coverage bled
+// in via the org-wide aggregate.
 func TestApplyCoverageMapToRecommendations(t *testing.T) {
+	const acctA = "test-account-a"
+	const acctB = "test-account-b"
 	recs := []common.Recommendation{
-		{Region: "us-east-1", ResourceType: "db.r6g.large"},
-		{Region: "eu-west-2", ResourceType: "db.r6g.large"},
-		{Region: "us-east-1", ResourceType: "db.m5.large"}, // no match
+		{Region: "us-east-1", ResourceType: "db.r6g.large", Account: acctA},
+		{Region: "eu-west-2", ResourceType: "db.r6g.large", Account: acctB},
+		{Region: "us-east-1", ResourceType: "db.m5.large", Account: acctA}, // no match
 	}
 	coverage := PoolCoverageMap{
-		"us-east-1:db.r6g.large": 50.0,
-		"eu-west-2:db.r6g.large": 33.7,
+		poolKey("us-east-1", "db.r6g.large", acctA): 50.0,
+		poolKey("eu-west-2", "db.r6g.large", acctB): 33.7,
 	}
 
 	ApplyCoverageMapToRecommendations(recs, coverage)
@@ -129,44 +135,74 @@ func TestApplyCoverageMapToRecommendations(t *testing.T) {
 
 	t.Run("empty map is a no-op", func(t *testing.T) {
 		recs := []common.Recommendation{
-			{Region: "us-east-1", ResourceType: "db.r6g.large", ExistingCoveragePct: 42},
+			{Region: "us-east-1", ResourceType: "db.r6g.large", Account: acctA, ExistingCoveragePct: 42},
 		}
 		ApplyCoverageMapToRecommendations(recs, nil)
 		assert.Equal(t, 42.0, recs[0].ExistingCoveragePct, "nil map must leave existing values untouched")
 	})
 
-	t.Run("case-insensitive matching", func(t *testing.T) {
+	t.Run("case-insensitive matching for region/instance", func(t *testing.T) {
 		// Recommendations carry mixed-case region/type strings; the lookup
 		// must normalise both sides via poolKey.
-		recs := []common.Recommendation{{Region: "US-EAST-1", ResourceType: "DB.R6G.LARGE"}}
-		cov := PoolCoverageMap{"us-east-1:db.r6g.large": 75.0}
+		recs := []common.Recommendation{{Region: "US-EAST-1", ResourceType: "DB.R6G.LARGE", Account: acctA}}
+		cov := PoolCoverageMap{poolKey("us-east-1", "db.r6g.large", acctA): 75.0}
 		ApplyCoverageMapToRecommendations(recs, cov)
 		assert.InDelta(t, 75.0, recs[0].ExistingCoveragePct, 0.001)
 	})
 
-	t.Run("RDS recs look up with engine-aware key", func(t *testing.T) {
-		// Same region + instance type, different engines, different
-		// existing coverage — the per-engine fetcher writes one entry per
-		// engine and the lookup must pick the right one. CE-side ("Aurora
-		// MySQL") and parser-side ("aurora-mysql") forms must collapse to
-		// the same key via normaliseRDSEngine.
+	t.Run("different accounts in same pool see different coverage", func(t *testing.T) {
+		// Production has 80% covered, staging has 0% — same pool dimensions
+		// otherwise. Without the per-account split this would average to ~40%
+		// for both. The per-account lookup keeps them distinct.
+		recs := []common.Recommendation{
+			{
+				Service:      common.ServiceRDS,
+				Region:       "us-east-1",
+				ResourceType: "db.t4g.medium",
+				Account:      "prod-account",
+				Details:      &common.DatabaseDetails{Engine: "aurora-mysql"},
+			},
+			{
+				Service:      common.ServiceRDS,
+				Region:       "us-east-1",
+				ResourceType: "db.t4g.medium",
+				Account:      "staging-account",
+				Details:      &common.DatabaseDetails{Engine: "aurora-mysql"},
+			},
+		}
+		cov := PoolCoverageMap{
+			rdsPoolKey("us-east-1", "db.t4g.medium", "Aurora MySQL", "prod-account"):    80.0,
+			rdsPoolKey("us-east-1", "db.t4g.medium", "Aurora MySQL", "staging-account"): 0.0,
+		}
+		ApplyCoverageMapToRecommendations(recs, cov)
+		assert.InDelta(t, 80.0, recs[0].ExistingCoveragePct, 0.001, "prod sees its own 80% coverage")
+		assert.Equal(t, 0.0, recs[1].ExistingCoveragePct, "staging sees 0%, not the prod-bled average")
+	})
+
+	t.Run("RDS recs look up with engine-aware key per account", func(t *testing.T) {
+		// Same region + instance type + account, different engines —
+		// the per-engine fetcher writes one entry per engine and the
+		// lookup must pick the right one. CE-side ("Aurora MySQL") and
+		// parser-side ("aurora-mysql") forms collapse to the same key.
 		recs := []common.Recommendation{
 			{
 				Service:      common.ServiceRDS,
 				Region:       "eu-west-2",
 				ResourceType: "db.r6g.large",
+				Account:      acctA,
 				Details:      &common.DatabaseDetails{Engine: "aurora-mysql"},
 			},
 			{
 				Service:      common.ServiceRDS,
 				Region:       "eu-west-2",
 				ResourceType: "db.r6g.large",
+				Account:      acctA,
 				Details:      &common.DatabaseDetails{Engine: "mysql"},
 			},
 		}
 		cov := PoolCoverageMap{
-			rdsPoolKey("eu-west-2", "db.r6g.large", "Aurora MySQL"): 98.5,
-			rdsPoolKey("eu-west-2", "db.r6g.large", "MySQL"):        0.0,
+			rdsPoolKey("eu-west-2", "db.r6g.large", "Aurora MySQL", acctA): 98.5,
+			rdsPoolKey("eu-west-2", "db.r6g.large", "MySQL", acctA):        0.0,
 		}
 		ApplyCoverageMapToRecommendations(recs, cov)
 		assert.InDelta(t, 98.5, recs[0].ExistingCoveragePct, 0.001, "aurora-mysql rec picks up Aurora MySQL coverage")

--- a/providers/aws/recommendations/coverage_test.go
+++ b/providers/aws/recommendations/coverage_test.go
@@ -41,8 +41,8 @@ func TestGetRICoverageMap_GroupsByRegionAndInstanceType(t *testing.T) {
 					Groups: []types.ReservationCoverageGroup{
 						{
 							Attributes: map[string]string{
-								"REGION":        "us-east-1",
-								"INSTANCE_TYPE": "db.r6g.large",
+								"region":       "us-east-1",
+								"instanceType": "db.r6g.large",
 							},
 							Coverage: &types.Coverage{
 								CoverageHours: &types.CoverageHours{
@@ -52,6 +52,9 @@ func TestGetRICoverageMap_GroupsByRegionAndInstanceType(t *testing.T) {
 						},
 						{
 							// Mixed-case region from CE should normalise to lowercase.
+							// Also exercises the SCREAMING_SNAKE_CASE fallback path:
+							// CE returns camelCase keys in practice but our parser
+							// tolerates either form.
 							Attributes: map[string]string{
 								"REGION":        "EU-WEST-2",
 								"INSTANCE_TYPE": "db.r6g.large",

--- a/providers/aws/recommendations/expiry.go
+++ b/providers/aws/recommendations/expiry.go
@@ -1,0 +1,110 @@
+package recommendations
+
+import (
+	"time"
+
+	"github.com/LeanerCloud/CUDly/pkg/common"
+)
+
+// AdjustExistingCoverageForExpiringCommitments reduces each rec's
+// ExistingCoveragePct by the share of pool demand attributable to RIs that
+// expire within windowDays. Sized purchases downstream then treat the
+// expiring share as already-uncovered and recommend replacements.
+//
+// Returns the number of recommendations whose ExistingCoveragePct was
+// adjusted, so the caller can log a meaningful summary.
+//
+// No-op when windowDays <= 0 or commitments is empty. The intent is that
+// --rebuy-window-days controls whether this adjustment runs at all;
+// callers gate the invocation on cfg.RebuyWindowDays.
+//
+// Pool matching uses the same engine-aware key as the coverage map so the
+// adjustment lines up with the data ApplyCoverageMapToRecommendations
+// just populated. Commitments whose pool key doesn't match any rec are
+// silently dropped (they're for instance types we're not currently
+// recommending; nothing to subtract from).
+func AdjustExistingCoverageForExpiringCommitments(
+	recs []common.Recommendation,
+	commitments []common.Commitment,
+	windowDays int,
+) int {
+	if windowDays <= 0 || len(commitments) == 0 {
+		return 0
+	}
+	cutoff := time.Now().Add(time.Duration(windowDays) * 24 * time.Hour)
+	expiringByPool := expiringCountsByPool(commitments, cutoff)
+	if len(expiringByPool) == 0 {
+		return 0
+	}
+	return applyExpiringAdjustments(recs, expiringByPool)
+}
+
+// expiringCountsByPool aggregates active commitments expiring at-or-before
+// cutoff into a pool-keyed count map. The State filter mirrors
+// DuplicateChecker.filterRecentCommitments — only RIs currently providing
+// coverage are counted (queued / retired RIs aren't covering demand now).
+func expiringCountsByPool(commitments []common.Commitment, cutoff time.Time) map[string]int {
+	out := make(map[string]int)
+	for _, c := range commitments {
+		if !commitmentIsActive(c) {
+			continue
+		}
+		if c.EndDate.IsZero() || c.EndDate.After(cutoff) {
+			continue
+		}
+		key := commitmentPoolKey(c)
+		if key == "" {
+			continue
+		}
+		out[key] += c.Count
+	}
+	return out
+}
+
+// applyExpiringAdjustments subtracts each rec's matching expiring-pool
+// share from ExistingCoveragePct, clamping at zero. Returns the number
+// of recs touched. Recs without a positive avg signal are skipped — we
+// can't compute a per-pool percentage without it.
+func applyExpiringAdjustments(recs []common.Recommendation, expiringByPool map[string]int) int {
+	adjusted := 0
+	for i := range recs {
+		if recs[i].AverageInstancesUsedPerHour <= 0 {
+			continue
+		}
+		expCount, ok := expiringByPool[lookupPoolKey(recs[i])]
+		if !ok || expCount == 0 {
+			continue
+		}
+		// Convert expiring count to percentage of pool demand. Clamp to
+		// avoid negative ExistingCoveragePct if the expiring share exceeds
+		// the CE-reported existing coverage (can happen when CE coverage
+		// is org-wide-averaged below per-pool truth, or when expiring
+		// count includes ZONAL RIs the regional aggregate doesn't credit).
+		expiringPct := float64(expCount) / recs[i].AverageInstancesUsedPerHour * 100.0
+		if expiringPct > recs[i].ExistingCoveragePct {
+			recs[i].ExistingCoveragePct = 0
+		} else {
+			recs[i].ExistingCoveragePct -= expiringPct
+		}
+		adjusted++
+	}
+	return adjusted
+}
+
+// commitmentIsActive returns true for commitments whose State indicates
+// they're currently providing coverage. Matches the state set used by
+// DuplicateChecker for consistency.
+func commitmentIsActive(c common.Commitment) bool {
+	return c.State == "active" || c.State == "payment-pending"
+}
+
+// commitmentPoolKey returns the same lookup key shape used by the coverage
+// map: engine-aware for RDS, region+instance-type for everything else.
+// The shape must match lookupPoolKey so adjustments align with the
+// existing-coverage signal they're modifying.
+func commitmentPoolKey(c common.Commitment) string {
+	if c.Service == common.ServiceRDS || c.Service == common.ServiceRelationalDB {
+		return rdsPoolKey(c.Region, c.ResourceType, c.Engine)
+	}
+	return poolKey(c.Region, c.ResourceType)
+}

--- a/providers/aws/recommendations/expiry.go
+++ b/providers/aws/recommendations/expiry.go
@@ -103,13 +103,14 @@ func commitmentIsActive(c common.Commitment) bool {
 // everything else. Keys are org-wide (no account dimension) so an
 // expiring RI in one linked account adjusts the org-wide coverage signal
 // for the pool it belongs to — matching the way the coverage map itself
-// is now aggregated. common.Commitment doesn't currently carry a
-// deployment-option field, so RDS expiry keys default to "" deployment
-// and will only match coverage entries written without a deployment
-// suffix — a known limitation tracked separately from this change.
+// is now aggregated. The Deployment field on common.Commitment carries
+// the same "single-az"/"multi-az" vocabulary as DatabaseDetails.AZConfig
+// on Recommendation, so a Multi-AZ commitment's expiry adjusts only the
+// Multi-AZ pool's existing-coverage signal (a Single-AZ RI cannot cover
+// Multi-AZ demand and vice versa).
 func commitmentPoolKey(c common.Commitment) string {
 	if c.Service == common.ServiceRDS || c.Service == common.ServiceRelationalDB {
-		return rdsPoolKey(c.Region, c.ResourceType, c.Engine, "")
+		return rdsPoolKey(c.Region, c.ResourceType, c.Engine, c.Deployment)
 	}
 	return poolKey(c.Region, c.ResourceType)
 }

--- a/providers/aws/recommendations/expiry.go
+++ b/providers/aws/recommendations/expiry.go
@@ -100,11 +100,11 @@ func commitmentIsActive(c common.Commitment) bool {
 
 // commitmentPoolKey returns the same lookup key shape used by the coverage
 // map: engine-aware for RDS, region+instance-type for everything else.
-// The shape must match lookupPoolKey so adjustments align with the
-// existing-coverage signal they're modifying.
+// Both forms include the linked-account ID so adjustments align with the
+// per-account existing-coverage signal they're modifying.
 func commitmentPoolKey(c common.Commitment) string {
 	if c.Service == common.ServiceRDS || c.Service == common.ServiceRelationalDB {
-		return rdsPoolKey(c.Region, c.ResourceType, c.Engine)
+		return rdsPoolKey(c.Region, c.ResourceType, c.Engine, c.Account)
 	}
-	return poolKey(c.Region, c.ResourceType)
+	return poolKey(c.Region, c.ResourceType, c.Account)
 }

--- a/providers/aws/recommendations/expiry.go
+++ b/providers/aws/recommendations/expiry.go
@@ -99,12 +99,17 @@ func commitmentIsActive(c common.Commitment) bool {
 }
 
 // commitmentPoolKey returns the same lookup key shape used by the coverage
-// map: engine-aware for RDS, region+instance-type for everything else.
-// Both forms include the linked-account ID so adjustments align with the
-// per-account existing-coverage signal they're modifying.
+// map: engine + deployment-aware for RDS, region+instance-type for
+// everything else. Keys are org-wide (no account dimension) so an
+// expiring RI in one linked account adjusts the org-wide coverage signal
+// for the pool it belongs to — matching the way the coverage map itself
+// is now aggregated. common.Commitment doesn't currently carry a
+// deployment-option field, so RDS expiry keys default to "" deployment
+// and will only match coverage entries written without a deployment
+// suffix — a known limitation tracked separately from this change.
 func commitmentPoolKey(c common.Commitment) string {
 	if c.Service == common.ServiceRDS || c.Service == common.ServiceRelationalDB {
-		return rdsPoolKey(c.Region, c.ResourceType, c.Engine, c.Account)
+		return rdsPoolKey(c.Region, c.ResourceType, c.Engine, "")
 	}
-	return poolKey(c.Region, c.ResourceType, c.Account)
+	return poolKey(c.Region, c.ResourceType)
 }

--- a/providers/aws/recommendations/expiry_test.go
+++ b/providers/aws/recommendations/expiry_test.go
@@ -1,0 +1,210 @@
+package recommendations
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/LeanerCloud/CUDly/pkg/common"
+)
+
+// TestAdjustExistingCoverageForExpiringCommitments covers the four cases:
+// the no-op guards, the typical case (some commitments expiring, some not),
+// the over-subtract clamp, and pool-key mismatch (commitment for a pool
+// nobody recommended).
+func TestAdjustExistingCoverageForExpiringCommitments(t *testing.T) {
+	now := time.Now()
+	soon := now.Add(15 * 24 * time.Hour)     // expires in 15 days
+	later := now.Add(180 * 24 * time.Hour)   // expires in 180 days
+	pastDate := now.Add(-7 * 24 * time.Hour) // already expired
+	pgEngine := "Aurora PostgreSQL"
+
+	t.Run("no-op when windowDays is zero", func(t *testing.T) {
+		recs := []common.Recommendation{{
+			Service:                     common.ServiceRDS,
+			Region:                      "us-east-1",
+			ResourceType:                "db.r6g.large",
+			AverageInstancesUsedPerHour: 10,
+			ExistingCoveragePct:         80,
+			Details:                     &common.DatabaseDetails{Engine: pgEngine},
+		}}
+		commits := []common.Commitment{{
+			Service:      common.ServiceRDS,
+			Region:       "us-east-1",
+			ResourceType: "db.r6g.large",
+			Engine:       pgEngine,
+			Count:        5,
+			State:        "active",
+			EndDate:      soon,
+		}}
+		n := AdjustExistingCoverageForExpiringCommitments(recs, commits, 0)
+		assert.Equal(t, 0, n)
+		assert.Equal(t, 80.0, recs[0].ExistingCoveragePct, "ExistingCoveragePct must be untouched when windowDays=0")
+	})
+
+	t.Run("typical case: subtracts expiring share within window", func(t *testing.T) {
+		// avg=10, existing=80%, 5 of those covered by RIs expiring in 15 days.
+		// expiringPct = 5/10*100 = 50. New existing = 80 - 50 = 30.
+		recs := []common.Recommendation{{
+			Service:                     common.ServiceRDS,
+			Region:                      "us-east-1",
+			ResourceType:                "db.r6g.large",
+			AverageInstancesUsedPerHour: 10,
+			ExistingCoveragePct:         80,
+			Details:                     &common.DatabaseDetails{Engine: pgEngine},
+		}}
+		commits := []common.Commitment{{
+			Service:      common.ServiceRDS,
+			Region:       "us-east-1",
+			ResourceType: "db.r6g.large",
+			Engine:       pgEngine,
+			Count:        5,
+			State:        "active",
+			EndDate:      soon,
+		}}
+		n := AdjustExistingCoverageForExpiringCommitments(recs, commits, 30)
+		assert.Equal(t, 1, n, "one rec adjusted")
+		assert.InDelta(t, 30.0, recs[0].ExistingCoveragePct, 0.001)
+	})
+
+	t.Run("commitments expiring outside window are ignored", func(t *testing.T) {
+		recs := []common.Recommendation{{
+			Service:                     common.ServiceRDS,
+			Region:                      "us-east-1",
+			ResourceType:                "db.r6g.large",
+			AverageInstancesUsedPerHour: 10,
+			ExistingCoveragePct:         80,
+			Details:                     &common.DatabaseDetails{Engine: pgEngine},
+		}}
+		commits := []common.Commitment{{
+			Service:      common.ServiceRDS,
+			Region:       "us-east-1",
+			ResourceType: "db.r6g.large",
+			Engine:       pgEngine,
+			Count:        5,
+			State:        "active",
+			EndDate:      later, // outside window
+		}}
+		n := AdjustExistingCoverageForExpiringCommitments(recs, commits, 30)
+		assert.Equal(t, 0, n)
+		assert.Equal(t, 80.0, recs[0].ExistingCoveragePct)
+	})
+
+	t.Run("over-subtract clamps to zero", func(t *testing.T) {
+		// Expiring count exceeds the share that ExistingCoveragePct claims —
+		// can happen when CE coverage is averaged across accounts but the
+		// commitments list is for the full region. Clamp to 0 rather than
+		// going negative.
+		recs := []common.Recommendation{{
+			Service:                     common.ServiceRDS,
+			Region:                      "us-east-1",
+			ResourceType:                "db.r6g.large",
+			AverageInstancesUsedPerHour: 10,
+			ExistingCoveragePct:         20, // only 20% per CE
+			Details:                     &common.DatabaseDetails{Engine: pgEngine},
+		}}
+		commits := []common.Commitment{{
+			Service:      common.ServiceRDS,
+			Region:       "us-east-1",
+			ResourceType: "db.r6g.large",
+			Engine:       pgEngine,
+			Count:        5, // 5/10 = 50% expiring
+			State:        "active",
+			EndDate:      soon,
+		}}
+		n := AdjustExistingCoverageForExpiringCommitments(recs, commits, 30)
+		assert.Equal(t, 1, n)
+		assert.Equal(t, 0.0, recs[0].ExistingCoveragePct, "must clamp to 0, not go negative")
+	})
+
+	t.Run("non-matching pool key is skipped", func(t *testing.T) {
+		recs := []common.Recommendation{{
+			Service:                     common.ServiceRDS,
+			Region:                      "us-east-1",
+			ResourceType:                "db.r6g.large",
+			AverageInstancesUsedPerHour: 10,
+			ExistingCoveragePct:         80,
+			Details:                     &common.DatabaseDetails{Engine: pgEngine},
+		}}
+		commits := []common.Commitment{{
+			Service:      common.ServiceRDS,
+			Region:       "us-east-1",
+			ResourceType: "db.r6g.large",
+			Engine:       "MySQL", // different engine
+			Count:        5,
+			State:        "active",
+			EndDate:      soon,
+		}}
+		n := AdjustExistingCoverageForExpiringCommitments(recs, commits, 30)
+		assert.Equal(t, 0, n, "engine mismatch should skip")
+		assert.Equal(t, 80.0, recs[0].ExistingCoveragePct)
+	})
+
+	t.Run("inactive commitments are skipped", func(t *testing.T) {
+		recs := []common.Recommendation{{
+			Service:                     common.ServiceRDS,
+			Region:                      "us-east-1",
+			ResourceType:                "db.r6g.large",
+			AverageInstancesUsedPerHour: 10,
+			ExistingCoveragePct:         80,
+			Details:                     &common.DatabaseDetails{Engine: pgEngine},
+		}}
+		commits := []common.Commitment{{
+			Service:      common.ServiceRDS,
+			Region:       "us-east-1",
+			ResourceType: "db.r6g.large",
+			Engine:       pgEngine,
+			Count:        5,
+			State:        "retired", // not active
+			EndDate:      soon,
+		}}
+		n := AdjustExistingCoverageForExpiringCommitments(recs, commits, 30)
+		assert.Equal(t, 0, n, "retired commitments don't currently provide coverage; skip")
+		assert.Equal(t, 80.0, recs[0].ExistingCoveragePct)
+	})
+
+	t.Run("already-expired commitments are skipped", func(t *testing.T) {
+		// A commitment with EndDate in the past was already filtered by the
+		// State check upstream, but defensively the function should treat
+		// past dates as "not in the window" too. Past < cutoff but
+		// (past < now) means the RI is no longer providing coverage and
+		// shouldn't be deducted from current ExistingCoveragePct (which
+		// presumably already excludes it).
+		recs := []common.Recommendation{{
+			Service:                     common.ServiceRDS,
+			Region:                      "us-east-1",
+			ResourceType:                "db.r6g.large",
+			AverageInstancesUsedPerHour: 10,
+			ExistingCoveragePct:         80,
+			Details:                     &common.DatabaseDetails{Engine: pgEngine},
+		}}
+		commits := []common.Commitment{{
+			Service:      common.ServiceRDS,
+			Region:       "us-east-1",
+			ResourceType: "db.r6g.large",
+			Engine:       pgEngine,
+			Count:        5,
+			State:        "active",
+			EndDate:      pastDate,
+		}}
+		// pastDate IS before cutoff (now+30d), so the current implementation
+		// counts it. Document this as the intended behaviour: anything with
+		// State="active" and EndDate within the cutoff is treated as soon-
+		// to-expire. The State filter upstream catches truly expired ones.
+		n := AdjustExistingCoverageForExpiringCommitments(recs, commits, 30)
+		assert.Equal(t, 1, n)
+		assert.InDelta(t, 30.0, recs[0].ExistingCoveragePct, 0.001)
+	})
+
+	t.Run("no-op when commitments is empty", func(t *testing.T) {
+		recs := []common.Recommendation{{
+			Service:                     common.ServiceRDS,
+			AverageInstancesUsedPerHour: 10,
+			ExistingCoveragePct:         50,
+		}}
+		n := AdjustExistingCoverageForExpiringCommitments(recs, nil, 30)
+		assert.Equal(t, 0, n)
+		assert.Equal(t, 50.0, recs[0].ExistingCoveragePct)
+	})
+}

--- a/providers/aws/recommendations/expiry_test.go
+++ b/providers/aws/recommendations/expiry_test.go
@@ -205,13 +205,17 @@ func TestAdjustExistingCoverageForExpiringCommitments(t *testing.T) {
 		assert.Equal(t, 80.0, recs[0].ExistingCoveragePct)
 	})
 
-	t.Run("already-expired commitments are skipped", func(t *testing.T) {
-		// A commitment with EndDate in the past was already filtered by the
-		// State check upstream, but defensively the function should treat
-		// past dates as "not in the window" too. Past < cutoff but
-		// (past < now) means the RI is no longer providing coverage and
-		// shouldn't be deducted from current ExistingCoveragePct (which
-		// presumably already excludes it).
+	t.Run("active commits with EndDate before cutoff are counted (incl. past dates)", func(t *testing.T) {
+		// The window check is EndDate <= cutoff: past dates satisfy that
+		// too. State="active" + EndDate<cutoff is treated as expiring
+		// regardless of whether EndDate is in the past or future. The
+		// upstream State filter is the gate for "is this RI providing
+		// coverage right now"; once a commitment passes that filter, this
+		// function trusts its EndDate alone.
+		//
+		// Document the intent here so a future reader doesn't try to add
+		// "EndDate > now" as an additional guard and silently change the
+		// semantics of pastDate commitments.
 		recs := []common.Recommendation{{
 			Service:                     common.ServiceRDS,
 			Region:                      "us-east-1",
@@ -229,12 +233,8 @@ func TestAdjustExistingCoverageForExpiringCommitments(t *testing.T) {
 			State:        "active",
 			EndDate:      pastDate,
 		}}
-		// pastDate IS before cutoff (now+30d), so the current implementation
-		// counts it. Document this as the intended behaviour: anything with
-		// State="active" and EndDate within the cutoff is treated as soon-
-		// to-expire. The State filter upstream catches truly expired ones.
 		n := AdjustExistingCoverageForExpiringCommitments(recs, commits, 30)
-		assert.Equal(t, 1, n)
+		assert.Equal(t, 1, n, "EndDate=pastDate <= cutoff so the commit IS counted")
 		assert.InDelta(t, 30.0, recs[0].ExistingCoveragePct, 0.001)
 	})
 

--- a/providers/aws/recommendations/expiry_test.go
+++ b/providers/aws/recommendations/expiry_test.go
@@ -68,6 +68,47 @@ func TestAdjustExistingCoverageForExpiringCommitments(t *testing.T) {
 		assert.InDelta(t, 30.0, recs[0].ExistingCoveragePct, 0.001)
 	})
 
+	t.Run("deployment-aware matching: Single-AZ commit only adjusts Single-AZ rec", func(t *testing.T) {
+		// Two recs for the same (region, type, engine) but different
+		// deployments. An expiring Single-AZ commitment must only affect
+		// the Single-AZ rec's existing-coverage signal — a Single-AZ RI
+		// cannot cover Multi-AZ demand. Without Deployment threaded into
+		// commitmentPoolKey, the commitment's empty-deployment key would
+		// miss both recs (both have deployment-aware lookup keys).
+		recs := []common.Recommendation{
+			{
+				Service:                     common.ServiceRDS,
+				Region:                      "us-east-1",
+				ResourceType:                "db.r6g.large",
+				AverageInstancesUsedPerHour: 10,
+				ExistingCoveragePct:         80,
+				Details:                     &common.DatabaseDetails{Engine: pgEngine, AZConfig: "single-az"},
+			},
+			{
+				Service:                     common.ServiceRDS,
+				Region:                      "us-east-1",
+				ResourceType:                "db.r6g.large",
+				AverageInstancesUsedPerHour: 10,
+				ExistingCoveragePct:         80,
+				Details:                     &common.DatabaseDetails{Engine: pgEngine, AZConfig: "multi-az"},
+			},
+		}
+		commits := []common.Commitment{{
+			Service:      common.ServiceRDS,
+			Region:       "us-east-1",
+			ResourceType: "db.r6g.large",
+			Engine:       pgEngine,
+			Deployment:   "single-az",
+			Count:        5,
+			State:        "active",
+			EndDate:      soon,
+		}}
+		n := AdjustExistingCoverageForExpiringCommitments(recs, commits, 30)
+		assert.Equal(t, 1, n, "only the Single-AZ rec adjusted")
+		assert.InDelta(t, 30.0, recs[0].ExistingCoveragePct, 0.001, "Single-AZ rec: 80% - 50% expiring = 30%")
+		assert.Equal(t, 80.0, recs[1].ExistingCoveragePct, "Multi-AZ rec untouched (different deployment pool)")
+	})
+
 	t.Run("commitments expiring outside window are ignored", func(t *testing.T) {
 		recs := []common.Recommendation{{
 			Service:                     common.ServiceRDS,

--- a/providers/aws/recommendations/family_nu.go
+++ b/providers/aws/recommendations/family_nu.go
@@ -261,6 +261,10 @@ func scaleRDSRecInFamily(rec common.Recommendation, scale, existingPct, familyTo
 	rec.CommitmentCost *= ratio
 	rec.OnDemandCost *= ratio
 	rec.EstimatedSavings *= ratio
+	if rec.RecurringMonthlyCost != nil {
+		scaled := *rec.RecurringMonthlyCost * ratio
+		rec.RecurringMonthlyCost = &scaled
+	}
 	rec.ExistingCoveragePct = existingPct
 	newNU := float64(newCount) * rdsInstanceNUFromType(rec.ResourceType)
 	projCov := existingPct + newNU/familyTotalNU*100.0

--- a/providers/aws/recommendations/family_nu.go
+++ b/providers/aws/recommendations/family_nu.go
@@ -34,6 +34,23 @@ var rdsInstanceNU = map[string]float64{
 	"32xlarge": 256,
 }
 
+// RDSInstanceNUFromType is the exported counterpart of rdsInstanceNUFromType
+// for callers outside this package that need the NU value for an RDS
+// instance type (e.g. CSV writers displaying per-row family-NU
+// contribution). Returns 0 for unknown sizes — same fallback semantics
+// as the unexported helper.
+func RDSInstanceNUFromType(instanceType string) float64 {
+	return rdsInstanceNUFromType(instanceType)
+}
+
+// RDSFamilyFromType is the exported counterpart of rdsFamilyFromType for
+// callers outside this package that need the family prefix of an RDS
+// instance type (e.g. CSV writers grouping rows by family). Empty
+// string when the type doesn't carry a recognisable size suffix.
+func RDSFamilyFromType(instanceType string) string {
+	return rdsFamilyFromType(instanceType)
+}
+
 // rdsInstanceNUFromType returns the NU value for an instance type like
 // "db.r7g.2xlarge", parsing out the size suffix ("2xlarge" → 16). Returns
 // 0 when the size isn't recognised — callers treat that as "no family-NU

--- a/providers/aws/recommendations/family_nu.go
+++ b/providers/aws/recommendations/family_nu.go
@@ -202,9 +202,15 @@ func partitionRDSRecsByFamily(recs []common.Recommendation) (map[string][]int, [
 
 // sizeRDSFamilyRecs sizes the recs in one family-key group: returns the
 // sized recs, drops empty/over-target families, and returns the
-// unchanged AWS-recommended counts when there's no coverage signal. The
-// scaling math (target_NU_need / current_rec_NU) and per-rec field
-// rewrite live in scaleRDSRecInFamily.
+// unchanged AWS-recommended counts when there's no coverage signal.
+//
+// First pass scales each rec's Count and cost-bearing fields by the
+// family-wide scale factor; second pass sets the same family-level
+// ProjectedCoverage on every surviving rec so operators see the
+// cumulative family projection (existing% + sum-of-new-NU / totalNU)
+// rather than each rec's standalone contribution. Without the second
+// pass, a family with N recs would show N different ProjectedCoverage
+// values, each missing the other N-1 recs' contributions.
 func sizeRDSFamilyRecs(
 	recs []common.Recommendation,
 	indices []int,
@@ -235,22 +241,61 @@ func sizeRDSFamilyRecs(
 		return nil
 	}
 	scale := targetNU / currentNU
-	out := make([]common.Recommendation, 0, len(indices))
+	sized, totalNewNU := scaleFamilyRecs(recs, indices, scale)
+	annotateFamilyProjection(sized, existingPct, totalNewNU, family.TotalNU)
+	return sized
+}
+
+// scaleFamilyRecs is the first pass of sizeRDSFamilyRecs: applies the
+// family-wide scale factor to each rec's count and cost-bearing fields,
+// returning the surviving recs (newCount > 0) and the cumulative
+// post-scaling NU across them.
+func scaleFamilyRecs(recs []common.Recommendation, indices []int, scale float64) ([]common.Recommendation, float64) {
+	sized := make([]common.Recommendation, 0, len(indices))
+	totalNewNU := 0.0
 	for _, i := range indices {
-		sized, kept := scaleRDSRecInFamily(recs[i], scale, existingPct, family.TotalNU)
-		if kept {
-			out = append(out, sized)
+		rec, kept := scaleRDSRecInFamily(recs[i], scale)
+		if !kept {
+			continue
+		}
+		sized = append(sized, rec)
+		totalNewNU += float64(rec.Count) * rdsInstanceNUFromType(rec.ResourceType)
+	}
+	return sized, totalNewNU
+}
+
+// annotateFamilyProjection is the second pass: computes the cumulative
+// family ProjectedCoverage (existing% plus totalNewNU / familyTotalNU
+// expressed as %) and writes the same value onto every rec along with
+// the matching ExistingCoveragePct and per-rec ProjectedUtilization. The
+// same projection lands on every row so each one reflects "where the
+// family lands" rather than its own slice.
+func annotateFamilyProjection(sized []common.Recommendation, existingPct, totalNewNU, familyTotalNU float64) {
+	familyProj := existingPct + totalNewNU/familyTotalNU*100.0
+	if familyProj > 100 {
+		familyProj = 100
+	}
+	for i := range sized {
+		sized[i].ExistingCoveragePct = existingPct
+		sized[i].ProjectedCoverage = familyProj
+		if sized[i].AverageInstancesUsedPerHour > 0 {
+			util := sized[i].AverageInstancesUsedPerHour / float64(sized[i].Count) * 100.0
+			if util > 100 {
+				util = 100
+			}
+			sized[i].ProjectedUtilization = util
 		}
 	}
-	return out
 }
 
 // scaleRDSRecInFamily applies the family-wide scale factor to one rec:
-// computes newCount = floor(oldCount × scale), scales cost-bearing
-// fields by the same ratio, and rewrites projection metrics for the
-// family-NU view. Returns (rec, false) when newCount is zero so the
-// caller drops the rec (family target left no room for it).
-func scaleRDSRecInFamily(rec common.Recommendation, scale, existingPct, familyTotalNU float64) (common.Recommendation, bool) {
+// computes newCount = floor(oldCount × scale) and scales cost-bearing
+// fields by the same ratio. Returns (rec, false) when newCount is zero
+// so the caller drops the rec (family target left no room for it).
+// Projection / utilization metrics are NOT set here — those need the
+// family-wide cumulative NU which only the caller knows after sizing
+// every rec in the family.
+func scaleRDSRecInFamily(rec common.Recommendation, scale float64) (common.Recommendation, bool) {
 	oldCount := rec.Count
 	newCount := int(math.Floor(float64(oldCount) * scale))
 	if newCount <= 0 {
@@ -264,20 +309,6 @@ func scaleRDSRecInFamily(rec common.Recommendation, scale, existingPct, familyTo
 	if rec.RecurringMonthlyCost != nil {
 		scaled := *rec.RecurringMonthlyCost * ratio
 		rec.RecurringMonthlyCost = &scaled
-	}
-	rec.ExistingCoveragePct = existingPct
-	newNU := float64(newCount) * rdsInstanceNUFromType(rec.ResourceType)
-	projCov := existingPct + newNU/familyTotalNU*100.0
-	if projCov > 100 {
-		projCov = 100
-	}
-	rec.ProjectedCoverage = projCov
-	if rec.AverageInstancesUsedPerHour > 0 {
-		util := rec.AverageInstancesUsedPerHour / float64(newCount) * 100.0
-		if util > 100 {
-			util = 100
-		}
-		rec.ProjectedUtilization = util
 	}
 	return rec, true
 }

--- a/providers/aws/recommendations/family_nu.go
+++ b/providers/aws/recommendations/family_nu.go
@@ -277,6 +277,7 @@ func annotateFamilyProjection(sized []common.Recommendation, existingPct, totalN
 	}
 	for i := range sized {
 		sized[i].ExistingCoveragePct = existingPct
+		sized[i].ExistingCoverageKnown = true
 		sized[i].ProjectedCoverage = familyProj
 		if sized[i].AverageInstancesUsedPerHour > 0 {
 			util := sized[i].AverageInstancesUsedPerHour / float64(sized[i].Count) * 100.0

--- a/providers/aws/recommendations/family_nu.go
+++ b/providers/aws/recommendations/family_nu.go
@@ -1,0 +1,272 @@
+package recommendations
+
+import (
+	"math"
+	"strings"
+
+	"github.com/LeanerCloud/CUDly/pkg/common"
+)
+
+// rdsInstanceNU maps an RDS instance size suffix to the normalized-units
+// value AWS uses for RDS RI size-flexibility within an instance family.
+// Reference:
+// https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithReservedDBInstances.html#USER_WorkingWithReservedDBInstances.SizeFlexible
+//
+// Used by ApplyFamilyNUSizingRDS to translate AWS-rec-API's family-NU-
+// bundled buy recommendations into the family target NU need under
+// --target-coverage. Sizes not in this map evaluate to 0 NU, which
+// causes the family-NU step to leave the rec unchanged (the per-pool
+// sizing path still handles it downstream).
+var rdsInstanceNU = map[string]float64{
+	"nano":     0.25,
+	"micro":    0.5,
+	"small":    1,
+	"medium":   2,
+	"large":    4,
+	"xlarge":   8,
+	"2xlarge":  16,
+	"4xlarge":  32,
+	"8xlarge":  64,
+	"10xlarge": 80,
+	"12xlarge": 96,
+	"16xlarge": 128,
+	"24xlarge": 192,
+	"32xlarge": 256,
+}
+
+// rdsInstanceNUFromType returns the NU value for an instance type like
+// "db.r7g.2xlarge", parsing out the size suffix ("2xlarge" → 16). Returns
+// 0 when the size isn't recognised — callers treat that as "no family-NU
+// signal" and fall back to per-pool sizing.
+func rdsInstanceNUFromType(instanceType string) float64 {
+	parts := strings.Split(instanceType, ".")
+	if len(parts) < 3 {
+		return 0
+	}
+	return rdsInstanceNU[parts[len(parts)-1]]
+}
+
+// rdsFamilyFromType returns the family prefix for an instance type, e.g.
+// "db.r7g.2xlarge" → "db.r7g". Empty string when the type doesn't carry
+// a recognisable size suffix.
+func rdsFamilyFromType(instanceType string) string {
+	parts := strings.Split(instanceType, ".")
+	if len(parts) < 3 {
+		return ""
+	}
+	return strings.Join(parts[:len(parts)-1], ".")
+}
+
+// rdsFamilyKey returns the lookup key for an RDS family's aggregated
+// coverage view. Matches the shape of rdsPoolKey but at family-level
+// granularity ("db.r7g" rather than "db.r7g.large"), so the family-NU
+// step groups all sizes within (region, family, engine, deployment) into
+// a single demand bucket.
+func rdsFamilyKey(region, family, engine, deployment string) string {
+	return strings.ToLower(region) + ":" +
+		strings.ToLower(family) + ":" +
+		normaliseRDSEngine(engine) + ":" +
+		normaliseDeployment(deployment)
+}
+
+// FamilyCoverage is the family-NU-aggregated view of coverage for an
+// RDS instance family. TotalNU is the sum of (avg × NU(size)) across
+// every size in the family that has CE coverage data; CoveredNU is the
+// sum of (avg × NU(size) × pct/100). Pct can be derived as
+// CoveredNU / TotalNU × 100 (callers do this inline).
+type FamilyCoverage struct {
+	TotalNU   float64
+	CoveredNU float64
+}
+
+// AggregateRDSFamilyCoverage walks the per-pool coverage map and returns
+// a family-NU-aggregated view keyed by rdsFamilyKey. Used by family-NU
+// sizing to size buys against the total family demand rather than
+// per-size pool demand — matching how AWS's
+// GetReservationPurchaseRecommendation bundles size-flex demand into a
+// single rec at one size.
+//
+// Skips non-RDS entries (their keys are 2-part, not 4-part) and entries
+// whose instance size isn't in rdsInstanceNU.
+func AggregateRDSFamilyCoverage(coverage PoolCoverageMap) map[string]FamilyCoverage {
+	out := make(map[string]FamilyCoverage)
+	for key, pc := range coverage {
+		parts := strings.Split(key, ":")
+		if len(parts) != 4 {
+			// Non-RDS pool keys are "region:instance_type" (2 parts).
+			continue
+		}
+		region, instType, engine, deployment := parts[0], parts[1], parts[2], parts[3]
+		nu := rdsInstanceNUFromType(instType)
+		if nu == 0 {
+			continue
+		}
+		family := rdsFamilyFromType(instType)
+		if family == "" {
+			continue
+		}
+		fk := rdsFamilyKey(region, family, engine, deployment)
+		cur := out[fk]
+		cur.TotalNU += pc.AvgInstancesPerHour * nu
+		cur.CoveredNU += pc.AvgInstancesPerHour * nu * pc.Pct / 100.0
+		out[fk] = cur
+	}
+	return out
+}
+
+// ApplyFamilyNUSizingRDS replaces per-pool RI sizing with family-NU
+// sizing for RDS recommendations. AWS's GetReservationPurchaseRecommendation
+// already bundles size-flex demand within an instance family into a
+// single recommendation at one size; per-pool sizing under-buys because
+// it only sees that size's pool demand. Family-NU sizing rescales each
+// RDS rec's Count so the family-wide NU sum matches the user's target
+// across the whole family.
+//
+// Algorithm:
+//  1. Group RDS recs by (region, family, engine, deployment).
+//  2. For each family:
+//     a. Compute family existing_pct = covered_NU / total_NU * 100
+//     b. gap = targetPct − existing_pct (drop family if ≤ 0)
+//     c. target_NU_need = gap / 100 * total_NU
+//     d. current_rec_NU = Σ rec.Count × NU(rec.size)
+//     e. scale = target_NU_need / current_rec_NU
+//     f. Apply scale to each rec.Count and cost-bearing fields
+//  3. Recs scaled to zero are dropped (size flex left no room).
+//  4. Non-RDS recs are returned unchanged so callers can continue them
+//     through the per-pool sizing path.
+//
+// Returns (sizedRDS, nonRDS). When targetPct is outside (0,100] or
+// coverage has no family-NU signal for an RDS rec's family, the rec is
+// passed through unchanged in sizedRDS (so per-pool sizing downstream
+// doesn't re-process it — caller treats sizedRDS as already sized).
+func ApplyFamilyNUSizingRDS(
+	recs []common.Recommendation,
+	coverage PoolCoverageMap,
+	targetPct float64,
+) (sizedRDS, nonRDS []common.Recommendation) {
+	if targetPct <= 0 || targetPct > 100 {
+		return nil, recs
+	}
+	familyCov := AggregateRDSFamilyCoverage(coverage)
+	familyIdx, nonRDS := partitionRDSRecsByFamily(recs)
+	for fk, indices := range familyIdx {
+		sized := sizeRDSFamilyRecs(recs, indices, familyCov[fk], targetPct)
+		sizedRDS = append(sizedRDS, sized...)
+	}
+	return sizedRDS, nonRDS
+}
+
+// partitionRDSRecsByFamily splits recs into (a) an index map keyed by
+// rdsFamilyKey that groups RDS RI recs by their (region, family, engine,
+// deployment), and (b) a slice of non-RDS recs that flow through to the
+// caller's per-pool sizing path unchanged. Recs that are RDS RIs but
+// carry an instance type without a recognisable size suffix (and thus
+// can't be NU-scaled) fall into nonRDS so per-pool sizing still handles
+// them.
+func partitionRDSRecsByFamily(recs []common.Recommendation) (map[string][]int, []common.Recommendation) {
+	familyIdx := make(map[string][]int)
+	nonRDS := make([]common.Recommendation, 0)
+	for i := range recs {
+		if !isRDSRIRec(recs[i]) {
+			nonRDS = append(nonRDS, recs[i])
+			continue
+		}
+		family := rdsFamilyFromType(recs[i].ResourceType)
+		if family == "" {
+			nonRDS = append(nonRDS, recs[i])
+			continue
+		}
+		engine, deployment := rdsEngineDeploymentFromRec(recs[i])
+		fk := rdsFamilyKey(recs[i].Region, family, engine, deployment)
+		familyIdx[fk] = append(familyIdx[fk], i)
+	}
+	return familyIdx, nonRDS
+}
+
+// sizeRDSFamilyRecs sizes the recs in one family-key group: returns the
+// sized recs, drops empty/over-target families, and returns the
+// unchanged AWS-recommended counts when there's no coverage signal. The
+// scaling math (target_NU_need / current_rec_NU) and per-rec field
+// rewrite live in scaleRDSRecInFamily.
+func sizeRDSFamilyRecs(
+	recs []common.Recommendation,
+	indices []int,
+	family FamilyCoverage,
+	targetPct float64,
+) []common.Recommendation {
+	if family.TotalNU <= 0 {
+		// No coverage signal — keep AWS-recommended counts as-is.
+		out := make([]common.Recommendation, 0, len(indices))
+		for _, i := range indices {
+			out = append(out, recs[i])
+		}
+		return out
+	}
+	existingPct := family.CoveredNU / family.TotalNU * 100.0
+	gap := targetPct - existingPct
+	if gap <= 0 {
+		// Family already at-or-above target — drop the whole family's recs.
+		return nil
+	}
+	targetNU := gap / 100.0 * family.TotalNU
+	currentNU := 0.0
+	for _, i := range indices {
+		currentNU += float64(recs[i].Count) * rdsInstanceNUFromType(recs[i].ResourceType)
+	}
+	if currentNU <= 0 {
+		// Recs sum to zero NU — nothing to scale.
+		return nil
+	}
+	scale := targetNU / currentNU
+	out := make([]common.Recommendation, 0, len(indices))
+	for _, i := range indices {
+		sized, kept := scaleRDSRecInFamily(recs[i], scale, existingPct, family.TotalNU)
+		if kept {
+			out = append(out, sized)
+		}
+	}
+	return out
+}
+
+// scaleRDSRecInFamily applies the family-wide scale factor to one rec:
+// computes newCount = floor(oldCount × scale), scales cost-bearing
+// fields by the same ratio, and rewrites projection metrics for the
+// family-NU view. Returns (rec, false) when newCount is zero so the
+// caller drops the rec (family target left no room for it).
+func scaleRDSRecInFamily(rec common.Recommendation, scale, existingPct, familyTotalNU float64) (common.Recommendation, bool) {
+	oldCount := rec.Count
+	newCount := int(math.Floor(float64(oldCount) * scale))
+	if newCount <= 0 {
+		return rec, false
+	}
+	ratio := float64(newCount) / float64(oldCount)
+	rec.Count = newCount
+	rec.CommitmentCost *= ratio
+	rec.OnDemandCost *= ratio
+	rec.EstimatedSavings *= ratio
+	rec.ExistingCoveragePct = existingPct
+	newNU := float64(newCount) * rdsInstanceNUFromType(rec.ResourceType)
+	projCov := existingPct + newNU/familyTotalNU*100.0
+	if projCov > 100 {
+		projCov = 100
+	}
+	rec.ProjectedCoverage = projCov
+	if rec.AverageInstancesUsedPerHour > 0 {
+		util := rec.AverageInstancesUsedPerHour / float64(newCount) * 100.0
+		if util > 100 {
+			util = 100
+		}
+		rec.ProjectedUtilization = util
+	}
+	return rec, true
+}
+
+// isRDSRIRec reports whether rec is an RDS-family RI recommendation that
+// the family-NU pass should size. Excludes Savings Plans and any other
+// commitment type so they reach the per-pool sizing path unchanged.
+func isRDSRIRec(rec common.Recommendation) bool {
+	if rec.CommitmentType != common.CommitmentReservedInstance {
+		return false
+	}
+	return rec.Service == common.ServiceRDS || rec.Service == common.ServiceRelationalDB
+}

--- a/providers/aws/recommendations/family_nu.go
+++ b/providers/aws/recommendations/family_nu.go
@@ -303,14 +303,8 @@ func scaleRDSRecInFamily(rec common.Recommendation, scale float64) (common.Recom
 		return rec, false
 	}
 	ratio := float64(newCount) / float64(oldCount)
+	rec = common.ScaleRecommendationCosts(rec, ratio)
 	rec.Count = newCount
-	rec.CommitmentCost *= ratio
-	rec.OnDemandCost *= ratio
-	rec.EstimatedSavings *= ratio
-	if rec.RecurringMonthlyCost != nil {
-		scaled := *rec.RecurringMonthlyCost * ratio
-		rec.RecurringMonthlyCost = &scaled
-	}
 	return rec, true
 }
 

--- a/providers/aws/recommendations/family_nu_test.go
+++ b/providers/aws/recommendations/family_nu_test.go
@@ -283,6 +283,59 @@ func TestApplyFamilyNUSizingRDS(t *testing.T) {
 		assert.Equal(t, common.ServiceSavingsPlans, nonRDS[1].Service)
 	})
 
+	t.Run("ProjectedCoverage is cumulative across recs in a family", func(t *testing.T) {
+		// Two per-account recs in same family/engine/deployment: each rec
+		// must show the family-wide projected coverage (existing + sum-of-
+		// all-recs' new NU / family total NU), not just its own slice.
+		// Without cumulation, two recs each adding 20% of family NU would
+		// each report "existing + 20%" instead of the true "existing + 40%".
+		cov := PoolCoverageMap{
+			rdsPoolKey("us-east-1", "db.t4g.medium", "Aurora PostgreSQL", "Single-AZ"): {
+				Pct: 16.7, AvgInstancesPerHour: 12.0, // 24 NU at .medium (×2 NU)
+			},
+		}
+		// Family total NU = 24. AWS rec api returned two recs (per account)
+		// each .medium size; AWS-implied total = 5+3 = 8 RIs = 16 NU.
+		// existing=16.7%, gap=63.3, targetNU = 63.3/100 × 24 = 15.2.
+		// scale = 15.2/16 = 0.95 → floor(5×0.95)=4, floor(3×0.95)=2.
+		// Total new NU = (4+2) × 2 = 12. Cumulative projection =
+		// 16.7 + 12/24*100 = 16.7 + 50 = 66.7%.
+		recs := []common.Recommendation{
+			{
+				Service:        common.ServiceRDS,
+				CommitmentType: common.CommitmentReservedInstance,
+				Region:         "us-east-1",
+				ResourceType:   "db.t4g.medium",
+				Account:        "production",
+				Count:          5,
+				CommitmentCost: 500,
+				Details:        &common.DatabaseDetails{Engine: "aurora-postgresql", AZConfig: "single-az"},
+			},
+			{
+				Service:        common.ServiceRDS,
+				CommitmentType: common.CommitmentReservedInstance,
+				Region:         "us-east-1",
+				ResourceType:   "db.t4g.medium",
+				Account:        "staging",
+				Count:          3,
+				CommitmentCost: 300,
+				Details:        &common.DatabaseDetails{Engine: "aurora-postgresql", AZConfig: "single-az"},
+			},
+		}
+		sized, _ := ApplyFamilyNUSizingRDS(recs, cov, 80)
+		require.Len(t, sized, 2, "both recs kept after scaling")
+		// Both recs see the SAME cumulative projection.
+		assert.InDelta(t, sized[0].ProjectedCoverage, sized[1].ProjectedCoverage, 0.001,
+			"both recs in the same family must report the same ProjectedCoverage")
+		// And the projection reflects BOTH recs' contributions, not just
+		// either one alone. existing 16.7 + (4+2)*2 / 24 * 100 = 66.7
+		assert.InDelta(t, 66.7, sized[0].ProjectedCoverage, 0.01,
+			"cumulative projection: existing + sum-of-all-recs new NU / family total NU")
+		// Both rec.Count values reflect the scale-down.
+		assert.Equal(t, 4, sized[0].Count, "prod scaled 5→4")
+		assert.Equal(t, 2, sized[1].Count, "staging scaled 3→2")
+	})
+
 	t.Run("multiple sizes in same family scale together", func(t *testing.T) {
 		// Family db.r6g Aurora MySQL eu-west-2 has demand at .large and .xlarge.
 		// avg .large = 5 (20 NU), avg .xlarge = 5 (40 NU). Total = 60 NU; cov = 0.

--- a/providers/aws/recommendations/family_nu_test.go
+++ b/providers/aws/recommendations/family_nu_test.go
@@ -1,0 +1,304 @@
+package recommendations
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LeanerCloud/CUDly/pkg/common"
+)
+
+// TestRdsInstanceNUFromType covers the size→NU mapping for representative
+// sizes plus the unknown-size fallback (returns 0 so callers know to skip
+// family-NU sizing for that rec).
+func TestRdsInstanceNUFromType(t *testing.T) {
+	cases := map[string]float64{
+		"db.r7g.large":    4,
+		"db.r6g.2xlarge":  16,
+		"db.t4g.medium":   2,
+		"db.t4g.micro":    0.5,
+		"db.r6g.16xlarge": 128,
+		"db.r6g.24xlarge": 192,
+		"db.r6g.unknown":  0, // fallback
+		"not-an-rds-type": 0, // too few dots
+		"":                0,
+	}
+	for in, want := range cases {
+		t.Run(in, func(t *testing.T) {
+			assert.Equal(t, want, rdsInstanceNUFromType(in))
+		})
+	}
+}
+
+// TestRdsFamilyFromType locks the family-prefix extraction so all sizes
+// in the same family share a lookup key.
+func TestRdsFamilyFromType(t *testing.T) {
+	cases := map[string]string{
+		"db.r7g.large":   "db.r7g",
+		"db.r7g.2xlarge": "db.r7g",
+		"db.t4g.medium":  "db.t4g",
+		"db.m5.xlarge":   "db.m5",
+		"db.m6gd.xlarge": "db.m6gd",
+		"":               "",
+		"db.r7g":         "", // missing size suffix
+	}
+	for in, want := range cases {
+		t.Run(in, func(t *testing.T) {
+			assert.Equal(t, want, rdsFamilyFromType(in))
+		})
+	}
+}
+
+// TestAggregateRDSFamilyCoverage confirms per-pool coverage entries roll
+// up to family-NU correctly: sum-of-(avg × size_NU) for TotalNU and
+// sum-of-(avg × size_NU × pct/100) for CoveredNU. Mirrors the manual
+// family-level table that proved size flex was implicit in AWS rec API.
+func TestAggregateRDSFamilyCoverage(t *testing.T) {
+	// Family: us-east-1 / db.r7g / Aurora MySQL / Single-AZ
+	// Two sizes contributing:
+	//   db.r7g.large  avg=40.6 cov=58%  → 162.4 NU running, 94.2 NU covered
+	//   db.r7g.xlarge avg= 3.9 cov= 0%  →  31.2 NU running,    0 NU covered
+	// Family totals: 193.6 NU running, 94.2 NU covered.
+	cov := PoolCoverageMap{
+		rdsPoolKey("us-east-1", "db.r7g.large", "Aurora MySQL", "Single-AZ"): {
+			Pct: 58.0, AvgInstancesPerHour: 40.6,
+		},
+		rdsPoolKey("us-east-1", "db.r7g.xlarge", "Aurora MySQL", "Single-AZ"): {
+			Pct: 0.0, AvgInstancesPerHour: 3.9,
+		},
+		// Different family in same region — should NOT roll into the r7g key.
+		rdsPoolKey("us-east-1", "db.t4g.medium", "Aurora MySQL", "Single-AZ"): {
+			Pct: 50.0, AvgInstancesPerHour: 100.0,
+		},
+		// Same instance, different deployment — distinct family bucket.
+		rdsPoolKey("us-east-1", "db.r7g.large", "Aurora MySQL", "Multi-AZ"): {
+			Pct: 0.0, AvgInstancesPerHour: 5.0,
+		},
+		// Non-RDS pool key (2-part) — should be skipped entirely.
+		poolKey("us-east-1", "m5.large"): {Pct: 50.0, AvgInstancesPerHour: 10.0},
+	}
+	agg := AggregateRDSFamilyCoverage(cov)
+
+	fk := rdsFamilyKey("us-east-1", "db.r7g", "Aurora MySQL", "Single-AZ")
+	r7g := agg[fk]
+	assert.InDelta(t, 40.6*4+3.9*8, r7g.TotalNU, 0.01, "TotalNU = sum(avg × NU(size))")
+	assert.InDelta(t, 40.6*4*0.58+3.9*8*0.0, r7g.CoveredNU, 0.01, "CoveredNU = sum(avg × NU(size) × pct/100)")
+
+	// Different deployment — separate bucket.
+	multi := agg[rdsFamilyKey("us-east-1", "db.r7g", "Aurora MySQL", "Multi-AZ")]
+	assert.InDelta(t, 5.0*4, multi.TotalNU, 0.01, "Multi-AZ keeps a separate family bucket")
+
+	// Non-RDS key skipped.
+	assert.NotContains(t, agg, "us-east-1:m5.large", "non-RDS pool keys should be ignored")
+}
+
+// TestApplyFamilyNUSizingRDS exercises the four important cases:
+//  1. AWS rec at-target NU → scale = 1, no change
+//  2. AWS rec under-recommends → scale > 1, counts grow
+//  3. AWS rec over-recommends → scale < 1, counts shrink
+//  4. Family already at target → all recs dropped
+func TestApplyFamilyNUSizingRDS(t *testing.T) {
+	t.Run("AWS rec NU matches target → counts unchanged", func(t *testing.T) {
+		// Family db.r7g Aurora MySQL us-east-1:
+		// TotalNU = 40.6*4 + 3.9*8 = 193.6; CoveredNU = 162.4*0.58 = 94.2
+		// existing_pct = 48.66; gap = 80 − 48.66 = 31.34
+		// target_NU = 31.34/100 × 193.6 ≈ 60.7
+		// AWS rec: 15 × db.r7g.large = 60 NU → scale ≈ 1.01 → floor(15.1) = 15
+		cov := PoolCoverageMap{
+			rdsPoolKey("us-east-1", "db.r7g.large", "Aurora MySQL", "Single-AZ"): {
+				Pct: 58.0, AvgInstancesPerHour: 40.6,
+			},
+			rdsPoolKey("us-east-1", "db.r7g.xlarge", "Aurora MySQL", "Single-AZ"): {
+				Pct: 0.0, AvgInstancesPerHour: 3.9,
+			},
+		}
+		recs := []common.Recommendation{
+			{
+				Service:        common.ServiceRDS,
+				CommitmentType: common.CommitmentReservedInstance,
+				Region:         "us-east-1",
+				ResourceType:   "db.r7g.large",
+				Count:          15,
+				CommitmentCost: 1500, OnDemandCost: 3000, EstimatedSavings: 600,
+				Details: &common.DatabaseDetails{Engine: "aurora-mysql", AZConfig: "single-az"},
+			},
+		}
+		sized, nonRDS := ApplyFamilyNUSizingRDS(recs, cov, 80)
+		require.Len(t, sized, 1, "RDS rec kept (target NU > 0)")
+		assert.Empty(t, nonRDS, "no non-RDS recs in this fixture")
+		assert.Equal(t, 15, sized[0].Count, "AWS-rec NU already matches target → count preserved")
+		// Costs unchanged (ratio = 1)
+		assert.InDelta(t, 1500.0, sized[0].CommitmentCost, 0.01)
+	})
+
+	t.Run("AWS rec under-recommends → counts scale up", func(t *testing.T) {
+		// Family eu-west-2 / db.r7g / MySQL / Multi-AZ:
+		// Only db.r7g.large size in this fixture, avg=10, cov=0%.
+		// TotalNU = 10*4 = 40; CoveredNU = 0; existing=0; gap=80 → target_NU = 32
+		// AWS rec: 5 × db.r7g.large = 20 NU → scale = 32/20 = 1.6 → floor(8.0) = 8
+		cov := PoolCoverageMap{
+			rdsPoolKey("eu-west-2", "db.r7g.large", "MySQL", "Multi-AZ"): {
+				Pct: 0.0, AvgInstancesPerHour: 10,
+			},
+		}
+		recs := []common.Recommendation{
+			{
+				Service:        common.ServiceRDS,
+				CommitmentType: common.CommitmentReservedInstance,
+				Region:         "eu-west-2",
+				ResourceType:   "db.r7g.large",
+				Count:          5,
+				CommitmentCost: 5000, OnDemandCost: 10000, EstimatedSavings: 2000,
+				AverageInstancesUsedPerHour: 10,
+				Details:                     &common.DatabaseDetails{Engine: "mysql", AZConfig: "multi-az"},
+			},
+		}
+		sized, _ := ApplyFamilyNUSizingRDS(recs, cov, 80)
+		require.Len(t, sized, 1)
+		assert.Equal(t, 8, sized[0].Count, "scale 32/20 = 1.6 × 5 = 8 RIs to deliver 32 NU at 80% target")
+		assert.InDelta(t, 5000*8.0/5.0, sized[0].CommitmentCost, 0.01, "CommitmentCost scales by 8/5")
+	})
+
+	t.Run("AWS rec over-recommends → counts scale down", func(t *testing.T) {
+		// Family with low demand; AWS rec proposes more NU than 80% target needs.
+		// TotalNU = 10*4 = 40; existing=0; target=80 → target_NU = 32
+		// AWS rec: 20 × .large = 80 NU → scale = 32/80 = 0.4 → floor(8.0) = 8
+		cov := PoolCoverageMap{
+			rdsPoolKey("eu-west-2", "db.r7g.large", "MySQL", "Multi-AZ"): {
+				Pct: 0.0, AvgInstancesPerHour: 10,
+			},
+		}
+		recs := []common.Recommendation{
+			{
+				Service:        common.ServiceRDS,
+				CommitmentType: common.CommitmentReservedInstance,
+				Region:         "eu-west-2",
+				ResourceType:   "db.r7g.large",
+				Count:          20,
+				CommitmentCost: 20000,
+				Details:        &common.DatabaseDetails{Engine: "mysql", AZConfig: "multi-az"},
+			},
+		}
+		sized, _ := ApplyFamilyNUSizingRDS(recs, cov, 80)
+		require.Len(t, sized, 1)
+		assert.Equal(t, 8, sized[0].Count, "AWS over-proposed; scale down to family target")
+	})
+
+	t.Run("family at-or-above target → all recs dropped", func(t *testing.T) {
+		// existing_pct = 90% > target 80% → drop.
+		cov := PoolCoverageMap{
+			rdsPoolKey("us-east-1", "db.r7g.large", "Aurora MySQL", "Single-AZ"): {
+				Pct: 90.0, AvgInstancesPerHour: 10,
+			},
+		}
+		recs := []common.Recommendation{
+			{
+				Service:        common.ServiceRDS,
+				CommitmentType: common.CommitmentReservedInstance,
+				Region:         "us-east-1",
+				ResourceType:   "db.r7g.large",
+				Count:          5,
+				Details:        &common.DatabaseDetails{Engine: "aurora-mysql", AZConfig: "single-az"},
+			},
+		}
+		sized, _ := ApplyFamilyNUSizingRDS(recs, cov, 80)
+		assert.Empty(t, sized, "family already covered → drop all recs")
+	})
+
+	t.Run("no coverage signal → recs pass through unchanged", func(t *testing.T) {
+		// Empty coverage map → rec.Count untouched, rec returned in sizedRDS
+		// (caller treats as already-sized to avoid double-sizing).
+		recs := []common.Recommendation{
+			{
+				Service:        common.ServiceRDS,
+				CommitmentType: common.CommitmentReservedInstance,
+				Region:         "ap-east-1",
+				ResourceType:   "db.r7g.large",
+				Count:          5,
+				Details:        &common.DatabaseDetails{Engine: "aurora-mysql", AZConfig: "single-az"},
+			},
+		}
+		sized, _ := ApplyFamilyNUSizingRDS(recs, PoolCoverageMap{}, 80)
+		require.Len(t, sized, 1, "rec preserved as-is when no family-NU signal")
+		assert.Equal(t, 5, sized[0].Count)
+	})
+
+	t.Run("non-RDS recs flow through nonRDS partition", func(t *testing.T) {
+		// EC2 and SP recs should NOT be touched by family-NU; they appear
+		// in the nonRDS slice for per-pool sizing.
+		recs := []common.Recommendation{
+			{Service: common.ServiceEC2, CommitmentType: common.CommitmentReservedInstance, Count: 3},
+			{Service: common.ServiceSavingsPlans, CommitmentType: common.CommitmentSavingsPlan, Count: 1},
+			{
+				Service:        common.ServiceRDS,
+				CommitmentType: common.CommitmentReservedInstance,
+				Region:         "us-east-1",
+				ResourceType:   "db.r7g.large",
+				Count:          5,
+				Details:        &common.DatabaseDetails{Engine: "aurora-mysql", AZConfig: "single-az"},
+			},
+		}
+		cov := PoolCoverageMap{
+			rdsPoolKey("us-east-1", "db.r7g.large", "Aurora MySQL", "Single-AZ"): {
+				Pct: 0.0, AvgInstancesPerHour: 10,
+			},
+		}
+		sized, nonRDS := ApplyFamilyNUSizingRDS(recs, cov, 80)
+		require.Len(t, sized, 1, "only the RDS rec went through family-NU")
+		require.Len(t, nonRDS, 2, "EC2 + SP recs left for per-pool sizing")
+		assert.Equal(t, common.ServiceEC2, nonRDS[0].Service)
+		assert.Equal(t, common.ServiceSavingsPlans, nonRDS[1].Service)
+	})
+
+	t.Run("multiple sizes in same family scale together", func(t *testing.T) {
+		// Family db.r6g Aurora MySQL eu-west-2 has demand at .large and .xlarge.
+		// avg .large = 5 (20 NU), avg .xlarge = 5 (40 NU). Total = 60 NU; cov = 0.
+		// target_NU @ 80% = 48.
+		// AWS rec: 10 × .large = 40 NU. scale = 48/40 = 1.2 → floor(12.0) = 12 .large.
+		// (No AWS rec at .xlarge — the bundled .large covers via size flex.)
+		cov := PoolCoverageMap{
+			rdsPoolKey("eu-west-2", "db.r6g.large", "Aurora MySQL", "Single-AZ"): {
+				Pct: 0.0, AvgInstancesPerHour: 5,
+			},
+			rdsPoolKey("eu-west-2", "db.r6g.xlarge", "Aurora MySQL", "Single-AZ"): {
+				Pct: 0.0, AvgInstancesPerHour: 5,
+			},
+		}
+		recs := []common.Recommendation{
+			{
+				Service:        common.ServiceRDS,
+				CommitmentType: common.CommitmentReservedInstance,
+				Region:         "eu-west-2",
+				ResourceType:   "db.r6g.large",
+				Count:          10,
+				Details:        &common.DatabaseDetails{Engine: "aurora-mysql", AZConfig: "single-az"},
+			},
+		}
+		sized, _ := ApplyFamilyNUSizingRDS(recs, cov, 80)
+		require.Len(t, sized, 1)
+		assert.Equal(t, 12, sized[0].Count, "family-NU need includes .xlarge demand even though AWS rec is at .large")
+	})
+}
+
+// TestIsRDSRIRec covers the dispatch predicate that gates family-NU
+// sizing — must reject SP/non-RDS commitments so they reach per-pool
+// sizing untouched.
+func TestIsRDSRIRec(t *testing.T) {
+	cases := []struct {
+		name string
+		rec  common.Recommendation
+		want bool
+	}{
+		{"RDS RI", common.Recommendation{Service: common.ServiceRDS, CommitmentType: common.CommitmentReservedInstance}, true},
+		{"RelationalDB alias", common.Recommendation{Service: common.ServiceRelationalDB, CommitmentType: common.CommitmentReservedInstance}, true},
+		{"EC2 RI", common.Recommendation{Service: common.ServiceEC2, CommitmentType: common.CommitmentReservedInstance}, false},
+		{"RDS SP (impossible but defensive)", common.Recommendation{Service: common.ServiceRDS, CommitmentType: common.CommitmentSavingsPlan}, false},
+		{"SP", common.Recommendation{Service: common.ServiceSavingsPlans, CommitmentType: common.CommitmentSavingsPlan}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isRDSRIRec(tc.rec))
+		})
+	}
+}

--- a/providers/aws/recommendations/family_nu_test.go
+++ b/providers/aws/recommendations/family_nu_test.go
@@ -132,6 +132,38 @@ func TestApplyFamilyNUSizingRDS(t *testing.T) {
 		assert.InDelta(t, 1500.0, sized[0].CommitmentCost, 0.01)
 	})
 
+	t.Run("RecurringMonthlyCost scales with count when populated", func(t *testing.T) {
+		// Partial-upfront RIs carry a per-month fee in addition to upfront.
+		// Family-NU sizing must scale this fee by newCount/oldCount so the
+		// returned rec's monthly cost reflects what the user actually buys
+		// (not AWS's original recommendation count). nil input stays nil.
+		monthly := 100.0
+		cov := PoolCoverageMap{
+			rdsPoolKey("eu-west-2", "db.r7g.large", "MySQL", "Multi-AZ"): {
+				Pct: 0.0, AvgInstancesPerHour: 10,
+			},
+		}
+		recs := []common.Recommendation{
+			{
+				Service:              common.ServiceRDS,
+				CommitmentType:       common.CommitmentReservedInstance,
+				Region:               "eu-west-2",
+				ResourceType:         "db.r7g.large",
+				Count:                5,
+				CommitmentCost:       5000,
+				RecurringMonthlyCost: &monthly,
+				Details:              &common.DatabaseDetails{Engine: "mysql", AZConfig: "multi-az"},
+			},
+		}
+		sized, _ := ApplyFamilyNUSizingRDS(recs, cov, 80)
+		require.Len(t, sized, 1)
+		// Scale 32/20 = 1.6 → newCount = 8 → monthly = 100 × 8/5 = 160
+		assert.Equal(t, 8, sized[0].Count)
+		require.NotNil(t, sized[0].RecurringMonthlyCost)
+		assert.InDelta(t, 160.0, *sized[0].RecurringMonthlyCost, 0.001, "monthly fee scales by 8/5 alongside other costs")
+		assert.Equal(t, 100.0, monthly, "original target should not be mutated (new pointer)")
+	})
+
 	t.Run("AWS rec under-recommends → counts scale up", func(t *testing.T) {
 		// Family eu-west-2 / db.r7g / MySQL / Multi-AZ:
 		// Only db.r7g.large size in this fixture, avg=10, cov=0%.

--- a/providers/aws/recommendations/parser_ri.go
+++ b/providers/aws/recommendations/parser_ri.go
@@ -66,12 +66,36 @@ func (c *Client) parseRecommendationDetail(details *types.ReservationPurchaseRec
 	// Parse AWS-provided cost details
 	c.parseAWSCostDetails(rec, details)
 
+	// Parse RI utilization signals used by --target-utilization sizing
+	c.parseRIUtilizationSignals(rec, details)
+
 	// Parse service-specific details
 	if err := c.parseServiceSpecificDetails(rec, details, params.Service); err != nil {
 		return nil, err
 	}
 
 	return rec, nil
+}
+
+// parseRIUtilizationSignals populates AverageInstancesUsedPerHour and
+// RecommendedUtilization from the CE response. Both fields are *string in the
+// SDK; nil or unparseable values leave the destination at zero, which the
+// --target-utilization sizing path treats as "no signal" and skips.
+func (c *Client) parseRIUtilizationSignals(rec *common.Recommendation, details *types.ReservationPurchaseRecommendationDetail) {
+	if details.AverageNumberOfInstancesUsedPerHour != nil {
+		if v, err := strconv.ParseFloat(*details.AverageNumberOfInstancesUsedPerHour, 64); err == nil {
+			rec.AverageInstancesUsedPerHour = v
+		} else {
+			log.Printf("WARNING: failed to parse AverageNumberOfInstancesUsedPerHour %q for RI recommendation (service=%s, account=%s): %v", *details.AverageNumberOfInstancesUsedPerHour, rec.Service, rec.Account, err)
+		}
+	}
+	if details.AverageUtilization != nil {
+		if v, err := strconv.ParseFloat(*details.AverageUtilization, 64); err == nil {
+			rec.RecommendedUtilization = v
+		} else {
+			log.Printf("WARNING: failed to parse AverageUtilization %q for RI recommendation (service=%s, account=%s): %v", *details.AverageUtilization, rec.Service, rec.Account, err)
+		}
+	}
 }
 
 // parseRecommendedQuantity extracts the recommended quantity from details

--- a/providers/aws/recommendations/parser_ri.go
+++ b/providers/aws/recommendations/parser_ri.go
@@ -45,12 +45,16 @@ func (c *Client) parseRecommendationDetail(details *types.ReservationPurchaseRec
 		Timestamp:      time.Now(),
 	}
 
-	// Parse recommended quantity
+	// Parse recommended quantity. RecommendedCount preserves AWS's pre-sizing
+	// count so the CSV can show what AWS proposed alongside what --coverage /
+	// --target-coverage chose; Count is the working value the sizing step
+	// mutates.
 	count, err := c.parseRecommendedQuantity(details)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse recommended quantity: %w", err)
 	}
 	rec.Count = count
+	rec.RecommendedCount = count
 
 	// Parse cost information
 	rec.EstimatedSavings, rec.SavingsPercentage, err = c.parseCostInformation(details)

--- a/providers/aws/recommendations/parser_ri.go
+++ b/providers/aws/recommendations/parser_ri.go
@@ -66,7 +66,7 @@ func (c *Client) parseRecommendationDetail(details *types.ReservationPurchaseRec
 	// Parse AWS-provided cost details
 	c.parseAWSCostDetails(rec, details)
 
-	// Parse RI utilization signals used by --target-utilization sizing
+	// Parse RI utilization signals used by --target-coverage sizing
 	c.parseRIUtilizationSignals(rec, details)
 
 	// Parse service-specific details
@@ -80,7 +80,7 @@ func (c *Client) parseRecommendationDetail(details *types.ReservationPurchaseRec
 // parseRIUtilizationSignals populates AverageInstancesUsedPerHour and
 // RecommendedUtilization from the CE response. Both fields are *string in the
 // SDK; nil or unparseable values leave the destination at zero, which the
-// --target-utilization sizing path treats as "no signal" and skips.
+// --target-coverage sizing path treats as "no signal" and skips.
 func (c *Client) parseRIUtilizationSignals(rec *common.Recommendation, details *types.ReservationPurchaseRecommendationDetail) {
 	if details.AverageNumberOfInstancesUsedPerHour != nil {
 		if v, err := strconv.ParseFloat(*details.AverageNumberOfInstancesUsedPerHour, 64); err == nil {

--- a/providers/aws/recommendations/parser_ri_test.go
+++ b/providers/aws/recommendations/parser_ri_test.go
@@ -395,3 +395,71 @@ func TestParseRecommendations_EmptyInput(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, recs)
 }
+
+// TestParseRIUtilizationSignals covers the AverageNumberOfInstancesUsedPerHour
+// and AverageUtilization fields added for issue #338 (--target-utilization).
+// Verifies both successful parses, nil-pointer fallback to zero, and
+// parse-failure fallback to zero — the sizing path in cmd/helpers.go treats
+// zero as "no signal" so the fallback behaviour matters.
+func TestParseRIUtilizationSignals(t *testing.T) {
+	client := &Client{}
+
+	tests := []struct {
+		name             string
+		details          *types.ReservationPurchaseRecommendationDetail
+		wantAvgInstances float64
+		wantUtilization  float64
+	}{
+		{
+			name: "both fields parsed",
+			details: &types.ReservationPurchaseRecommendationDetail{
+				AverageNumberOfInstancesUsedPerHour: aws.String("8.5"),
+				AverageUtilization:                  aws.String("85.3"),
+			},
+			wantAvgInstances: 8.5,
+			wantUtilization:  85.3,
+		},
+		{
+			name:             "both fields nil → both zero",
+			details:          &types.ReservationPurchaseRecommendationDetail{},
+			wantAvgInstances: 0,
+			wantUtilization:  0,
+		},
+		{
+			name: "unparseable AverageNumberOfInstancesUsedPerHour → that field zero, other still parses",
+			details: &types.ReservationPurchaseRecommendationDetail{
+				AverageNumberOfInstancesUsedPerHour: aws.String("not-a-number"),
+				AverageUtilization:                  aws.String("90.0"),
+			},
+			wantAvgInstances: 0,
+			wantUtilization:  90.0,
+		},
+		{
+			name: "unparseable AverageUtilization → that field zero, other still parses",
+			details: &types.ReservationPurchaseRecommendationDetail{
+				AverageNumberOfInstancesUsedPerHour: aws.String("5.0"),
+				AverageUtilization:                  aws.String("garbage"),
+			},
+			wantAvgInstances: 5.0,
+			wantUtilization:  0,
+		},
+		{
+			name: "zero values parse as zero (not treated as missing at parse time)",
+			details: &types.ReservationPurchaseRecommendationDetail{
+				AverageNumberOfInstancesUsedPerHour: aws.String("0"),
+				AverageUtilization:                  aws.String("0.0"),
+			},
+			wantAvgInstances: 0,
+			wantUtilization:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := &common.Recommendation{}
+			client.parseRIUtilizationSignals(rec, tt.details)
+			assert.Equal(t, tt.wantAvgInstances, rec.AverageInstancesUsedPerHour)
+			assert.Equal(t, tt.wantUtilization, rec.RecommendedUtilization)
+		})
+	}
+}

--- a/providers/aws/recommendations/parser_ri_test.go
+++ b/providers/aws/recommendations/parser_ri_test.go
@@ -397,7 +397,7 @@ func TestParseRecommendations_EmptyInput(t *testing.T) {
 }
 
 // TestParseRIUtilizationSignals covers the AverageNumberOfInstancesUsedPerHour
-// and AverageUtilization fields added for issue #338 (--target-utilization).
+// and AverageUtilization fields added for issue #338 (--target-coverage).
 // Verifies both successful parses, nil-pointer fallback to zero, and
 // parse-failure fallback to zero — the sizing path in cmd/helpers.go treats
 // zero as "no signal" so the fallback behaviour matters.

--- a/providers/aws/recommendations/parser_sp.go
+++ b/providers/aws/recommendations/parser_sp.go
@@ -137,7 +137,7 @@ func (c *Client) parseSavingsPlanDetail(
 	savingsPercent := parseOptionalFloat("EstimatedSavingsPercentage", detail.EstimatedSavingsPercentage)
 	upfrontCost := parseOptionalFloat("UpfrontCost", detail.UpfrontCost)
 	// EstimatedAverageUtilization carries the "if you buy exactly this commitment,
-	// what % of it will AWS expect to be used" signal. Used by --target-utilization
+	// what % of it will AWS expect to be used" signal. Used by --target-coverage
 	// sizing in cmd/helpers.go; zero (nil pointer or parse failure) means "no signal"
 	// and the sizing path leaves the recommendation unchanged.
 	recommendedUtilization := parseOptionalFloat("EstimatedAverageUtilization", detail.EstimatedAverageUtilization)

--- a/providers/aws/recommendations/parser_sp.go
+++ b/providers/aws/recommendations/parser_sp.go
@@ -136,6 +136,11 @@ func (c *Client) parseSavingsPlanDetail(
 	monthlySavings := parseOptionalFloat("EstimatedMonthlySavingsAmount", detail.EstimatedMonthlySavingsAmount)
 	savingsPercent := parseOptionalFloat("EstimatedSavingsPercentage", detail.EstimatedSavingsPercentage)
 	upfrontCost := parseOptionalFloat("UpfrontCost", detail.UpfrontCost)
+	// EstimatedAverageUtilization carries the "if you buy exactly this commitment,
+	// what % of it will AWS expect to be used" signal. Used by --target-utilization
+	// sizing in cmd/helpers.go; zero (nil pointer or parse failure) means "no signal"
+	// and the sizing path leaves the recommendation unchanged.
+	recommendedUtilization := parseOptionalFloat("EstimatedAverageUtilization", detail.EstimatedAverageUtilization)
 	// onDemandCost is the canonical monthly on-demand baseline for this SP
 	// recommendation. AWS Cost Explorer returns the average hourly on-demand
 	// spend over the lookback period in CurrentAverageHourlyOnDemandSpend;
@@ -196,19 +201,20 @@ func (c *Client) parseSavingsPlanDetail(
 	}
 
 	return &common.Recommendation{
-		Provider:             common.ProviderAWS,
-		Service:              serviceSlugForPlanType(planType),
-		PaymentOption:        params.PaymentOption,
-		Term:                 params.Term,
-		CommitmentType:       common.CommitmentSavingsPlan,
-		Count:                1,
-		EstimatedSavings:     monthlySavings,
-		SavingsPercentage:    savingsPercent,
-		CommitmentCost:       upfrontCost,
-		OnDemandCost:         onDemandCost,
-		RecurringMonthlyCost: recurringMonthlyCost,
-		Timestamp:            time.Now(),
-		Account:              accountID,
+		Provider:               common.ProviderAWS,
+		Service:                serviceSlugForPlanType(planType),
+		PaymentOption:          params.PaymentOption,
+		Term:                   params.Term,
+		CommitmentType:         common.CommitmentSavingsPlan,
+		Count:                  1,
+		EstimatedSavings:       monthlySavings,
+		SavingsPercentage:      savingsPercent,
+		CommitmentCost:         upfrontCost,
+		OnDemandCost:           onDemandCost,
+		RecurringMonthlyCost:   recurringMonthlyCost,
+		RecommendedUtilization: recommendedUtilization,
+		Timestamp:              time.Now(),
+		Account:                accountID,
 		Details: &common.SavingsPlanDetails{
 			PlanType:         planTypeStr,
 			HourlyCommitment: hourlyCommitment,

--- a/providers/aws/recommendations/parser_sp_additional_test.go
+++ b/providers/aws/recommendations/parser_sp_additional_test.go
@@ -240,6 +240,10 @@ func (m *mockCostExplorerForSP) GetReservationUtilization(ctx context.Context, p
 	return &costexplorer.GetReservationUtilizationOutput{}, nil
 }
 
+func (m *mockCostExplorerForSP) GetReservationCoverage(ctx context.Context, params *costexplorer.GetReservationCoverageInput, optFns ...func(*costexplorer.Options)) (*costexplorer.GetReservationCoverageOutput, error) {
+	return &costexplorer.GetReservationCoverageOutput{}, nil
+}
+
 func TestGetSavingsPlansRecommendations_WithFilters(t *testing.T) {
 	mockAPI := &mockCostExplorerForSP{
 		responses: map[types.SupportedSavingsPlansType]*costexplorer.GetSavingsPlansPurchaseRecommendationOutput{

--- a/providers/aws/recommendations/parser_sp_test.go
+++ b/providers/aws/recommendations/parser_sp_test.go
@@ -153,7 +153,7 @@ func TestGetFilteredPlanTypes(t *testing.T) {
 
 // TestParseSavingsPlanDetail_RecommendedUtilization covers the
 // EstimatedAverageUtilization field added for issue #338 — the SP equivalent
-// of the RI AverageUtilization signal that drives --target-utilization sizing.
+// of the RI AverageUtilization signal that drives --target-coverage sizing.
 func TestParseSavingsPlanDetail_RecommendedUtilization(t *testing.T) {
 	client := &Client{}
 	params := common.RecommendationParams{

--- a/providers/aws/recommendations/parser_sp_test.go
+++ b/providers/aws/recommendations/parser_sp_test.go
@@ -3,8 +3,12 @@ package recommendations
 import (
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/costexplorer/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LeanerCloud/CUDly/pkg/common"
 )
 
 func TestGetFilteredPlanTypes(t *testing.T) {
@@ -143,6 +147,59 @@ func TestGetFilteredPlanTypes(t *testing.T) {
 			for _, excluded := range tt.shouldExclude {
 				assert.NotContains(t, result, excluded, "Expected result to NOT contain %s", excluded)
 			}
+		})
+	}
+}
+
+// TestParseSavingsPlanDetail_RecommendedUtilization covers the
+// EstimatedAverageUtilization field added for issue #338 — the SP equivalent
+// of the RI AverageUtilization signal that drives --target-utilization sizing.
+func TestParseSavingsPlanDetail_RecommendedUtilization(t *testing.T) {
+	client := &Client{}
+	params := common.RecommendationParams{
+		Service:       common.ServiceSavingsPlansCompute,
+		PaymentOption: "no-upfront",
+		Term:          "1yr",
+	}
+
+	tests := []struct {
+		name               string
+		utilizationStr     *string
+		wantUtilization    float64
+		wantAvgInstancesIs float64
+	}{
+		{
+			name:               "field present and parseable",
+			utilizationStr:     aws.String("87.5"),
+			wantUtilization:    87.5,
+			wantAvgInstancesIs: 0,
+		},
+		{
+			name:               "field nil → zero",
+			utilizationStr:     nil,
+			wantUtilization:    0,
+			wantAvgInstancesIs: 0,
+		},
+		{
+			name:               "field unparseable → zero (parseOptionalFloat logs warn)",
+			utilizationStr:     aws.String("not-a-number"),
+			wantUtilization:    0,
+			wantAvgInstancesIs: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			detail := &types.SavingsPlansPurchaseRecommendationDetail{
+				HourlyCommitmentToPurchase:  aws.String("1.0"),
+				EstimatedAverageUtilization: tt.utilizationStr,
+			}
+			rec := client.parseSavingsPlanDetail(detail, params, types.SupportedSavingsPlansTypeComputeSp)
+			require.NotNil(t, rec)
+			assert.Equal(t, tt.wantUtilization, rec.RecommendedUtilization,
+				"SP utilization should be parsed into rec.RecommendedUtilization")
+			assert.Equal(t, tt.wantAvgInstancesIs, rec.AverageInstancesUsedPerHour,
+				"SP recs leave AverageInstancesUsedPerHour at zero (not applicable for SPs)")
 		})
 	}
 }

--- a/providers/aws/service_client.go
+++ b/providers/aws/service_client.go
@@ -165,11 +165,13 @@ func (r *RecommendationsClientAdapter) GetRIUtilization(ctx context.Context, loo
 }
 
 // GetRICoverageMap returns the per-pool RI coverage % over the last
-// lookbackDays days, keyed by "region:instance_type". Used by the
-// --target-coverage sizing path to subtract existing pool coverage from
-// the under-buy formula.
-func (r *RecommendationsClientAdapter) GetRICoverageMap(ctx context.Context, lookbackDays int) (recommendations.PoolCoverageMap, error) {
-	return r.client.GetRICoverageMap(ctx, lookbackDays)
+// lookbackDays days, keyed by "region:instance_type:account" (or
+// "region:instance_type:engine:account" for RDS) so the apply helper
+// can look up per-linked-account coverage. Caller passes the regions
+// to scan; CE returns coverage filtered to that region and grouped by
+// LINKED_ACCOUNT + INSTANCE_TYPE.
+func (r *RecommendationsClientAdapter) GetRICoverageMap(ctx context.Context, lookbackDays int, regions []string) (recommendations.PoolCoverageMap, error) {
+	return r.client.GetRICoverageMap(ctx, lookbackDays, regions)
 }
 
 // NewRecommendationsClientDirect creates a new recommendations client returning the concrete type

--- a/providers/aws/service_client.go
+++ b/providers/aws/service_client.go
@@ -164,6 +164,14 @@ func (r *RecommendationsClientAdapter) GetRIUtilization(ctx context.Context, loo
 	return r.client.GetRIUtilization(ctx, lookbackDays)
 }
 
+// GetRICoverageMap returns the per-pool RI coverage % over the last
+// lookbackDays days, keyed by "region:instance_type". Used by the
+// --target-coverage sizing path to subtract existing pool coverage from
+// the under-buy formula.
+func (r *RecommendationsClientAdapter) GetRICoverageMap(ctx context.Context, lookbackDays int) (recommendations.PoolCoverageMap, error) {
+	return r.client.GetRICoverageMap(ctx, lookbackDays)
+}
+
 // NewRecommendationsClientDirect creates a new recommendations client returning the concrete type
 // (needed for GetRIUtilization which is not part of the generic provider interface).
 func NewRecommendationsClientDirect(cfg aws.Config) *RecommendationsClientAdapter {

--- a/providers/aws/service_client_test.go
+++ b/providers/aws/service_client_test.go
@@ -32,6 +32,10 @@ func (m *mockCostExplorerClient) GetReservationUtilization(ctx context.Context, 
 	return &costexplorer.GetReservationUtilizationOutput{}, nil
 }
 
+func (m *mockCostExplorerClient) GetReservationCoverage(ctx context.Context, params *costexplorer.GetReservationCoverageInput, optFns ...func(*costexplorer.Options)) (*costexplorer.GetReservationCoverageOutput, error) {
+	return &costexplorer.GetReservationCoverageOutput{}, nil
+}
+
 // newTestRecommendationsClient creates a recommendations client with a mock CE client
 func newTestRecommendationsClient(ce *mockCostExplorerClient) *recommendations.Client {
 	return recommendations.NewClientWithAPI(ce, "us-east-1")

--- a/providers/aws/services/rds/client.go
+++ b/providers/aws/services/rds/client.go
@@ -87,6 +87,15 @@ func (c *Client) GetExistingCommitments(ctx context.Context) ([]common.Commitmen
 				termMonths = 36
 			}
 
+			// Deployment carries the same vocabulary as DatabaseDetails.AZConfig
+			// on Recommendation so pool-key matching aligns deployment-wise
+			// between recs and existing commitments (used by expiry adjustment).
+			// AWS RDS SDK exposes MultiAZ as a *bool on ReservedDBInstance;
+			// nil or false → "single-az", true → "multi-az".
+			deployment := "single-az"
+			if aws.ToBool(instance.MultiAZ) {
+				deployment = "multi-az"
+			}
 			commitment := common.Commitment{
 				Provider:       common.ProviderAWS,
 				CommitmentID:   aws.ToString(instance.ReservedDBInstanceId),
@@ -95,6 +104,7 @@ func (c *Client) GetExistingCommitments(ctx context.Context) ([]common.Commitmen
 				Region:         c.region,
 				ResourceType:   aws.ToString(instance.DBInstanceClass),
 				Engine:         aws.ToString(instance.ProductDescription), // Capture engine for accurate duplicate checking
+				Deployment:     deployment,
 				Count:          int(aws.ToInt32(instance.DBInstanceCount)),
 				State:          state,
 				StartDate:      aws.ToTime(instance.StartTime),


### PR DESCRIPTION
## Summary

- Adds a new CLI flag `--target-utilization` (`-u`) that sizes RI/SP purchases by **projected post-purchase utilization** instead of `--coverage` % of recommendations.
- Reuses utilization signals already on the wire (`AverageNumberOfInstancesUsedPerHour`, `AverageUtilization`, `EstimatedAverageUtilization`) — **no new AWS API call**.
- Emits three new columns on the dry-run/purchase CSV: `ProjectedUtilization`, `ProjectedCoverage`, `RecommendedUtilization`.

Closes #338.

## Why a separate sizing mode

`--coverage 80` is "buy 80% of each recommendation's instance count." It answers "how much of demand do we cover?" but ignores "how much of what we buy will actually be used?" In bursty/seasonal workloads, `--coverage 80` can still over-buy, leaving commitments idle.

`--target-utilization 95` is "buy enough that projected utilization stays ≥ 95%." Counter-intuitively, **higher target ⇒ fewer commitments bought** (the math is `used÷bought`; raising the target shrinks the bought side). Use it when under-buying-and-spilling-to-on-demand beats over-buying-and-wasting-commitment.

The two modes are mutually exclusive: when `--target-utilization` is set, `--coverage` is ignored with an info log.

## Math

- **RI**: `n_target = floor(AverageInstancesUsedPerHour / (target/100))`, capped at `rec.Count` (never exceed AWS's recommended ceiling). Drop with explanatory INFO log when `n_target == 0` (target unreachable). Pass through unmodified when avg is zero (no signal); counted in a single end-of-run skip summary.
- **SP**: if `RecommendedUtilization >= target`, no scaling (AWS already projects above target). Else `ratio = RecommendedUtilization / target` (always < 1); scales `SavingsPlanDetails.HourlyCommitment` and `rec.EstimatedSavings` — **exactly the fields `ApplyCoverage` scales on the SP branch**, so the two modes stay structurally consistent. Pass through when `RecommendedUtilization <= 0` OR `HourlyCommitment <= 0` (CE placeholder rows).

## Changes

| Commit | Scope |
|---|---|
| `7d7baf6d1` | `pkg/common`: 4 new fields on Recommendation |
| `bbbc36a24` | parser_ri.go + parser_sp.go: populate the new fields |
| `7d83ec948` | `cmd/main.go`: flag + Config field + validation |
| `79cf1a5ad` | `cmd/helpers.go`: ApplyTargetUtilization + applySizing |
| `9468b0aaf` | `cmd/multi_service*.go`: route both call sites through applySizing |
| `5f1e982e1` | CSV writer: 3 new columns |
| `d40001f6a` | README: flag table + semantics explainer |
| `2bded0b15` | Post-impl review: SP edge cases + target=100 test |

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` — full suite passes (no regressions in 30+ existing packages)
- [x] `cudly --help` shows `--target-utilization` with the inversion-warning copy
- [x] `TestApplyTargetUtilization_RI` covers happy path / AWS-ceiling cap / target unreachable drop / no signal pass-through / target met exactly
- [x] `TestApplyTargetUtilization_RI_Target100` covers the AC's "target == 100 → only purchases with perfectly-matched existing usage" boundary
- [x] `TestApplyTargetUtilization_RI_CostScaling` — cost fields untouched on RI branch (matches ApplyCoverage)
- [x] `TestApplyTargetUtilization_SP` — no-op / scale-down / no-signal
- [x] `TestApplyTargetUtilization_SP_NoSignalGuards` — `HourlyCommitment=0` + wrong-Details-type edge cases
- [x] `TestApplySizing` — routes based on `cfg.TargetUtilization > 0`
- [x] `TestValidateTargetUtilization` — range + both-flags-set behaviour
- [x] `TestParseRIUtilizationSignals` + `TestParseSavingsPlanDetail_RecommendedUtilization` — fall back to zero on nil/unparseable
- [x] `TestWriteMultiServiceCSVReport_UtilizationColumns` — header + blank-when-zero formatting

## Design notes

- Two self-review passes (plan: 10 passes against the design; impl: a fresh-eyes Sonnet fork against the actual code) caught: floor-vs-ceil math, missing `ProjectedCoverage` AC field, wrong parser function for SPs (`parseSavingsPlanDetail`, not `parseRecommendationDetail`), wrong enum identifier names, wrong SP cost-field list, missing explanatory log for unreachable target, and two SP edge cases in this branch. All fixed before the push.
- Frontend visibility of the new columns is **out of scope** for this PR per the issue's "Out of scope" section. The CSV change is for the CLI's existing CSV output, not the React frontend.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --target-coverage sizing (supersedes --coverage when set), plus --rebuy-window-days and --min-pool-size flags.
  * Fetches existing RI coverage, accounts for expiring commitments, and adds RDS family-NU sizing to hit target coverage.
  * CSV report expanded with utilization/coverage columns, richer RDS fields, sorting and a TOTAL row.
* **Documentation**
  * README clarifies --coverage vs --target-coverage semantics and precedence.
* **Tests**
  * Large suite of unit tests added/extended for sizing, coverage, CSV and validation logic.
* **Other**
  * Summary output now shows estimated savings as monthly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/339)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->