### PR TITLE
feat(frontend): chip-select component + global filter chips in topbar (#344 T1+T2)

### DIFF
--- a/frontend/src/__tests__/chip-select.test.ts
+++ b/frontend/src/__tests__/chip-select.test.ts
@@ -228,4 +228,113 @@ describe('createChipSelect', () => {
     trigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
     expect(root.querySelector('.chip-select-menu')?.classList.contains('hidden')).toBe(false);
   });
+
+  test('role="listbox" is on the ul, not the outer div', () => {
+    const { root } = createChipSelect({
+      label: 'Provider',
+      options: SHORT_OPTIONS,
+      value: '',
+      onChange: () => {},
+    });
+    document.body.appendChild(root);
+    const trigger = root.querySelector<HTMLButtonElement>('.chip-select')!;
+    trigger.click();
+
+    const ul = root.querySelector('ul');
+    const menu = root.querySelector('.chip-select-menu');
+    expect(ul?.getAttribute('role')).toBe('listbox');
+    expect(menu?.getAttribute('role')).toBeNull();
+  });
+
+  test('option li elements have stable ids and aria-activedescendant tracks the highlight', () => {
+    const { root } = createChipSelect({
+      label: 'Provider',
+      options: SHORT_OPTIONS,
+      value: 'aws',
+      onChange: () => {},
+    });
+    document.body.appendChild(root);
+    const trigger = root.querySelector<HTMLButtonElement>('.chip-select')!;
+    trigger.click();
+
+    const options = root.querySelectorAll<HTMLLIElement>('.chip-select-option');
+    // Every option must have a non-empty id.
+    options.forEach((li) => expect(li.id).toBeTruthy());
+
+    // aria-activedescendant should point at the highlighted option (aws = index 1).
+    const activeId = trigger.getAttribute('aria-activedescendant');
+    expect(activeId).toBeTruthy();
+    const activeLi = document.getElementById(activeId!);
+    expect(activeLi?.dataset['value']).toBe('aws');
+  });
+
+  test('aria-activedescendant is cleared when the menu closes', () => {
+    const { root } = createChipSelect({
+      label: 'Provider',
+      options: SHORT_OPTIONS,
+      value: 'aws',
+      onChange: () => {},
+    });
+    document.body.appendChild(root);
+    const trigger = root.querySelector<HTMLButtonElement>('.chip-select')!;
+    trigger.click();
+    expect(trigger.getAttribute('aria-activedescendant')).toBeTruthy();
+
+    trigger.click(); // close
+    expect(trigger.getAttribute('aria-activedescendant')).toBeNull();
+  });
+
+  test('ArrowDown on trigger does not skip the initial active option (double-fire fix)', () => {
+    const { root } = createChipSelect({
+      label: 'Provider',
+      options: SHORT_OPTIONS,
+      value: 'aws', // index 1 in SHORT_OPTIONS
+      onChange: () => {},
+    });
+    document.body.appendChild(root);
+    const trigger = root.querySelector<HTMLButtonElement>('.chip-select')!;
+
+    // ArrowDown should open the menu with 'aws' highlighted, NOT advance it to 'azure'.
+    trigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    const activeId = trigger.getAttribute('aria-activedescendant');
+    const activeLi = activeId ? document.getElementById(activeId) : null;
+    expect(activeLi?.dataset['value']).toBe('aws');
+  });
+
+  test('Tab on search input closes the menu', () => {
+    const { root } = createChipSelect({
+      label: 'Account',
+      options: LONG_OPTIONS,
+      value: '',
+      onChange: () => {},
+    });
+    document.body.appendChild(root);
+    root.querySelector<HTMLButtonElement>('.chip-select')!.click();
+
+    const search = root.querySelector<HTMLInputElement>('.chip-select-search')!;
+    expect(root.querySelector('.chip-select-menu')?.classList.contains('hidden')).toBe(false);
+
+    search.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+    expect(root.querySelector('.chip-select-menu')?.classList.contains('hidden')).toBe(true);
+  });
+
+  test('"No matches" hint has role="option" and aria-disabled="true"', () => {
+    const { root } = createChipSelect({
+      label: 'Account',
+      options: LONG_OPTIONS,
+      value: '',
+      onChange: () => {},
+    });
+    document.body.appendChild(root);
+    root.querySelector<HTMLButtonElement>('.chip-select')!.click();
+
+    const search = root.querySelector<HTMLInputElement>('.chip-select-search')!;
+    search.value = 'zzzzz nope';
+    search.dispatchEvent(new Event('input', { bubbles: true }));
+
+    const empty = root.querySelector('.chip-select-empty');
+    expect(empty?.getAttribute('role')).toBe('option');
+    expect(empty?.getAttribute('aria-disabled')).toBe('true');
+    expect(empty?.getAttribute('aria-selected')).toBe('false');
+  });
 });

--- a/frontend/src/__tests__/chip-select.test.ts
+++ b/frontend/src/__tests__/chip-select.test.ts
@@ -1,0 +1,231 @@
+/**
+ * chip-select component tests (issue #344 T1).
+ */
+
+import { createChipSelect, type ChipSelectOption } from '../lib/chip-select';
+
+const SHORT_OPTIONS: ChipSelectOption[] = [
+  { value: '', label: 'All' },
+  { value: 'aws', label: 'AWS' },
+  { value: 'azure', label: 'Azure' },
+  { value: 'gcp', label: 'GCP' },
+];
+
+// Long enough to trigger the in-popover search filter (>8 options).
+const LONG_OPTIONS: ChipSelectOption[] = Array.from({ length: 12 }, (_, i) => ({
+  value: `acct-${i}`,
+  label: `Account ${i}`,
+}));
+
+describe('createChipSelect', () => {
+  afterEach(() => {
+    while (document.body.firstChild) document.body.removeChild(document.body.firstChild);
+  });
+
+  test('renders a trigger with label + current value', () => {
+    const { root } = createChipSelect({
+      label: 'Provider',
+      options: SHORT_OPTIONS,
+      value: 'aws',
+      onChange: () => {},
+    });
+    document.body.appendChild(root);
+
+    const trigger = root.querySelector<HTMLButtonElement>('.chip-select');
+    expect(trigger).not.toBeNull();
+    expect(trigger?.getAttribute('aria-haspopup')).toBe('listbox');
+    expect(trigger?.getAttribute('aria-expanded')).toBe('false');
+    expect(root.querySelector('.chip-select-label')?.textContent).toBe('Provider:');
+    expect(root.querySelector('.chip-select-value')?.textContent).toBe('AWS');
+  });
+
+  test('clicking the trigger opens the menu; clicking again closes it', () => {
+    const { root } = createChipSelect({
+      label: 'Provider',
+      options: SHORT_OPTIONS,
+      value: '',
+      onChange: () => {},
+    });
+    document.body.appendChild(root);
+
+    const trigger = root.querySelector<HTMLButtonElement>('.chip-select')!;
+    const menu = root.querySelector<HTMLDivElement>('.chip-select-menu')!;
+
+    expect(menu.classList.contains('hidden')).toBe(true);
+    trigger.click();
+    expect(menu.classList.contains('hidden')).toBe(false);
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+
+    trigger.click();
+    expect(menu.classList.contains('hidden')).toBe(true);
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  test('selecting an option fires onChange and updates the trigger label', () => {
+    const onChange = jest.fn();
+    const { root, getValue } = createChipSelect({
+      label: 'Provider',
+      options: SHORT_OPTIONS,
+      value: '',
+      onChange,
+    });
+    document.body.appendChild(root);
+
+    const trigger = root.querySelector<HTMLButtonElement>('.chip-select')!;
+    trigger.click();
+
+    // Find the Azure option and click it.
+    const azureOption = Array.from(
+      root.querySelectorAll<HTMLLIElement>('.chip-select-option'),
+    ).find((li) => li.dataset['value'] === 'azure')!;
+
+    // mousedown is the event the component listens for (avoids focus race).
+    azureOption.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true }));
+
+    expect(onChange).toHaveBeenCalledWith('azure');
+    expect(getValue()).toBe('azure');
+    expect(root.querySelector('.chip-select-value')?.textContent).toBe('Azure');
+    // Menu closes on selection.
+    expect(root.querySelector('.chip-select-menu')?.classList.contains('hidden')).toBe(true);
+  });
+
+  test('Escape closes the menu', () => {
+    const { root } = createChipSelect({
+      label: 'Provider',
+      options: SHORT_OPTIONS,
+      value: '',
+      onChange: () => {},
+    });
+    document.body.appendChild(root);
+
+    const trigger = root.querySelector<HTMLButtonElement>('.chip-select')!;
+    trigger.click();
+    expect(root.querySelector('.chip-select-menu')?.classList.contains('hidden')).toBe(false);
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(root.querySelector('.chip-select-menu')?.classList.contains('hidden')).toBe(true);
+  });
+
+  test('click outside closes the menu', () => {
+    const { root } = createChipSelect({
+      label: 'Provider',
+      options: SHORT_OPTIONS,
+      value: '',
+      onChange: () => {},
+    });
+    document.body.appendChild(root);
+
+    const outside = document.createElement('button');
+    outside.textContent = 'somewhere else';
+    document.body.appendChild(outside);
+
+    const trigger = root.querySelector<HTMLButtonElement>('.chip-select')!;
+    trigger.click();
+    expect(root.querySelector('.chip-select-menu')?.classList.contains('hidden')).toBe(false);
+
+    outside.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true }));
+    expect(root.querySelector('.chip-select-menu')?.classList.contains('hidden')).toBe(true);
+  });
+
+  test('search input renders only when options exceed the threshold', () => {
+    // Short list — no search input.
+    const short = createChipSelect({
+      label: 'Provider',
+      options: SHORT_OPTIONS,
+      value: '',
+      onChange: () => {},
+    });
+    document.body.appendChild(short.root);
+    short.root.querySelector<HTMLButtonElement>('.chip-select')!.click();
+    expect(short.root.querySelector('.chip-select-search')).toBeNull();
+
+    // Long list — search input appears.
+    document.body.removeChild(short.root);
+    const long = createChipSelect({
+      label: 'Account',
+      options: LONG_OPTIONS,
+      value: '',
+      onChange: () => {},
+    });
+    document.body.appendChild(long.root);
+    long.root.querySelector<HTMLButtonElement>('.chip-select')!.click();
+    expect(long.root.querySelector('.chip-select-search')).not.toBeNull();
+  });
+
+  test('typing in search filters options case-insensitively', () => {
+    const { root } = createChipSelect({
+      label: 'Account',
+      options: LONG_OPTIONS,
+      value: '',
+      onChange: () => {},
+    });
+    document.body.appendChild(root);
+
+    root.querySelector<HTMLButtonElement>('.chip-select')!.click();
+    const search = root.querySelector<HTMLInputElement>('.chip-select-search')!;
+    search.value = 'account 1'; // matches Account 1, 10, 11
+    search.dispatchEvent(new Event('input', { bubbles: true }));
+
+    const visibleOptions = root.querySelectorAll<HTMLLIElement>('.chip-select-option');
+    expect(visibleOptions.length).toBe(3);
+    expect(Array.from(visibleOptions).map((li) => li.textContent)).toEqual([
+      'Account 1', 'Account 10', 'Account 11',
+    ]);
+  });
+
+  test('search with no matches shows the empty hint', () => {
+    const { root } = createChipSelect({
+      label: 'Account',
+      options: LONG_OPTIONS,
+      value: '',
+      onChange: () => {},
+    });
+    document.body.appendChild(root);
+
+    root.querySelector<HTMLButtonElement>('.chip-select')!.click();
+    const search = root.querySelector<HTMLInputElement>('.chip-select-search')!;
+    search.value = 'zzzzz nope';
+    search.dispatchEvent(new Event('input', { bubbles: true }));
+
+    expect(root.querySelector('.chip-select-empty')?.textContent).toBe('No matches');
+  });
+
+  test('setValue + setOptions update the trigger and the open menu', () => {
+    const { root, setValue, setOptions, getValue } = createChipSelect({
+      label: 'Account',
+      options: [{ value: 'a', label: 'A' }],
+      value: 'a',
+      onChange: () => {},
+    });
+    document.body.appendChild(root);
+    expect(root.querySelector('.chip-select-value')?.textContent).toBe('A');
+
+    setOptions([
+      { value: 'b', label: 'B' },
+      { value: 'c', label: 'C' },
+    ]);
+    // setOptions doesn't change the value automatically; trigger now shows
+    // the empty fallback because 'a' isn't in the new options.
+    expect(getValue()).toBe('a');
+    expect(root.querySelector('.chip-select-value')?.textContent).toBe('(any)');
+
+    setValue('c');
+    expect(getValue()).toBe('c');
+    expect(root.querySelector('.chip-select-value')?.textContent).toBe('C');
+  });
+
+  test('ArrowDown on the trigger opens the menu', () => {
+    const { root } = createChipSelect({
+      label: 'Provider',
+      options: SHORT_OPTIONS,
+      value: '',
+      onChange: () => {},
+    });
+    document.body.appendChild(root);
+
+    const trigger = root.querySelector<HTMLButtonElement>('.chip-select')!;
+    expect(root.querySelector('.chip-select-menu')?.classList.contains('hidden')).toBe(true);
+    trigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    expect(root.querySelector('.chip-select-menu')?.classList.contains('hidden')).toBe(false);
+  });
+});

--- a/frontend/src/__tests__/dashboard.test.ts
+++ b/frontend/src/__tests__/dashboard.test.ts
@@ -69,12 +69,18 @@ import { loadSavingsTrendChart, setupSavingsTrendHandlers } from '../dashboard';
 
 // Mock state module
 jest.mock('../state', () => ({
-  getCurrentProvider: jest.fn().mockReturnValue('all'),
+  // Issue #344 T2: AppState.currentProvider is `api.Provider | ''` —
+  // '' is the topbar's "All Providers" sentinel, not the string 'all'.
+  getCurrentProvider: jest.fn().mockReturnValue(''),
   setCurrentProvider: jest.fn(),
   getCurrentAccountIDs: jest.fn().mockReturnValue([]),
   setCurrentAccountIDs: jest.fn(),
   getSavingsChart: jest.fn().mockReturnValue(null),
-  setSavingsChart: jest.fn()
+  setSavingsChart: jest.fn(),
+  // Global topbar filter subscriptions. Each section calls subscribe*
+  // during setup to register its reload callback.
+  subscribeProvider: jest.fn().mockReturnValue(() => {}),
+  subscribeAccount: jest.fn().mockReturnValue(() => {}),
 }));
 
 // Mock utils
@@ -132,7 +138,9 @@ describe('Dashboard Module', () => {
 
       await loadDashboard();
 
-      expect(api.getDashboardSummary).toHaveBeenCalledWith('all', []);
+      // Issue #344 T2: AppState.currentProvider is `api.Provider | ''`,
+      // not a literal 'all' — '' is the "All Providers" sentinel.
+      expect(api.getDashboardSummary).toHaveBeenCalledWith('', []);
       expect(api.getUpcomingPurchases).toHaveBeenCalled();
     });
 
@@ -680,107 +688,15 @@ describe('Dashboard Module', () => {
     });
   });
 
-  // Issue #185: provider-change handler must clear state.currentAccountIDs
-  // before loadDashboard reads it, AND must await populateAccountFilter
-  // so the dropdown is in a consistent state with the post-load state.
-  describe('Issue #185: provider switch clears stale account state before reload', () => {
-    let setupDashboardHandlers: typeof import('../dashboard').setupDashboardHandlers;
-
-    beforeEach(async () => {
-      setupDashboardHandlers = (await import('../dashboard')).setupDashboardHandlers;
-      // Build the test DOM via createElement (avoids innerHTML).
-      document.body.replaceChildren();
-      const providerSel = document.createElement('select');
-      providerSel.id = 'dashboard-provider-filter';
-      for (const [v, t] of [['', 'All'], ['aws', 'AWS'], ['azure', 'Azure']] as const) {
-        const opt = document.createElement('option');
-        opt.value = v; opt.textContent = t;
-        providerSel.appendChild(opt);
-      }
-      document.body.appendChild(providerSel);
-      const acctSel = document.createElement('select');
-      acctSel.id = 'dashboard-account-filter';
-      for (const [v, t] of [['', '(All accounts)'], ['aws-acct-1', 'aws-acct-1']] as const) {
-        const opt = document.createElement('option');
-        opt.value = v; opt.textContent = t;
-        acctSel.appendChild(opt);
-      }
-      document.body.appendChild(acctSel);
-      const summaryDiv = document.createElement('div');
-      summaryDiv.id = 'summary';
-      document.body.appendChild(summaryDiv);
-      const upcomingDiv = document.createElement('div');
-      upcomingDiv.id = 'upcoming-list';
-      document.body.appendChild(upcomingDiv);
-      const canvas = document.createElement('canvas');
-      canvas.id = 'savings-chart';
-      document.body.appendChild(canvas);
-
-      // Pre-load with an AWS account selected so we can prove the
-      // handler clears it.
-      (state.getCurrentProvider as jest.Mock).mockReturnValue('aws');
-      (state.getCurrentAccountIDs as jest.Mock).mockReturnValue(['aws-acct-1']);
-      (api.getDashboardSummary as jest.Mock).mockResolvedValue({
-        potential_monthly_savings: 0, total_recommendations: 0, active_commitments: 0,
-        committed_monthly: 0, current_coverage: 0, target_coverage: 0, ytd_savings: 0,
-        by_service: {}
-      });
-      (api.getUpcomingPurchases as jest.Mock).mockResolvedValue({ purchases: [] });
-    });
-
-    test('switching provider clears state.currentAccountIDs and dispatches loadDashboard', async () => {
-      setupDashboardHandlers();
-      const providerSel = document.getElementById('dashboard-provider-filter') as HTMLSelectElement;
-      providerSel.value = 'azure';
-      providerSel.dispatchEvent(new Event('change'));
-
-      // Wait for the async handler chain to settle.
-      await new Promise(r => setTimeout(r, 0));
-      await new Promise(r => setTimeout(r, 0));
-
-      expect(state.setCurrentProvider).toHaveBeenCalledWith('azure');
-      // setCurrentAccountIDs([]) must be called so loadDashboard reads
-      // a clean state.
-      const clearCalls = (state.setCurrentAccountIDs as jest.Mock).mock.calls;
-      expect(clearCalls.some((c: unknown[]) => Array.isArray(c[0]) && (c[0] as unknown[]).length === 0)).toBe(true);
-      // The dashboard summary call must run AFTER the clear.
-      expect(api.getDashboardSummary).toHaveBeenCalled();
-    });
-
-    test('switching provider awaits populateAccountFilter before reloading the dashboard', async () => {
-      let resolvePopulate: (() => void) | undefined;
-      const populateBlocker = new Promise<void>((resolve) => { resolvePopulate = resolve; });
-      const utils = await import('../utils');
-      // setupDashboardHandlers runs an init populateAccountFilter call
-      // before any user interaction — let that one resolve immediately,
-      // and only block the second call (the provider-change one).
-      (utils.populateAccountFilter as jest.Mock)
-        .mockImplementationOnce(() => Promise.resolve())
-        .mockImplementationOnce(() => populateBlocker);
-
-      setupDashboardHandlers();
-      // Yield so the init populate + setupSavingsTrendHandlers settle
-      // (they don't call getDashboardSummary, so the assertion below
-      // is sound).
-      await new Promise(r => setTimeout(r, 0));
-      const providerSel = document.getElementById('dashboard-provider-filter') as HTMLSelectElement;
-      providerSel.value = 'azure';
-      providerSel.dispatchEvent(new Event('change'));
-
-      // Yield once — populateAccountFilter is pending; getDashboardSummary
-      // must NOT have fired yet.
-      await new Promise(r => setTimeout(r, 0));
-      const callsBefore = (api.getDashboardSummary as jest.Mock).mock.calls.length;
-      expect(callsBefore).toBe(0);
-
-      // Resolve populate; loadDashboard runs after.
-      resolvePopulate!();
-      await new Promise(r => setTimeout(r, 0));
-      await new Promise(r => setTimeout(r, 0));
-
-      const callsAfter = (api.getDashboardSummary as jest.Mock).mock.calls.length;
-      expect(callsAfter).toBeGreaterThan(0);
-    });
+  // Issue #185 invariant — clear account state BEFORE awaiting the
+  // account-list refetch on provider change — moved from dashboard.ts
+  // to topbar-filters.ts as part of issue #344 T2. The dashboard no
+  // longer owns the provider-change handler; it just reloads in
+  // response to state.subscribeProvider. The ordering test now lives
+  // alongside the owning module in topbar-filters.test.ts. See
+  // src/topbar-filters.ts::initTopbarFilters for the implementation.
+  describe.skip('Issue #185: provider switch clears stale account state before reload (moved to topbar-filters.test.ts)', () => {
+    test('placeholder — see topbar-filters.test.ts', () => {});
   });
 
   // KPI tile sparklines (issue #340 T6).

--- a/frontend/src/__tests__/history-approve-button.test.ts
+++ b/frontend/src/__tests__/history-approve-button.test.ts
@@ -48,6 +48,15 @@ jest.mock('../toast', () => ({
 
 jest.mock('../state', () => ({
   getCurrentUser: jest.fn(),
+  // Issue #344 T2: history.ts reads provider/account from the global
+  // topbar filter via state. Default provider 'all' + no account scope
+  // preserves the pre-topbar behaviour these tests assume.
+  getCurrentProvider: jest.fn().mockReturnValue(''),
+  setCurrentProvider: jest.fn(),
+  getCurrentAccountIDs: jest.fn().mockReturnValue([]),
+  setCurrentAccountIDs: jest.fn(),
+  subscribeProvider: jest.fn().mockReturnValue(() => {}),
+  subscribeAccount: jest.fn().mockReturnValue(() => {}),
 }));
 
 import * as api from '../api';

--- a/frontend/src/__tests__/history-cancel-button.test.ts
+++ b/frontend/src/__tests__/history-cancel-button.test.ts
@@ -45,6 +45,15 @@ jest.mock('../toast', () => ({
 
 jest.mock('../state', () => ({
   getCurrentUser: jest.fn(),
+  // Issue #344 T2: history.ts reads provider/account from the global
+  // topbar filter via state. Default provider 'all' + no account scope
+  // preserves the pre-topbar behaviour these tests assume.
+  getCurrentProvider: jest.fn().mockReturnValue(''),
+  setCurrentProvider: jest.fn(),
+  getCurrentAccountIDs: jest.fn().mockReturnValue([]),
+  setCurrentAccountIDs: jest.fn(),
+  subscribeProvider: jest.fn().mockReturnValue(() => {}),
+  subscribeAccount: jest.fn().mockReturnValue(() => {}),
 }));
 
 import * as api from '../api';

--- a/frontend/src/__tests__/history-retry-button.test.ts
+++ b/frontend/src/__tests__/history-retry-button.test.ts
@@ -51,6 +51,15 @@ jest.mock('../toast', () => ({
 
 jest.mock('../state', () => ({
   getCurrentUser: jest.fn(),
+  // Issue #344 T2: history.ts reads provider/account from the global
+  // topbar filter via state. Default provider 'all' + no account scope
+  // preserves the pre-topbar behaviour these tests assume.
+  getCurrentProvider: jest.fn().mockReturnValue(''),
+  setCurrentProvider: jest.fn(),
+  getCurrentAccountIDs: jest.fn().mockReturnValue([]),
+  setCurrentAccountIDs: jest.fn(),
+  subscribeProvider: jest.fn().mockReturnValue(() => {}),
+  subscribeAccount: jest.fn().mockReturnValue(() => {}),
 }));
 
 import * as api from '../api';

--- a/frontend/src/__tests__/history.test.ts
+++ b/frontend/src/__tests__/history.test.ts
@@ -20,26 +20,39 @@ jest.mock('../utils', () => ({
   populateAccountFilter: jest.fn(() => Promise.resolve())
 }));
 
+// Issue #344 T2: history.ts reads provider/account from the global
+// topbar filter via state — mock the module so each test can pre-set
+// the values it wants `loadHistory` to read.
+const mockGetCurrentProvider = jest.fn<string, []>().mockReturnValue('all');
+const mockGetCurrentAccountIDs = jest.fn<string[], []>().mockReturnValue([]);
+jest.mock('../state', () => ({
+  getCurrentUser: jest.fn(),
+  getCurrentProvider: () => mockGetCurrentProvider(),
+  setCurrentProvider: jest.fn(),
+  getCurrentAccountIDs: () => mockGetCurrentAccountIDs(),
+  setCurrentAccountIDs: jest.fn(),
+  subscribeProvider: jest.fn().mockReturnValue(() => {}),
+  subscribeAccount: jest.fn().mockReturnValue(() => {}),
+}));
+
 import * as api from '../api';
 import { switchTab } from '../navigation';
 
 describe('History Module', () => {
   beforeEach(() => {
-    // Reset DOM
+    // Reset DOM. Issue #344 T2: provider/account filters now live in
+    // the global topbar (state-driven); only the per-section controls
+    // remain on the history page.
     document.body.innerHTML = `
       <input type="date" id="history-start">
       <input type="date" id="history-end">
-      <select id="history-provider-filter">
-        <option value="">All Providers</option>
-        <option value="aws">AWS</option>
-        <option value="azure">Azure</option>
-        <option value="gcp">GCP</option>
-      </select>
       <div id="history-summary"></div>
       <div id="history-list"></div>
     `;
 
     jest.clearAllMocks();
+    mockGetCurrentProvider.mockReturnValue('all');
+    mockGetCurrentAccountIDs.mockReturnValue([]);
   });
 
   describe('initHistoryDateRange', () => {
@@ -192,11 +205,11 @@ describe('History Module', () => {
 
       const startInput = document.getElementById('history-start') as HTMLInputElement;
       const endInput = document.getElementById('history-end') as HTMLInputElement;
-      const providerFilter = document.getElementById('history-provider-filter') as HTMLSelectElement;
 
       startInput.value = '2024-01-01';
       endInput.value = '2024-03-01';
-      providerFilter.value = 'aws';
+      // Provider scope now comes from the global topbar (state.ts).
+      mockGetCurrentProvider.mockReturnValue('aws');
 
       await loadHistory();
 
@@ -262,8 +275,10 @@ describe('History Module', () => {
         purchases: []
       });
 
-      const providerFilter = document.getElementById('history-provider-filter') as HTMLSelectElement;
-      providerFilter.value = '';
+      // 'all' is the topbar-chip "All providers" value, which loadHistory
+      // translates to `provider: undefined` (no provider scope on the API
+      // call). Same semantic as the old empty-string select value.
+      mockGetCurrentProvider.mockReturnValue('all');
 
       await loadHistory();
 

--- a/frontend/src/__tests__/html.test.ts
+++ b/frontend/src/__tests__/html.test.ts
@@ -206,10 +206,10 @@ describe('HTML Structure', () => {
       expect(endDate?.getAttribute('type')).toBe('date');
     });
 
-    test('has provider filter', () => {
-      const filter = document.getElementById('history-provider-filter');
-      expect(filter).toBeTruthy();
-    });
+    // Issue #344 T2: provider/account filters moved out of the History
+    // tab into the global topbar. The history page now only carries the
+    // date-range inputs + Load History button. Coverage for the topbar
+    // slot lives in the "Topbar" describe block below.
 
     test('has history list container', () => {
       const list = document.getElementById('history-list');
@@ -328,15 +328,14 @@ describe('HTML Structure', () => {
   });
 
   describe('Select Options', () => {
-    test('dashboard provider filter has correct options', () => {
-      const selector = document.getElementById('dashboard-provider-filter');
-      const options = selector?.querySelectorAll('option') ?? [];
-      const values = Array.from(options).map(o => o.value);
-
-      expect(values).toContain('');
-      expect(values).toContain('aws');
-      expect(values).toContain('azure');
-      expect(values).toContain('gcp');
+    // Issue #344 T2: per-section provider filter <select>s removed.
+    // The provider filter now lives in the global topbar as a chip-
+    // select (custom popover listbox, not a <select>). The slot exists
+    // at #topbar-filters; chip-select option coverage lives in
+    // chip-select.test.ts and topbar-filters.test.ts.
+    test('topbar filters slot exists', () => {
+      const slot = document.getElementById('topbar-filters');
+      expect(slot).toBeTruthy();
     });
 
     // Bundle B: #service-filter <select> deleted; service filtering happens

--- a/frontend/src/__tests__/plans.test.ts
+++ b/frontend/src/__tests__/plans.test.ts
@@ -32,6 +32,16 @@ jest.mock('../state', () => ({
   // behaviour (no recommendations attached to plan).
   getVisibleRecommendations: jest.fn().mockReturnValue([]),
   setVisibleRecommendations: jest.fn(),
+  // Issue #344 T2: plans.ts reads the global filter via state and
+  // subscribes to changes so the list re-renders when the topbar chips
+  // change. The topbar's "All providers" chip writes '' to state, which
+  // is the falsy "no filter" value plans.ts checks for.
+  getCurrentProvider: jest.fn().mockReturnValue(''),
+  setCurrentProvider: jest.fn(),
+  getCurrentAccountIDs: jest.fn().mockReturnValue([]),
+  setCurrentAccountIDs: jest.fn(),
+  subscribeProvider: jest.fn().mockReturnValue(() => {}),
+  subscribeAccount: jest.fn().mockReturnValue(() => {}),
 }));
 
 // Mock history module
@@ -263,15 +273,12 @@ describe('Plans Module', () => {
       // map. Filtering via p.provider directly returned 0 rows every
       // time and was the cause of "switching Provider: AWS empties the
       // list" seen in the 2026-04-22 screenshots.
-      const filter = document.createElement('select');
-      filter.id = 'plans-provider-filter';
-      ['', 'aws', 'azure', 'gcp'].forEach((v) => {
-        const o = document.createElement('option');
-        o.value = v;
-        filter.appendChild(o);
-      });
-      filter.value = 'aws';
-      document.body.appendChild(filter);
+      //
+      // Issue #344 T2: provider filter source moved from a per-section
+      // <select> to the global topbar (state.ts). Simulate "user picked
+      // AWS in the topbar" by pointing the mock at 'aws'.
+      const state = await import('../state');
+      (state.getCurrentProvider as jest.Mock).mockReturnValue('aws');
 
       (api.getPlans as jest.Mock).mockResolvedValue({
         plans: [
@@ -293,11 +300,17 @@ describe('Plans Module', () => {
       });
       (api.getPlannedPurchases as jest.Mock).mockResolvedValue({ purchases: [] });
 
-      await loadPlans();
+      try {
+        await loadPlans();
 
-      const list = document.getElementById('plans-list');
-      expect(list?.innerHTML).toContain('AWS fanout');
-      expect(list?.innerHTML).not.toContain('GCP CUDs');
+        const list = document.getElementById('plans-list');
+        expect(list?.innerHTML).toContain('AWS fanout');
+        expect(list?.innerHTML).not.toContain('GCP CUDs');
+      } finally {
+        // Restore the mock so the next test's "no provider scope"
+        // default holds (it relies on getCurrentProvider returning '').
+        (state.getCurrentProvider as jest.Mock).mockReturnValue('');
+      }
     });
 
     test('shows error on API failure', async () => {

--- a/frontend/src/__tests__/topbar-filters.test.ts
+++ b/frontend/src/__tests__/topbar-filters.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Topbar filter chips (issue #344 T2).
+ *
+ * Carries the regression coverage that used to live in dashboard.test.ts
+ * before the per-section provider/account <select>s were retired:
+ *
+ *   - Issue #185 ordering invariant: a provider change MUST clear
+ *     state.currentAccountIDs BEFORE awaiting the new account-list
+ *     fetch. Any reader that races us must see the cleared value, not
+ *     the stale account id from the prior provider.
+ *
+ * The chip-select internals are covered by chip-select.test.ts; this
+ * file only exercises the wiring topbar-filters.ts adds on top.
+ */
+
+jest.mock('../api', () => ({
+  listAccounts: jest.fn(),
+}));
+
+import * as api from '../api';
+import * as state from '../state';
+import { initTopbarFilters } from '../topbar-filters';
+
+function setupSlot(): void {
+  while (document.body.firstChild) document.body.removeChild(document.body.firstChild);
+  const slot = document.createElement('div');
+  slot.id = 'topbar-filters';
+  document.body.appendChild(slot);
+}
+
+describe('Topbar filters', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setupSlot();
+    state.setCurrentProvider('');
+    state.setCurrentAccountIDs([]);
+    (api.listAccounts as jest.Mock).mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    state.setCurrentProvider('');
+    state.setCurrentAccountIDs([]);
+  });
+
+  test('initTopbarFilters mounts two chip-selects into the topbar slot', () => {
+    initTopbarFilters();
+    const slot = document.getElementById('topbar-filters');
+    // Each chip is a `.chip-select-root` (see lib/chip-select.ts). Two
+    // chips: provider + account.
+    const chips = slot?.querySelectorAll('.chip-select-root');
+    expect(chips?.length).toBe(2);
+  });
+
+  // Issue #185 ordering invariant: a provider change clears
+  // state.currentAccountIDs BEFORE awaiting the new account-list refetch.
+  // The implementation lives in topbar-filters.ts::initTopbarFilters'
+  // onChange handler — see the inline comment there.
+  test('provider change clears currentAccountIDs before listAccounts is awaited', async () => {
+    state.setCurrentProvider('aws');
+    state.setCurrentAccountIDs(['aws-acct-1']);
+
+    // Block the in-flight account refetch so we can observe state mid-flight.
+    let resolveFirst: ((value: unknown[]) => void) | undefined;
+    const firstBlocker = new Promise<unknown[]>((r) => { resolveFirst = r; });
+    let resolveSecond: ((value: unknown[]) => void) | undefined;
+    const secondBlocker = new Promise<unknown[]>((r) => { resolveSecond = r; });
+    (api.listAccounts as jest.Mock)
+      .mockReturnValueOnce(firstBlocker)
+      .mockReturnValueOnce(secondBlocker);
+
+    initTopbarFilters();
+    // Drain the initial populateAccountOptions call so subsequent
+    // listAccounts() goes through secondBlocker.
+    resolveFirst!([]);
+    await new Promise(r => setTimeout(r, 0));
+
+    // Locate the provider chip's trigger (first .chip-select.) and open it.
+    const triggers = document.querySelectorAll<HTMLButtonElement>('.chip-select');
+    expect(triggers.length).toBe(2);
+    const providerTrigger = triggers[0] as HTMLButtonElement;
+    providerTrigger.click();
+
+    // Pick the "Azure" option by data-value.
+    const azureOption = Array.from(
+      document.querySelectorAll<HTMLLIElement>('.chip-select-option')
+    ).find((el) => el.dataset['value'] === 'azure');
+    expect(azureOption).toBeDefined();
+    // chip-select listens on `mousedown` (not click) to dodge a focus
+    // race with the listbox's close-on-blur — fire mousedown so the
+    // option commits.
+    azureOption!.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+
+    // listAccounts({provider: 'azure'}) is now in-flight (blocked on
+    // secondBlocker). Issue #185 invariant: state.currentAccountIDs
+    // must already be cleared, even though the new account list hasn't
+    // arrived yet.
+    expect(state.getCurrentAccountIDs()).toEqual([]);
+    expect(state.getCurrentProvider()).toBe('azure');
+
+    // Release the refetch so the pending promise doesn't leak.
+    resolveSecond!([]);
+    await new Promise(r => setTimeout(r, 0));
+  });
+});

--- a/frontend/src/dashboard.ts
+++ b/frontend/src/dashboard.ts
@@ -5,7 +5,7 @@
 import { Chart, registerables } from 'chart.js';
 import * as api from './api';
 import * as state from './state';
-import { formatCurrency, getDateParts, escapeHtml, populateAccountFilter } from './utils';
+import { formatCurrency, getDateParts, escapeHtml } from './utils';
 import { renderFreshness } from './freshness';
 import type { DashboardSummary, UpcomingPurchase, ServiceSavings, LocalRecommendation } from './types';
 import type { SavingsDataPoint } from './api';
@@ -36,50 +36,14 @@ let upcomingPurchasesIndex: Map<string, UpcomingPurchase> = new Map();
  * Setup dashboard event handlers
  */
 export function setupDashboardHandlers(): void {
-  const providerFilter = document.getElementById('dashboard-provider-filter') as HTMLSelectElement | null;
-  if (providerFilter) {
-    // Set initial value from state
-    providerFilter.value = state.getCurrentProvider();
+  // Filter source-of-truth lives in state.ts (mutated by the global
+  // topbar chips). Subscribe to filter changes and reload the dashboard;
+  // the issue #185 ordering rule (clear accounts before refetching for a
+  // new provider) is enforced by topbar-filters.ts at the source so the
+  // dashboard's loadDashboard() always sees consistent state.
+  state.subscribeProvider(() => void loadDashboard());
+  state.subscribeAccount(() => void loadDashboard());
 
-    // Issue #185: previously this handler fired populateAccountFilter
-    // and loadDashboard in parallel via two `void` calls. loadDashboard
-    // ran first, reading stale `state.currentAccountIDs` from the
-    // prior provider — so the dashboard rendered with the wrong
-    // account filter. Worse, populateAccountFilter restores
-    // `select.value = current` after repopulating; if the previously-
-    // picked account isn't in the new provider's account list, the
-    // dropdown silently goes empty (programmatic value change → no
-    // `change` event fires) and state never resyncs. The fix:
-    //   (a) clear the account selection in state synchronously so any
-    //       in-flight read sees the cleared value,
-    //   (b) await populateAccountFilter so loadDashboard sees a
-    //       fully-populated dropdown,
-    //   (c) explicitly reset the dropdown's display value to "(All
-    //       accounts)" — no account from the previous provider can
-    //       ever be valid here.
-    providerFilter.addEventListener('change', () => {
-      void (async (): Promise<void> => {
-        const newProvider = providerFilter.value as '' | 'aws' | 'azure' | 'gcp';
-        state.setCurrentProvider(newProvider);
-        state.setCurrentAccountIDs([]);
-        await populateAccountFilter('dashboard-account-filter', api.listAccounts, newProvider);
-        const accountSel = document.getElementById('dashboard-account-filter') as HTMLSelectElement | null;
-        if (accountSel) accountSel.value = '';
-        await loadDashboard();
-      })();
-    });
-  }
-
-  const accountFilter = document.getElementById('dashboard-account-filter') as HTMLSelectElement | null;
-  if (accountFilter) {
-    accountFilter.addEventListener('change', () => {
-      const val = accountFilter.value;
-      state.setCurrentAccountIDs(val ? [val] : []);
-      void loadDashboard();
-    });
-  }
-
-  void populateAccountFilter('dashboard-account-filter', api.listAccounts, state.getCurrentProvider());
   setupSavingsTrendHandlers();
 }
 

--- a/frontend/src/history.ts
+++ b/frontend/src/history.ts
@@ -3,7 +3,8 @@
  */
 
 import * as api from './api';
-import { formatCurrency, formatDate, formatTerm, escapeHtml, populateAccountFilter } from './utils';
+import * as state from './state';
+import { formatCurrency, formatDate, formatTerm, escapeHtml } from './utils';
 import type { HistoryResponse, HistorySummary, HistoryPurchase } from './types';
 import { switchTab } from './navigation';
 import { confirmDialog } from './confirmDialog';
@@ -59,21 +60,16 @@ function applyExecutionDeepLink(): boolean {
   return true;
 }
 
-function populateHistoryAccountFilter(provider?: string): Promise<void> {
-  return populateAccountFilter('history-account-filter', api.listAccounts, provider);
-}
-
 /**
- * Setup history filter event handlers
+ * Setup history filter event handlers.
+ *
+ * Provider/account filters are global (sourced from state.ts via the
+ * topbar chips). The history-section's own controls are just date range
+ * + Load History button — those stay here.
  */
 export function setupHistoryHandlers(): void {
-  const providerFilter = document.getElementById('history-provider-filter') as HTMLSelectElement | null;
-  if (providerFilter) {
-    providerFilter.addEventListener('change', () => {
-      void populateHistoryAccountFilter(providerFilter.value);
-    });
-  }
-  void populateHistoryAccountFilter();
+  state.subscribeProvider(() => void loadHistory());
+  state.subscribeAccount(() => void loadHistory());
 }
 
 /**
@@ -162,13 +158,14 @@ function snapDateInputsToPurchases(purchases: HistoryPurchase[]): void {
  */
 export async function loadHistory(): Promise<void> {
   try {
-    const rawProvider = (document.getElementById('history-provider-filter') as HTMLSelectElement | null)?.value || '';
+    // Provider/account filters live in state.ts now (mutated by topbar chips).
+    const rawProvider = state.getCurrentProvider();
     const provider: api.Provider | undefined = (VALID_PROVIDERS as string[]).includes(rawProvider)
       ? (rawProvider as api.Provider)
       : undefined;
 
-    const rawAccountId = (document.getElementById('history-account-filter') as HTMLSelectElement | null)?.value || '';
-    const accountIDs: string[] | undefined = rawAccountId ? [rawAccountId] : undefined;
+    const stateAccountIDs = state.getCurrentAccountIDs();
+    const accountIDs: string[] | undefined = stateAccountIDs.length > 0 ? stateAccountIDs : undefined;
 
     const filters: api.HistoryFilters = {
       start: (document.getElementById('history-start') as HTMLInputElement | null)?.value,

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -29,6 +29,7 @@
                 </span>
                 <h1>CUDly</h1>
             </div>
+            <div id="topbar-filters" class="app-topbar-filters" aria-label="Global filters"></div>
             <div id="user-info">
                 <span id="user-email-display"></span>
                 <span id="user-role-display" class="role-badge"></span>
@@ -70,29 +71,9 @@
                 </nav>
             </aside>
             <main class="app-main" id="main-content">
-            <!-- Home Tab -->
+            <!-- Home Tab. Provider/Account filters live in the topbar
+                 (#topbar-filters); they're global across all sections. -->
             <div id="home-tab" class="tab-content active" role="tabpanel" aria-labelledby="home-tab-btn">
-                <section id="dashboard-controls">
-                    <div class="controls-bar">
-                        <div class="filter-group">
-                            <label>Provider:
-                                <select id="dashboard-provider-filter">
-                                    <option value="">All Providers</option>
-                                    <option value="aws">AWS</option>
-                                    <option value="azure">Azure</option>
-                                    <option value="gcp">GCP</option>
-                                </select>
-                            </label>
-                        </div>
-                        <div class="filter-group">
-                            <label>Account:
-                                <select id="dashboard-account-filter">
-                                    <option value="">All Accounts</option>
-                                </select>
-                            </label>
-                        </div>
-                    </div>
-                </section>
                 <section id="dashboard-freshness" class="freshness-indicator" aria-live="polite"></section>
                 <section id="summary"></section>
                 <section id="savings-trend-section" class="card chart-section">
@@ -134,25 +115,8 @@
             <div id="plans-tab" class="tab-content" role="tabpanel" aria-labelledby="plans-tab-btn">
                 <section id="plans-header" class="card page-hero">
                     <h2>Purchase Plans</h2>
-                    <div class="controls-bar">
-                        <div class="filter-group">
-                            <label>Provider:
-                                <select id="plans-provider-filter">
-                                    <option value="">All Providers</option>
-                                    <option value="aws">AWS</option>
-                                    <option value="azure">Azure</option>
-                                    <option value="gcp">GCP</option>
-                                </select>
-                            </label>
-                        </div>
-                        <div class="filter-group">
-                            <label>Account:
-                                <select id="plans-account-filter">
-                                    <option value="">All Accounts</option>
-                                </select>
-                            </label>
-                        </div>
-                    </div>
+                    <!-- Provider/Account filters now live in the topbar
+                         (#topbar-filters), globally shared across sections. -->
                     <button id="new-plan-btn" class="primary">New Plan</button>
                 </section>
                 <section id="plans-list"></section>
@@ -218,19 +182,9 @@
                         <div class="date-range-picker">
                             <label>From: <input type="date" id="history-start"></label>
                             <label>To: <input type="date" id="history-end"></label>
-                            <label>Provider:
-                                <select id="history-provider-filter">
-                                    <option value="">All Providers</option>
-                                    <option value="aws">AWS</option>
-                                    <option value="azure">Azure</option>
-                                    <option value="gcp">GCP</option>
-                                </select>
-                            </label>
-                            <label>Account:
-                                <select id="history-account-filter">
-                                    <option value="">All Accounts</option>
-                                </select>
-                            </label>
+                            <!-- Provider/Account filters now live in the
+                                 topbar (#topbar-filters); date-range stays
+                                 here because it's history-specific. -->
                             <button id="load-history-btn">Load History</button>
                         </div>
                     </section>

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -14,6 +14,7 @@ import { loadHistory } from './history';
 import { logout } from './auth';
 import { openCreateUserModal, closeUserModal } from './users/userModals';
 import { openCreateGroupModal, closeGroupModal, addPermission, closeDuplicateGroupModal, saveDuplicateGroup } from './groups/groupModals';
+import { initTopbarFilters } from './topbar-filters';
 
 // Re-export for external use
 export { api, utils };
@@ -64,6 +65,12 @@ document.addEventListener('DOMContentLoaded', () => {
       localStorage.setItem(STORAGE_KEY, isCollapsed ? '1' : '0');
     });
   }
+
+  // Global filter chips in the topbar (issue #344 T2). Replaces the
+  // per-section provider/account dropdowns that Home / Plans / Purchases
+  // used to carry; sections subscribe to state.subscribeProvider /
+  // subscribeAccount and reload themselves when the filter changes.
+  initTopbarFilters();
 });
 
 // Initialize on page load

--- a/frontend/src/lib/chip-select.ts
+++ b/frontend/src/lib/chip-select.ts
@@ -1,0 +1,341 @@
+/**
+ * chip-select — a filter chip that opens a popover menu (issue #344 T1).
+ *
+ * Replaces native `<select>` for filter use-cases where we want a compact
+ * pill-shaped trigger that opens a custom listbox. The native dropdown
+ * styling is the browser's job; this lets us own the menu's look + the
+ * search-filter behaviour for long option lists.
+ *
+ * Usage:
+ *   const { root, setValue, getValue, setOptions } = createChipSelect({
+ *     label: 'Provider',
+ *     options: [
+ *       { value: '', label: 'All Providers' },
+ *       { value: 'aws', label: 'AWS' },
+ *       { value: 'azure', label: 'Azure' },
+ *       { value: 'gcp', label: 'GCP' },
+ *     ],
+ *     value: '',
+ *     onChange: (newValue) => console.log(newValue),
+ *   });
+ *   container.appendChild(root);
+ *
+ * Keyboard:
+ *   Enter / Space / Down on the trigger → open
+ *   Esc on the menu → close + focus trigger
+ *   Arrow Up / Down → move highlight
+ *   Enter on highlighted option → select + close
+ *   Tab on menu → close (and let focus continue)
+ *
+ * Search-filter input appears at top of popover when options.length > 8.
+ *
+ * ARIA: the trigger uses `aria-haspopup="listbox"` + `aria-expanded`. The
+ * menu is `role="listbox"` with `role="option"` children; the active
+ * option carries `aria-selected="true"`.
+ */
+
+export interface ChipSelectOption {
+  value: string;
+  label: string;
+}
+
+export interface ChipSelectConfig {
+  label: string;
+  options: readonly ChipSelectOption[];
+  value: string;
+  onChange: (newValue: string) => void;
+  /** Threshold (inclusive) above which the in-popover search input renders. */
+  searchThreshold?: number;
+}
+
+export interface ChipSelectHandle {
+  root: HTMLElement;
+  setValue: (v: string) => void;
+  getValue: () => string;
+  setOptions: (opts: readonly ChipSelectOption[]) => void;
+}
+
+const DEFAULT_SEARCH_THRESHOLD = 8;
+
+function findOptionLabel(opts: readonly ChipSelectOption[], value: string): string {
+  const hit = opts.find((o) => o.value === value);
+  return hit ? hit.label : '';
+}
+
+export function createChipSelect(cfg: ChipSelectConfig): ChipSelectHandle {
+  const searchThreshold = cfg.searchThreshold ?? DEFAULT_SEARCH_THRESHOLD;
+
+  // State held in closure so handles + handlers see the latest.
+  let currentValue = cfg.value;
+  let options = cfg.options.slice();
+  let isOpen = false;
+  let filterText = '';
+  let activeIndex = -1;
+  let outsideListener: ((ev: MouseEvent) => void) | null = null;
+  let escListener: ((ev: KeyboardEvent) => void) | null = null;
+
+  // DOM nodes — built once, mutated thereafter.
+  const root = document.createElement('div');
+  root.classList.add('chip-select-root');
+
+  const trigger = document.createElement('button');
+  trigger.type = 'button';
+  trigger.classList.add('chip-select');
+  trigger.setAttribute('aria-haspopup', 'listbox');
+  trigger.setAttribute('aria-expanded', 'false');
+  trigger.setAttribute('aria-label', cfg.label);
+
+  const triggerLabel = document.createElement('span');
+  triggerLabel.classList.add('chip-select-label');
+  trigger.appendChild(triggerLabel);
+
+  const triggerValue = document.createElement('span');
+  triggerValue.classList.add('chip-select-value');
+  trigger.appendChild(triggerValue);
+
+  const triggerCaret = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  triggerCaret.classList.add('chip-select-caret');
+  triggerCaret.setAttribute('viewBox', '0 0 12 12');
+  triggerCaret.setAttribute('width', '10');
+  triggerCaret.setAttribute('height', '10');
+  triggerCaret.setAttribute('aria-hidden', 'true');
+  const caretPath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  caretPath.setAttribute('d', 'M2 4l4 4 4-4');
+  caretPath.setAttribute('fill', 'none');
+  caretPath.setAttribute('stroke', 'currentColor');
+  caretPath.setAttribute('stroke-width', '1.5');
+  caretPath.setAttribute('stroke-linecap', 'round');
+  caretPath.setAttribute('stroke-linejoin', 'round');
+  triggerCaret.appendChild(caretPath);
+  trigger.appendChild(triggerCaret);
+
+  root.appendChild(trigger);
+
+  const menu = document.createElement('div');
+  menu.classList.add('chip-select-menu', 'hidden');
+  menu.setAttribute('role', 'listbox');
+  menu.setAttribute('aria-label', cfg.label);
+  root.appendChild(menu);
+
+  // Search input is created lazily because it only renders for long lists.
+  const search = document.createElement('input');
+  search.type = 'search';
+  search.classList.add('chip-select-search');
+  search.placeholder = 'Filter…';
+  search.setAttribute('aria-label', `Filter ${cfg.label} options`);
+
+  const optionsList = document.createElement('ul');
+  optionsList.classList.add('chip-select-options');
+  menu.appendChild(optionsList);
+
+  /**
+   * Visible options after applying the search-filter text. Returned in the
+   * same order as `options`; case-insensitive substring match on label.
+   */
+  function visibleOptions(): ChipSelectOption[] {
+    if (filterText === '') return options.slice();
+    const needle = filterText.toLowerCase();
+    return options.filter((o) => o.label.toLowerCase().includes(needle));
+  }
+
+  function renderTrigger(): void {
+    triggerLabel.textContent = `${cfg.label}:`;
+    triggerValue.textContent = findOptionLabel(options, currentValue) || '(any)';
+  }
+
+  function renderOptions(): void {
+    while (optionsList.firstChild) optionsList.removeChild(optionsList.firstChild);
+    const visible = visibleOptions();
+    visible.forEach((opt, i) => {
+      const li = document.createElement('li');
+      li.setAttribute('role', 'option');
+      li.classList.add('chip-select-option');
+      li.dataset['value'] = opt.value;
+      li.textContent = opt.label;
+      const isCurrent = opt.value === currentValue;
+      li.setAttribute('aria-selected', isCurrent ? 'true' : 'false');
+      if (i === activeIndex) li.classList.add('active');
+      if (isCurrent) li.classList.add('current');
+      li.addEventListener('mousedown', (ev) => {
+        // mousedown not click — fires before the focusout that would close
+        // the menu, so we can read currentValue without race.
+        ev.preventDefault();
+        selectByValue(opt.value);
+      });
+      optionsList.appendChild(li);
+    });
+    // Empty-result hint when filter doesn't match anything.
+    if (visible.length === 0) {
+      const li = document.createElement('li');
+      li.classList.add('chip-select-empty');
+      li.textContent = 'No matches';
+      li.setAttribute('aria-disabled', 'true');
+      optionsList.appendChild(li);
+    }
+  }
+
+  function selectByValue(value: string): void {
+    currentValue = value;
+    renderTrigger();
+    closeMenu();
+    cfg.onChange(value);
+  }
+
+  function shouldShowSearch(): boolean {
+    return options.length > searchThreshold;
+  }
+
+  function syncSearchVisibility(): void {
+    // Either present at top of menu or absent. Idempotent on repeated calls.
+    if (shouldShowSearch()) {
+      if (!menu.contains(search)) {
+        menu.insertBefore(search, optionsList);
+      }
+    } else if (menu.contains(search)) {
+      menu.removeChild(search);
+    }
+  }
+
+  function openMenu(): void {
+    if (isOpen) return;
+    isOpen = true;
+    filterText = '';
+    search.value = '';
+    activeIndex = visibleOptions().findIndex((o) => o.value === currentValue);
+    syncSearchVisibility();
+    renderOptions();
+    menu.classList.remove('hidden');
+    trigger.setAttribute('aria-expanded', 'true');
+    // Flip-upward when the menu would extend past the viewport bottom.
+    positionMenu();
+    // Focus management — for keyboard users.
+    if (shouldShowSearch()) {
+      search.focus();
+    } else {
+      // Don't steal focus from the trigger when no search input;
+      // keyboard arrow handlers still work because the trigger keeps focus.
+    }
+
+    outsideListener = (ev: MouseEvent): void => {
+      if (!root.contains(ev.target as Node)) closeMenu();
+    };
+    document.addEventListener('mousedown', outsideListener);
+
+    escListener = (ev: KeyboardEvent): void => {
+      if (ev.key === 'Escape') {
+        ev.preventDefault();
+        closeMenu();
+        trigger.focus();
+      }
+    };
+    document.addEventListener('keydown', escListener);
+  }
+
+  function closeMenu(): void {
+    if (!isOpen) return;
+    isOpen = false;
+    menu.classList.add('hidden');
+    trigger.setAttribute('aria-expanded', 'false');
+    if (outsideListener) {
+      document.removeEventListener('mousedown', outsideListener);
+      outsideListener = null;
+    }
+    if (escListener) {
+      document.removeEventListener('keydown', escListener);
+      escListener = null;
+    }
+  }
+
+  function positionMenu(): void {
+    // Reset any prior flip; default is below the trigger.
+    menu.classList.remove('chip-select-menu-up');
+    const rect = trigger.getBoundingClientRect();
+    const viewportH = window.innerHeight;
+    // Estimate menu height as 280px (search + ~6 visible rows) — close enough
+    // for the flip decision. Refine after first render if needed.
+    const estimatedMenuH = 280;
+    if (rect.bottom + estimatedMenuH > viewportH && rect.top > estimatedMenuH) {
+      menu.classList.add('chip-select-menu-up');
+    }
+  }
+
+  // Trigger interactions.
+  trigger.addEventListener('click', () => {
+    if (isOpen) {
+      closeMenu();
+    } else {
+      openMenu();
+    }
+  });
+  trigger.addEventListener('keydown', (ev) => {
+    if (ev.key === 'Enter' || ev.key === ' ' || ev.key === 'ArrowDown') {
+      ev.preventDefault();
+      openMenu();
+    }
+  });
+
+  // Search input interactions.
+  search.addEventListener('input', () => {
+    filterText = search.value;
+    activeIndex = 0;
+    renderOptions();
+  });
+  search.addEventListener('keydown', (ev) => {
+    if (ev.key === 'ArrowDown') {
+      ev.preventDefault();
+      activeIndex = Math.min(activeIndex + 1, visibleOptions().length - 1);
+      renderOptions();
+    } else if (ev.key === 'ArrowUp') {
+      ev.preventDefault();
+      activeIndex = Math.max(activeIndex - 1, 0);
+      renderOptions();
+    } else if (ev.key === 'Enter') {
+      ev.preventDefault();
+      const visible = visibleOptions();
+      const pick = visible[activeIndex];
+      if (pick) selectByValue(pick.value);
+    }
+  });
+
+  // Menu-level keyboard handling when search isn't present (focus stays on
+  // trigger; keyboard goes through document-level handler installed in
+  // openMenu's escListener — extend for arrows below).
+  trigger.addEventListener('keydown', (ev) => {
+    if (!isOpen) return;
+    const visible = visibleOptions();
+    if (ev.key === 'ArrowDown') {
+      ev.preventDefault();
+      activeIndex = Math.min(activeIndex + 1, visible.length - 1);
+      renderOptions();
+    } else if (ev.key === 'ArrowUp') {
+      ev.preventDefault();
+      activeIndex = Math.max(activeIndex - 1, 0);
+      renderOptions();
+    } else if (ev.key === 'Enter') {
+      ev.preventDefault();
+      const pick = visible[activeIndex];
+      if (pick) selectByValue(pick.value);
+    }
+  });
+
+  // Initial render.
+  renderTrigger();
+
+  return {
+    root,
+    getValue: () => currentValue,
+    setValue: (v: string): void => {
+      currentValue = v;
+      renderTrigger();
+      if (isOpen) renderOptions();
+    },
+    setOptions: (opts: readonly ChipSelectOption[]): void => {
+      options = opts.slice();
+      renderTrigger();
+      if (isOpen) {
+        syncSearchVisibility();
+        renderOptions();
+      }
+    },
+  };
+}

--- a/frontend/src/lib/chip-select.ts
+++ b/frontend/src/lib/chip-select.ts
@@ -113,8 +113,6 @@ export function createChipSelect(cfg: ChipSelectConfig): ChipSelectHandle {
 
   const menu = document.createElement('div');
   menu.classList.add('chip-select-menu', 'hidden');
-  menu.setAttribute('role', 'listbox');
-  menu.setAttribute('aria-label', cfg.label);
   root.appendChild(menu);
 
   // Search input is created lazily because it only renders for long lists.
@@ -126,6 +124,11 @@ export function createChipSelect(cfg: ChipSelectConfig): ChipSelectHandle {
 
   const optionsList = document.createElement('ul');
   optionsList.classList.add('chip-select-options');
+  // role="listbox" lives on the ul so option elements are directly owned by
+  // their listbox — placing it on the outer div would make them grandchildren,
+  // which violates the ARIA ownership requirement (WAI-ARIA §6.6.12).
+  optionsList.setAttribute('role', 'listbox');
+  optionsList.setAttribute('aria-label', cfg.label);
   menu.appendChild(optionsList);
 
   /**
@@ -143,18 +146,27 @@ export function createChipSelect(cfg: ChipSelectConfig): ChipSelectHandle {
     triggerValue.textContent = findOptionLabel(options, currentValue) || '(any)';
   }
 
+  // Stable id prefix for this instance, used for aria-activedescendant.
+  const idPrefix = `chip-select-opt-${cfg.label.toLowerCase().replace(/\s+/g, '-')}`;
+
   function renderOptions(): void {
     while (optionsList.firstChild) optionsList.removeChild(optionsList.firstChild);
     const visible = visibleOptions();
+    let activeOptId: string | null = null;
     visible.forEach((opt, i) => {
       const li = document.createElement('li');
+      const optId = `${idPrefix}-${opt.value !== '' ? opt.value : 'empty'}-${i}`;
+      li.id = optId;
       li.setAttribute('role', 'option');
       li.classList.add('chip-select-option');
       li.dataset['value'] = opt.value;
       li.textContent = opt.label;
       const isCurrent = opt.value === currentValue;
       li.setAttribute('aria-selected', isCurrent ? 'true' : 'false');
-      if (i === activeIndex) li.classList.add('active');
+      if (i === activeIndex) {
+        li.classList.add('active');
+        activeOptId = optId;
+      }
       if (isCurrent) li.classList.add('current');
       li.addEventListener('mousedown', (ev) => {
         // mousedown not click — fires before the focusout that would close
@@ -164,12 +176,22 @@ export function createChipSelect(cfg: ChipSelectConfig): ChipSelectHandle {
       });
       optionsList.appendChild(li);
     });
+    // Keep aria-activedescendant in sync with the highlighted option.
+    if (activeOptId !== null) {
+      trigger.setAttribute('aria-activedescendant', activeOptId);
+    } else {
+      trigger.removeAttribute('aria-activedescendant');
+    }
     // Empty-result hint when filter doesn't match anything.
     if (visible.length === 0) {
       const li = document.createElement('li');
       li.classList.add('chip-select-empty');
       li.textContent = 'No matches';
+      // role="option" + aria-disabled so AT users hear "No matches, dimmed"
+      // rather than encountering an orphaned element inside role="listbox".
+      li.setAttribute('role', 'option');
       li.setAttribute('aria-disabled', 'true');
+      li.setAttribute('aria-selected', 'false');
       optionsList.appendChild(li);
     }
   }
@@ -236,6 +258,7 @@ export function createChipSelect(cfg: ChipSelectConfig): ChipSelectHandle {
     isOpen = false;
     menu.classList.add('hidden');
     trigger.setAttribute('aria-expanded', 'false');
+    trigger.removeAttribute('aria-activedescendant');
     if (outsideListener) {
       document.removeEventListener('mousedown', outsideListener);
       outsideListener = null;
@@ -267,41 +290,21 @@ export function createChipSelect(cfg: ChipSelectConfig): ChipSelectHandle {
       openMenu();
     }
   });
+  // Single keydown handler on the trigger — captures wasOpen before any
+  // mutation so open and navigate are mutually exclusive for the same event.
+  // Previously two separate listeners caused ArrowDown to both open the menu
+  // (setting activeIndex) and immediately advance it by one.
   trigger.addEventListener('keydown', (ev) => {
-    if (ev.key === 'Enter' || ev.key === ' ' || ev.key === 'ArrowDown') {
-      ev.preventDefault();
-      openMenu();
+    const wasOpen = isOpen;
+    if (!wasOpen) {
+      // Closed — open on Enter / Space / ArrowDown.
+      if (ev.key === 'Enter' || ev.key === ' ' || ev.key === 'ArrowDown') {
+        ev.preventDefault();
+        openMenu();
+      }
+      return;
     }
-  });
-
-  // Search input interactions.
-  search.addEventListener('input', () => {
-    filterText = search.value;
-    activeIndex = 0;
-    renderOptions();
-  });
-  search.addEventListener('keydown', (ev) => {
-    if (ev.key === 'ArrowDown') {
-      ev.preventDefault();
-      activeIndex = Math.min(activeIndex + 1, visibleOptions().length - 1);
-      renderOptions();
-    } else if (ev.key === 'ArrowUp') {
-      ev.preventDefault();
-      activeIndex = Math.max(activeIndex - 1, 0);
-      renderOptions();
-    } else if (ev.key === 'Enter') {
-      ev.preventDefault();
-      const visible = visibleOptions();
-      const pick = visible[activeIndex];
-      if (pick) selectByValue(pick.value);
-    }
-  });
-
-  // Menu-level keyboard handling when search isn't present (focus stays on
-  // trigger; keyboard goes through document-level handler installed in
-  // openMenu's escListener — extend for arrows below).
-  trigger.addEventListener('keydown', (ev) => {
-    if (!isOpen) return;
+    // Already open — navigate.
     const visible = visibleOptions();
     if (ev.key === 'ArrowDown') {
       ev.preventDefault();
@@ -313,6 +316,34 @@ export function createChipSelect(cfg: ChipSelectConfig): ChipSelectHandle {
       renderOptions();
     } else if (ev.key === 'Enter') {
       ev.preventDefault();
+      const pick = visible[activeIndex];
+      if (pick) selectByValue(pick.value);
+    }
+  });
+
+  // Search input interactions.
+  search.addEventListener('input', () => {
+    filterText = search.value;
+    activeIndex = 0;
+    renderOptions();
+  });
+  search.addEventListener('keydown', (ev) => {
+    if (ev.key === 'Tab') {
+      // Close menu but let Tab continue to the next focusable element.
+      closeMenu();
+      return;
+    }
+    if (ev.key === 'ArrowDown') {
+      ev.preventDefault();
+      activeIndex = Math.min(activeIndex + 1, visibleOptions().length - 1);
+      renderOptions();
+    } else if (ev.key === 'ArrowUp') {
+      ev.preventDefault();
+      activeIndex = Math.max(activeIndex - 1, 0);
+      renderOptions();
+    } else if (ev.key === 'Enter') {
+      ev.preventDefault();
+      const visible = visibleOptions();
       const pick = visible[activeIndex];
       if (pick) selectByValue(pick.value);
     }

--- a/frontend/src/plans.ts
+++ b/frontend/src/plans.ts
@@ -1106,6 +1106,12 @@ async function handleAddPurchases(e: Event): Promise<void> {
   }
 }
 
+// Unsubscribe handles kept at module scope so setupPlanHandlers stays
+// idempotent: calling it more than once (e.g. in tests or after HMR)
+// replaces the old subscriptions rather than stacking duplicates.
+let _unsubProvider: (() => void) | null = null;
+let _unsubAccount: (() => void) | null = null;
+
 /**
  * Setup plan form event handlers (provider-aware service dropdown).
  *
@@ -1114,8 +1120,12 @@ async function handleAddPurchases(e: Event): Promise<void> {
  * the page level.
  */
 export function setupPlanHandlers(): void {
-  state.subscribeProvider(() => void loadPlans());
-  state.subscribeAccount(() => void loadPlans());
+  // Drop any previous subscriptions before re-registering so we don't
+  // accumulate duplicate loadPlans() calls on each invocation.
+  _unsubProvider?.();
+  _unsubAccount?.();
+  _unsubProvider = state.subscribeProvider(() => void loadPlans());
+  _unsubAccount = state.subscribeAccount(() => void loadPlans());
 
   const providerSelect = document.getElementById('plan-provider') as HTMLSelectElement | null;
   const serviceSelect = document.getElementById('plan-service') as HTMLSelectElement | null;

--- a/frontend/src/plans.ts
+++ b/frontend/src/plans.ts
@@ -3,7 +3,8 @@
  */
 
 import * as api from './api';
-import { formatDate, formatTerm, getStatusBadge, escapeHtml, formatCurrency, populateAccountFilter } from './utils';
+import * as state from './state';
+import { formatDate, formatTerm, getStatusBadge, escapeHtml, formatCurrency } from './utils';
 import { showToast } from './toast';
 import { confirmDialog } from './confirmDialog';
 import type { PlansResponse, LocalPlan, SavePlanData } from './types';
@@ -36,7 +37,10 @@ export async function loadPlans(): Promise<void> {
     // its first service entry (see extractPlanInfo below). Filtering on
     // `p.provider` directly silently returned zero rows for every
     // non-empty filter value.
-    const providerFilter = (document.getElementById('plans-provider-filter') as HTMLSelectElement | null)?.value;
+    // Filter source is the global topbar (state.ts), shared across
+    // sections. The topbar's "All Providers" chip writes '' to state,
+    // which is falsy so the filter is naturally skipped.
+    const providerFilter = state.getCurrentProvider();
     if (providerFilter) {
       plans = plans.filter(p => extractPlanInfo(p as unknown as BackendPlan).provider === providerFilter);
     }
@@ -1103,27 +1107,15 @@ async function handleAddPurchases(e: Event): Promise<void> {
 }
 
 /**
- * Setup plan form event handlers (provider-aware service dropdown)
+ * Setup plan form event handlers (provider-aware service dropdown).
+ *
+ * Provider/account filter source-of-truth is the global topbar (state.ts);
+ * subscribe so the plans list re-renders when the user changes filters at
+ * the page level.
  */
-function populatePlansAccountFilter(provider?: string): Promise<void> {
-  return populateAccountFilter('plans-account-filter', api.listAccounts, provider);
-}
-
 export function setupPlanHandlers(): void {
-  const plansProviderFilter = document.getElementById('plans-provider-filter') as HTMLSelectElement | null;
-  if (plansProviderFilter) {
-    plansProviderFilter.addEventListener('change', () => {
-      void populatePlansAccountFilter(plansProviderFilter.value);
-      void loadPlans();
-    });
-  }
-
-  const plansAccountFilter = document.getElementById('plans-account-filter') as HTMLSelectElement | null;
-  if (plansAccountFilter) {
-    plansAccountFilter.addEventListener('change', () => void loadPlans());
-  }
-
-  void populatePlansAccountFilter();
+  state.subscribeProvider(() => void loadPlans());
+  state.subscribeAccount(() => void loadPlans());
 
   const providerSelect = document.getElementById('plan-provider') as HTMLSelectElement | null;
   const serviceSelect = document.getElementById('plan-service') as HTMLSelectElement | null;

--- a/frontend/src/state.ts
+++ b/frontend/src/state.ts
@@ -62,12 +62,44 @@ export function setCurrentUser(user: AppState['currentUser']) {
   state.currentUser = user;
 }
 
+// ──────────────────────────────────────────────────────────────────────────
+// Filter subscription pattern (issue #344 T2).
+//
+// Each section (Home / Opportunities / Plans / Purchases) used to bind its
+// own `change` listener to a per-section `<select>` to know when the
+// provider/account filter changed. With the filter relocated to the topbar,
+// every section subscribes through this module instead. Topbar-filters
+// updates state via setCurrentProvider/setCurrentAccountIDs; subscribers
+// then re-run their loaders.
+//
+// Unsubscribe is returned so tests and dev-only init paths can clean up.
+// ──────────────────────────────────────────────────────────────────────────
+type Listener = () => void;
+const providerListeners: Set<Listener> = new Set();
+const accountListeners: Set<Listener> = new Set();
+
+export function subscribeProvider(cb: Listener): () => void {
+  providerListeners.add(cb);
+  return () => providerListeners.delete(cb);
+}
+
+export function subscribeAccount(cb: Listener): () => void {
+  accountListeners.add(cb);
+  return () => accountListeners.delete(cb);
+}
+
 export function getCurrentProvider() {
   return state.currentProvider;
 }
 
 export function setCurrentProvider(provider: AppState['currentProvider']) {
+  const changed = state.currentProvider !== provider;
   state.currentProvider = provider;
+  if (changed) {
+    providerListeners.forEach((cb) => {
+      try { cb(); } catch (err) { console.warn('subscribeProvider listener error:', err); }
+    });
+  }
 }
 
 export function getRecommendations(): AppState['currentRecommendations'] {
@@ -112,7 +144,16 @@ export function getCurrentAccountIDs(): string[] {
 }
 
 export function setCurrentAccountIDs(ids: string[]) {
+  const current = state.currentAccountIDs;
+  const changed =
+    ids.length !== current.length ||
+    ids.some((id, i) => id !== current[i]);
   state.currentAccountIDs = ids;
+  if (changed) {
+    accountListeners.forEach((cb) => {
+      try { cb(); } catch (err) { console.warn('subscribeAccount listener error:', err); }
+    });
+  }
 }
 
 // Per-column filters live in their own module-scoped state, in-memory only.

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -1535,3 +1535,139 @@ tr.rec-variant-row:hover td:not(.checkbox-col) {
     font-size: 0.85rem;
     margin-bottom: 0.5rem;
 }
+
+/* ---------------------------------------------------------------------------
+ * chip-select component (issue #344 T1) — pill trigger that opens a popover
+ * listbox. Replaces native <select> for filter use-cases where we want a
+ * compact custom menu pattern. Used by topbar-filters (T2) to host the
+ * shared provider + account filters.
+ * ------------------------------------------------------------------------- */
+
+.chip-select-root {
+    position: relative;
+    display: inline-block;
+}
+
+.chip-select {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--cudly-sp-2);
+    padding: 0.4rem 0.9rem;
+    border: 1px solid var(--cudly-border-strong);
+    border-radius: var(--cudly-r-full);
+    background: var(--cudly-surface);
+    color: var(--cudly-text);
+    font-size: var(--cudly-fs-sm);
+    cursor: pointer;
+    transition: border-color 0.15s, box-shadow 0.15s, background-color 0.15s;
+}
+
+.chip-select:hover {
+    border-color: var(--cudly-primary);
+}
+
+.chip-select:focus-visible {
+    outline: none;
+    border-color: var(--cudly-primary);
+    box-shadow: 0 0 0 3px var(--cudly-info-bg);
+}
+
+.chip-select[aria-expanded="true"] {
+    border-color: var(--cudly-primary);
+    background: var(--cudly-info-bg);
+}
+
+.chip-select-label {
+    color: var(--cudly-text-muted);
+}
+
+.chip-select-value {
+    font-weight: var(--cudly-fw-medium);
+}
+
+.chip-select-caret {
+    transition: transform 0.15s ease;
+}
+
+.chip-select[aria-expanded="true"] .chip-select-caret {
+    transform: rotate(180deg);
+}
+
+/* The popover menu. Positioned absolutely below (or above) the trigger.
+ * Z-index sits above the topbar's sticky position so the menu doesn't
+ * get clipped at the page-content boundary. */
+.chip-select-menu {
+    position: absolute;
+    top: calc(100% + var(--cudly-sp-1));
+    left: 0;
+    min-width: 200px;
+    max-width: 320px;
+    max-height: 320px;
+    overflow-y: auto;
+    background: var(--cudly-surface);
+    border: 1px solid var(--cudly-border);
+    border-radius: var(--cudly-r-md);
+    box-shadow: var(--cudly-shadow-lg);
+    z-index: 60;
+    padding: var(--cudly-sp-1);
+}
+
+.chip-select-menu.chip-select-menu-up {
+    top: auto;
+    bottom: calc(100% + var(--cudly-sp-1));
+}
+
+.chip-select-search {
+    width: 100%;
+    padding: var(--cudly-sp-2) var(--cudly-sp-3);
+    border: 1px solid var(--cudly-border);
+    border-radius: var(--cudly-r-sm);
+    font-size: var(--cudly-fs-sm);
+    margin-bottom: var(--cudly-sp-1);
+    box-sizing: border-box;
+}
+
+.chip-select-search:focus-visible {
+    outline: none;
+    border-color: var(--cudly-primary);
+    box-shadow: 0 0 0 2px var(--cudly-info-bg);
+}
+
+.chip-select-options {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.chip-select-option {
+    padding: var(--cudly-sp-2) var(--cudly-sp-3);
+    border-radius: var(--cudly-r-sm);
+    cursor: pointer;
+    color: var(--cudly-text);
+    font-size: var(--cudly-fs-sm);
+    user-select: none;
+}
+
+.chip-select-option:hover,
+.chip-select-option.active {
+    background: var(--cudly-info-bg);
+    color: var(--cudly-primary);
+}
+
+.chip-select-option.current {
+    font-weight: var(--cudly-fw-semibold);
+}
+
+.chip-select-option.current::after {
+    content: '✓';
+    float: right;
+    color: var(--cudly-primary);
+}
+
+.chip-select-empty {
+    padding: var(--cudly-sp-3);
+    text-align: center;
+    color: var(--cudly-text-muted);
+    font-size: var(--cudly-fs-sm);
+    font-style: italic;
+}

--- a/frontend/src/styles/layout.css
+++ b/frontend/src/styles/layout.css
@@ -286,3 +286,14 @@ footer a:hover {
     gap: 0.5rem;
     align-items: center;
 }
+
+/* Global filter chips strip in the topbar (issue #344 T2). Hosts the
+ * shared Provider + Account chip-selects between the brand and the
+ * user-info block. */
+.app-topbar-filters {
+    display: flex;
+    align-items: center;
+    gap: var(--cudly-sp-3);
+    margin-left: auto;
+    margin-right: var(--cudly-sp-4);
+}

--- a/frontend/src/topbar-filters.ts
+++ b/frontend/src/topbar-filters.ts
@@ -31,18 +31,27 @@ const PROVIDER_OPTIONS: ChipSelectOption[] = [
 let providerChip: ChipSelectHandle | null = null;
 let accountChip: ChipSelectHandle | null = null;
 
+// Monotonically-increasing request counter. Each populateAccountOptions call
+// captures its generation before awaiting; the result is discarded if a newer
+// call has started, preventing stale responses from overwriting fresh options.
+let _accountRequestGen = 0;
+
 /**
  * Build the account chip's option list from the current provider context.
  * Always includes the "All Accounts" option at the top.
+ * Uses a generation counter to discard responses from superseded requests.
  */
 async function populateAccountOptions(provider: string): Promise<void> {
   if (!accountChip) return;
+  const gen = ++_accountRequestGen;
   try {
     const filter =
       provider && provider !== '' && provider !== 'all'
         ? { provider: provider as 'aws' | 'azure' | 'gcp' }
         : undefined;
     const accounts = await api.listAccounts(filter);
+    // Discard if a newer request has already started.
+    if (gen !== _accountRequestGen) return;
     const options: ChipSelectOption[] = [
       { value: '', label: 'All Accounts' },
       ...accounts.map((a) => ({
@@ -52,6 +61,7 @@ async function populateAccountOptions(provider: string): Promise<void> {
     ];
     accountChip.setOptions(options);
   } catch (err) {
+    if (gen !== _accountRequestGen) return;
     console.warn('topbar-filters: failed to list accounts for chip:', err);
     accountChip.setOptions([{ value: '', label: 'All Accounts' }]);
   }

--- a/frontend/src/topbar-filters.ts
+++ b/frontend/src/topbar-filters.ts
@@ -1,0 +1,114 @@
+/**
+ * Topbar filters (issue #344 T2).
+ *
+ * Owns the two global filter chips (Provider + Account) that sit in the
+ * topbar after the brand. Each chip updates `state.ts` and the state's
+ * subscription pattern (subscribeProvider / subscribeAccount) fans the
+ * change out to every section that has registered a reload callback.
+ *
+ * Replaces the per-section provider/account `<select>` dropdowns that
+ * Home / Plans / Purchases used to carry. Those are removed from
+ * index.html in the same PR; sections register their reload callback
+ * via state.subscribe* instead of binding to a DOM `change` event.
+ *
+ * Pre-#344 the filter logic in dashboard.ts had a subtle ordering rule
+ * (issue #185 fix: clear accounts in state BEFORE awaiting
+ * populateAccountFilter, so any in-flight read sees the cleared value).
+ * That same rule applies here — keep it in the provider-change handler.
+ */
+
+import * as api from './api';
+import * as state from './state';
+import { createChipSelect, type ChipSelectHandle, type ChipSelectOption } from './lib/chip-select';
+
+const PROVIDER_OPTIONS: ChipSelectOption[] = [
+  { value: '', label: 'All Providers' },
+  { value: 'aws', label: 'AWS' },
+  { value: 'azure', label: 'Azure' },
+  { value: 'gcp', label: 'GCP' },
+];
+
+let providerChip: ChipSelectHandle | null = null;
+let accountChip: ChipSelectHandle | null = null;
+
+/**
+ * Build the account chip's option list from the current provider context.
+ * Always includes the "All Accounts" option at the top.
+ */
+async function populateAccountOptions(provider: string): Promise<void> {
+  if (!accountChip) return;
+  try {
+    const filter =
+      provider && provider !== '' && provider !== 'all'
+        ? { provider: provider as 'aws' | 'azure' | 'gcp' }
+        : undefined;
+    const accounts = await api.listAccounts(filter);
+    const options: ChipSelectOption[] = [
+      { value: '', label: 'All Accounts' },
+      ...accounts.map((a) => ({
+        value: a.id,
+        label: `${a.name} (${a.external_id})`,
+      })),
+    ];
+    accountChip.setOptions(options);
+  } catch (err) {
+    console.warn('topbar-filters: failed to list accounts for chip:', err);
+    accountChip.setOptions([{ value: '', label: 'All Accounts' }]);
+  }
+}
+
+/**
+ * Initialise the topbar filter chips. Idempotent — calling again rebuilds
+ * the chips in case the slot was wiped (it shouldn't be, but defensive).
+ *
+ * Returns immediately; the initial account list populates asynchronously
+ * in the background.
+ */
+export function initTopbarFilters(): void {
+  const slot = document.getElementById('topbar-filters');
+  if (!slot) {
+    console.warn('topbar-filters: #topbar-filters slot not in DOM, skipping');
+    return;
+  }
+
+  // Tear down any prior chips before re-mount (idempotent).
+  while (slot.firstChild) slot.removeChild(slot.firstChild);
+  providerChip = null;
+  accountChip = null;
+
+  providerChip = createChipSelect({
+    label: 'Provider',
+    options: PROVIDER_OPTIONS,
+    value: state.getCurrentProvider(),
+    onChange: (newProvider) => {
+      // Per issue #185 ordering: clear account selection in state BEFORE
+      // we await the account-list refetch. Any in-flight reader that
+      // races us sees the cleared value, not the stale account id from
+      // the prior provider.
+      state.setCurrentAccountIDs([]);
+      state.setCurrentProvider(newProvider as '' | 'aws' | 'azure' | 'gcp');
+      // Refresh account options for the new provider; chip resets to
+      // "All Accounts".
+      void populateAccountOptions(newProvider).then(() => {
+        accountChip?.setValue('');
+      });
+    },
+  });
+
+  accountChip = createChipSelect({
+    label: 'Account',
+    // Seed with just "All Accounts"; real list arrives after
+    // populateAccountOptions resolves.
+    options: [{ value: '', label: 'All Accounts' }],
+    value: state.getCurrentAccountIDs()[0] ?? '',
+    onChange: (newAccountId) => {
+      state.setCurrentAccountIDs(newAccountId ? [newAccountId] : []);
+    },
+  });
+
+  slot.appendChild(providerChip.root);
+  slot.appendChild(accountChip.root);
+
+  // Kick off the initial account list fetch.
+  void populateAccountOptions(state.getCurrentProvider());
+}


### PR DESCRIPTION
## Summary

Issue #344 (UI revamp phase 2) — this PR bundles tasks **T1 + T2** of the original 4-task plan:

- **T1**: ship the `chip-select` component (custom popover listbox).
- **T2**: relocate the Provider + Account filters from the per-section `<select>` dropdowns into a single pair of `chip-select` chips in the global topbar.

T3 (loading skeletons) and T4 (Plan-builder drawer) land in follow-up PRs against this branch.

## T1 — chip-select component

`frontend/src/lib/chip-select.ts` — pill trigger + custom popover listbox. API:

```ts
const { root, setValue, getValue, setOptions } = createChipSelect({
  label: 'Provider',
  options: [{ value: '', label: 'All' }, { value: 'aws', label: 'AWS' }, …],
  value: '',
  onChange: (newValue) => …,
});
```

**Behaviour**: click-toggle / keyboard open (Enter / Space / ArrowDown), Esc + click-outside both close, arrow-key option navigation, in-popover search above 8 options, menu flips upward near viewport bottom, full ARIA (`aria-haspopup="listbox"`, `aria-expanded`, `role="listbox"` + `role="option"` + `aria-selected`), DOM via `createElement` + `textContent` only (no `innerHTML`).

## T2 — global filter chips in topbar

`frontend/src/topbar-filters.ts` mounts two chip-selects (Provider + Account) into a new `#topbar-filters` slot in the topbar. Each section subscribes to filter changes via `state.subscribeProvider` / `state.subscribeAccount` and reloads itself — no more three near-identical copies of the same filter on three different tabs.

The provider/account `<select>` dropdowns are deleted from `#dashboard-controls`, `#plans-header`, and `#history-controls` in `index.html`. `dashboard.ts`, `plans.ts`, and `history.ts` lose their DOM-binding / `populateAccountFilter` calls and gain a single `state.subscribe*` registration each. Issue #185's ordering invariant (clear `state.currentAccountIDs` BEFORE awaiting the account-list refetch on provider change) moves from `dashboard.ts` to `topbar-filters.ts` so it stays at the mutation site — regression test moves with it (`__tests__/topbar-filters.test.ts`).

## Verification

- **Tests**: 1609 pass / 1 skipped (one dashboard test relocated to `topbar-filters.test.ts`).
- **Coverage**: 80.76% stmts / 68.08% branches / 70.77% funcs / 82.54% lines — parity with post-#343 baseline (80.76 / 68.10 / 70.70 / 82.40).
- **Bundle**: 519 KiB (+1.4% vs 512 KiB baseline; well within the ±10% gate).
- **Manual smoke**: docker-compose running this branch — provider chip + account chip render, switching provider refetches account list and clears the prior account selection (Issue #185), every section reloads on filter change.

## Not in this PR

- T3 (loading skeletons across data fetchers)
- T4 (Plan-builder drawer on Opportunities)

Both will be stacked on top of this branch in follow-up PRs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Moved provider and account filters to a global topbar location, making them accessible across all tabs for consistent filtering.
  * Introduced a new chip-select filter component with search functionality for easier provider and account selection.

* **Tests**
  * Added comprehensive test coverage for the new chip-select component and topbar filter integration.
  * Updated existing tests to align with the refactored filter architecture.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/345)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->