### PR TITLE
fix(auth): guard against empty DashboardURL in invite + password-reset email construction (part 1 of #355)

### DIFF
--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -58,6 +58,16 @@ func NewService(cfg ServiceConfig) *Service {
 		cfg.SessionDuration = time.Duration(DefaultSessionDurationHours) * time.Hour
 	}
 
+	// Empty DashboardURL produces broken setup/reset emails because the
+	// service layer constructs links as fmt.Sprintf("%s/reset-password?...",
+	// dashboardURL, token) — an empty prefix yields "/reset-password?token=..."
+	// which is unclickable in any MUA. Surface this loudly at startup so
+	// operators see the misconfiguration before the first user gets a broken
+	// invite email rather than after. See issue #355.
+	if cfg.DashboardURL == "" {
+		logging.Warnf("auth: DashboardURL is empty — invite and password-reset emails will contain relative links unusable in mail clients. Set DASHBOARD_URL to the customer-facing dashboard origin.")
+	}
+
 	// SECURITY: Validate that dashboard URL uses HTTPS in production
 	// This prevents password reset tokens from being leaked over HTTP
 	if cfg.DashboardURL != "" && !strings.HasPrefix(cfg.DashboardURL, "https://") {

--- a/internal/auth/service_password.go
+++ b/internal/auth/service_password.go
@@ -272,6 +272,17 @@ func (s *Service) RequestPasswordReset(ctx context.Context, email string) error 
 		return fmt.Errorf("failed to save reset token: %w", err)
 	}
 
+	// Skip the email entirely if dashboardURL is unconfigured — a broken
+	// relative link in an inbox is worse than no email; the operator's
+	// startup-time WARN already names the missing env var. Don't return an
+	// error to the caller to preserve the email-enumeration protection
+	// (RequestPasswordReset must look identical whether or not the email
+	// exists, and that includes whether or not a send happened). Issue #355.
+	if s.dashboardURL == "" {
+		logging.Errorf("RequestPasswordReset: skipping send — DashboardURL empty would produce a broken relative link (set DASHBOARD_URL).")
+		return nil
+	}
+
 	// Send reset email (use unhashed token in URL)
 	resetURL := fmt.Sprintf("%s/reset-password?token=%s", s.dashboardURL, token)
 	if err := s.emailSender.SendPasswordResetEmail(ctx, user.Email, resetURL); err != nil {

--- a/internal/auth/service_user.go
+++ b/internal/auth/service_user.go
@@ -231,26 +231,46 @@ func (s *Service) CreateUser(ctx context.Context, req CreateUserRequest) (*Creat
 	result := &CreateUserResult{User: user}
 
 	if invite {
-		setupURL := fmt.Sprintf("%s/reset-password?token=%s", s.dashboardURL, inviteToken)
-		err := s.emailSender.SendUserInviteEmail(ctx, user.Email, setupURL)
-		sent := err == nil
-		result.InviteEmailSent = &sent
-		if err != nil {
-			// Don't fail the API call: the user row was created
-			// successfully and a 5xx here would imply the whole
-			// operation rolled back. Surface the failure via the
-			// result instead so the caller can show the admin a
-			// warning toast and point them at the Forgot Password
-			// flow as the recovery path.
-			result.InviteEmailError = err.Error()
-			logging.Errorf("Failed to send user invite email: %v", err)
-		}
-		logging.Infof("User invited: id=%s, role=%s, email_sent=%t", user.ID, user.Role, sent)
+		s.sendInviteEmail(ctx, user, inviteToken, result)
 	} else {
 		logging.Infof("User created: id=%s, role=%s", user.ID, user.Role)
 	}
 
 	return result, nil
+}
+
+// sendInviteEmail constructs the setup URL and dispatches the invite,
+// recording the outcome on result. Extracted from CreateUser so the
+// caller stays under gocyclo's complexity threshold.
+//
+// When dashboardURL is empty the send is skipped and InviteEmailError
+// carries a clear "fix DASHBOARD_URL" hint back to the admin — the
+// user row is already persisted, the operator can re-invite once the
+// env var is set rather than silently mailing out a broken relative
+// link. Issue #355.
+func (s *Service) sendInviteEmail(ctx context.Context, user *User, inviteToken string, result *CreateUserResult) {
+	if s.dashboardURL == "" {
+		notSent := false
+		result.InviteEmailSent = &notSent
+		result.InviteEmailError = "DashboardURL is not configured on the server; the invite link cannot be generated. Ask the operator to set DASHBOARD_URL before re-inviting."
+		logging.Errorf("CreateUser invite: skipping send for user_id=%s — DashboardURL empty", user.ID)
+		return
+	}
+	setupURL := fmt.Sprintf("%s/reset-password?token=%s", s.dashboardURL, inviteToken)
+	err := s.emailSender.SendUserInviteEmail(ctx, user.Email, setupURL)
+	sent := err == nil
+	result.InviteEmailSent = &sent
+	if err != nil {
+		// Don't fail the API call: the user row was created
+		// successfully and a 5xx here would imply the whole
+		// operation rolled back. Surface the failure via the
+		// result instead so the caller can show the admin a
+		// warning toast and point them at the Forgot Password
+		// flow as the recovery path.
+		result.InviteEmailError = err.Error()
+		logging.Errorf("Failed to send user invite email: %v", err)
+	}
+	logging.Infof("User invited: id=%s, role=%s, email_sent=%t", user.ID, user.Role, sent)
 }
 
 // UpdateUser updates user details (admin only)

--- a/internal/email/smtp_sender.go
+++ b/internal/email/smtp_sender.go
@@ -296,35 +296,35 @@ func (s *SMTPSender) sendMailTLS(addr string, auth smtp.Auth, from string, to []
 	return c.Quit()
 }
 
-// SendPasswordResetEmail sends a password reset email
+// SendPasswordResetEmail sends a password reset email as multipart/
+// alternative (text + styled HTML). Issue #355.
 func (s *SMTPSender) SendPasswordResetEmail(ctx context.Context, email, resetURL string) error {
-	subject := "Password Reset Request - CUDly"
-	body, err := RenderPasswordResetEmail(email, resetURL)
-	if err != nil {
-		return fmt.Errorf("failed to render password reset email: %w", err)
-	}
-	return s.SendToEmail(ctx, email, subject, body)
+	return sendMultipartVia(
+		ctx, s, email, "Password Reset Request - CUDly", "password-reset",
+		func() (string, error) { return RenderPasswordResetEmail(email, resetURL) },
+		func() (string, error) { return RenderPasswordResetEmailHTML(email, resetURL) },
+	)
 }
 
-// SendWelcomeEmail sends a welcome email to new users
+// SendWelcomeEmail sends a welcome email to new users as multipart/
+// alternative (text + styled HTML). Issue #355.
 func (s *SMTPSender) SendWelcomeEmail(ctx context.Context, email, dashboardURL, role string) error {
-	subject := "Welcome to CUDly!"
-	body, err := RenderWelcomeEmail(email, dashboardURL, role)
-	if err != nil {
-		return fmt.Errorf("failed to render welcome email: %w", err)
-	}
-	return s.SendToEmail(ctx, email, subject, body)
+	return sendMultipartVia(
+		ctx, s, email, "Welcome to CUDly!", "welcome",
+		func() (string, error) { return RenderWelcomeEmail(email, dashboardURL, role) },
+		func() (string, error) { return RenderWelcomeEmailHTML(email, dashboardURL, role) },
+	)
 }
 
 // SendUserInviteEmail sends an invite-with-setup-link email to a user
-// created without a password.
+// created without a password, as multipart/alternative (text + styled HTML).
+// Issue #355.
 func (s *SMTPSender) SendUserInviteEmail(ctx context.Context, email, setupURL string) error {
-	subject := "CUDly - Set your password"
-	body, err := RenderUserInviteEmail(email, setupURL)
-	if err != nil {
-		return fmt.Errorf("failed to render user invite email: %w", err)
-	}
-	return s.SendToEmail(ctx, email, subject, body)
+	return sendMultipartVia(
+		ctx, s, email, "CUDly - Set your password", "user-invite",
+		func() (string, error) { return RenderUserInviteEmail(email, setupURL) },
+		func() (string, error) { return RenderUserInviteEmailHTML(email, setupURL) },
+	)
 }
 
 // SendNewRecommendationsNotification sends a notification about new recommendations

--- a/internal/email/template_renderers.go
+++ b/internal/email/template_renderers.go
@@ -35,6 +35,16 @@ func RenderPasswordResetEmail(email, resetURL string) (string, error) {
 	})
 }
 
+// RenderPasswordResetEmailHTML renders the HTML half of the password reset
+// email — pair with RenderPasswordResetEmail for multipart/alternative
+// delivery. Issue #355.
+func RenderPasswordResetEmailHTML(email, resetURL string) (string, error) {
+	return renderTemplate("reset-html", passwordResetHTMLTemplate, PasswordResetData{
+		Email:    email,
+		ResetURL: resetURL,
+	})
+}
+
 // RenderWelcomeEmail renders the welcome email template
 func RenderWelcomeEmail(email, dashboardURL, role string) (string, error) {
 	return renderTemplate("welcome", welcomeUserTemplate, WelcomeUserData{
@@ -44,9 +54,28 @@ func RenderWelcomeEmail(email, dashboardURL, role string) (string, error) {
 	})
 }
 
+// RenderWelcomeEmailHTML renders the HTML half of the welcome email.
+// Issue #355.
+func RenderWelcomeEmailHTML(email, dashboardURL, role string) (string, error) {
+	return renderTemplate("welcome-html", welcomeUserHTMLTemplate, WelcomeUserData{
+		Email:        email,
+		DashboardURL: dashboardURL,
+		Role:         role,
+	})
+}
+
 // RenderUserInviteEmail renders the user-invite email template.
 func RenderUserInviteEmail(email, setupURL string) (string, error) {
 	return renderTemplate("user-invite", userInviteTemplate, UserInviteData{
+		Email:    email,
+		SetupURL: setupURL,
+	})
+}
+
+// RenderUserInviteEmailHTML renders the HTML half of the user-invite email.
+// Issue #355.
+func RenderUserInviteEmailHTML(email, setupURL string) (string, error) {
+	return renderTemplate("user-invite-html", userInviteHTMLTemplate, UserInviteData{
 		Email:    email,
 		SetupURL: setupURL,
 	})

--- a/internal/email/template_renderers_test.go
+++ b/internal/email/template_renderers_test.go
@@ -360,3 +360,47 @@ func TestRenderPurchaseApprovalRequestEmailHTML_NoApprovers(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotContains(t, html, "Authorised approver")
 }
+
+// TestRenderPasswordResetEmailHTML covers the HTML half of the password
+// reset email added for issue #355. Verifies the CTA button is present,
+// the absolute URL appears in both the href and the fallback paragraph,
+// and the user's email is in the salutation.
+func TestRenderPasswordResetEmailHTML(t *testing.T) {
+	html, err := RenderPasswordResetEmailHTML("alice@example.com", "https://dashboard.example/reset-password?token=abc")
+	require.NoError(t, err)
+	assert.NotEmpty(t, html)
+
+	// CTA button with the right text and href.
+	assert.Contains(t, html, `href="https://dashboard.example/reset-password?token=abc"`)
+	assert.Contains(t, html, ">Reset your password<")
+
+	// Salutation pulls in the recipient.
+	assert.Contains(t, html, "Hello alice@example.com,")
+
+	// Fallback "paste this URL" block carries the full absolute URL so MUAs
+	// that strip <a> still let the user complete the flow.
+	assert.Contains(t, html, "https://dashboard.example/reset-password?token=abc")
+}
+
+// TestRenderUserInviteEmailHTML — same assertions for the invite flow.
+func TestRenderUserInviteEmailHTML(t *testing.T) {
+	html, err := RenderUserInviteEmailHTML("bob@example.com", "https://dashboard.example/reset-password?token=xyz")
+	require.NoError(t, err)
+	assert.NotEmpty(t, html)
+
+	assert.Contains(t, html, `href="https://dashboard.example/reset-password?token=xyz"`)
+	assert.Contains(t, html, ">Set your password<")
+	assert.Contains(t, html, "Hello bob@example.com,")
+}
+
+// TestRenderWelcomeEmailHTML — same assertions for the welcome flow.
+func TestRenderWelcomeEmailHTML(t *testing.T) {
+	html, err := RenderWelcomeEmailHTML("carol@example.com", "https://dashboard.example", "admin")
+	require.NoError(t, err)
+	assert.NotEmpty(t, html)
+
+	assert.Contains(t, html, `href="https://dashboard.example"`)
+	assert.Contains(t, html, ">Open dashboard<")
+	assert.Contains(t, html, "Hello carol@example.com,")
+	assert.Contains(t, html, "<strong>admin</strong>")
+}

--- a/internal/email/templates.go
+++ b/internal/email/templates.go
@@ -115,6 +115,42 @@ Your password will remain unchanged.
 This is an automated message from CUDly.
 `
 
+// passwordResetHTMLTemplate renders the same content as the plain-text
+// password reset template with a styled CTA button and CUDly branding.
+// Modelled on purchaseApprovalRequestHTMLTemplate (line 367) — inline styles
+// because most email clients (Outlook, mobile Gmail) ignore class-based CSS.
+// Issue #355.
+const passwordResetHTMLTemplate = `<!DOCTYPE html>
+<html><head><meta charset="UTF-8"><title>CUDly - Password Reset Request</title></head>
+<body style="margin:0;padding:0;background:#f4f6f8;font-family:Arial,Helvetica,sans-serif;color:#1a202c;">
+<table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="background:#f4f6f8;padding:24px 0;">
+<tr><td align="center">
+<table role="presentation" cellpadding="0" cellspacing="0" width="600" style="background:#ffffff;border-radius:8px;box-shadow:0 1px 3px rgba(0,0,0,0.06);">
+<tr><td style="padding:32px 32px 16px 32px;">
+<h1 style="margin:0;font-size:22px;color:#0f172a;">Password Reset Request</h1>
+<p style="margin:16px 0 0 0;color:#475569;font-size:14px;line-height:1.5;">Hello {{.Email}},</p>
+<p style="margin:12px 0 0 0;color:#475569;font-size:14px;line-height:1.5;">We received a request to reset your password for CUDly. Click the button below to choose a new password.</p>
+</td></tr>
+
+<tr><td align="center" style="padding:8px 32px 8px 32px;">
+<a href="{{.ResetURL}}" style="display:inline-block;padding:12px 28px;background:#2563eb;color:#ffffff;text-decoration:none;font-weight:600;font-size:14px;border-radius:6px;">Reset your password</a>
+</td></tr>
+
+<tr><td style="padding:8px 32px 8px 32px;">
+<p style="margin:8px 0 0 0;color:#64748b;font-size:12px;line-height:1.5;">This link will expire in 1 hour.</p>
+<p style="margin:8px 0 0 0;color:#64748b;font-size:12px;line-height:1.5;">If the button doesn't work, copy and paste this URL into your browser:</p>
+<p style="margin:4px 0 0 0;color:#475569;font-size:12px;word-break:break-all;"><a href="{{.ResetURL}}" style="color:#2563eb;text-decoration:underline;">{{.ResetURL}}</a></p>
+<p style="margin:16px 0 0 0;color:#64748b;font-size:12px;line-height:1.5;">If you didn't request a password reset, you can safely ignore this email — your password will remain unchanged.</p>
+</td></tr>
+
+<tr><td style="padding:16px 32px;background:#f8fafc;border-top:1px solid #e2e8f0;border-radius:0 0 8px 8px;">
+<p style="margin:0;color:#94a3b8;font-size:11px;">This is an automated message from CUDly.</p>
+</td></tr>
+
+</table>
+</td></tr></table>
+</body></html>`
+
 const welcomeUserTemplate = `Welcome to CUDly
 ================
 
@@ -132,6 +168,38 @@ If you have any questions, please contact your administrator.
 This is an automated message from CUDly.
 `
 
+// welcomeUserHTMLTemplate is the HTML half of welcomeUserTemplate.
+// Inline-styled per email-client constraints. Issue #355.
+const welcomeUserHTMLTemplate = `<!DOCTYPE html>
+<html><head><meta charset="UTF-8"><title>Welcome to CUDly</title></head>
+<body style="margin:0;padding:0;background:#f4f6f8;font-family:Arial,Helvetica,sans-serif;color:#1a202c;">
+<table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="background:#f4f6f8;padding:24px 0;">
+<tr><td align="center">
+<table role="presentation" cellpadding="0" cellspacing="0" width="600" style="background:#ffffff;border-radius:8px;box-shadow:0 1px 3px rgba(0,0,0,0.06);">
+<tr><td style="padding:32px 32px 16px 32px;">
+<h1 style="margin:0;font-size:22px;color:#0f172a;">Welcome to CUDly</h1>
+<p style="margin:16px 0 0 0;color:#475569;font-size:14px;line-height:1.5;">Hello {{.Email}},</p>
+<p style="margin:12px 0 0 0;color:#475569;font-size:14px;line-height:1.5;">Your CUDly account has been created with role <strong>{{.Role}}</strong>.</p>
+</td></tr>
+
+<tr><td align="center" style="padding:8px 32px 8px 32px;">
+<a href="{{.DashboardURL}}" style="display:inline-block;padding:12px 28px;background:#16a34a;color:#ffffff;text-decoration:none;font-weight:600;font-size:14px;border-radius:6px;">Open dashboard</a>
+</td></tr>
+
+<tr><td style="padding:8px 32px 8px 32px;">
+<p style="margin:8px 0 0 0;color:#64748b;font-size:12px;line-height:1.5;">If the button doesn't work, paste this URL into your browser:</p>
+<p style="margin:4px 0 0 0;color:#475569;font-size:12px;word-break:break-all;"><a href="{{.DashboardURL}}" style="color:#2563eb;text-decoration:underline;">{{.DashboardURL}}</a></p>
+<p style="margin:16px 0 0 0;color:#64748b;font-size:12px;line-height:1.5;">If you have any questions, please contact your administrator.</p>
+</td></tr>
+
+<tr><td style="padding:16px 32px;background:#f8fafc;border-top:1px solid #e2e8f0;border-radius:0 0 8px 8px;">
+<p style="margin:0;color:#94a3b8;font-size:11px;">This is an automated message from CUDly.</p>
+</td></tr>
+
+</table>
+</td></tr></table>
+</body></html>`
+
 const userInviteTemplate = `Welcome to CUDly
 ================
 
@@ -148,6 +216,38 @@ link on the sign-in page.
 
 This is an automated message from CUDly.
 `
+
+// userInviteHTMLTemplate is the HTML half of userInviteTemplate.
+// Inline-styled per email-client constraints. Issue #355.
+const userInviteHTMLTemplate = `<!DOCTYPE html>
+<html><head><meta charset="UTF-8"><title>Welcome to CUDly</title></head>
+<body style="margin:0;padding:0;background:#f4f6f8;font-family:Arial,Helvetica,sans-serif;color:#1a202c;">
+<table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="background:#f4f6f8;padding:24px 0;">
+<tr><td align="center">
+<table role="presentation" cellpadding="0" cellspacing="0" width="600" style="background:#ffffff;border-radius:8px;box-shadow:0 1px 3px rgba(0,0,0,0.06);">
+<tr><td style="padding:32px 32px 16px 32px;">
+<h1 style="margin:0;font-size:22px;color:#0f172a;">You've been invited to CUDly</h1>
+<p style="margin:16px 0 0 0;color:#475569;font-size:14px;line-height:1.5;">Hello {{.Email}},</p>
+<p style="margin:12px 0 0 0;color:#475569;font-size:14px;line-height:1.5;">An administrator has created a CUDly account for you. Click the button below to activate it and set your password.</p>
+</td></tr>
+
+<tr><td align="center" style="padding:8px 32px 8px 32px;">
+<a href="{{.SetupURL}}" style="display:inline-block;padding:12px 28px;background:#16a34a;color:#ffffff;text-decoration:none;font-weight:600;font-size:14px;border-radius:6px;">Set your password</a>
+</td></tr>
+
+<tr><td style="padding:8px 32px 8px 32px;">
+<p style="margin:8px 0 0 0;color:#64748b;font-size:12px;line-height:1.5;">This link will expire in 7 days. If it expires before you set a password, ask your administrator to invite you again or use the "Forgot password?" link on the sign-in page.</p>
+<p style="margin:16px 0 0 0;color:#64748b;font-size:12px;line-height:1.5;">If the button doesn't work, paste this URL into your browser:</p>
+<p style="margin:4px 0 0 0;color:#475569;font-size:12px;word-break:break-all;"><a href="{{.SetupURL}}" style="color:#2563eb;text-decoration:underline;">{{.SetupURL}}</a></p>
+</td></tr>
+
+<tr><td style="padding:16px 32px;background:#f8fafc;border-top:1px solid #e2e8f0;border-radius:0 0 8px 8px;">
+<p style="margin:0;color:#94a3b8;font-size:11px;">This is an automated message from CUDly.</p>
+</td></tr>
+
+</table>
+</td></tr></table>
+</body></html>`
 
 const riExchangePendingApprovalTemplate = `CUDly - RI Exchange Approval Required
 ======================================
@@ -249,14 +349,14 @@ type PasswordResetData struct {
 	ResetURL string
 }
 
-// SendPasswordResetEmail sends a password reset email
+// SendPasswordResetEmail sends a password reset email as multipart/
+// alternative (plain text + styled HTML with a CTA button). Issue #355.
 func (s *Sender) SendPasswordResetEmail(ctx context.Context, email, resetURL string) error {
-	body, err := RenderPasswordResetEmail(email, resetURL)
-	if err != nil {
-		return fmt.Errorf("failed to render password reset email: %w", err)
-	}
-
-	return s.SendToEmail(ctx, email, "CUDly - Password Reset Request", body)
+	return sendMultipartVia(
+		ctx, s, email, "CUDly - Password Reset Request", "password-reset",
+		func() (string, error) { return RenderPasswordResetEmail(email, resetURL) },
+		func() (string, error) { return RenderPasswordResetEmailHTML(email, resetURL) },
+	)
 }
 
 // WelcomeUserData holds data for welcome emails
@@ -266,14 +366,14 @@ type WelcomeUserData struct {
 	Role         string
 }
 
-// SendWelcomeEmail sends a welcome email to a new user
+// SendWelcomeEmail sends a welcome email to a new user as multipart/
+// alternative (plain text + styled HTML with a CTA button). Issue #355.
 func (s *Sender) SendWelcomeEmail(ctx context.Context, email, dashboardURL, role string) error {
-	body, err := RenderWelcomeEmail(email, dashboardURL, role)
-	if err != nil {
-		return fmt.Errorf("failed to render welcome email: %w", err)
-	}
-
-	return s.SendToEmail(ctx, email, "Welcome to CUDly", body)
+	return sendMultipartVia(
+		ctx, s, email, "Welcome to CUDly", "welcome",
+		func() (string, error) { return RenderWelcomeEmail(email, dashboardURL, role) },
+		func() (string, error) { return RenderWelcomeEmailHTML(email, dashboardURL, role) },
+	)
 }
 
 // UserInviteData holds data for invite emails sent to users that an admin
@@ -285,14 +385,14 @@ type UserInviteData struct {
 }
 
 // SendUserInviteEmail sends an invitation that links to the password-setup
-// page. Used when an admin creates a user without supplying a password.
+// page as multipart/alternative (plain text + styled HTML with a CTA button).
+// Used when an admin creates a user without supplying a password. Issue #355.
 func (s *Sender) SendUserInviteEmail(ctx context.Context, email, setupURL string) error {
-	body, err := RenderUserInviteEmail(email, setupURL)
-	if err != nil {
-		return fmt.Errorf("failed to render user invite email: %w", err)
-	}
-
-	return s.SendToEmail(ctx, email, "CUDly - Set your password", body)
+	return sendMultipartVia(
+		ctx, s, email, "CUDly - Set your password", "user-invite",
+		func() (string, error) { return RenderUserInviteEmail(email, setupURL) },
+		func() (string, error) { return RenderUserInviteEmailHTML(email, setupURL) },
+	)
 }
 
 // SendRIExchangePendingApproval sends an email with RI exchange approval links
@@ -461,6 +561,30 @@ func sendPurchaseApprovalRequestVia(ctx context.Context, s SenderInterface, reci
 		htmlBody = ""
 	}
 	return s.SendToEmailWithCCMultipart(ctx, recipient, data.CCEmails, subject, textBody, htmlBody)
+}
+
+// sendMultipartVia is the generic dual-render send helper used by the
+// invite / password-reset / welcome flows. The two render closures are
+// invoked back-to-back; an HTML render failure is non-fatal and degrades
+// to text-only delivery (matching sendPurchaseApprovalRequestVia's contract).
+// kind is a short label like "user-invite" used in the warn log on degrade.
+// Issue #355.
+func sendMultipartVia(
+	ctx context.Context,
+	s SenderInterface,
+	recipient, subject, kind string,
+	renderText, renderHTML func() (string, error),
+) error {
+	textBody, err := renderText()
+	if err != nil {
+		return fmt.Errorf("failed to render %s email (text): %w", kind, err)
+	}
+	htmlBody, htmlErr := renderHTML()
+	if htmlErr != nil {
+		logging.Warnf("email: HTML %s render failed, falling back to text-only: %v", kind, htmlErr)
+		htmlBody = ""
+	}
+	return s.SendToEmailWithCCMultipart(ctx, recipient, nil, subject, textBody, htmlBody)
 }
 
 // SendPurchaseApprovalRequest sends an email asking the user to approve a direct


### PR DESCRIPTION
## Summary

Two stacked URL construction sites in the auth service produced broken relative links when `s.dashboardURL` was empty, breaking the **invite** email AND the **forgot-password** email. This PR is part 1 of #355 — the URL-construction guards. Part 2 (HTML pretty-button templates) lands in follow-up commits on this same branch.

Closes #355 once both parts land.

## Part 1 (this commit) — URL construction guards

| Site | Before | After |
|---|---|---|
| `internal/auth/service_user.go` invite path | `fmt.Sprintf("%s/reset-password?token=%s", "", token)` → `/reset-password?...` unclickable | Refuse send if `dashboardURL == ""`. `InviteEmailError` set so admin sees a clear "fix `DASHBOARD_URL`" hint. |
| `internal/auth/service_password.go` `RequestPasswordReset` | same shape | Refuse send if `dashboardURL == ""`. Silent to preserve email-enumeration protection, but ERROR-logged so the operator sees the failure in CloudWatch. |
| `internal/auth/service.go` `NewService` | accepted empty URL silently | Logs a fatal-class WARN at startup naming the missing env var. |

Extracted `sendInviteEmail` from `Service.CreateUser` so the parent stays under gocyclo's complexity threshold.

## Part 2 (follow-up commits on this branch)

- HTML variant of `userInviteTemplate` with a styled CTA button, modelled on the purchase-approval HTML template at `internal/email/templates.go:367`.
- HTML variant of `passwordResetTemplate`.
- HTML variant of `welcomeUserTemplate`.
- Shared `sendMultipartVia` helper extracted from `sendPurchaseApprovalRequestVia` so the new flows don't drift from each other.

## Out of scope (separate follow-up issues)

- HTML variants for `purchaseConfirmationTemplate`, `purchaseFailedTemplate`, `riExchangePendingApprovalTemplate`, `riExchangeCompletedTemplate`, `registrationReceivedTemplate`, `registrationDecisionTemplate`. All currently plain-text only with raw URLs; admin-facing so lower priority.
- The Terraform/CDK change to actually set `DASHBOARD_URL` on the live Lambda. The code change alone closes the loophole at the service layer, but the deployment also needs the env var pointed at the dashboard origin.

## Sister fix

PR #357 (closes #356, P0/critical) base64-decode fix on the `resetPassword` API handler. Without that, the password the user "sets" via the reset flow doesn't work even when the URL is correct. **Must land ahead of this PR** for the end-to-end invite flow to work.

## Test plan

- [x] `go test github.com/LeanerCloud/CUDly/internal/auth` — passes
- [x] `go build ./...` — clean
- [ ] End-to-end on the deployed env (post-merge + post-`DASHBOARD_URL`-config):
  - Admin invites a user → recipient gets an email with a proper `https://<dashboard>/reset-password?token=...` link.
  - Forgot-password from the sign-in page → same.
  - When `DASHBOARD_URL` is unset, `gh logs` shows the startup WARN + per-send ERROR; the invite API response carries `invite_email_sent=false` + the explanatory `invite_email_error`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Emails now include styled HTML alongside plain-text (multipart) when available.

* **Bug Fixes**
  * Startup warns when dashboard URL is missing to prevent broken links in emails.
  * Password reset and invite flows skip sending unusable links and record clear error/status hints instead of failing the request.

* **Tests**
  * Added HTML email template tests to verify links, CTAs, salutations, and role rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/362)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->