### PR TITLE
fix(users): align user-role select with backend role allowlist

### DIFF
--- a/frontend/src/__tests__/html.test.ts
+++ b/frontend/src/__tests__/html.test.ts
@@ -474,9 +474,10 @@ describe('HTML Structure', () => {
       const role = document.getElementById('user-role') as HTMLSelectElement | null;
       expect(role).toBeTruthy();
       const options = Array.from(role?.querySelectorAll('option') ?? []).map(o => o.value);
-      expect(options).toContain('readonly');
-      expect(options).toContain('user');
-      expect(options).toContain('admin');
+      // Exact-set equality (not toContain) so a regression that
+      // re-introduces the pre-fix viewer/editor values — or adds any
+      // other role the backend allowlist would reject — fails the test.
+      expect(new Set(options)).toEqual(new Set(['readonly', 'user', 'admin']));
     });
 
     test('has user groups multi-select', () => {

--- a/frontend/src/__tests__/html.test.ts
+++ b/frontend/src/__tests__/html.test.ts
@@ -474,8 +474,8 @@ describe('HTML Structure', () => {
       const role = document.getElementById('user-role') as HTMLSelectElement | null;
       expect(role).toBeTruthy();
       const options = Array.from(role?.querySelectorAll('option') ?? []).map(o => o.value);
-      expect(options).toContain('viewer');
-      expect(options).toContain('editor');
+      expect(options).toContain('readonly');
+      expect(options).toContain('user');
       expect(options).toContain('admin');
     });
 

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -914,8 +914,8 @@
                     <div class="form-group">
                         <label for="user-role">Role</label>
                         <select id="user-role" required>
-                            <option value="viewer">Viewer</option>
-                            <option value="editor">Editor</option>
+                            <option value="readonly">Viewer</option>
+                            <option value="user">Editor</option>
                             <option value="admin">Admin</option>
                         </select>
                     </div>

--- a/internal/api/handler_users.go
+++ b/internal/api/handler_users.go
@@ -49,10 +49,10 @@ func (h *Handler) createUser(ctx context.Context, req *events.LambdaFunctionURLR
 
 	// Validate role against allowlist
 	switch createReq.Role {
-	case "admin", "user":
+	case auth.RoleAdmin, auth.RoleUser, auth.RoleReadOnly:
 		// valid
 	default:
-		return nil, NewClientError(400, "role must be one of: admin, user")
+		return nil, NewClientError(400, "role must be one of: admin, user, readonly")
 	}
 
 	// Decode base64-encoded password


### PR DESCRIPTION
## Summary

The user-create modal's role `<select>` offered `viewer` / `editor` / `admin`
values (`frontend/src/index.html:917-919`, dating back to the original HTML
in `da36b64`), but the createUser handler's role allowlist accepts only
`admin` / `user` (`internal/api/handler_users.go:52`, added in `88e33e9`
"fix(security): validate role allowlist"). Picking "Viewer" or "Editor"
on the form therefore returned **400 "role must be one of: admin, user"**
and user creation broke for two of the three options.

## Fix

3 files, 6 lines:

- `frontend/src/index.html` — map labels to the backend role constants:
  Viewer → `readonly`, Editor → `user`, Admin → `admin`.
- `internal/api/handler_users.go` — extend the allowlist to
  `auth.RoleAdmin` / `auth.RoleUser` / `auth.RoleReadOnly`. The
  service-level `validateCreateUserRequest`, the `users.valid_role`
  CHECK constraint and the `RoleReadOnly` constant already permit
  `readonly`; the handler was the only narrower gate.
- `frontend/src/__tests__/html.test.ts` — update the role-option
  assertion to match the new values.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/api/...`
- [x] `go test ./internal/auth/...`
- [ ] Manual: open Settings → Users → + Add user, try each of Viewer /
      Editor / Admin and confirm the user is created instead of 400.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ECnwGTg2UNzuKHEgN69X4X)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated user role options in the Create User modal. The "Viewer" role now uses the `readonly` designation, and the "Editor" role now uses the `user` designation. The "Admin" role remains unchanged.
  * Updated backend role validation to support the new role designations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/347)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->