### PR TITLE
fix(frontend/tests): update users.test for invite flow + allowed_accounts

### DIFF
--- a/frontend/src/__tests__/users.test.ts
+++ b/frontend/src/__tests__/users.test.ts
@@ -985,9 +985,13 @@ describe('users/userActions', () => {
     { id: '2', email: 'user2@test.com', role: 'admin', groups: ['admins'], mfa_enabled: true }
   ];
 
+  // `allowed_accounts: []` matches the backend Group shape after the
+  // multi-cloud account-scoping work; renderGroups + state hydration
+  // now expect this field on every group, so the fixture has to carry
+  // it or deep-equal assertions diverge.
   const mockGroups = [
-    { id: 'admins', name: 'Admins', permissions: [], description: '' },
-    { id: 'developers', name: 'Developers', permissions: [], description: '' }
+    { id: 'admins', name: 'Admins', permissions: [], description: '', allowed_accounts: [] },
+    { id: 'developers', name: 'Developers', permissions: [], description: '', allowed_accounts: [] }
   ];
 
   beforeEach(() => {
@@ -1457,11 +1461,16 @@ describe('users/userModals', () => {
       expect(passwordFields?.classList.contains('hidden')).toBe(false);
     });
 
-    it('should make password required', () => {
+    it('should not mark password as required (blank invites the user)', () => {
+      // Issue #348 made password optional on create: leaving it blank
+      // emails an invite that lets the user set their own password on
+      // first login. Marking the field `required` on the form would
+      // block that flow at HTML-validation time, so userModals
+      // explicitly sets required=false on openCreateUserModal.
       userModals.openCreateUserModal();
 
       const passwordInput = document.getElementById('user-password') as HTMLInputElement;
-      expect(passwordInput?.required).toBe(true);
+      expect(passwordInput?.required).toBe(false);
     });
 
     it('should populate groups dropdown', () => {
@@ -1652,7 +1661,10 @@ describe('users/userModals', () => {
       expect(document.querySelector('.toast-error')).toBeTruthy();
     });
 
-    it('should validate empty password for new user', async () => {
+    it('should allow empty password for new user (invite flow, issue #348)', async () => {
+      // Empty password used to be a validation error; after issue #348
+      // it triggers the invite flow — createUser is called with an
+      // empty password and the backend emails a set-password link.
       userModals.openCreateUserModal();
 
       (document.getElementById('user-email') as HTMLInputElement).value = 'new@test.com';
@@ -1663,8 +1675,12 @@ describe('users/userModals', () => {
 
       await userModals.saveUser(event);
 
-      expect(api.createUser).not.toHaveBeenCalled();
-      expect(document.querySelector('.toast-error')).toBeTruthy();
+      expect(api.createUser).toHaveBeenCalled();
+      const callArg = (api.createUser as jest.Mock).mock.calls[0][0];
+      expect(callArg.email).toBe('new@test.com');
+      expect(callArg.password).toBe('');
+      // No error toast on the invite-path success.
+      expect(document.querySelector('.toast-error')).toBeNull();
     });
 
     it('should close modal after save', async () => {


### PR DESCRIPTION
## Summary

Four cases in `users.test.ts` are stale on `feat/multicloud-web-frontend` and failing on every PR-merge ref against the base — see https://github.com/LeanerCloud/CUDly/actions/runs/25825557119 (PR #336) and the same failure on https://github.com/LeanerCloud/CUDly/actions/runs/25825131269 (PR #352). Blocks the `frontend-build-sentinel` workflow across every open PR. Same shape as #337 (the factory_test.go merge glitch): pre-existing on base, every PR inherits it.

## Failures and fixes

| Test | Cause | Fix |
|---|---|---|
| `loadUsers › should load users and groups` (L1023) | `mockGroups` is missing `allowed_accounts: []` that the backend now ships on every group | Add `allowed_accounts: []` to both fixture entries |
| `loadUsers › should render groups after loading` (L1036) | Same `mockGroups` shape mismatch | Same fix |
| `openCreateUserModal › should make password required` (L1464) | Issue #348 ("invite users without a password") made password optional; userModals.ts now sets `passwordInput.required = false` so the form-level HTML validation doesn't block the invite flow | Invert the assertion: rename to "should not mark password as required (blank invites the user)" and assert `required === false` |
| `saveUser › should validate empty password for new user` (L1666) | Empty password used to be a validation error; after #348 it triggers the invite flow (`api.createUser` is called with empty password, backend emails a set-password link) | Rename to "should allow empty password for new user (invite flow)" and assert `api.createUser` is called with `password: ''` and no error toast renders |

No production code changes — this is a test-only catch-up for behavior that already shipped in #347 (allowed_accounts) and #348 (invite-without-password).

## Test plan

- [x] `npx jest --testPathPattern="users.test"` on the fix branch — 1633 passing, 0 failing.
- [ ] After merge: re-run CI on PR #336 / #352 — `frontend-build-sentinel` should go green.

## Notes

- The "invite flow" assertion is intentionally a positive check (`api.createUser` was called with empty password) rather than just removing the test, so a future regression that re-introduces the empty-password block would still fail this case.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test coverage for user management and authentication workflows to reflect current system behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/358)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->