### PR TITLE
chore(ci): pass TF_VAR_dashboard_url into AWS Lambda deploy workflow (follow-up to #363)

### DIFF
--- a/.github/workflows/deploy-aws-lambda.yml
+++ b/.github/workflows/deploy-aws-lambda.yml
@@ -139,6 +139,14 @@ jobs:
         env:
           TF_VAR_admin_email: ${{ secrets.ADMIN_EMAIL }}
           TF_VAR_from_email: ${{ secrets.FROM_EMAIL }}
+          # DASHBOARD_URL is the customer-facing dashboard origin used in
+          # email links (invite, password reset, welcome). For Lambda-
+          # Function-URL deployments (no custom domain), set the repo
+          # secret DASHBOARD_URL to the function URL — see #363 +
+          # github-dev.tfvars for the bootstrap pattern. Empty string is
+          # accepted by the var (the Terraform local then falls back to
+          # frontend_domain_names[0]).
+          TF_VAR_dashboard_url: ${{ secrets.DASHBOARD_URL }}
         run: |
           cd terraform/environments/aws
           terraform plan \
@@ -150,6 +158,14 @@ jobs:
         env:
           TF_VAR_admin_email: ${{ secrets.ADMIN_EMAIL }}
           TF_VAR_from_email: ${{ secrets.FROM_EMAIL }}
+          # DASHBOARD_URL is the customer-facing dashboard origin used in
+          # email links (invite, password reset, welcome). For Lambda-
+          # Function-URL deployments (no custom domain), set the repo
+          # secret DASHBOARD_URL to the function URL — see #363 +
+          # github-dev.tfvars for the bootstrap pattern. Empty string is
+          # accepted by the var (the Terraform local then falls back to
+          # frontend_domain_names[0]).
+          TF_VAR_dashboard_url: ${{ secrets.DASHBOARD_URL }}
         run: |
           cd terraform/environments/aws
           terraform apply -auto-approve tfplan

--- a/.github/workflows/deploy-aws-lambda.yml
+++ b/.github/workflows/deploy-aws-lambda.yml
@@ -105,6 +105,14 @@ jobs:
     name: Build & Deploy
     runs-on: ubuntu-24.04-arm  # ARM runner: Docker build targets linux/arm64 (Lambda/Fargate Graviton2)
     needs: prepare
+    # Bind to the named GitHub Environment matching the target so
+    # secrets.* resolve to environment-scoped values when defined,
+    # falling back to repo-scoped secrets otherwise. Without this,
+    # DASHBOARD_URL (and any other per-env secret like FROM_EMAIL,
+    # ADMIN_EMAIL) would be repo-wide and dev/staging/prod would
+    # all share one value — producing wrong email links in customer
+    # mailboxes. Per CR review on PR #368.
+    environment: ${{ needs.prepare.outputs.environment }}
     outputs:
       function_url: ${{ steps.outputs.outputs.function_url }}
       function_name: ${{ steps.outputs.outputs.function_name }}


### PR DESCRIPTION
## Summary

Follow-up to #363 (merged). #363 added `var.dashboard_url` to the AWS Terraform environment. This PR threads it into the deploy workflow so the dev (and any future) Lambda gets `DASHBOARD_URL` populated on every apply — closing the loop on the recurring email-link bug that's been clobbering my one-off `aws lambda update-function-configuration` pokes.

Without this commit: `TF_VAR_dashboard_url` is never set in CI, `local.dashboard_url` evaluates to `""`, `additional_env_vars` writes `DASHBOARD_URL=""` to the Lambda, the auth service refuses to send invite / password-reset emails, operator sees `"DashboardURL is not configured on the server"` in the toast. Exactly the loop @cmagherusan just hit on `aniqa@archera.ai`.

## What changes

`.github/workflows/deploy-aws-lambda.yml` — adds `TF_VAR_dashboard_url: ${{ secrets.DASHBOARD_URL }}` to both the `Terraform Plan` and `Terraform Apply` env blocks. Matches the existing pattern used by `TF_VAR_admin_email` (line 140 / 151) and `TF_VAR_from_email` (line 141 / 152). One source of truth (repo secret), one threaded path (workflow env), no special-casing per environment.

## Required operator action after merge

**Set the GitHub repo secret `DASHBOARD_URL`** per environment that uses this workflow:

| Environment | Value |
|---|---|
| dev (current) | `https://33pz7pombdqwu3bdlxp4lqxyra0bsriy.lambda-url.us-east-1.on.aws` |
| staging / prod | Either the Lambda Function URL for that environment, OR leave empty if `frontend_domain_names` is configured with a custom domain (Terraform falls back to the existing chain). |

Once the secret is in place, the very next deploy persists `DASHBOARD_URL` to the Lambda env permanently — no more manual pokes that get clobbered.

## Test plan

- [x] Workflow YAML syntactically valid (env block matches existing pattern).
- [ ] After merge + set repo secret + trigger deploy:
  - `aws lambda get-function-configuration --function-name cudly-dev-* | grep DASHBOARD_URL` returns the Function URL.
  - Re-invite a user → invite email lands with a proper absolute link.
  - Trigger a forgot-password → reset email lands.
  - Subsequent deploys leave the value intact (no more reset to empty).

## Related

- #363 (merged) — Terraform variable definition + local priority chain.
- #355 (open via #362) — auth-layer guards + HTML CTA-button email templates.
- #357 (open) — P0 base64-decode on the reset-password handler so the password the user sets via the link actually works.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated AWS Lambda deployment workflow to support configurable dashboard URL through GitHub secrets, enabling flexible environment configuration during deployments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/368)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->