### PR TITLE
feat(auth): invite users without a password and let them set it on first login

### DIFF
--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -278,6 +278,18 @@ export interface CreateUserRequest {
   groups?: string[];
 }
 
+// CreateUserResponse extends APIUser with optional invite-delivery
+// status fields that POST /api/users returns when the request created
+// an invited (passwordless) user. invite_email_sent is undefined for
+// password-up-front creates, true when the invite email was handed to
+// the configured sender, and false when the user row exists but the
+// recipient has not been told how to activate it (admin should re-mail
+// the setup link via Forgot Password).
+export interface CreateUserResponse extends APIUser {
+  invite_email_sent?: boolean;
+  invite_email_error?: string;
+}
+
 export interface UpdateUserRequest {
   email?: string;
   role?: string;

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -23,8 +23,14 @@ export async function getUser(userId: string): Promise<APIUser> {
  * Create a new user
  */
 export async function createUser(req: CreateUserRequest): Promise<APIUser> {
-  // Base64 encode password to match backend expectation
-  const encodedReq = { ...req, password: base64Encode(req.password) };
+  // Base64 encode password to match backend expectation. Pass an empty
+  // string through unmodified so the backend's invite-on-empty-password
+  // path triggers — base64-encoding "" would still produce "" but
+  // skipping the call keeps intent obvious.
+  const encodedReq = {
+    ...req,
+    password: req.password ? base64Encode(req.password) : ''
+  };
   return apiRequest<APIUser>('/users', {
     method: 'POST',
     body: JSON.stringify(encodedReq)

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -3,7 +3,12 @@
  */
 
 import { apiRequest, base64Encode } from './client';
-import type { APIUser, CreateUserRequest, UpdateUserRequest } from './types';
+import type {
+  APIUser,
+  CreateUserRequest,
+  CreateUserResponse,
+  UpdateUserRequest
+} from './types';
 
 /**
  * List all users
@@ -22,7 +27,7 @@ export async function getUser(userId: string): Promise<APIUser> {
 /**
  * Create a new user
  */
-export async function createUser(req: CreateUserRequest): Promise<APIUser> {
+export async function createUser(req: CreateUserRequest): Promise<CreateUserResponse> {
   // Base64 encode password to match backend expectation. Pass an empty
   // string through unmodified so the backend's invite-on-empty-password
   // path triggers — base64-encoding "" would still produce "" but
@@ -31,7 +36,7 @@ export async function createUser(req: CreateUserRequest): Promise<APIUser> {
     ...req,
     password: req.password ? base64Encode(req.password) : ''
   };
-  return apiRequest<APIUser>('/users', {
+  return apiRequest<CreateUserResponse>('/users', {
     method: 'POST',
     body: JSON.stringify(encodedReq)
   });

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -909,7 +909,8 @@
                     </div>
                     <div id="password-fields" class="form-group">
                         <label for="user-password">Password</label>
-                        <input type="password" id="user-password" minlength="12" placeholder="Minimum 12 characters">
+                        <input type="password" id="user-password" minlength="12" placeholder="Leave blank to email an invitation">
+                        <small class="form-help">Leave blank to send the user an invitation email; they will set their own password on first login. If you enter a password it must be at least 12 characters and include upper / lower / number / special.</small>
                     </div>
                     <div class="form-group">
                         <label for="user-role">Role</label>

--- a/frontend/src/users/userModals.ts
+++ b/frontend/src/users/userModals.ts
@@ -27,11 +27,13 @@ export function openCreateUserModal(): void {
   form.reset();
   (document.getElementById('user-id') as HTMLInputElement).value = '';
 
-  // Show password field for new user
+  // Show password field for new user. Password is optional: leaving it
+  // blank invites the user via email to set their own password on first
+  // login, so don't mark the field required.
   const passwordFields = document.getElementById('password-fields');
   if (passwordFields) {
     passwordFields.classList.remove('hidden');
-    (document.getElementById('user-password') as HTMLInputElement).required = true;
+    (document.getElementById('user-password') as HTMLInputElement).required = false;
   }
 
   // Populate groups dropdown
@@ -109,18 +111,23 @@ export async function saveUser(e: Event): Promise<void> {
       });
       showSuccess('User updated successfully');
     } else {
-      // Create new user
-      if (!password || password.length < 12) {
-        showError('Password must be at least 12 characters');
-        return;
-      }
-      const hasUppercase = /[A-Z]/.test(password);
-      const hasLowercase = /[a-z]/.test(password);
-      const hasNumber = /[0-9]/.test(password);
-      const hasSpecial = /[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]/.test(password);
-      if (!hasUppercase || !hasLowercase || !hasNumber || !hasSpecial) {
-        showError('Password must contain uppercase, lowercase, number, and special character');
-        return;
+      // Create new user. Password is optional: if blank, the backend
+      // emails an invite that lets the user pick their own password on
+      // first login. Only run client-side strength checks when a
+      // password was actually entered.
+      if (password) {
+        if (password.length < 12) {
+          showError('Password must be at least 12 characters');
+          return;
+        }
+        const hasUppercase = /[A-Z]/.test(password);
+        const hasLowercase = /[a-z]/.test(password);
+        const hasNumber = /[0-9]/.test(password);
+        const hasSpecial = /[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]/.test(password);
+        if (!hasUppercase || !hasLowercase || !hasNumber || !hasSpecial) {
+          showError('Password must contain uppercase, lowercase, number, and special character');
+          return;
+        }
       }
       await api.createUser({
         email,
@@ -128,7 +135,11 @@ export async function saveUser(e: Event): Promise<void> {
         role,
         groups: selectedGroups
       });
-      showSuccess('User created successfully');
+      showSuccess(
+        password
+          ? 'User created successfully'
+          : `Invitation email sent to ${email} — they will set their password on first login`
+      );
     }
 
     closeUserModal();

--- a/frontend/src/users/userModals.ts
+++ b/frontend/src/users/userModals.ts
@@ -129,17 +129,30 @@ export async function saveUser(e: Event): Promise<void> {
           return;
         }
       }
-      await api.createUser({
+      const result = await api.createUser({
         email,
         password,
         role,
         groups: selectedGroups
       });
-      showSuccess(
-        password
-          ? 'User created successfully'
-          : `Invitation email sent to ${email} — they will set their password on first login`
-      );
+      // Three outcomes: password-up-front (no invite),
+      // password-omitted + invite delivered, password-omitted + invite
+      // send failed (user row exists but the recipient is unreachable
+      // — surface a warning so the admin knows to re-mail the link via
+      // Forgot Password).
+      if (password) {
+        showSuccess('User created successfully');
+      } else if (result.invite_email_sent === false) {
+        showError(
+          `User ${email} created but the invitation email could not be sent` +
+            (result.invite_email_error ? `: ${result.invite_email_error}` : '') +
+            '. Use the Forgot Password link from the sign-in page to re-mail the setup link.'
+        );
+      } else {
+        showSuccess(
+          `Invitation email sent to ${email} — they will set their password on first login`
+        );
+      }
     }
 
     closeUserModal();

--- a/internal/api/coverage_gaps_test.go
+++ b/internal/api/coverage_gaps_test.go
@@ -806,6 +806,7 @@ func (s *stubEmailNotifier) SendPurchaseFailedNotification(_ context.Context, _ 
 }
 func (s *stubEmailNotifier) SendPasswordResetEmail(_ context.Context, _, _ string) error { return nil }
 func (s *stubEmailNotifier) SendWelcomeEmail(_ context.Context, _, _, _ string) error    { return nil }
+func (s *stubEmailNotifier) SendUserInviteEmail(_ context.Context, _, _ string) error    { return nil }
 func (s *stubEmailNotifier) SendRIExchangePendingApproval(_ context.Context, _ email.RIExchangeNotificationData) error {
 	return nil
 }

--- a/internal/auth/interfaces.go
+++ b/internal/auth/interfaces.go
@@ -47,4 +47,5 @@ type StoreInterface interface {
 type EmailSenderInterface interface {
 	SendPasswordResetEmail(ctx context.Context, email, resetURL string) error
 	SendWelcomeEmail(ctx context.Context, email, dashboardURL, role string) error
+	SendUserInviteEmail(ctx context.Context, email, setupURL string) error
 }

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -16,6 +16,12 @@ const (
 	// PasswordResetExpiry is how long password reset tokens are valid
 	PasswordResetExpiry = 1 * time.Hour
 
+	// PasswordSetupExpiry is how long an invited user has to set their
+	// initial password via the link in the welcome email. Longer than
+	// PasswordResetExpiry because invites typically wait in an inbox
+	// before the recipient acts on them.
+	PasswordSetupExpiry = 7 * 24 * time.Hour
+
 	// DefaultSessionDurationHours is the default session duration in hours
 	DefaultSessionDurationHours = 24
 

--- a/internal/auth/service_api.go
+++ b/internal/auth/service_api.go
@@ -55,6 +55,22 @@ type APICreateUserRequest struct {
 	Groups   []string `json:"groups,omitempty"`
 }
 
+// APICreateUserResponse is the response type for POST /api/users. It
+// embeds APIUser so existing consumers keep reading the flat
+// {id, email, role, ...} fields and only callers that need the new
+// invite-status information have to look at the extra optional fields.
+//
+// InviteEmailSent is non-nil only when the request created an invited
+// (passwordless) user. true means the invite email was handed to the
+// configured sender; false means the user row exists but the recipient
+// hasn't been told how to activate it and the admin should re-mail the
+// setup link via Forgot Password.
+type APICreateUserResponse struct {
+	*APIUser
+	InviteEmailSent  *bool  `json:"invite_email_sent,omitempty"`
+	InviteEmailError string `json:"invite_email_error,omitempty"`
+}
+
 // APIUpdateUserRequest is the request type for updating users via API
 type APIUpdateUserRequest struct {
 	Email  string   `json:"email,omitempty"`
@@ -170,11 +186,15 @@ func (s *Service) CreateUserAPI(ctx context.Context, reqInterface any) (any, err
 		Role:     req.Role,
 		GroupIDs: req.Groups,
 	}
-	user, err := s.CreateUser(ctx, authReq)
+	result, err := s.CreateUser(ctx, authReq)
 	if err != nil {
 		return nil, err
 	}
-	return userToAPIUser(user), nil
+	return &APICreateUserResponse{
+		APIUser:          userToAPIUser(result.User),
+		InviteEmailSent:  result.InviteEmailSent,
+		InviteEmailError: result.InviteEmailError,
+	}, nil
 }
 
 // UpdateUserAPI updates a user via the API

--- a/internal/auth/service_api_test.go
+++ b/internal/auth/service_api_test.go
@@ -149,13 +149,17 @@ func TestService_CreateUserAPI(t *testing.T) {
 
 		result, err := service.CreateUserAPI(ctx, req)
 		require.NoError(t, err)
-		assert.NotNil(t, result)
+		require.NotNil(t, result)
 
-		apiUser, ok := result.(*APIUser)
-		assert.True(t, ok)
-		assert.Equal(t, "newuser@example.com", apiUser.Email)
-		assert.Equal(t, RoleUser, apiUser.Role)
-		assert.Equal(t, []string{"group-1"}, apiUser.Groups)
+		resp, ok := result.(*APICreateUserResponse)
+		require.True(t, ok, "CreateUserAPI should wrap the response in APICreateUserResponse")
+		require.NotNil(t, resp.APIUser)
+		assert.Equal(t, "newuser@example.com", resp.Email)
+		assert.Equal(t, RoleUser, resp.Role)
+		assert.Equal(t, []string{"group-1"}, resp.Groups)
+		// Non-invite path: no invite-email status fields.
+		assert.Nil(t, resp.InviteEmailSent)
+		assert.Empty(t, resp.InviteEmailError)
 
 		mockStore.AssertExpectations(t)
 	})

--- a/internal/auth/service_user.go
+++ b/internal/auth/service_user.go
@@ -93,6 +93,9 @@ func (s *Service) CheckAdminExists(ctx context.Context) (bool, error) {
 
 // validateCreateUserRequest validates the fields of a CreateUserRequest before creating
 // the user record. Returns an error if any field is invalid.
+//
+// When req.Password is empty the user is invited and will set their own
+// password via the welcome email link, so the password validator is skipped.
 func (s *Service) validateCreateUserRequest(ctx context.Context, req CreateUserRequest) error {
 	if _, err := mail.ParseAddress(req.Email); err != nil {
 		return fmt.Errorf("invalid email format")
@@ -107,22 +110,44 @@ func (s *Service) validateCreateUserRequest(ctx context.Context, req CreateUserR
 	if req.Role != RoleAdmin && req.Role != RoleUser && req.Role != RoleReadOnly {
 		return fmt.Errorf("invalid role: %s", req.Role)
 	}
+	if req.Password == "" {
+		return nil
+	}
 	return s.validatePassword(req.Password)
 }
 
-// CreateUser creates a new user (admin only)
+// CreateUser creates a new user (admin only).
+//
+// If req.Password is empty the user is created in the "invited" state:
+// inactive, with an unguessable placeholder password hash that no client
+// input can match, and a setup token mailed to req.Email. The recipient
+// activates the account and chooses their own password by following the
+// link, which lands on the existing ConfirmPasswordReset flow.
 func (s *Service) CreateUser(ctx context.Context, req CreateUserRequest) (*User, error) {
 	if err := s.validateCreateUserRequest(ctx, req); err != nil {
 		return nil, err
 	}
 
-	// Hash password directly with bcrypt (no custom salt needed)
-	passwordHash, err := s.hashPassword(req.Password)
+	invite := req.Password == ""
+
+	passwordSource := req.Password
+	if invite {
+		// Hash a fresh random token rather than the empty string so the
+		// resulting bcrypt hash is unguessable. Login already short-circuits
+		// on !user.Active, but this guards against any future code path that
+		// reaches the bcrypt compare with this account.
+		placeholder, err := generateToken()
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate placeholder password: %w", err)
+		}
+		passwordSource = placeholder
+	}
+
+	passwordHash, err := s.hashPassword(passwordSource)
 	if err != nil {
 		return nil, fmt.Errorf("failed to hash password: %w", err)
 	}
 
-	// Create user
 	now := time.Now()
 	user := &User{
 		ID:           uuid.New().String(),
@@ -133,14 +158,37 @@ func (s *Service) CreateUser(ctx context.Context, req CreateUserRequest) (*User,
 		GroupIDs:     req.GroupIDs,
 		CreatedAt:    now,
 		UpdatedAt:    now,
-		Active:       true,
+		Active:       !invite,
+	}
+
+	var inviteToken string
+	if invite {
+		token, err := generateToken()
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate invite token: %w", err)
+		}
+		expiry := now.Add(PasswordSetupExpiry)
+		user.PasswordResetToken = hashSessionToken(token)
+		user.PasswordResetExpiry = &expiry
+		inviteToken = token
 	}
 
 	if err := s.store.CreateUser(ctx, user); err != nil {
 		return nil, fmt.Errorf("failed to create user: %w", err)
 	}
 
-	logging.Infof("User created: id=%s, role=%s", user.ID, user.Role)
+	if invite {
+		setupURL := fmt.Sprintf("%s/reset-password?token=%s", s.dashboardURL, inviteToken)
+		if err := s.emailSender.SendUserInviteEmail(ctx, user.Email, setupURL); err != nil {
+			// Mirror the password-reset flow: log but don't fail the
+			// caller — the admin already sees a created user, and the
+			// invite can be re-sent through the password-reset endpoint.
+			logging.Errorf("Failed to send user invite email: %v", err)
+		}
+		logging.Infof("User invited: id=%s, role=%s", user.ID, user.Role)
+	} else {
+		logging.Infof("User created: id=%s, role=%s", user.ID, user.Role)
+	}
 
 	return user, nil
 }

--- a/internal/auth/service_user.go
+++ b/internal/auth/service_user.go
@@ -116,6 +116,20 @@ func (s *Service) validateCreateUserRequest(ctx context.Context, req CreateUserR
 	return s.validatePassword(req.Password)
 }
 
+// CreateUserResult bundles the created user with optional invite-email
+// delivery status. InviteEmailSent is nil unless the request triggered
+// an invite (req.Password == ""). When non-nil it reflects whether the
+// invite email actually reached the configured sender — false means the
+// account exists but the recipient has no way to activate it yet and the
+// admin should re-mail the setup link via the Forgot Password flow until
+// a dedicated Resend Invite endpoint exists. InviteEmailError carries
+// the underlying send error in the false case so callers can surface it.
+type CreateUserResult struct {
+	User             *User
+	InviteEmailSent  *bool
+	InviteEmailError string
+}
+
 // CreateUser creates a new user (admin only).
 //
 // If req.Password is empty the user is created in the "invited" state:
@@ -123,7 +137,13 @@ func (s *Service) validateCreateUserRequest(ctx context.Context, req CreateUserR
 // input can match, and a setup token mailed to req.Email. The recipient
 // activates the account and chooses their own password by following the
 // link, which lands on the existing ConfirmPasswordReset flow.
-func (s *Service) CreateUser(ctx context.Context, req CreateUserRequest) (*User, error) {
+//
+// On an invite request the returned CreateUserResult always carries a
+// non-nil InviteEmailSent so callers can distinguish "delivered" from
+// "stored, but the user is currently unreachable". An invite-email send
+// failure is reported via the result (not as an error) so the user row
+// is still surfaced and the admin can react instead of seeing a 5xx.
+func (s *Service) CreateUser(ctx context.Context, req CreateUserRequest) (*CreateUserResult, error) {
 	if err := s.validateCreateUserRequest(ctx, req); err != nil {
 		return nil, err
 	}
@@ -177,20 +197,29 @@ func (s *Service) CreateUser(ctx context.Context, req CreateUserRequest) (*User,
 		return nil, fmt.Errorf("failed to create user: %w", err)
 	}
 
+	result := &CreateUserResult{User: user}
+
 	if invite {
 		setupURL := fmt.Sprintf("%s/reset-password?token=%s", s.dashboardURL, inviteToken)
-		if err := s.emailSender.SendUserInviteEmail(ctx, user.Email, setupURL); err != nil {
-			// Mirror the password-reset flow: log but don't fail the
-			// caller — the admin already sees a created user, and the
-			// invite can be re-sent through the password-reset endpoint.
+		err := s.emailSender.SendUserInviteEmail(ctx, user.Email, setupURL)
+		sent := err == nil
+		result.InviteEmailSent = &sent
+		if err != nil {
+			// Don't fail the API call: the user row was created
+			// successfully and a 5xx here would imply the whole
+			// operation rolled back. Surface the failure via the
+			// result instead so the caller can show the admin a
+			// warning toast and point them at the Forgot Password
+			// flow as the recovery path.
+			result.InviteEmailError = err.Error()
 			logging.Errorf("Failed to send user invite email: %v", err)
 		}
-		logging.Infof("User invited: id=%s, role=%s", user.ID, user.Role)
+		logging.Infof("User invited: id=%s, role=%s, email_sent=%t", user.ID, user.Role, sent)
 	} else {
 		logging.Infof("User created: id=%s, role=%s", user.ID, user.Role)
 	}
 
-	return user, nil
+	return result, nil
 }
 
 // UpdateUser updates user details (admin only)

--- a/internal/auth/service_user_test.go
+++ b/internal/auth/service_user_test.go
@@ -222,6 +222,71 @@ func TestService_CreateUser(t *testing.T) {
 
 		mockStore.AssertExpectations(t)
 	})
+
+	t.Run("invite flow when password omitted", func(t *testing.T) {
+		mockStore := new(MockStore)
+		mockEmail := new(MockEmailSender)
+		service := createTestService(mockStore, mockEmail)
+
+		mockStore.On("GetUserByEmail", ctx, "invitee@example.com").Return(nil, nil).Once()
+
+		var captured *User
+		mockStore.On("CreateUser", ctx, mock.AnythingOfType("*auth.User")).
+			Run(func(args mock.Arguments) { captured = args.Get(1).(*User) }).
+			Return(nil).Once()
+		mockEmail.On("SendUserInviteEmail", ctx, "invitee@example.com", mock.AnythingOfType("string")).
+			Return(nil).Once()
+
+		req := CreateUserRequest{
+			Email: "invitee@example.com",
+			Role:  RoleUser,
+			// Password intentionally empty — admin is inviting the user.
+		}
+
+		user, err := service.CreateUser(ctx, req)
+		require.NoError(t, err)
+		require.NotNil(t, user)
+		require.NotNil(t, captured)
+
+		// Invited users land inactive and only flip to active after they
+		// set their password through the welcome-link flow.
+		assert.False(t, captured.Active)
+
+		// A setup token must be stored so the welcome-link flow can find
+		// the user; the placeholder hash must not be empty so the
+		// password_hash NOT NULL constraint is satisfied and no client
+		// input can match it.
+		assert.NotEmpty(t, captured.PasswordResetToken)
+		require.NotNil(t, captured.PasswordResetExpiry)
+		assert.True(t, captured.PasswordResetExpiry.After(time.Now()))
+		assert.NotEmpty(t, captured.PasswordHash)
+
+		mockStore.AssertExpectations(t)
+		mockEmail.AssertExpectations(t)
+	})
+
+	t.Run("invite flow still succeeds when email send fails", func(t *testing.T) {
+		mockStore := new(MockStore)
+		mockEmail := new(MockEmailSender)
+		service := createTestService(mockStore, mockEmail)
+
+		mockStore.On("GetUserByEmail", ctx, "invitee@example.com").Return(nil, nil).Once()
+		mockStore.On("CreateUser", ctx, mock.AnythingOfType("*auth.User")).Return(nil).Once()
+		mockEmail.On("SendUserInviteEmail", ctx, "invitee@example.com", mock.AnythingOfType("string")).
+			Return(assert.AnError).Once()
+
+		req := CreateUserRequest{
+			Email: "invitee@example.com",
+			Role:  RoleUser,
+		}
+
+		user, err := service.CreateUser(ctx, req)
+		require.NoError(t, err)
+		assert.NotNil(t, user)
+
+		mockStore.AssertExpectations(t)
+		mockEmail.AssertExpectations(t)
+	})
 }
 
 func TestService_DeleteUser(t *testing.T) {

--- a/internal/auth/service_user_test.go
+++ b/internal/auth/service_user_test.go
@@ -126,12 +126,16 @@ func TestService_CreateUser(t *testing.T) {
 			Role:     RoleUser,
 		}
 
-		user, err := service.CreateUser(ctx, req)
+		result, err := service.CreateUser(ctx, req)
 		require.NoError(t, err)
-		assert.NotNil(t, user)
-		assert.Equal(t, "newuser@example.com", user.Email)
-		assert.Equal(t, RoleUser, user.Role)
-		assert.True(t, user.Active)
+		require.NotNil(t, result)
+		require.NotNil(t, result.User)
+		assert.Equal(t, "newuser@example.com", result.User.Email)
+		assert.Equal(t, RoleUser, result.User.Role)
+		assert.True(t, result.User.Active)
+		// Non-invite path: no invite-email status.
+		assert.Nil(t, result.InviteEmailSent)
+		assert.Empty(t, result.InviteEmailError)
 
 		mockStore.AssertExpectations(t)
 	})
@@ -153,9 +157,9 @@ func TestService_CreateUser(t *testing.T) {
 			Role:     RoleUser,
 		}
 
-		user, err := service.CreateUser(ctx, req)
+		result, err := service.CreateUser(ctx, req)
 		assert.Error(t, err)
-		assert.Nil(t, user)
+		assert.Nil(t, result)
 		assert.Contains(t, err.Error(), "email already in use")
 
 		mockStore.AssertExpectations(t)
@@ -174,9 +178,9 @@ func TestService_CreateUser(t *testing.T) {
 			Role:     "invalid-role",
 		}
 
-		user, err := service.CreateUser(ctx, req)
+		result, err := service.CreateUser(ctx, req)
 		assert.Error(t, err)
-		assert.Nil(t, user)
+		assert.Nil(t, result)
 		assert.Contains(t, err.Error(), "invalid role")
 
 		mockStore.AssertExpectations(t)
@@ -195,9 +199,9 @@ func TestService_CreateUser(t *testing.T) {
 			Role:     RoleUser,
 		}
 
-		user, err := service.CreateUser(ctx, req)
+		result, err := service.CreateUser(ctx, req)
 		assert.Error(t, err)
-		assert.Nil(t, user)
+		assert.Nil(t, result)
 
 		mockStore.AssertExpectations(t)
 	})
@@ -216,9 +220,9 @@ func TestService_CreateUser(t *testing.T) {
 			Role:     RoleUser,
 		}
 
-		user, err := service.CreateUser(ctx, req)
+		result, err := service.CreateUser(ctx, req)
 		assert.Error(t, err)
-		assert.Nil(t, user)
+		assert.Nil(t, result)
 
 		mockStore.AssertExpectations(t)
 	})
@@ -243,9 +247,9 @@ func TestService_CreateUser(t *testing.T) {
 			// Password intentionally empty — admin is inviting the user.
 		}
 
-		user, err := service.CreateUser(ctx, req)
+		result, err := service.CreateUser(ctx, req)
 		require.NoError(t, err)
-		require.NotNil(t, user)
+		require.NotNil(t, result)
 		require.NotNil(t, captured)
 
 		// Invited users land inactive and only flip to active after they
@@ -261,11 +265,16 @@ func TestService_CreateUser(t *testing.T) {
 		assert.True(t, captured.PasswordResetExpiry.After(time.Now()))
 		assert.NotEmpty(t, captured.PasswordHash)
 
+		// Email delivery succeeded — caller should see invite_email_sent=true.
+		require.NotNil(t, result.InviteEmailSent)
+		assert.True(t, *result.InviteEmailSent)
+		assert.Empty(t, result.InviteEmailError)
+
 		mockStore.AssertExpectations(t)
 		mockEmail.AssertExpectations(t)
 	})
 
-	t.Run("invite flow still succeeds when email send fails", func(t *testing.T) {
+	t.Run("invite flow surfaces delivery failure without 5xx", func(t *testing.T) {
 		mockStore := new(MockStore)
 		mockEmail := new(MockEmailSender)
 		service := createTestService(mockStore, mockEmail)
@@ -280,9 +289,18 @@ func TestService_CreateUser(t *testing.T) {
 			Role:  RoleUser,
 		}
 
-		user, err := service.CreateUser(ctx, req)
+		result, err := service.CreateUser(ctx, req)
+		// The user row exists, so the caller must not see an error —
+		// otherwise the admin assumes the operation rolled back and may
+		// re-submit, hitting the duplicate-email guard. The delivery
+		// failure is surfaced via the result fields instead so the UI
+		// can show a warning and point the admin at Forgot Password.
 		require.NoError(t, err)
-		assert.NotNil(t, user)
+		require.NotNil(t, result)
+		require.NotNil(t, result.User)
+		require.NotNil(t, result.InviteEmailSent)
+		assert.False(t, *result.InviteEmailSent)
+		assert.NotEmpty(t, result.InviteEmailError)
 
 		mockStore.AssertExpectations(t)
 		mockEmail.AssertExpectations(t)
@@ -577,9 +595,9 @@ func TestService_CreateUser_EdgeCases(t *testing.T) {
 			Role:     RoleUser,
 		}
 
-		user, err := service.CreateUser(ctx, req)
+		result, err := service.CreateUser(ctx, req)
 		assert.Error(t, err)
-		assert.Nil(t, user)
+		assert.Nil(t, result)
 		assert.Contains(t, err.Error(), "invalid email format")
 	})
 
@@ -596,9 +614,9 @@ func TestService_CreateUser_EdgeCases(t *testing.T) {
 			Role:     RoleUser,
 		}
 
-		user, err := service.CreateUser(ctx, req)
+		result, err := service.CreateUser(ctx, req)
 		assert.Error(t, err)
-		assert.Nil(t, user)
+		assert.Nil(t, result)
 
 		mockStore.AssertExpectations(t)
 	})
@@ -618,10 +636,11 @@ func TestService_CreateUser_EdgeCases(t *testing.T) {
 			GroupIDs: []string{"group-1", "group-2"},
 		}
 
-		user, err := service.CreateUser(ctx, req)
+		result, err := service.CreateUser(ctx, req)
 		require.NoError(t, err)
-		assert.NotNil(t, user)
-		assert.Equal(t, []string{"group-1", "group-2"}, user.GroupIDs)
+		require.NotNil(t, result)
+		require.NotNil(t, result.User)
+		assert.Equal(t, []string{"group-1", "group-2"}, result.User.GroupIDs)
 
 		mockStore.AssertExpectations(t)
 	})
@@ -640,10 +659,11 @@ func TestService_CreateUser_EdgeCases(t *testing.T) {
 			Role:     RoleAdmin,
 		}
 
-		user, err := service.CreateUser(ctx, req)
+		result, err := service.CreateUser(ctx, req)
 		require.NoError(t, err)
-		assert.NotNil(t, user)
-		assert.Equal(t, RoleAdmin, user.Role)
+		require.NotNil(t, result)
+		require.NotNil(t, result.User)
+		assert.Equal(t, RoleAdmin, result.User.Role)
 
 		mockStore.AssertExpectations(t)
 	})
@@ -662,10 +682,11 @@ func TestService_CreateUser_EdgeCases(t *testing.T) {
 			Role:     RoleReadOnly,
 		}
 
-		user, err := service.CreateUser(ctx, req)
+		result, err := service.CreateUser(ctx, req)
 		require.NoError(t, err)
-		assert.NotNil(t, user)
-		assert.Equal(t, RoleReadOnly, user.Role)
+		require.NotNil(t, result)
+		require.NotNil(t, result.User)
+		assert.Equal(t, RoleReadOnly, result.User.Role)
 
 		mockStore.AssertExpectations(t)
 	})

--- a/internal/auth/test_helpers.go
+++ b/internal/auth/test_helpers.go
@@ -191,6 +191,11 @@ func (m *MockEmailSender) SendWelcomeEmail(ctx context.Context, email, dashboard
 	return args.Error(0)
 }
 
+func (m *MockEmailSender) SendUserInviteEmail(ctx context.Context, email, setupURL string) error {
+	args := m.Called(ctx, email, setupURL)
+	return args.Error(0)
+}
+
 // Verify that MockStore implements StoreInterface
 var _ StoreInterface = (*MockStore)(nil)
 

--- a/internal/email/interfaces.go
+++ b/internal/email/interfaces.go
@@ -18,6 +18,7 @@ type SenderInterface interface {
 	SendPurchaseFailedNotification(ctx context.Context, data NotificationData) error
 	SendPasswordResetEmail(ctx context.Context, email, resetURL string) error
 	SendWelcomeEmail(ctx context.Context, email, dashboardURL, role string) error
+	SendUserInviteEmail(ctx context.Context, email, setupURL string) error
 	SendRIExchangePendingApproval(ctx context.Context, data RIExchangeNotificationData) error
 	SendRIExchangeCompleted(ctx context.Context, data RIExchangeNotificationData) error
 	SendPurchaseApprovalRequest(ctx context.Context, data NotificationData) error

--- a/internal/email/nop_sender.go
+++ b/internal/email/nop_sender.go
@@ -70,6 +70,11 @@ func (n *NopSender) SendWelcomeEmail(_ context.Context, _, _, role string) error
 	return nil
 }
 
+func (n *NopSender) SendUserInviteEmail(_ context.Context, _, _ string) error {
+	logging.Debugf("email/nop: SendUserInviteEmail suppressed")
+	return nil
+}
+
 func (n *NopSender) SendRIExchangePendingApproval(_ context.Context, _ RIExchangeNotificationData) error {
 	logging.Debugf("email/nop: SendRIExchangePendingApproval suppressed")
 	return nil

--- a/internal/email/smtp_sender.go
+++ b/internal/email/smtp_sender.go
@@ -316,6 +316,17 @@ func (s *SMTPSender) SendWelcomeEmail(ctx context.Context, email, dashboardURL, 
 	return s.SendToEmail(ctx, email, subject, body)
 }
 
+// SendUserInviteEmail sends an invite-with-setup-link email to a user
+// created without a password.
+func (s *SMTPSender) SendUserInviteEmail(ctx context.Context, email, setupURL string) error {
+	subject := "CUDly - Set your password"
+	body, err := RenderUserInviteEmail(email, setupURL)
+	if err != nil {
+		return fmt.Errorf("failed to render user invite email: %w", err)
+	}
+	return s.SendToEmail(ctx, email, subject, body)
+}
+
 // SendNewRecommendationsNotification sends a notification about new recommendations
 func (s *SMTPSender) SendNewRecommendationsNotification(ctx context.Context, data NotificationData) error {
 	subject := "New CUDly Recommendations Available"

--- a/internal/email/template_renderers.go
+++ b/internal/email/template_renderers.go
@@ -44,6 +44,14 @@ func RenderWelcomeEmail(email, dashboardURL, role string) (string, error) {
 	})
 }
 
+// RenderUserInviteEmail renders the user-invite email template.
+func RenderUserInviteEmail(email, setupURL string) (string, error) {
+	return renderTemplate("user-invite", userInviteTemplate, UserInviteData{
+		Email:    email,
+		SetupURL: setupURL,
+	})
+}
+
 // RenderNewRecommendationsEmail renders the new recommendations email template
 func RenderNewRecommendationsEmail(data NotificationData) (string, error) {
 	return renderTemplate("recommendations", newRecommendationsTemplate, data)

--- a/internal/email/templates.go
+++ b/internal/email/templates.go
@@ -132,6 +132,23 @@ If you have any questions, please contact your administrator.
 This is an automated message from CUDly.
 `
 
+const userInviteTemplate = `Welcome to CUDly
+================
+
+Hello {{.Email}},
+
+An administrator has created a CUDly account for you. To activate it,
+click the link below to set your password:
+
+{{.SetupURL}}
+
+This link will expire in 7 days. If it expires before you set a password,
+ask your administrator to invite you again or use the "Forgot password?"
+link on the sign-in page.
+
+This is an automated message from CUDly.
+`
+
 const riExchangePendingApprovalTemplate = `CUDly - RI Exchange Approval Required
 ======================================
 
@@ -257,6 +274,25 @@ func (s *Sender) SendWelcomeEmail(ctx context.Context, email, dashboardURL, role
 	}
 
 	return s.SendToEmail(ctx, email, "Welcome to CUDly", body)
+}
+
+// UserInviteData holds data for invite emails sent to users that an admin
+// created without a password. The recipient sets their own password by
+// following SetupURL.
+type UserInviteData struct {
+	Email    string
+	SetupURL string
+}
+
+// SendUserInviteEmail sends an invitation that links to the password-setup
+// page. Used when an admin creates a user without supplying a password.
+func (s *Sender) SendUserInviteEmail(ctx context.Context, email, setupURL string) error {
+	body, err := RenderUserInviteEmail(email, setupURL)
+	if err != nil {
+		return fmt.Errorf("failed to render user invite email: %w", err)
+	}
+
+	return s.SendToEmail(ctx, email, "CUDly - Set your password", body)
 }
 
 // SendRIExchangePendingApproval sends an email with RI exchange approval links

--- a/internal/purchase/mocks_test.go
+++ b/internal/purchase/mocks_test.go
@@ -570,6 +570,11 @@ func (m *MockEmailSender) SendWelcomeEmail(ctx context.Context, emailAddr, dashb
 	return args.Error(0)
 }
 
+func (m *MockEmailSender) SendUserInviteEmail(ctx context.Context, emailAddr, setupURL string) error {
+	args := m.Called(ctx, emailAddr, setupURL)
+	return args.Error(0)
+}
+
 func (m *MockEmailSender) SendRIExchangePendingApproval(ctx context.Context, data email.RIExchangeNotificationData) error {
 	args := m.Called(ctx, data)
 	return args.Error(0)

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -450,6 +450,11 @@ func (m *MockEmailSender) SendWelcomeEmail(ctx context.Context, email, dashboard
 	return args.Error(0)
 }
 
+func (m *MockEmailSender) SendUserInviteEmail(ctx context.Context, email, setupURL string) error {
+	args := m.Called(ctx, email, setupURL)
+	return args.Error(0)
+}
+
 func (m *MockEmailSender) SendRIExchangePendingApproval(ctx context.Context, data email.RIExchangeNotificationData) error {
 	args := m.Called(ctx, data)
 	return args.Error(0)

--- a/internal/server/app_test.go
+++ b/internal/server/app_test.go
@@ -296,6 +296,9 @@ func (n *noopEmailSender) SendPasswordResetEmail(ctx context.Context, emailAddr,
 func (n *noopEmailSender) SendWelcomeEmail(ctx context.Context, emailAddr, dashboardURL, role string) error {
 	return nil
 }
+func (n *noopEmailSender) SendUserInviteEmail(ctx context.Context, emailAddr, setupURL string) error {
+	return nil
+}
 func (n *noopEmailSender) SendRIExchangePendingApproval(ctx context.Context, data email.RIExchangeNotificationData) error {
 	return nil
 }

--- a/internal/server/handler_ri_exchange_test.go
+++ b/internal/server/handler_ri_exchange_test.go
@@ -799,6 +799,9 @@ func (m *mockEmailSender) SendPasswordResetEmail(context.Context, string, string
 func (m *mockEmailSender) SendWelcomeEmail(context.Context, string, string, string) error {
 	return nil
 }
+func (m *mockEmailSender) SendUserInviteEmail(context.Context, string, string) error {
+	return nil
+}
 
 func (m *mockEmailSender) SendRIExchangePendingApproval(ctx context.Context, data email.RIExchangeNotificationData) error {
 	if m.sendApprovalFunc != nil {


### PR DESCRIPTION
## Summary

Admins can now create a user with the password field left blank. When that
happens the backend mails the recipient a "Set your password" link and
keeps the account inactive until they follow it — the recipient picks their
own password, never one the admin has to type and transmit.

Independent of #347 (role-allowlist fix); both branch off
`feat/multicloud-web-frontend` and can land in either order.

## What changes

**Backend (auth service)** — `internal/auth/service_user.go`
- When `req.Password == ""`:
  - Hashes a random unguessable token as the `password_hash` so the
    `users.password_hash NOT NULL` constraint stays satisfied and no
    client input can ever match the placeholder.
  - Stores the user with `Active = false`, a hashed setup token, and a
    `PasswordResetExpiry` 7 days out (new `PasswordSetupExpiry` constant
    — longer than the 1-hour `PasswordResetExpiry` because invites
    typically sit in an inbox before the recipient acts).
  - Calls the new `emailSender.SendUserInviteEmail(ctx, email, setupURL)`.
  - Re-uses the existing `/reset-password?token=…` URL — the
    `ConfirmPasswordReset` flow already activates inactive users on first
    password set (admin-bootstrap flow), so the welcome link doubles as
    activation with no schema migration.
- Email-send failures log + continue rather than failing the API call,
  mirroring the password-reset endpoint's anti-enumeration behaviour.

**Email** — `internal/email/{interfaces,templates,template_renderers,smtp_sender,nop_sender}.go`
- New `SendUserInviteEmail(ctx, email, setupURL)` across the
  `SenderInterface`, SMTP sender and no-op sender.
- New `userInviteTemplate` ("Set your password" copy, 7-day expiry hint,
  pointer to "Forgot password?" if the link expires).

**Frontend** — `frontend/src/users/userModals.ts`, `frontend/src/api/users.ts`, `frontend/src/index.html`
- Password input is no longer `required`; the placeholder + a `<small>`
  hint explain the invite behaviour.
- Client-side strength checks now run only when a password was actually
  typed.
- `createUser` API helper passes an empty password through verbatim
  instead of base64-wrapping it.
- The success toast distinguishes the two paths:
  > "User created successfully" *vs* "Invitation email sent to … —
  > they will set their password on first login"

**Tests / interface mocks**
- New `service_user_test.go` cases: invite happy path captures the
  stored `User` and asserts `Active == false`, non-empty
  `PasswordResetToken`, an `PasswordResetExpiry` in the future, and a
  non-empty placeholder `PasswordHash`. Second case asserts the API
  call still succeeds when `SendUserInviteEmail` returns an error.
- All cross-package `SenderInterface` impls / mocks updated:
  `internal/auth/test_helpers.go`, `internal/api/coverage_gaps_test.go`,
  `internal/purchase/mocks_test.go`,
  `internal/scheduler/scheduler_test.go`,
  `internal/server/app_test.go`,
  `internal/server/handler_ri_exchange_test.go`.

## Why not a schema migration

The `users.password_hash NOT NULL` constraint stays — the placeholder is
a real bcrypt hash of a fresh 32-byte token, just one no client can
reproduce. This avoids an irreversible migration on a constraint that's
defended other code paths since `000001_initial_schema.up.sql`. The
admin-bootstrap flow (`SetupAdmin` ↔ `ConfirmPasswordReset`) has
already established the "inactive user, password set later" pattern in
production, so we're slotting into an existing groove rather than
inventing a new account state.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (full repo, all green)
- [x] `go test -v -run TestService_CreateUser ./internal/auth/...` —
      both new cases pass: `invite_flow_when_password_omitted`,
      `invite_flow_still_succeeds_when_email_send_fails`.
- [ ] Manual end-to-end: create a user in the admin UI with the password
      field blank → confirm the success toast names the invitee's email,
      the invite email arrives with a `/reset-password?token=…` link,
      following the link lets the user set a password and lands them
      logged in.
- [ ] Manual sanity: create a user with a password filled in → existing
      flow unchanged, toast says "User created successfully".

## Out of scope (separate work if needed)

- The reset-password modal still says "Reset Your Password" — works for
  invites but a friendlier "Set your password" heading when the user is
  inactive would be nicer.
- No "Resend invite" button in the Users list — for now admins can use
  the existing Forgot Password flow on the invitee's behalf.
- Invite-revocation / "uninvite" — admins can already delete the user.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ECnwGTg2UNzuKHEgN69X4X)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * User invitations: Create user accounts without immediately assigning passwords. New users receive an invitation email with a secure setup link to configure their own password on first login. Password setup must be completed within 7 days.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/348)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->