### PR TITLE
fix(frontend/users): make Edit/Delete user row buttons usable (text labels match groups list convention)

### DIFF
--- a/frontend/src/users/userList.ts
+++ b/frontend/src/users/userList.ts
@@ -109,12 +109,8 @@ export function renderUsers(users: APIUser[]): void {
             <td><span class="text-muted">${user.last_login ? formatRelativeTime(user.last_login) : 'Never'}</span></td>
             <td>
               <div class="action-buttons">
-                <button class="btn-small btn-icon edit-user-btn" data-user-id="${escapeHtml(user.id)}" title="Edit user" aria-label="Edit user ${escapeHtml(user.email)}">
-                  <i class="icon-edit" aria-hidden="true"></i>
-                </button>
-                <button class="btn-small btn-icon btn-danger delete-user-btn" data-user-id="${escapeHtml(user.id)}" title="Delete user" aria-label="Delete user ${escapeHtml(user.email)}">
-                  <i class="icon-trash" aria-hidden="true"></i>
-                </button>
+                <button class="btn-small edit-user-btn" data-user-id="${escapeHtml(user.id)}" aria-label="Edit user ${escapeHtml(user.email)}">Edit</button>
+                <button class="btn-small btn-danger delete-user-btn" data-user-id="${escapeHtml(user.id)}" aria-label="Delete user ${escapeHtml(user.email)}">Delete</button>
               </div>
             </td>
           </tr>


### PR DESCRIPTION
## Summary

The Edit / Delete user buttons on the Admin → Users page were rendered as minuscule click targets — `.btn-small btn-icon` with only an icon-font glyph inside, and `.btn-icon` has no CSS rule defined anywhere so the icons came out as text-size glyphs with no padding or framing.

Switching to text labels matches the convention used immediately below on the same page in `frontend/src/groups/groupList.ts:65-67`:

```html
<button class="btn-small edit-group-btn">Edit</button>
<button class="btn-small btn-danger delete-group-btn">Delete</button>
```

The Admin Users rows now use the same shape.

## Preserved unchanged

- `data-user-id` attribute (the JS event handler reads it).
- `.edit-user-btn` / `.delete-user-btn` class hooks (`setupUserTableListeners` in the same file binds to these selectors).
- `aria-label` that names the specific user — the visible text "Edit" / "Delete" is generic by row, screen readers still announce per-row context.

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] Visual check on the deployed env after merge — the Admin Users row buttons should match the size + shape of the Group row Edit/Delete buttons directly below.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated user list action buttons from icon-based to text-based labels (Edit and Delete) for improved clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/354)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->