### PR TITLE
fix(terraform/aws): add dashboard_url override for Lambda-Function-URL deployments (follow-up to #355)

### DIFF
--- a/terraform/environments/aws/github-dev.tfvars
+++ b/terraform/environments/aws/github-dev.tfvars
@@ -81,6 +81,14 @@ recommendation_schedule = "rate(1 day)"
 #   TF_VAR_image_uri      = (from build step)
 #   TF_VAR_subdomain_zone_name    = cudly.leanercloud.com
 #   TF_VAR_frontend_domain_names  = ["lambda-dev.cudly.leanercloud.com"]
+#   TF_VAR_dashboard_url  = "https://<lambda-function-url-host>"
+#     # Set this only when serving from a raw Lambda Function URL — i.e.
+#     # frontend_domain_names is not pointing at a Route53/ACM-fronted
+#     # custom domain. Bootstrap: run `terraform apply` once, then
+#     # `terraform output frontend_url` gives the value; copy it in here
+#     # and re-apply so DASHBOARD_URL is persisted in the Lambda env (the
+#     # auth Service refuses to send invite/password-reset emails when
+#     # DASHBOARD_URL is empty — see #355).
 #   TF_VAR_from_email     = ${{ secrets.FROM_EMAIL }}
 #     # Required when subdomain_zone_name is unset. Must be an SES-verified
 #     # identity in the target account. Without it, FROM_EMAIL reaches the

--- a/terraform/environments/aws/main.tf
+++ b/terraform/environments/aws/main.tf
@@ -53,9 +53,25 @@ resource "random_id" "suffix" {
 
 locals {
   stack_name = "${var.project_name}-${var.environment}-${random_id.suffix.hex}"
-  # Dashboard URL for CORS and email links
-  # Priority: custom domain > CDN domain > compute default endpoint
-  dashboard_url = length(var.frontend_domain_names) > 0 ? "https://${var.frontend_domain_names[0]}" : ""
+  # Dashboard URL for CORS and email links.
+  #
+  # Priority (matches outputs.tf's frontend_url chain, modulo the Lambda
+  # Function URL tier which can't go here without a dependency cycle —
+  # see var.dashboard_url for the explanation):
+  #   1. var.dashboard_url (explicit override — used when serving from
+  #      a raw Lambda Function URL, since Terraform locals can't
+  #      reference module.compute_lambda.function_url without a cycle).
+  #   2. var.frontend_domain_names[0] (custom domain fronted by
+  #      ACM + Route53 — set together with subdomain_zone_name).
+  #   3. Empty — the auth Service refuses to send invite / password-reset
+  #      emails when this is empty (see internal/auth/service.go's
+  #      startup WARN + service_user.go / service_password.go per-send
+  #      guards) so a misconfigured deployment doesn't ship broken links.
+  dashboard_url = (
+    var.dashboard_url != "" ? var.dashboard_url :
+    length(var.frontend_domain_names) > 0 ? "https://${var.frontend_domain_names[0]}" :
+    ""
+  )
 
   # FROM_EMAIL resolution order:
   #   1. Explicit var.from_email (use when subdomain_zone_name is unset

--- a/terraform/environments/aws/variables.tf
+++ b/terraform/environments/aws/variables.tf
@@ -414,6 +414,36 @@ variable "rds_cluster_id_for_rotation" {
   }
 }
 
+variable "dashboard_url" {
+  description = <<-EOT
+    Customer-facing dashboard origin used for email links (invite, password
+    reset, welcome) and as the default for CORS_ALLOWED_ORIGIN. Takes
+    precedence over frontend_domain_names.
+
+    Set this for deployments that serve the dashboard from somewhere
+    Terraform can't safely auto-derive — typically a raw Lambda Function
+    URL. The Lambda Function URL only exists after the function is
+    created, but locals can't reference module.compute_lambda outputs
+    without creating a dependency cycle (the same module consumes
+    local.dashboard_url via additional_env_vars), so the operator
+    bootstraps this manually: run `terraform apply` once, copy
+    `terraform output frontend_url`, set the value here, re-apply.
+
+    Leave empty to use the existing chain (frontend_domain_names →
+    empty), which is correct for deployments with a custom domain
+    fronted by ACM + Route53 already configured.
+
+    Must include the scheme. Must NOT have a trailing slash.
+  EOT
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.dashboard_url == "" || can(regex("^https?://[^/]+(?::[0-9]+)?$", var.dashboard_url))
+    error_message = "dashboard_url must be empty OR a scheme + host (+ optional port), with no trailing slash and no path."
+  }
+}
+
 variable "frontend_domain_names" {
   description = <<-EOT
     Custom domain names for the frontend CloudFront distribution. The first

--- a/terraform/environments/aws/variables.tf
+++ b/terraform/environments/aws/variables.tf
@@ -439,8 +439,18 @@ variable "dashboard_url" {
   default     = ""
 
   validation {
-    condition     = var.dashboard_url == "" || can(regex("^https?://[^/]+(?::[0-9]+)?$", var.dashboard_url))
-    error_message = "dashboard_url must be empty OR a scheme + host (+ optional port), with no trailing slash and no path."
+    # Empty short-circuit, or a strict scheme + host (+ optional port).
+    # Pattern breakdown:
+    #   ^https?://                        scheme: http or https
+    #   (?:                               host: one of...
+    #     [A-Za-z0-9.-]+                    hostname / FQDN (letters, digits, dots, dashes)
+    #     |\\[[0-9A-Fa-f:]+\\]              OR bracketed IPv6 literal, e.g. [::1]
+    #   )
+    #   (?::[0-9]+)?                      optional numeric port
+    #   $                                 end-of-string — no path, query (?…),
+    #                                     fragment (#…), or userinfo (user@…)
+    condition     = var.dashboard_url == "" || can(regex("^https?://(?:[A-Za-z0-9.-]+|\\[[0-9A-Fa-f:]+\\])(?::[0-9]+)?$", var.dashboard_url))
+    error_message = "dashboard_url must be empty OR scheme + host (+ optional port). No trailing slash, path, query string, fragment, or userinfo (user@) allowed; the dashboard URL is used as an origin only."
   }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #355: even with PR #362's app-layer guards in place, the dev Lambda deployment had `DASHBOARD_URL=""` because `local.dashboard_url` (used to build the env var) only fell back to custom domains, not to the Lambda Function URL itself. Operators of any Lambda-Function-URL deployment without a custom domain configured got silent email loss.

This PR adds a `var.dashboard_url` tfvar that takes priority over `var.frontend_domain_names`, so operators can bootstrap the env var manually for Function-URL deployments.

## Why not just read `module.compute_lambda[0].function_url` directly?

Dependency cycle. The same module consumes `additional_env_vars` (which contains `local.dashboard_url`), so referencing its output from the local would mean:

```
local.dashboard_url  →  module.compute_lambda.function_url
                      ↗  (output of the lambda function URL resource)
                     ↗  (depends on the lambda function resource)
                    ↗  (which depends on additional_env_vars)
                   ↗  (which depends on local.dashboard_url)  ← cycle
```

The workable Terraform-only path is a manual bootstrap:
1. First `terraform apply` — `DASHBOARD_URL=""` in the env, app refuses to send.
2. `terraform output frontend_url` — gives the function URL.
3. Set `dashboard_url = "<that value>"` in tfvars.
4. Re-apply — `DASHBOARD_URL` is now persisted across deploys.

The trace was: `local.dashboard_url` priority chain (`main.tf:58`) was shallower than the `frontend_url` output's chain (`outputs.tf:195-200`), which already handles all four tiers correctly. This PR closes the gap with a single override variable (the cycle prevents a direct mirror).

## Changes

- `terraform/environments/aws/variables.tf` — new `dashboard_url` variable with validation (must include scheme, no trailing slash, no path).
- `terraform/environments/aws/main.tf` — `local.dashboard_url` checks the new var first, then falls back to the existing `frontend_domain_names` path. Comment refreshed to spell out why the Lambda-Function-URL tier can't live here.
- `terraform/environments/aws/github-dev.tfvars` — comment updated to call out the new tfvar + the bootstrap pattern. The CI/CD `TF_VAR_dashboard_url` line is documented but not hard-coded (it's per-environment).

## Test plan

- [x] `terraform fmt -check -recursive` clean.
- [ ] `terraform validate` — not run locally; this PR's CI will exercise it against the prod state backend.
- [ ] After merge + apply on dev: `DASHBOARD_URL` in the Lambda env survives subsequent applies (no longer reset to empty by `additional_env_vars` reconciliation).

## Out of scope

- Auto-populating `dashboard_url` for CDN / Fargate / custom-domain deployments — those already work via the existing chain. The new tfvar is the Lambda-Function-URL escape hatch.
- The temporary `aws lambda update-function-configuration` env-var poke applied directly to the live Lambda earlier today gets clobbered by the next `terraform apply` until this PR's `dashboard_url` tfvar value is set in the dev CI/CD pipeline. That's the operational follow-up.

## Sister PRs

- **#362** (open) — auth-layer guards that REFUSE to send broken emails when `DASHBOARD_URL` is empty + HTML CTA-button templates. The code change works as designed; this PR fills in the IaC half.
- **#357** (open) — P0 base64-decode on the reset-password handler. Lands first; without it, the password set via the reset link doesn't work even when the URL is right.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new dashboard_url configuration option to specify a custom dashboard origin for email links and CORS headers; it can be set explicitly or will fall back to existing frontend domain values when unset.
* **Documentation**
  * Included guidance on when to set the dashboard_url and the expected http/https host-only format (no trailing slash, path, query, fragment, or userinfo).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/363)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->