### PR TITLE
feat(frontend/recs): row-click toggles selection on Opportunities (closes #344)

### DIFF
--- a/frontend/src/__tests__/recommendations.test.ts
+++ b/frontend/src/__tests__/recommendations.test.ts
@@ -1,7 +1,7 @@
 /**
  * Recommendations module tests
  */
-import { loadRecommendations, openPurchaseModal, getPurchaseModalRecommendations, clearPurchaseModalRecommendations, refreshRecommendations, setupRecommendationsHandlers, clearRecommendationDetailCache, pickBestVariantPerCell, seedGlobalDefaults, effectiveMonthlySavings, effectiveSavingsPct, onDemandMonthly, groupRecsByCell, cellSummary, pageLevelRange, resetExpandedCells, resetAutoRefreshInFlight, scaleCost, formatCostForPeriod, periodSuffix, loadColumnVisibility, saveColumnVisibility, resetColumnVisibilityState, TOGGLEABLE_COLUMNS, COLUMN_DEFS } from '../recommendations';
+import { loadRecommendations, openPurchaseModal, getPurchaseModalRecommendations, clearPurchaseModalRecommendations, refreshRecommendations, setupRecommendationsHandlers, pickBestVariantPerCell, seedGlobalDefaults, effectiveMonthlySavings, effectiveSavingsPct, onDemandMonthly, groupRecsByCell, cellSummary, pageLevelRange, resetExpandedCells, resetAutoRefreshInFlight, scaleCost, formatCostForPeriod, periodSuffix, loadColumnVisibility, saveColumnVisibility, resetColumnVisibilityState, TOGGLEABLE_COLUMNS, COLUMN_DEFS } from '../recommendations';
 import type { CostPeriod } from '../state';
 
 // Mock the api module
@@ -1036,140 +1036,111 @@ describe('Recommendations Module', () => {
       expect(document.querySelector('.recommendations-bulk-toolbar')).toBeNull();
     });
 
-    test('clicking a row opens the detail drawer with that recommendation', async () => {
-      await loadRecommendations();
-      // Simulate clicking the first data row (not on a checkbox / button).
-      const firstRow = document.querySelector<HTMLTableRowElement>('tr.recommendation-row');
-      const cell = firstRow?.querySelectorAll('td')[3]; // Service cell — safe to click
-      cell?.click();
-      const drawer = document.querySelector('.detail-drawer');
-      expect(drawer).not.toBeNull();
-      expect(drawer?.querySelector('h3')?.textContent).toContain('AWS');
-    });
+    // Issue #344 T4': row-click toggles selection. The previous
+    // row-click → openDetailDrawer behaviour was dropped (per plan.md
+    // §T4) — the drawer payload duplicated the table, with
+    // backend-deferred fields the only differentiators. Tests below
+    // cover the new selection-toggle contract.
+    //
+    // The shared `wireSelection` helper hooks the state mocks to a real
+    // Set so addSelectedRecommendation actually surfaces in subsequent
+    // getSelectedRecommendationIDs reads — without this, re-renders see
+    // an empty selection and the row checkbox renders unchecked.
+    describe('row-click selection (T4′)', () => {
+      function wireSelection(): Set<string> {
+        const selected = new Set<string>();
+        (state.getSelectedRecommendationIDs as jest.Mock).mockImplementation(() => new Set(selected));
+        (state.addSelectedRecommendation as jest.Mock).mockImplementation((id: string) => { selected.add(id); });
+        (state.removeSelectedRecommendation as jest.Mock).mockImplementation((id: string) => { selected.delete(id); });
+        (state.clearSelectedRecommendations as jest.Mock).mockImplementation(() => { selected.clear(); });
+        (state.getRecommendations as jest.Mock).mockReturnValue(twoRecs);
+        (state.getVisibleRecommendations as jest.Mock).mockReturnValue(twoRecs);
+        return selected;
+      }
 
-    test('ESC closes the detail drawer', async () => {
-      await loadRecommendations();
-      const firstRow = document.querySelector<HTMLTableRowElement>('tr.recommendation-row');
-      const cell = firstRow?.querySelectorAll('td')[3];
-      cell?.click();
-      expect(document.querySelector('.detail-drawer')).not.toBeNull();
-      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
-      expect(document.querySelector('.detail-drawer')).toBeNull();
-    });
-
-    describe('drawer fetches detail from /api/recommendations/:id/detail (issue #44)', () => {
-      // The detail-fetch mock lives on the api/recommendations module
-      // so the test can assert call shape without round-tripping
-      // through apiRequest.
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const recApi = require('../api/recommendations') as { getRecommendationDetail: jest.Mock };
-
-      beforeEach(() => {
-        // Real timers — the drawer's fetch uses microtasks (Promise
-        // resolution) which jest's fake timers don't auto-advance.
-        jest.useRealTimers();
-        clearRecommendationDetailCache();
-        recApi.getRecommendationDetail.mockReset();
-      });
-
-      afterEach(() => {
-        jest.useFakeTimers();
-      });
-
-      test('drawer fetches detail once per id and renders backend confidence + provenance', async () => {
-        recApi.getRecommendationDetail.mockResolvedValue({
-          id: 'rec-15',
-          usage_history: [],
-          confidence_bucket: 'high',
-          provenance_note: 'AWS ec2 recommendation APIs · last collected 2026-04-24T12:00:00Z',
-        });
-
+      test('clicking a non-interactive cell on a row toggles the row checkbox', async () => {
+        wireSelection();
         await loadRecommendations();
         const firstRow = document.querySelector<HTMLTableRowElement>('tr.recommendation-row');
+        const cb = firstRow?.querySelector<HTMLInputElement>('input[type="checkbox"][data-rec-id]');
+        expect(cb).not.toBeNull();
+        expect(cb!.checked).toBe(false);
+        const recId = cb!.dataset['recId']!;
+
+        // Service cell (index 3) is non-interactive — safe to click.
         firstRow?.querySelectorAll('td')[3]?.click();
 
-        // Allow the .then() handler to run.
-        await Promise.resolve();
-        await Promise.resolve();
-
-        expect(recApi.getRecommendationDetail).toHaveBeenCalledTimes(1);
-        // Default sort is savings desc → rec-15 ($1500) renders first.
-        expect(recApi.getRecommendationDetail).toHaveBeenCalledWith('rec-15');
-
-        const badge = document.querySelector('.detail-drawer .confidence-badge');
-        expect(badge?.classList.contains('confidence-high')).toBe(true);
-        expect(badge?.textContent).toBe('High');
-
-        const provenance = document.querySelector('.detail-drawer .detail-drawer-note');
-        expect(provenance?.textContent).toContain('last collected 2026-04-24T12:00:00Z');
+        const cbAfter = document.querySelector<HTMLInputElement>(
+          `tr.recommendation-row input[data-rec-id="${recId}"]`,
+        );
+        expect(cbAfter?.checked).toBe(true);
       });
 
-      test('empty usage_history renders the "not yet available" placeholder, not a broken chart', async () => {
-        recApi.getRecommendationDetail.mockResolvedValue({
-          id: 'rec-15',
-          usage_history: [],
-          confidence_bucket: 'medium',
-          provenance_note: 'AWS ec2 recommendation APIs.',
-        });
-
+      test('clicking a row a second time unselects it', async () => {
+        wireSelection();
         await loadRecommendations();
         const firstRow = document.querySelector<HTMLTableRowElement>('tr.recommendation-row');
-        firstRow?.querySelectorAll('td')[3]?.click();
-        await Promise.resolve();
-        await Promise.resolve();
+        const cb = firstRow?.querySelector<HTMLInputElement>('input[type="checkbox"][data-rec-id]');
+        const recId = cb!.dataset['recId']!;
 
-        // No SVG sparkline — degraded path.
-        expect(document.querySelector('.detail-drawer-sparkline')).toBeNull();
-        // Placeholder note present.
-        const usageNote = document.querySelector('.detail-drawer-usage .detail-drawer-note-muted');
-        expect(usageNote?.textContent).toBe('Usage history not yet available.');
+        firstRow?.querySelectorAll('td')[3]?.click();
+        let cbAfter = document.querySelector<HTMLInputElement>(
+          `tr.recommendation-row input[data-rec-id="${recId}"]`,
+        );
+        expect(cbAfter?.checked).toBe(true);
+
+        // Second click on the (post-rerender) row toggles back off.
+        const rerenderedRow = cbAfter!.closest('tr')!;
+        rerenderedRow.querySelectorAll('td')[3]?.click();
+
+        cbAfter = document.querySelector<HTMLInputElement>(
+          `tr.recommendation-row input[data-rec-id="${recId}"]`,
+        );
+        expect(cbAfter?.checked).toBe(false);
       });
 
-      test('non-empty usage_history renders an inline SVG sparkline', async () => {
-        recApi.getRecommendationDetail.mockResolvedValue({
-          id: 'rec-15',
-          usage_history: [
-            { timestamp: '2026-04-23T00:00:00Z', cpu_pct: 12, mem_pct: 30 },
-            { timestamp: '2026-04-23T01:00:00Z', cpu_pct: 18, mem_pct: 32 },
-            { timestamp: '2026-04-23T02:00:00Z', cpu_pct: 25, mem_pct: 40 },
-          ],
-          confidence_bucket: 'high',
-          provenance_note: 'AWS ec2 recommendation APIs.',
-        });
-
+      test('row-click does NOT trigger when the click originates on an interactive descendant', async () => {
+        wireSelection();
         await loadRecommendations();
         const firstRow = document.querySelector<HTMLTableRowElement>('tr.recommendation-row');
-        firstRow?.querySelectorAll('td')[3]?.click();
-        await Promise.resolve();
-        await Promise.resolve();
+        const cb = firstRow?.querySelector<HTMLInputElement>('input[type="checkbox"][data-rec-id]');
+        expect(cb!.checked).toBe(false);
 
-        const svg = document.querySelector('.detail-drawer-sparkline');
-        expect(svg).not.toBeNull();
-        // Two paths (CPU + memory).
-        expect(svg?.querySelectorAll('path').length).toBe(2);
+        // Inject a synthetic action button into the first row to model
+        // any inline per-row CTA (the production table doesn't currently
+        // render one, but the click-filter rule must still hold).
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.textContent = 'Inline action';
+        firstRow!.querySelectorAll('td')[3]!.appendChild(btn);
+
+        btn.click();
+
+        // Selection state must NOT change just because the click
+        // bubbled from the button to the row.
+        const cbAfter = document.querySelector<HTMLInputElement>(
+          `tr.recommendation-row input[data-rec-id="${cb!.dataset['recId']}"]`,
+        );
+        expect(cbAfter?.checked).toBe(false);
       });
 
-      test('repeated open of same drawer reuses the cached detail (one fetch per id)', async () => {
-        recApi.getRecommendationDetail.mockResolvedValue({
-          id: 'rec-15',
-          usage_history: [],
-          confidence_bucket: 'low',
-          provenance_note: 'AWS ec2 recommendation APIs.',
-        });
-
+      test('clicking the checkbox itself does not double-toggle (native click handles it)', async () => {
+        wireSelection();
         await loadRecommendations();
         const firstRow = document.querySelector<HTMLTableRowElement>('tr.recommendation-row');
-        firstRow?.querySelectorAll('td')[3]?.click();
-        await Promise.resolve();
-        await Promise.resolve();
+        const cb = firstRow?.querySelector<HTMLInputElement>('input[type="checkbox"][data-rec-id]')!;
+        expect(cb.checked).toBe(false);
 
-        // Close and re-open the same drawer.
-        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
-        firstRow?.querySelectorAll('td')[3]?.click();
-        await Promise.resolve();
-        await Promise.resolve();
+        // Native click on a <input type="checkbox"> toggles checked
+        // before the click event fires. Our row-click handler must skip
+        // when the originating target is the checkbox so we don't
+        // re-toggle it back to its prior state.
+        cb.click();
 
-        expect(recApi.getRecommendationDetail).toHaveBeenCalledTimes(1);
+        const cbAfter = document.querySelector<HTMLInputElement>(
+          `tr.recommendation-row input[data-rec-id="${cb.dataset['recId']}"]`,
+        );
+        expect(cbAfter?.checked).toBe(true);
       });
     });
   });

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -6,7 +6,7 @@ import * as api from './api';
 import * as state from './state';
 import type { CostPeriod } from './state';
 import { formatCurrency, formatTerm, escapeHtml } from './utils';
-import { getRecommendationDetail, getRecommendationsFreshness, refreshRecommendations as refreshRecommendationsAPI, type RecommendationDetail } from './api/recommendations';
+import { getRecommendationsFreshness, refreshRecommendations as refreshRecommendationsAPI } from './api/recommendations';
 import { showToast } from './toast';
 import {
   isPaymentSupported,
@@ -2007,229 +2007,6 @@ function mountCostPeriodSelector(bar: HTMLElement): void {
 // inside the bottom action box. The old helper had only one caller; folding
 // keeps the action-target logic centralised in one place.
 
-function openDetailDrawer(rec: LocalRecommendation): void {
-  // Remove any previous drawer so repeat clicks don't stack.
-  document.querySelectorAll('.detail-drawer').forEach((el) => el.remove());
-  document.querySelectorAll('.detail-drawer-backdrop').forEach((el) => el.remove());
-
-  const backdrop = document.createElement('div');
-  backdrop.className = 'detail-drawer-backdrop';
-
-  const drawer = document.createElement('aside');
-  drawer.className = 'detail-drawer';
-  drawer.setAttribute('role', 'dialog');
-  drawer.setAttribute('aria-label', 'Recommendation details');
-
-  const onClose = (): void => {
-    drawer.remove();
-    backdrop.remove();
-    document.removeEventListener('keydown', onKey);
-  };
-  const onKey = (e: KeyboardEvent): void => {
-    if (e.key === 'Escape') onClose();
-  };
-  backdrop.addEventListener('click', onClose);
-  document.addEventListener('keydown', onKey);
-
-  const title = document.createElement('h3');
-  title.textContent = `${rec.provider.toUpperCase()} ${rec.service} \u2014 ${rec.resource_type}`;
-  drawer.appendChild(title);
-
-  const closeBtn = document.createElement('button');
-  closeBtn.type = 'button';
-  closeBtn.className = 'detail-drawer-close btn btn-small';
-  closeBtn.setAttribute('aria-label', 'Close details');
-  closeBtn.textContent = '\u2715';
-  closeBtn.addEventListener('click', onClose);
-  drawer.appendChild(closeBtn);
-
-  const fields: Array<[string, string]> = [
-    ['Provider', rec.provider.toUpperCase()],
-    ['Service', rec.service],
-    ['Resource type', rec.resource_type + (rec.engine ? ` (${rec.engine})` : '')],
-    ['Region', rec.region],
-    ['Instances', String(rec.count)],
-    ['Term', formatTerm(rec.term)],
-    ['Monthly savings', formatCurrency(rec.savings)],
-    ['Upfront cost', formatCurrency(rec.upfront_cost)],
-  ];
-  const dl = document.createElement('dl');
-  dl.className = 'detail-drawer-fields';
-  fields.forEach(([k, v]) => {
-    const dt = document.createElement('dt');
-    dt.textContent = k;
-    const dd = document.createElement('dd');
-    dd.textContent = v;
-    dl.appendChild(dt);
-    dl.appendChild(dd);
-  });
-  drawer.appendChild(dl);
-
-  // Confidence + provenance + usage history are sourced from the
-  // per-id detail endpoint (issue #44). The drawer renders a loading
-  // placeholder for each block immediately, then fills them in once
-  // the fetch resolves. The fetch is memoised per id for the drawer
-  // lifetime so re-opening the same row never re-hits the network
-  // within a single session (cache cleared on drawer close).
-  const confidenceRow = document.createElement('dl');
-  confidenceRow.className = 'detail-drawer-fields';
-  const confDt = document.createElement('dt');
-  confDt.textContent = 'Confidence';
-  const confDd = document.createElement('dd');
-  const badge = document.createElement('span');
-  badge.className = 'confidence-badge confidence-loading';
-  badge.textContent = '…';
-  confDd.appendChild(badge);
-  confidenceRow.appendChild(confDt);
-  confidenceRow.appendChild(confDd);
-  drawer.appendChild(confidenceRow);
-
-  const provenance = document.createElement('p');
-  provenance.className = 'detail-drawer-note';
-  provenance.textContent = 'Loading recommendation details\u2026';
-  drawer.appendChild(provenance);
-
-  // Usage history container \u2014 replaced once the detail fetch resolves
-  // with either an inline SVG sparkline (when usage_history is
-  // non-empty) or a "not yet available" note (the documented default
-  // until the collector starts persisting time-series usage \u2014
-  // known_issues/28).
-  const usageContainer = document.createElement('div');
-  usageContainer.className = 'detail-drawer-usage';
-  const usagePlaceholder = document.createElement('p');
-  usagePlaceholder.className = 'detail-drawer-note detail-drawer-note-muted';
-  usagePlaceholder.textContent = 'Loading usage history\u2026';
-  usageContainer.appendChild(usagePlaceholder);
-  drawer.appendChild(usageContainer);
-
-  const renderUsageEmptyNote = (): HTMLParagraphElement => {
-    const note = document.createElement('p');
-    note.className = 'detail-drawer-note detail-drawer-note-muted';
-    note.textContent = 'Usage history not yet available.';
-    return note;
-  };
-
-  void fetchRecommendationDetail(rec.id)
-    .then((detail) => {
-      // Confidence: server-supplied bucket replaces the previous
-      // client-side heuristic so the label tracks the collector's
-      // view of the rec rather than a frontend approximation.
-      const bucket = detail.confidence_bucket;
-      badge.className = `confidence-badge confidence-${bucket}`;
-      badge.textContent = bucket.charAt(0).toUpperCase() + bucket.slice(1);
-
-      // Provenance: rendered verbatim \u2014 the backend already names
-      // the collector + last-collected timestamp.
-      provenance.textContent = detail.provenance_note;
-
-      // Usage history: render the sparkline when we have points,
-      // else a one-line note. The empty case is the documented
-      // default until the collector wiring follow-up lands.
-      const next = (detail.usage_history && detail.usage_history.length > 0)
-        ? renderUsageSparkline(detail.usage_history)
-        : renderUsageEmptyNote();
-      usageContainer.replaceChildren(next);
-    })
-    .catch(() => {
-      // Detail-endpoint failure shouldn't blank the drawer \u2014 fall
-      // back to a minimal "details unavailable" state. Confidence
-      // badge is reset to an explicit Unknown rather than mis-claiming
-      // a bucket on a failed fetch.
-      badge.className = 'confidence-badge confidence-unknown';
-      badge.textContent = 'Unknown';
-      provenance.textContent = `Derived from ${providerDisplayName(rec.provider)} recommendation APIs. (Details temporarily unavailable.)`;
-      usageContainer.replaceChildren(renderUsageEmptyNote());
-    });
-
-  document.body.appendChild(backdrop);
-  document.body.appendChild(drawer);
-  closeBtn.focus();
-}
-
-// detailFetchCache memoises in-flight + resolved detail fetches per id
-// so re-opening the same row never re-hits the network within a single
-// session. Cleared via clearRecommendationDetailCache() so a long-lived
-// dashboard tab doesn't pin stale details indefinitely (the values
-// evolve on every collector cycle).
-const detailFetchCache = new Map<string, Promise<RecommendationDetail>>();
-
-function fetchRecommendationDetail(id: string): Promise<RecommendationDetail> {
-  const existing = detailFetchCache.get(id);
-  if (existing) return existing;
-  const inflight = getRecommendationDetail(id);
-  detailFetchCache.set(id, inflight);
-  // On rejection, drop the cached promise so the next open retries.
-  inflight.catch(() => detailFetchCache.delete(id));
-  return inflight;
-}
-
-/**
- * Clear the per-id detail-fetch cache. Exposed for tests + for any
- * future explicit "refresh details" affordance.
- */
-export function clearRecommendationDetailCache(): void {
-  detailFetchCache.clear();
-}
-
-/**
- * Render a tiny inline SVG sparkline of the per-recommendation usage
- * history. Two polylines (CPU + memory) over a shared time axis, no
- * axes/legend — just enough to give a directional sense of utilisation
- * over the collection window without pulling in a chart library.
- */
-function renderUsageSparkline(points: ReadonlyArray<{ timestamp: string; cpu_pct: number; mem_pct: number }>): SVGSVGElement {
-  const svgNS = 'http://www.w3.org/2000/svg';
-  const width = 280;
-  const height = 60;
-  const padX = 4;
-  const padY = 4;
-  const usableW = width - padX * 2;
-  const usableH = height - padY * 2;
-
-  // Y axis is fixed to 0..100 since CPU/mem percentages have a known
-  // range — keeps the visual comparison stable across recs.
-  const yMax = 100;
-  const xStep = points.length > 1 ? usableW / (points.length - 1) : 0;
-  const project = (val: number, idx: number): [number, number] => {
-    const clamped = Math.max(0, Math.min(yMax, val));
-    const x = padX + xStep * idx;
-    const y = padY + usableH * (1 - clamped / yMax);
-    return [x, y];
-  };
-
-  const buildPath = (selector: (p: { cpu_pct: number; mem_pct: number }) => number): string =>
-    points.map((p, i) => {
-      const [x, y] = project(selector(p), i);
-      return `${i === 0 ? 'M' : 'L'}${x.toFixed(1)},${y.toFixed(1)}`;
-    }).join(' ');
-
-  const svg = document.createElementNS(svgNS, 'svg');
-  svg.setAttribute('class', 'detail-drawer-sparkline');
-  svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
-  svg.setAttribute('width', String(width));
-  svg.setAttribute('height', String(height));
-  svg.setAttribute('role', 'img');
-  svg.setAttribute('aria-label', `Usage history: ${points.length} samples, CPU and memory percent over time`);
-
-  const cpu = document.createElementNS(svgNS, 'path');
-  cpu.setAttribute('d', buildPath((p) => p.cpu_pct));
-  cpu.setAttribute('fill', 'none');
-  cpu.setAttribute('stroke', 'currentColor');
-  cpu.setAttribute('stroke-width', '1.5');
-  cpu.setAttribute('class', 'sparkline-cpu');
-  svg.appendChild(cpu);
-
-  const mem = document.createElementNS(svgNS, 'path');
-  mem.setAttribute('d', buildPath((p) => p.mem_pct));
-  mem.setAttribute('fill', 'none');
-  mem.setAttribute('stroke', 'currentColor');
-  mem.setAttribute('stroke-width', '1.5');
-  mem.setAttribute('stroke-dasharray', '3,2');
-  mem.setAttribute('class', 'sparkline-mem');
-  svg.appendChild(mem);
-
-  return svg;
-}
 
 function providerDisplayName(provider: string): string {
   switch (provider.toLowerCase()) {
@@ -3496,18 +3273,24 @@ function renderRecommendationsList(loadedRecs: LocalRecommendation[]): void {
     });
   });
 
-  // Row-click opens the detail drawer — skip clicks that originated on
-  // the checkbox or any interactive child (anchors, buttons) so those
-  // flow through to their own handlers without also triggering the
-  // drawer. Also skip summary rows (they represent a cell group, not
-  // a single rec, so have no detail to show).
+  // Row-click toggles selection (issue #344 T4'). Clicking anywhere on
+  // the row's body now toggles the row's checkbox + dispatches the
+  // existing change handler — which already enforces the
+  // one-variant-per-cell radio behaviour (issue #224) and rerenders.
+  // Skip clicks on the checkbox itself (its native click already
+  // toggles) and on any interactive child (button / a / input / label /
+  // select / [data-action]) so per-row controls keep their own
+  // semantics. The previous row-click → openDetailDrawer behaviour was
+  // dropped: see plan.md §T4 (the detail drawer's payload duplicated
+  // the table, with backend-deferred fields the only differentiators).
   container.querySelectorAll<HTMLTableRowElement>('tr.recommendation-row').forEach((tr) => {
     tr.addEventListener('click', (e) => {
       const target = e.target as HTMLElement;
-      if (target.closest('input[type="checkbox"], button, a')) return;
-      const id = tr.dataset['recId'] || '';
-      const rec = recommendations.find((r) => r.id === id);
-      if (rec) openDetailDrawer(rec);
+      if (target.closest('input, button, a, label, select, [data-action]')) return;
+      const cb = tr.querySelector<HTMLInputElement>('input[type="checkbox"][data-rec-id]');
+      if (!cb) return;
+      cb.checked = !cb.checked;
+      cb.dispatchEvent(new Event('change', { bubbles: true }));
     });
   });
 }

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -3285,6 +3285,7 @@ function renderRecommendationsList(loadedRecs: LocalRecommendation[]): void {
   // the table, with backend-deferred fields the only differentiators).
   container.querySelectorAll<HTMLTableRowElement>('tr.recommendation-row').forEach((tr) => {
     tr.addEventListener('click', (e) => {
+      if (!(e.target instanceof Element)) return;
       const target = e.target as HTMLElement;
       if (target.closest('input, button, a, label, select, [data-action]')) return;
       const cb = tr.querySelector<HTMLInputElement>('input[type="checkbox"][data-rec-id]');

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -1039,62 +1039,6 @@ tr.rec-variant-row:hover td:not(.checkbox-col) {
     background: #f0f4fc;
 }
 
-.detail-drawer-backdrop {
-    position: fixed;
-    inset: 0;
-    background: rgba(0, 0, 0, 0.25);
-    z-index: 1500;
-}
-
-.detail-drawer {
-    position: fixed;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    width: min(480px, 90vw);
-    background: white;
-    box-shadow: -6px 0 24px rgba(0, 0, 0, 0.15);
-    padding: 1.5rem;
-    z-index: 1600;
-    overflow-y: auto;
-}
-
-.detail-drawer h3 {
-    margin: 0 0 1rem;
-    padding-right: 2rem;
-}
-
-.detail-drawer-close {
-    position: absolute;
-    top: 0.75rem;
-    right: 0.75rem;
-}
-
-.detail-drawer-fields {
-    display: grid;
-    grid-template-columns: max-content 1fr;
-    gap: 0.5rem 1rem;
-    margin: 0 0 1rem;
-}
-
-.detail-drawer-fields dt {
-    color: var(--cudly-text-muted);
-    font-size: 0.85rem;
-}
-
-.detail-drawer-fields dd {
-    margin: 0;
-    color: #222;
-    font-size: 0.9rem;
-}
-
-.detail-drawer-note {
-    color: var(--cudly-text-muted);
-    font-size: 0.85rem;
-    font-style: italic;
-    margin: 1rem 0 0;
-}
-
 /* Confirm-dialog modal. Rendered via confirmDialog.ts. */
 .modal-confirm-backdrop {
     position: fixed;
@@ -1284,34 +1228,6 @@ tr.rec-variant-row:hover td:not(.checkbox-col) {
 .info-icon:hover .tooltip-text {
     visibility: visible;
     opacity: 1;
-}
-
-/* Confidence badge in the recommendation detail drawer. A directional
- * client-computed high/medium/low bucket — a proper per-recommendation
- * score requires backend usage-history (known_issues #28). */
-.confidence-badge {
-    display: inline-block;
-    padding: 0.2rem 0.55rem;
-    border-radius: 999px;
-    font-size: 0.75rem;
-    font-weight: 600;
-    letter-spacing: 0.02em;
-}
-.confidence-high {
-    background: var(--cudly-success-bg);
-    color: #0f5132;
-}
-.confidence-medium {
-    background: #fff3cd;
-    color: #7c5600;
-}
-.confidence-low {
-    background: #f3f4f6;
-    color: #5f6368;
-}
-.detail-drawer-note-muted {
-    color: #777;
-    font-size: 0.85rem;
 }
 
 /* Role badge */


### PR DESCRIPTION
## Summary

Closes the last task in the issue-344 phase-2 plan — **row-click toggles selection on Opportunities**, replacing the previous row-click → detail-drawer behaviour.

The original T4 (right-side Plan-builder drawer) was dropped in plan review on 2026-05-13: every payload the drawer could carry (per-rec payment-option comparison, target/baseline tracking) is explicitly backend-deferred, so the drawer would have shipped as a prettier copy of the existing bottom action-box with no new information. The detail drawer that already opened on row-click had the same character: confidence + provenance duplicated the table, and `usage_history` is empty by design until the collector wiring follow-up lands (`known_issues/28`).

## What changes

**Behaviour**:
- Click anywhere on a recommendation row's body → toggles that row's checkbox (which dispatches the existing change handler — enforces the one-variant-per-cell radio rule from #224 + rerenders).
- Clicks on interactive descendants (`input`, `button`, `a`, `label`, `select`, `[data-action]`) still flow through to their own handlers, untouched. Native checkbox clicks don't double-toggle.
- The detail drawer (issue #44) is removed.

**Code**:
- `frontend/src/recommendations.ts`: `-227` lines (`openDetailDrawer` + `fetchRecommendationDetail` + `detailFetchCache` + `clearRecommendationDetailCache` + `renderUsageSparkline` removed); `+13` lines for the row-click toggle handler.
- `frontend/src/styles/components.css`: `-84` lines (`.detail-drawer*` + `.confidence-*` rules).
- `frontend/src/__tests__/recommendations.test.ts`: `-136` lines (5 drawer tests removed) + `+84` lines (4 row-click selection tests).
- `frontend/src/api/recommendations.ts`: **untouched** — `getRecommendationDetail` stays exported so the backend endpoint contract is preserved. Resurrecting the drawer if we ever want it back is a git revert of this commit.

## New tests (4)

1. Clicking a non-interactive cell on a row toggles the row checkbox.
2. Clicking a row a second time unselects it.
3. Row-click does NOT trigger when the click originates on an interactive descendant.
4. Clicking the checkbox itself does not double-toggle (native click handles it; the row handler must skip the input).

## Verification

- **Tests**: 1629 pass / 1 skipped. 2 failing in `users.test.ts` (`openCreateUserModal › should make password required`, `saveUser › should validate empty password for new user`) **pre-date this branch** — they came in with PR #348 (invite users without password). Verified by running the failing tests on a clean stash of this branch's base.
- **Coverage**: 80.70% stmts / 68.07% branches / 70.93% funcs / 82.46% lines. Slight dip from the post-T3 baseline (80.93 / 68.21 / 71.04 / 82.70) as expected when removing tested code paths; still inside parity gates.
- **Build**: 517 KiB (down from 522 KiB after T3 — the deleted drawer assets shaved ~5 KiB).

Closes #344.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Changes**
* Row click behavior updated: selecting a recommendation row now toggles its checkbox instead of opening a detail drawer
* Detail drawer view has been removed from the interface
* Confidence badge indicators have been removed
* Row selection properly handles interactions with interactive elements within rows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/352)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->