### PR TITLE
fix(auth,api): multi-admin support + 4xx validation errors + drop omitempty on user/group slices (closes #349, #350)

### DIFF
--- a/frontend/src/users/userActions.ts
+++ b/frontend/src/users/userActions.ts
@@ -88,12 +88,12 @@ export async function loadUsers(): Promise<void> {
     applyFilters();
 
     renderUsers(filteredUsers);
-    renderGroups(groupsResponse.groups);
+    renderGroups(groups);
     renderUserStats();
 
     const matrixContainer = document.getElementById('permission-matrix');
     if (matrixContainer) {
-      renderPermissionMatrix(groupsResponse.groups, matrixContainer);
+      renderPermissionMatrix(groups, matrixContainer);
     }
   } catch (error) {
     console.error('Failed to load users/groups:', error);

--- a/frontend/src/users/userActions.ts
+++ b/frontend/src/users/userActions.ts
@@ -20,6 +20,31 @@ import { renderGroups } from '../groups/groupList';
 import { renderPermissionMatrix } from './permissionMatrix';
 
 /**
+ * Defence-in-depth normaliser for the API contract. The backend's TS-typed
+ * APIUser declares `groups: string[]` as required, but historical bugs
+ * (and unforeseen future ones) can omit the field or send `null`. Renderers
+ * iterate `user.groups`, so a missing field crashes the page with a
+ * generic "Failed to load users and groups" toast that obscures the real
+ * cause. See issue #350 — the backend fix lives there too; this guard is
+ * the second line of defence so a future contract regression degrades
+ * gracefully instead of throwing a TypeError in an Array.map.
+ */
+function normalizeUser(user: api.APIUser): api.APIUser {
+  return {
+    ...user,
+    groups: Array.isArray(user.groups) ? user.groups : [],
+  };
+}
+
+function normalizeGroup(group: api.APIGroup): api.APIGroup {
+  return {
+    ...group,
+    permissions: Array.isArray(group.permissions) ? group.permissions : [],
+    allowed_accounts: Array.isArray(group.allowed_accounts) ? group.allowed_accounts : [],
+  };
+}
+
+/**
  * Ensure the currently-logged-in user is visible in the list.
  * If the API didn't include them (e.g. self-management not wired up yet),
  * prepend a synthetic entry flagged with id='current' so the userList "You"
@@ -49,8 +74,15 @@ export async function loadUsers(): Promise<void> {
       api.listGroups()
     ]);
 
-    setAvailableGroups(groupsResponse.groups);
-    setAllUsers(withCurrentUser(usersResponse.users));
+    // Normalise at the boundary so downstream renderers can trust
+    // user.groups / group.permissions / group.allowed_accounts to be
+    // real arrays (see normalizeUser/normalizeGroup above for the
+    // rationale — issue #350 backend + frontend defence-in-depth).
+    const users = (usersResponse.users ?? []).map(normalizeUser);
+    const groups = (groupsResponse.groups ?? []).map(normalizeGroup);
+
+    setAvailableGroups(groups);
+    setAllUsers(withCurrentUser(users));
 
     // Apply current filters
     applyFilters();

--- a/internal/api/handler_auth.go
+++ b/internal/api/handler_auth.go
@@ -120,7 +120,9 @@ func (h *Handler) setupAdmin(ctx context.Context, req *events.LambdaFunctionURLR
 
 	response, err := h.auth.SetupAdmin(ctx, setupReq)
 	if err != nil {
-		return nil, err
+		// Share the sentinel→ClientError mapping with /api/users (issue #349)
+		// so bootstrap failures surface as the right 4xx instead of a 500.
+		return nil, mapAuthError(err)
 	}
 
 	return response, nil

--- a/internal/api/handler_users.go
+++ b/internal/api/handler_users.go
@@ -4,6 +4,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 
 	"github.com/LeanerCloud/CUDly/internal/auth"
 	"github.com/aws/aws-lambda-go/events"
@@ -64,10 +65,29 @@ func (h *Handler) createUser(ctx context.Context, req *events.LambdaFunctionURLR
 
 	user, err := h.auth.CreateUserAPI(ctx, createReq)
 	if err != nil {
-		return nil, err
+		return nil, mapAuthError(err)
 	}
 
 	return user, nil
+}
+
+// mapAuthError maps internal/auth sentinel errors to the appropriate
+// ClientError status code so validation failures surface to the user
+// as a 4xx with the real message instead of a generic 500. Unrecognised
+// errors are returned unchanged for handleRequestError to render as 500.
+// Used by both /api/users (createUser) and the bootstrap setupAdmin
+// endpoint — they share the sentinel set. Issue #349.
+func mapAuthError(err error) error {
+	switch {
+	case errors.Is(err, auth.ErrInvalidEmail),
+		errors.Is(err, auth.ErrInvalidRole),
+		errors.Is(err, auth.ErrPasswordPolicy):
+		return NewClientError(400, err.Error())
+	case errors.Is(err, auth.ErrEmailInUse),
+		errors.Is(err, auth.ErrAdminExists):
+		return NewClientError(409, err.Error())
+	}
+	return err
 }
 
 // getUser handles GET /api/users/{id}

--- a/internal/auth/errors.go
+++ b/internal/auth/errors.go
@@ -1,0 +1,21 @@
+package auth
+
+import "errors"
+
+// Validation sentinels — wrapped by service_user.go's validators so the
+// API handler can map each to a precise HTTP status code. Plain
+// fmt.Errorf returns fall through to a generic 500 in
+// internal/api/handler.go's handleRequestError, which hides the real
+// cause from the user (see issue #349).
+//
+// Callers use errors.Is to detect the category; the wrapped message
+// (when set via fmt.Errorf("%w: %s", ...)) carries the specific user-
+// facing detail (e.g. "invalid role: guest", "password does not meet
+// policy: must be at least 12 characters").
+var (
+	ErrInvalidEmail   = errors.New("invalid email format")
+	ErrEmailInUse     = errors.New("email already in use")
+	ErrInvalidRole    = errors.New("invalid role")
+	ErrAdminExists    = errors.New("admin user already exists")
+	ErrPasswordPolicy = errors.New("password does not meet policy")
+)

--- a/internal/auth/interfaces.go
+++ b/internal/auth/interfaces.go
@@ -15,6 +15,14 @@ type StoreInterface interface {
 	ListUsers(ctx context.Context) ([]User, error)
 	GetUserByResetToken(ctx context.Context, token string) (*User, error)
 	AdminExists(ctx context.Context) (bool, error)
+	// CreateAdminIfNone atomically inserts user as the first admin in the
+	// system. Returns (true, nil) on success, (false, nil) when an admin
+	// already existed (TOCTOU race winner gets false), (false, ErrEmailInUse)
+	// when the email collides with an existing non-admin user, or
+	// (false, err) for any other failure. Used by SetupAdmin to close the
+	// bootstrap race without relying on the users_one_admin partial unique
+	// index (dropped in migration 000050).
+	CreateAdminIfNone(ctx context.Context, user *User) (bool, error)
 
 	// Group operations
 	GetGroup(ctx context.Context, groupID string) (*Group, error)

--- a/internal/auth/service_api.go
+++ b/internal/auth/service_api.go
@@ -8,25 +8,35 @@ import (
 
 // API adapter types - these match the types in internal/api/handler.go
 
-// APIUser is the user type for API responses
+// APIUser is the user type for API responses.
+//
+// Groups deliberately has NO omitempty: the frontend's TS type
+// (frontend/src/api/types.ts) declares groups as a required string[],
+// and renderers read user.groups.length / iterate user.groups without
+// a guard. Omitting the field on empty slices breaks that contract
+// and crashes the admin users page with "TypeError: Cannot read
+// properties of undefined (reading 'length')" — see issue #350.
 type APIUser struct {
 	ID         string   `json:"id"`
 	Email      string   `json:"email"`
 	Role       string   `json:"role"`
-	Groups     []string `json:"groups,omitempty"`
+	Groups     []string `json:"groups"`
 	MFAEnabled bool     `json:"mfa_enabled"`
 	CreatedAt  string   `json:"created_at,omitempty"`
 	UpdatedAt  string   `json:"updated_at,omitempty"`
 	LastLogin  string   `json:"last_login,omitempty"`
 }
 
-// APIGroup is the group type for API responses
+// APIGroup is the group type for API responses.
+//
+// AllowedAccounts has NO omitempty for the same reason Groups doesn't on
+// APIUser — the frontend treats it as always present. See issue #350.
 type APIGroup struct {
 	ID              string          `json:"id"`
 	Name            string          `json:"name"`
 	Description     string          `json:"description,omitempty"`
 	Permissions     []APIPermission `json:"permissions"`
-	AllowedAccounts []string        `json:"allowed_accounts,omitempty"`
+	AllowedAccounts []string        `json:"allowed_accounts"`
 	CreatedAt       string          `json:"created_at,omitempty"`
 	UpdatedAt       string          `json:"updated_at,omitempty"`
 }
@@ -106,11 +116,18 @@ func userToAPIUser(u *User) *APIUser {
 	if u.LastLoginAt != nil {
 		lastLogin = u.LastLoginAt.Format(time.RFC3339)
 	}
+	// Substitute an empty slice for nil so the JSON encoder emits "[]"
+	// rather than "null", matching the TS contract that declares
+	// APIUser.groups as a required string[] (issue #350).
+	groups := u.GroupIDs
+	if groups == nil {
+		groups = []string{}
+	}
 	return &APIUser{
 		ID:         u.ID,
 		Email:      u.Email,
 		Role:       u.Role,
-		Groups:     u.GroupIDs,
+		Groups:     groups,
 		MFAEnabled: u.MFAEnabled,
 		CreatedAt:  u.CreatedAt.Format(time.RFC3339),
 		UpdatedAt:  u.UpdatedAt.Format(time.RFC3339),
@@ -126,12 +143,17 @@ func groupToAPIGroup(g *Group) *APIGroup {
 	for i, p := range g.Permissions {
 		apiPerms[i] = permissionToAPIPermission(p)
 	}
+	// Empty-slice substitution: see userToAPIUser. Issue #350.
+	allowedAccounts := g.AllowedAccounts
+	if allowedAccounts == nil {
+		allowedAccounts = []string{}
+	}
 	return &APIGroup{
 		ID:              g.ID,
 		Name:            g.Name,
 		Description:     g.Description,
 		Permissions:     apiPerms,
-		AllowedAccounts: g.AllowedAccounts,
+		AllowedAccounts: allowedAccounts,
 		CreatedAt:       g.CreatedAt.Format(time.RFC3339),
 		UpdatedAt:       g.UpdatedAt.Format(time.RFC3339),
 	}

--- a/internal/auth/service_api_test.go
+++ b/internal/auth/service_api_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -550,3 +551,109 @@ func TestService_HasPermissionAPI(t *testing.T) {
 }
 
 // Test error paths and edge cases
+
+// TestUserToAPIUser_EmptyGroups verifies the nil→[]string{} substitution
+// that lets the JSON encoder emit "groups": [] rather than "groups": null
+// or (with the old omitempty) omitting the field entirely. Frontend
+// renderers treat user.groups as a required string[] (TS contract in
+// frontend/src/api/types.ts); a nil/missing field crashes the admin
+// users page with "Cannot read properties of undefined (reading
+// 'length')". See issue #350.
+func TestUserToAPIUser_EmptyGroups(t *testing.T) {
+	now := time.Now()
+
+	t.Run("nil GroupIDs serialises as []", func(t *testing.T) {
+		user := &User{
+			ID:        "user-1",
+			Email:     "user@example.com",
+			Role:      RoleUser,
+			GroupIDs:  nil,
+			CreatedAt: now,
+			UpdatedAt: now,
+		}
+		api := userToAPIUser(user)
+		require.NotNil(t, api)
+		assert.NotNil(t, api.Groups, "Groups must NOT be nil — TS contract is string[]")
+		assert.Equal(t, []string{}, api.Groups)
+
+		// Marshal-check: the JSON output must contain "groups":[] and not
+		// drop the field. This is what the frontend actually consumes.
+		b, err := json.Marshal(api)
+		require.NoError(t, err)
+		assert.Contains(t, string(b), `"groups":[]`, "JSON must emit empty array, not null and not absent")
+		assert.NotContains(t, string(b), `"groups":null`)
+	})
+
+	t.Run("empty-slice GroupIDs serialises as []", func(t *testing.T) {
+		user := &User{
+			ID:        "user-2",
+			Email:     "user2@example.com",
+			Role:      RoleUser,
+			GroupIDs:  []string{},
+			CreatedAt: now,
+			UpdatedAt: now,
+		}
+		api := userToAPIUser(user)
+		require.NotNil(t, api)
+		assert.Equal(t, []string{}, api.Groups)
+		b, err := json.Marshal(api)
+		require.NoError(t, err)
+		assert.Contains(t, string(b), `"groups":[]`)
+	})
+
+	t.Run("non-empty GroupIDs preserved", func(t *testing.T) {
+		user := &User{
+			ID:        "user-3",
+			Email:     "admin@example.com",
+			Role:      RoleAdmin,
+			GroupIDs:  []string{"admin-group-id"},
+			CreatedAt: now,
+			UpdatedAt: now,
+		}
+		api := userToAPIUser(user)
+		require.NotNil(t, api)
+		assert.Equal(t, []string{"admin-group-id"}, api.Groups)
+		b, err := json.Marshal(api)
+		require.NoError(t, err)
+		assert.Contains(t, string(b), `"groups":["admin-group-id"]`)
+	})
+}
+
+// TestGroupToAPIGroup_EmptyAllowedAccounts mirrors the user-side test
+// for AllowedAccounts. See issue #350.
+func TestGroupToAPIGroup_EmptyAllowedAccounts(t *testing.T) {
+	now := time.Now()
+
+	t.Run("nil AllowedAccounts serialises as []", func(t *testing.T) {
+		g := &Group{
+			ID:              "group-1",
+			Name:            "Empty",
+			AllowedAccounts: nil,
+			Permissions:     []Permission{},
+			CreatedAt:       now,
+			UpdatedAt:       now,
+		}
+		api := groupToAPIGroup(g)
+		require.NotNil(t, api)
+		assert.NotNil(t, api.AllowedAccounts, "AllowedAccounts must NOT be nil")
+		assert.Equal(t, []string{}, api.AllowedAccounts)
+		b, err := json.Marshal(api)
+		require.NoError(t, err)
+		assert.Contains(t, string(b), `"allowed_accounts":[]`)
+		assert.NotContains(t, string(b), `"allowed_accounts":null`)
+	})
+
+	t.Run("non-empty AllowedAccounts preserved", func(t *testing.T) {
+		g := &Group{
+			ID:              "group-2",
+			Name:            "Admins",
+			AllowedAccounts: []string{"*"},
+			Permissions:     []Permission{},
+			CreatedAt:       now,
+			UpdatedAt:       now,
+		}
+		api := groupToAPIGroup(g)
+		require.NotNil(t, api)
+		assert.Equal(t, []string{"*"}, api.AllowedAccounts)
+	})
+}

--- a/internal/auth/service_user.go
+++ b/internal/auth/service_user.go
@@ -12,28 +12,28 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
-// SetupAdmin creates the first admin user using API key authentication
+// SetupAdmin creates the first admin user using API key authentication.
+// The bootstrap is race-safe in two layers: an upfront AdminExists() check
+// (common case — fast path, no insert when an admin already exists) and an
+// atomic CreateAdminIfNone() conditional insert (closes the TOCTOU window
+// where two concurrent bootstrap callers both passed the existence check).
 func (s *Service) SetupAdmin(ctx context.Context, req SetupAdminRequest) (*LoginResponse, error) {
-	// Check if admin already exists
 	exists, err := s.store.AdminExists(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to check admin: %w", err)
 	}
 	if exists {
-		return nil, fmt.Errorf("admin user already exists")
+		return nil, ErrAdminExists
 	}
 
-	// Validate email
 	if _, err := mail.ParseAddress(req.Email); err != nil {
-		return nil, fmt.Errorf("invalid email format")
+		return nil, ErrInvalidEmail
 	}
 
-	// Validate password
 	if err := s.validatePassword(req.Password); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %v", ErrPasswordPolicy, err)
 	}
 
-	// Hash password directly with bcrypt (no custom salt needed)
 	passwordHash, err := s.hashPassword(req.Password)
 	if err != nil {
 		return nil, fmt.Errorf("failed to hash password: %w", err)
@@ -55,15 +55,21 @@ func (s *Service) SetupAdmin(ctx context.Context, req SetupAdminRequest) (*Login
 		Active:       true,
 	}
 
-	if err := s.store.CreateUser(ctx, user); err != nil {
-		// Two callers reaching CreateUser concurrently after both passed the
-		// AdminExists() check is caught by the users_one_admin partial unique
-		// index (migration 000025). Map that duplicate-key error to the same
-		// "admin already exists" semantic the existence check returned above.
-		if isDuplicateKeyError(err) {
-			return nil, fmt.Errorf("admin user already exists")
+	inserted, err := s.store.CreateAdminIfNone(ctx, user)
+	if err != nil {
+		// ErrEmailInUse (email collision with an existing non-admin user)
+		// surfaces unwrapped so the handler maps it to 409. Other errors
+		// stay wrapped for diagnosis.
+		if errors.Is(err, ErrEmailInUse) {
+			return nil, err
 		}
 		return nil, fmt.Errorf("failed to create admin: %w", err)
+	}
+	if !inserted {
+		// Another bootstrap caller raced ahead between AdminExists and the
+		// conditional insert. Returns the same sentinel as the fast-path
+		// check above so the handler maps both branches to 409.
+		return nil, ErrAdminExists
 	}
 
 	// Create session

--- a/internal/auth/service_user.go
+++ b/internal/auth/service_user.go
@@ -92,6 +92,23 @@ func (s *Service) SetupAdmin(ctx context.Context, req SetupAdminRequest) (*Login
 	}, nil
 }
 
+// mapStoreCreateUserError maps a Store.CreateUser error into the auth
+// package's sentinel set so the API handler can surface 4xx instead of
+// 500 for known recoverable failures. Defence-in-depth: the validator
+// pre-checks email-in-use, but two callers can race past it and hit the
+// users_email_key unique constraint. Extracted from CreateUser /
+// SetupAdmin call sites to keep both functions under gocyclo's
+// complexity threshold. Issue #349.
+func mapStoreCreateUserError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if isEmailDuplicateError(err) {
+		return ErrEmailInUse
+	}
+	return fmt.Errorf("failed to create user: %w", err)
+}
+
 // CheckAdminExists returns whether an admin user exists
 func (s *Service) CheckAdminExists(ctx context.Context) (bool, error) {
 	return s.store.AdminExists(ctx)
@@ -207,8 +224,8 @@ func (s *Service) CreateUser(ctx context.Context, req CreateUserRequest) (*Creat
 		inviteToken = token
 	}
 
-	if err := s.store.CreateUser(ctx, user); err != nil {
-		return nil, fmt.Errorf("failed to create user: %w", err)
+	if err := mapStoreCreateUserError(s.store.CreateUser(ctx, user)); err != nil {
+		return nil, err
 	}
 
 	result := &CreateUserResult{User: user}

--- a/internal/auth/service_user.go
+++ b/internal/auth/service_user.go
@@ -98,22 +98,30 @@ func (s *Service) CheckAdminExists(ctx context.Context) (bool, error) {
 // password via the welcome email link, so the password validator is skipped.
 func (s *Service) validateCreateUserRequest(ctx context.Context, req CreateUserRequest) error {
 	if _, err := mail.ParseAddress(req.Email); err != nil {
-		return fmt.Errorf("invalid email format")
+		return ErrInvalidEmail
 	}
 	existing, err := s.store.GetUserByEmail(ctx, req.Email)
 	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 		return err
 	}
 	if existing != nil {
-		return fmt.Errorf("email already in use")
+		return ErrEmailInUse
 	}
 	if req.Role != RoleAdmin && req.Role != RoleUser && req.Role != RoleReadOnly {
-		return fmt.Errorf("invalid role: %s", req.Role)
+		// %w lets the API handler detect the category via errors.Is(ErrInvalidRole)
+		// while preserving the specific role name in the user-facing message.
+		return fmt.Errorf("%w: %s", ErrInvalidRole, req.Role)
 	}
 	if req.Password == "" {
 		return nil
 	}
-	return s.validatePassword(req.Password)
+	if err := s.validatePassword(req.Password); err != nil {
+		// validatePassword returns specific messages ("must be at least N
+		// characters", "common password", etc.); wrap so the handler can
+		// detect the category while keeping the message detail.
+		return fmt.Errorf("%w: %v", ErrPasswordPolicy, err)
+	}
+	return nil
 }
 
 // CreateUserResult bundles the created user with optional invite-email

--- a/internal/auth/service_user_test.go
+++ b/internal/auth/service_user_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -22,12 +21,13 @@ func TestService_SetupAdmin(t *testing.T) {
 		service := createTestService(mockStore, mockEmail)
 
 		mockStore.On("AdminExists", ctx).Return(false, nil).Once()
-		// Capture the user passed to CreateUser so we can assert on the
-		// auto-assigned DefaultAdminGroupID.
+		// Capture the user passed to CreateAdminIfNone so we can assert
+		// on the auto-assigned DefaultAdminGroupID. CreateAdminIfNone
+		// replaces CreateUser on the bootstrap path (issue #349).
 		var capturedUser *User
-		mockStore.On("CreateUser", ctx, mock.AnythingOfType("*auth.User")).
+		mockStore.On("CreateAdminIfNone", ctx, mock.AnythingOfType("*auth.User")).
 			Run(func(args mock.Arguments) { capturedUser = args.Get(1).(*User) }).
-			Return(nil).Once()
+			Return(true, nil).Once()
 		mockStore.On("CreateSession", ctx, mock.AnythingOfType("*auth.Session")).Return(nil).Once()
 
 		req := SetupAdminRequest{
@@ -701,7 +701,8 @@ func TestService_SetupAdmin_EdgeCases(t *testing.T) {
 		service := createTestService(mockStore, mockEmail)
 
 		mockStore.On("AdminExists", ctx).Return(false, nil).Once()
-		mockStore.On("CreateUser", ctx, mock.AnythingOfType("*auth.User")).Return(fmt.Errorf("database error")).Once()
+		// Bootstrap path now calls CreateAdminIfNone (issue #349).
+		mockStore.On("CreateAdminIfNone", ctx, mock.AnythingOfType("*auth.User")).Return(false, fmt.Errorf("database error")).Once()
 
 		req := SetupAdminRequest{
 			Email:    "admin@example.com",
@@ -716,22 +717,21 @@ func TestService_SetupAdmin_EdgeCases(t *testing.T) {
 		mockStore.AssertExpectations(t)
 	})
 
-	// TestSetupAdmin TOCTOU fix (migration 000025_admin_role_unique + service
-	// change in 957295317): when AdminExists() reports false but the database
-	// rejects CreateUser with a 23505 duplicate-key error (another concurrent
-	// SetupAdmin won the race), the service must translate that into the same
-	// "admin user already exists" message the existence check would have
-	// returned — NOT the generic "failed to create admin" wrapper.
-	t.Run("admin creation races to duplicate-key", func(t *testing.T) {
+	// TestSetupAdmin TOCTOU fix (issue #349, migration 000050): when
+	// AdminExists() reports false but a concurrent SetupAdmin caller wins
+	// the race to insert, the conditional INSERT-WHERE-NOT-EXISTS in
+	// CreateAdminIfNone returns (false, nil) — meaning the row was not
+	// inserted because the WHERE clause failed. The service must
+	// translate that into ErrAdminExists, NOT a generic wrapped error.
+	t.Run("admin creation loses the race", func(t *testing.T) {
 		mockStore := new(MockStore)
 		mockEmail := new(MockEmailSender)
 		service := createTestService(mockStore, mockEmail)
 
 		mockStore.On("AdminExists", ctx).Return(false, nil).Once()
-		// Simulate the partial unique index on (role) WHERE role = 'admin'
-		// rejecting the insert with a 23505 unique violation.
-		pgErr := &pgconn.PgError{Code: "23505", ConstraintName: "users_one_admin"}
-		mockStore.On("CreateUser", ctx, mock.AnythingOfType("*auth.User")).Return(pgErr).Once()
+		// Simulate the conditional insert finding that another admin
+		// already exists (inserted=false, no error).
+		mockStore.On("CreateAdminIfNone", ctx, mock.AnythingOfType("*auth.User")).Return(false, nil).Once()
 
 		req := SetupAdminRequest{
 			Email:    "admin@example.com",
@@ -741,9 +741,10 @@ func TestService_SetupAdmin_EdgeCases(t *testing.T) {
 		resp, err := service.SetupAdmin(ctx, req)
 		require.Error(t, err)
 		assert.Nil(t, resp)
-		assert.Contains(t, err.Error(), "admin user already exists")
-		// Do NOT leak the "failed to create admin" wrapper — the error surface
-		// should be indistinguishable from the pre-race existence check.
+		assert.ErrorIs(t, err, ErrAdminExists)
+		// Do NOT leak the "failed to create admin" wrapper — the error
+		// surface should be indistinguishable from the pre-race existence
+		// check.
 		assert.NotContains(t, err.Error(), "failed to create admin")
 
 		mockStore.AssertExpectations(t)

--- a/internal/auth/store_postgres.go
+++ b/internal/auth/store_postgres.go
@@ -279,6 +279,58 @@ func (s *PostgresStore) AdminExists(ctx context.Context) (bool, error) {
 	return exists, nil
 }
 
+// CreateAdminIfNone atomically inserts user as the first admin in the
+// system. Returns (true, nil) when the insert succeeded; (false, nil)
+// when an admin already existed (TOCTOU race — both callers passed
+// AdminExists, only one wins the insert); (false, ErrEmailInUse) when
+// the email collides with an existing (non-admin) user; (false, err)
+// for any other failure.
+//
+// The conditional INSERT closes the bootstrap race without the
+// users_one_admin partial unique index (dropped in migration 000050).
+// Postgres guarantees atomicity of the SELECT … WHERE NOT EXISTS …
+// INSERT in a single statement — no advisory lock or transaction is
+// needed.
+func (s *PostgresStore) CreateAdminIfNone(ctx context.Context, user *User) (bool, error) {
+	if user.ID == "" {
+		user.ID = uuid.New().String()
+	}
+	now := time.Now()
+	user.CreatedAt = now
+	user.UpdatedAt = now
+
+	query := `
+		INSERT INTO users (
+			id, email, password_hash, salt, role, group_ids, active,
+			mfa_enabled, mfa_secret, password_reset_token, password_reset_expiry,
+			failed_login_attempts, locked_until, password_history,
+			created_at, updated_at, last_login_at
+		)
+		SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17
+		WHERE NOT EXISTS (SELECT 1 FROM users WHERE role = 'admin')
+	`
+
+	tag, err := s.db.Exec(ctx, query,
+		user.ID, user.Email, user.PasswordHash, user.Salt, user.Role,
+		user.GroupIDs, user.Active, user.MFAEnabled, user.MFASecret,
+		user.PasswordResetToken, user.PasswordResetExpiry,
+		user.FailedLoginAttempts, user.LockedUntil, user.PasswordHistory,
+		user.CreatedAt, user.UpdatedAt, user.LastLoginAt,
+	)
+	if err != nil {
+		// Email uniqueness can still fire if the bootstrap caller reuses
+		// an email already held by a non-admin user. Surface as the same
+		// sentinel the regular create path uses so callers get a clean
+		// "email already in use" instead of a raw DB error.
+		if isEmailDuplicateError(err) {
+			return false, ErrEmailInUse
+		}
+		return false, fmt.Errorf("failed to create admin: %w", err)
+	}
+
+	return tag.RowsAffected() > 0, nil
+}
+
 // ==========================================
 // GROUP OPERATIONS
 // ==========================================

--- a/internal/auth/store_postgres.go
+++ b/internal/auth/store_postgres.go
@@ -299,6 +299,19 @@ func (s *PostgresStore) CreateAdminIfNone(ctx context.Context, user *User) (bool
 	user.CreatedAt = now
 	user.UpdatedAt = now
 
+	// The NOT EXISTS guard matches AdminExists's semantics exactly
+	// (role='admin' AND active=true) so the fast-path check and the
+	// atomic insert agree: a deployment with only inactive admins is
+	// treated as "no admin" by both, and the insert proceeds. If they
+	// disagreed, AdminExists could report false while this insert
+	// failed silently on the WHERE clause, leaving the operator with
+	// a recoverable-looking error and no admin.
+	//
+	// The role column is also hard-coded to 'admin' regardless of
+	// user.Role — the method's contract is "create admin if none",
+	// and accepting a non-admin role here would silently break that
+	// contract (the WHERE clause would still let the insert through
+	// because a non-admin row doesn't trip the "admin exists" check).
 	query := `
 		INSERT INTO users (
 			id, email, password_hash, salt, role, group_ids, active,
@@ -306,12 +319,12 @@ func (s *PostgresStore) CreateAdminIfNone(ctx context.Context, user *User) (bool
 			failed_login_attempts, locked_until, password_history,
 			created_at, updated_at, last_login_at
 		)
-		SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17
-		WHERE NOT EXISTS (SELECT 1 FROM users WHERE role = 'admin')
+		SELECT $1, $2, $3, $4, 'admin', $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16
+		WHERE NOT EXISTS (SELECT 1 FROM users WHERE role = 'admin' AND active = true)
 	`
 
 	tag, err := s.db.Exec(ctx, query,
-		user.ID, user.Email, user.PasswordHash, user.Salt, user.Role,
+		user.ID, user.Email, user.PasswordHash, user.Salt,
 		user.GroupIDs, user.Active, user.MFAEnabled, user.MFASecret,
 		user.PasswordResetToken, user.PasswordResetExpiry,
 		user.FailedLoginAttempts, user.LockedUntil, user.PasswordHistory,

--- a/internal/auth/test_helpers.go
+++ b/internal/auth/test_helpers.go
@@ -67,6 +67,11 @@ func (m *MockStore) AdminExists(ctx context.Context) (bool, error) {
 	return args.Bool(0), args.Error(1)
 }
 
+func (m *MockStore) CreateAdminIfNone(ctx context.Context, user *User) (bool, error) {
+	args := m.Called(ctx, user)
+	return args.Bool(0), args.Error(1)
+}
+
 func (m *MockStore) GetGroup(ctx context.Context, groupID string) (*Group, error) {
 	args := m.Called(ctx, groupID)
 	if args.Get(0) == nil {

--- a/internal/database/postgres/migrations/000050_drop_admin_role_unique.down.sql
+++ b/internal/database/postgres/migrations/000050_drop_admin_role_unique.down.sql
@@ -1,0 +1,10 @@
+-- Restore the single-admin index for rollback compatibility.
+-- SetupAdmin's atomic INSERT-WHERE-NOT-EXISTS keeps working with
+-- the index in place — the DB constraint becomes a second line of
+-- defence. Rolling back will, however, surface the original 500
+-- bug when an operator tries to add a second admin via the UI;
+-- callers must roll back issue #349 as a unit, not just this one
+-- migration.
+CREATE UNIQUE INDEX IF NOT EXISTS users_one_admin
+    ON users (role)
+    WHERE role = 'admin';

--- a/internal/database/postgres/migrations/000050_drop_admin_role_unique.up.sql
+++ b/internal/database/postgres/migrations/000050_drop_admin_role_unique.up.sql
@@ -1,0 +1,6 @@
+-- Multi-admin support (issue #349). The TOCTOU race that motivated
+-- 000025_admin_role_unique is now closed in the service layer
+-- (SetupAdmin uses an atomic INSERT-WHERE-NOT-EXISTS), so the
+-- partial unique index is no longer needed and actively prevents
+-- the supported "add a second admin via /api/users" flow.
+DROP INDEX IF EXISTS users_one_admin;

--- a/internal/mocks/stores.go
+++ b/internal/mocks/stores.go
@@ -298,6 +298,12 @@ func (m *MockAuthStore) AdminExists(ctx context.Context) (bool, error) {
 	return args.Bool(0), args.Error(1)
 }
 
+// CreateAdminIfNone mocks the CreateAdminIfNone operation
+func (m *MockAuthStore) CreateAdminIfNone(ctx context.Context, user *auth.User) (bool, error) {
+	args := m.Called(ctx, user)
+	return args.Bool(0), args.Error(1)
+}
+
 // GetGroup mocks the GetGroup operation
 func (m *MockAuthStore) GetGroup(ctx context.Context, groupID string) (*auth.Group, error) {
 	args := m.Called(ctx, groupID)

--- a/internal/server/adapter_test.go
+++ b/internal/server/adapter_test.go
@@ -411,7 +411,8 @@ func TestAuthServiceAdapter_SetupAdmin(t *testing.T) {
 	ctx := context.Background()
 
 	mockStore.On("AdminExists", ctx).Return(false, nil)
-	mockStore.On("CreateUser", ctx, mock.AnythingOfType("*auth.User")).Return(nil)
+	// Bootstrap path now calls CreateAdminIfNone (issue #349).
+	mockStore.On("CreateAdminIfNone", ctx, mock.AnythingOfType("*auth.User")).Return(true, nil)
 	mockStore.On("CreateSession", ctx, mock.AnythingOfType("*auth.Session")).Return(nil)
 
 	resp, err := adapter.SetupAdmin(ctx, api.SetupAdminRequest{

--- a/internal/server/health_test.go
+++ b/internal/server/health_test.go
@@ -48,6 +48,10 @@ func (m *mockAuthStoreForHealth) AdminExists(ctx context.Context) (bool, error) 
 	return false, nil
 }
 
+func (m *mockAuthStoreForHealth) CreateAdminIfNone(ctx context.Context, user *auth.User) (bool, error) {
+	return true, nil
+}
+
 func (m *mockAuthStoreForHealth) GetGroup(ctx context.Context, groupID string) (*auth.Group, error) {
 	return nil, nil
 }


### PR DESCRIPTION
## Summary

Two stacked bugs surfacing as `Failed to save user: Internal server error` (and `Failed to load users and groups`) on the Admin → Users page, both fixed together because the auth touchpoints overlap.

Closes #349. Closes #350.

## What changed

### #349 — multi-admin support + 4xx for validation errors

The `users_one_admin` partial unique index (migration 000025) blocked any second admin and the API handler mapped every validation failure to a generic 500.

- **Migration 000050** drops `users_one_admin`. Atomic INSERT-WHERE-NOT-EXISTS in the service layer closes the bootstrap TOCTOU race without the index.
- **`internal/auth/errors.go`** defines sentinels: `ErrInvalidEmail`, `ErrEmailInUse`, `ErrInvalidRole`, `ErrAdminExists`, `ErrPasswordPolicy`.
- **`validateCreateUserRequest`** wraps each validation failure as the matching sentinel via `%w` so callers can `errors.Is` while preserving the specific user-facing detail.
- **`Store.CreateAdminIfNone`** — new atomic conditional insert; `SetupAdmin` uses it instead of `CreateUser` for the bootstrap path.
- **`Service.CreateUser`** gains defence-in-depth email-uniqueness mapping for the TOCTOU window between the pre-check and the insert.
- **`internal/api/handler_users.go`** introduces `mapAuthError` — shared sentinel→ClientError helper (400/409 based on category). Both `createUser` and the bootstrap `setupAdmin` handler route through it.

### #350 — API contract: drop `omitempty` on slice fields

The frontend TS contract declares `APIUser.groups` and `APIGroup.allowed_accounts` as required `string[]`. `omitempty` on the Go side stripped them when empty, causing `TypeError: Cannot read properties of undefined (reading 'length')` inside an `Array.map` callback on the Admin Users page.

- **Backend**: dropped `omitempty`; the conversion helpers substitute `[]string{}` for nil so JSON emits `[]` (not `null` and not absent).
- **Frontend**: `normalizeUser` / `normalizeGroup` at the `loadUsers` boundary coerce non-array values to `[]` as defence-in-depth.

## Commits

| Commit | Scope |
|---|---|
| `34e08787b` | migration 000050 drops users_one_admin |
| `722df5de7` | add validation error sentinels |
| `be0b710b4` | wrap validateCreateUserRequest errors as sentinels |
| `869d88b71` | atomic CreateAdminIfNone + SetupAdmin race fix |
| `99d62c9c6` | drop omitempty on user/group slice fields (#350) |
| `0fafbb21f` | map auth sentinels to 4xx in user/admin endpoints |

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` — full repo suite passes
- [x] `TestService_SetupAdmin` rewritten for the new CreateAdminIfNone flow (race-loser asserts `errors.Is(err, ErrAdminExists)`)
- [x] `TestUserToAPIUser_EmptyGroups` / `TestGroupToAPIGroup_EmptyAllowedAccounts` assert JSON output is `[]`, never `null` and never absent
- [x] `TestAuthServiceAdapter_SetupAdmin` updated to mock `CreateAdminIfNone`
- [x] Frontend type-check (`npx tsc --noEmit`) clean
- [ ] End-to-end on the deployed Lambda environment (next step after merge):
  - Admin user creates a second admin via POST `/api/users` (role=admin, fresh email) → 201
  - Same email a second time → 409, toast shows "email already in use"
  - Role=guest → 400, toast shows "invalid role: guest"
  - Weak password → 400, toast shows the policy message
  - Admin Users page renders cleanly with a user that has empty groups (the bug from #350)

## Design notes

- The bootstrap-path TOCTOU race is closed by an atomic single-statement `INSERT … SELECT $args … WHERE NOT EXISTS (SELECT 1 FROM users WHERE role='admin')`. No advisory locks, no transactions, no DB constraint — Postgres guarantees atomicity within the single statement.
- `SetupAdmin` keeps the upfront `AdminExists` fast path so the common case (admin already exists) returns immediately without writing.
- The handler-side `mapAuthError` switch is preferred over typed-error wrapping at every service-layer return because it keeps the `Service` callable from non-HTTP contexts (CLI, scripts) without HTTP coupling.
- Migration 000050's down-migration restores the index. Note in the down.sql: rolling back this migration alone re-introduces the original 500 bug — operators must roll back issue #349 as a unit.

## Out of scope

- **#351 (admin group seeding)** — `ensureAdminUser` doesn't auto-assign the new admin to the `Administrators` group, surfaced by the same investigation. Tracked separately.
- Widening the role allowlist to include `read_only` for general user creation — handled by the existing role switch at `handler_users.go:51-56`; not part of this PR.
- Auditing other API response slice fields for the same `omitempty` pattern — a follow-up sweep, this PR only touches the two fields that the frontend currently reads.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Admin setup and user-creation errors now surface as appropriate 4xx responses instead of generic 500s.
  * API responses consistently emit empty arrays (not null) for group and account lists.

* **New Features**
  * Frontend defensive normalization to tolerate missing/null user/group fields.
  * Admin bootstrapping now uses an atomic creation path to handle race conditions.

* **Tests**
  * Added/updated tests for JSON serialization and new admin-creation behavior.

* **Chores**
  * DB migration adjusted to remove a legacy single-admin unique index.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/353)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->