### PR TITLE
fix(api/auth): base64-decode new_password in resetPassword handler (P0 — invited users locked out, closes #356)

### DIFF
--- a/internal/api/handler_auth.go
+++ b/internal/api/handler_auth.go
@@ -174,6 +174,17 @@ func (h *Handler) resetPassword(ctx context.Context, req *events.LambdaFunctionU
 		return nil, NewClientError(400, "invalid request body")
 	}
 
+	// The frontend base64-encodes new_password (see frontend/src/api/auth.ts:
+	// resetPassword) — same pattern as login / change-password / update-profile.
+	// Decode it back to plaintext before handing to the service or the bcrypt
+	// hash stored represents the base64 string, leaving the user unable to log
+	// in with the password they thought they set. See issue #356.
+	decoded, err := decodeBase64Password(pwdResetReq.NewPassword)
+	if err != nil {
+		return nil, err
+	}
+	pwdResetReq.NewPassword = decoded
+
 	if err := h.auth.ConfirmPasswordReset(ctx, pwdResetReq); err != nil {
 		return nil, err
 	}

--- a/internal/api/handler_auth_test.go
+++ b/internal/api/handler_auth_test.go
@@ -541,7 +541,11 @@ func TestHandler_resetPassword_Success(t *testing.T) {
 
 	handler := &Handler{auth: mockAuth}
 
-	req := &events.LambdaFunctionURLRequest{Body: `{"token": "reset-token", "new_password": "newpassword123"}`}
+	// The handler base64-decodes new_password before forwarding to the
+	// service (issue #356), matching the frontend's submission shape. The
+	// service still receives the plaintext.
+	encoded := base64.StdEncoding.EncodeToString([]byte("newpassword123"))
+	req := &events.LambdaFunctionURLRequest{Body: `{"token": "reset-token", "new_password": "` + encoded + `"}`}
 	result, err := handler.resetPassword(ctx, req)
 	require.NoError(t, err)
 
@@ -580,7 +584,11 @@ func TestHandler_resetPassword_Error(t *testing.T) {
 
 	handler := &Handler{auth: mockAuth}
 
-	req := &events.LambdaFunctionURLRequest{Body: `{"token": "bad-token", "new_password": "newpassword123"}`}
+	// new_password must be base64-encoded — the handler now decodes before
+	// forwarding (issue #356). Encoding "newpassword123" so the decode step
+	// passes and the error path under test (bad token) is the one that fires.
+	encoded := base64.StdEncoding.EncodeToString([]byte("newpassword123"))
+	req := &events.LambdaFunctionURLRequest{Body: `{"token": "bad-token", "new_password": "` + encoded + `"}`}
 	result, err := handler.resetPassword(ctx, req)
 	assert.Error(t, err)
 	assert.Nil(t, result)
@@ -770,4 +778,56 @@ func TestHandler_updateProfile_InvalidJSON(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "invalid request body")
+}
+
+// TestHandler_resetPassword_DecodesBase64 verifies issue #356: the
+// resetPassword handler must base64-decode new_password before forwarding to
+// the service, matching the pattern used by login / change-password /
+// update-profile. Without this, the bcrypt hash stored represents the base64
+// string rather than the plaintext, and the user gets locked out after
+// completing the reset.
+func TestHandler_resetPassword_DecodesBase64(t *testing.T) {
+	ctx := context.Background()
+	mockAuth := new(MockAuthService)
+
+	// The service must receive the DECODED password — that's what bcrypt then
+	// hashes and stores. If the handler skipped the decode, the captured
+	// req.NewPassword would be the base64 string and this expectation would
+	// fail.
+	mockAuth.On("ConfirmPasswordReset", ctx, PasswordResetConfirm{
+		Token:       "tok-abc",
+		NewPassword: "PlainText#1",
+	}).Return(nil)
+
+	handler := &Handler{auth: mockAuth}
+
+	encoded := base64.StdEncoding.EncodeToString([]byte("PlainText#1"))
+	req := &events.LambdaFunctionURLRequest{
+		Body: `{"token": "tok-abc", "new_password": "` + encoded + `"}`,
+	}
+
+	result, err := handler.resetPassword(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	mockAuth.AssertExpectations(t)
+}
+
+// TestHandler_resetPassword_InvalidBase64 covers the malformed-input path —
+// the regression test mentioned in #356's acceptance criteria. A garbled
+// payload must surface as a 4xx, not a 5xx, so the operator gets a clear
+// "the link/payload is bad" instead of "internal server error".
+func TestHandler_resetPassword_InvalidBase64(t *testing.T) {
+	ctx := context.Background()
+	mockAuth := new(MockAuthService)
+	handler := &Handler{auth: mockAuth}
+
+	req := &events.LambdaFunctionURLRequest{
+		Body: `{"token": "tok-abc", "new_password": "!!!not-valid-base64!!!"}`,
+	}
+
+	_, err := handler.resetPassword(ctx, req)
+	assert.Error(t, err)
+	// decodeBase64Password returns a ClientError(400) — assert the helper
+	// short-circuited before any service call fired.
+	mockAuth.AssertNotCalled(t, "ConfirmPasswordReset", mock.Anything, mock.Anything)
 }


### PR DESCRIPTION
## Summary

**P0/critical.** Every user invited via the new invite flow (#348) was locked out the moment they "set" a password. Forgot-Password for existing users was equally broken.

The frontend at `frontend/src/api/auth.ts:91-101` base64-encodes `new_password` before POSTing to `/api/auth/reset-password`, matching the convention used by login / change-password / update-profile. Every other password-handling endpoint in `internal/api/handler_auth.go` calls `decodeBase64Password` before forwarding to the service. `resetPassword` was the only one that didn't, so the bcrypt hash stored represented the base64 string rather than the plaintext. Login then decoded the typed-in plaintext and bcrypt-compared against the wrong hash → "invalid email or password" with no way to recover.

Closes #356.

## Fix

One-line addition to `handler_auth.go:resetPassword`: call `decodeBase64Password(pwdResetReq.NewPassword)` between the `json.Unmarshal` and the service call, mirroring the pattern at lines 32 (login), 209/215 (update-profile), 234/238 (change-password).

## Test plan

- [x] `TestHandler_resetPassword_DecodesBase64` — base64 payload arrives, service sees the plaintext.
- [x] `TestHandler_resetPassword_InvalidBase64` — malformed payload returns 400 before the service call fires (AC item from #356).
- [x] `TestHandler_resetPassword_Success` / `_Error` updated to send properly-encoded payloads now that the handler decodes them.
- [x] `go test github.com/LeanerCloud/CUDly/internal/api -run TestHandler_resetPassword` — passes.
- [x] `go test github.com/LeanerCloud/CUDly/cmd github.com/LeanerCloud/CUDly/cmd/lambda github.com/LeanerCloud/CUDly/internal/server github.com/LeanerCloud/CUDly/internal/auth` — all pass.
- [ ] **End-to-end on the deployed env after merge** — invite a user, complete the reset flow, log in with the same password.

## Out of scope (separate issues)

- #355 — invite email has a relative setup URL + needs HTML body. Different fix path; this PR just makes the eventual login work once the URL gets fixed.
- Adding a CI guard against this class of bug (handler that takes a password but skips the decode step) — a follow-up.
