### PR TITLE
fix(purchases): approve now executes synchronously and parallel across recs (closes #372)

### DIFF
--- a/internal/api/handler_history.go
+++ b/internal/api/handler_history.go
@@ -64,13 +64,16 @@ func (h *Handler) getHistory(ctx context.Context, req *events.LambdaFunctionURLR
 
 // historyExecutionStatuses enumerates the PurchaseExecution statuses the
 // History view shows alongside completed purchases. "approved" and
-// "completed" are excluded because an approved execution becomes a
-// purchase_history row once the scheduler processes it, and completed
-// executions live in purchase_history directly — listing them here would
-// duplicate rows. Everything else (pending, notified, failed, expired,
-// cancelled) is a terminal or in-flight state the user needs audit-trail
-// visibility into: a cancelled purchase that simply vanishes is worse UX
-// than a cancelled row with a clear badge.
+// "completed" are excluded because approval now executes synchronously
+// (issue #372): an Approve click drives the row through "approved" inside
+// a single HTTP request and lands on either "completed" (already in
+// purchase_history) or "failed" (which is in this list). Listing
+// "approved" would either duplicate a completed row or surface a ghost
+// row that no longer exists from the user's perspective. The remaining
+// states (pending, notified, failed, expired, cancelled) are terminal or
+// in-flight states the user needs audit-trail visibility into: a
+// cancelled purchase that simply vanishes is worse UX than a cancelled
+// row with a clear badge.
 var historyExecutionStatuses = []string{"pending", "notified", "failed", "expired", "cancelled"}
 
 // approvalExpiryWindow is how long a pending approval stays actionable

--- a/internal/api/handler_purchases.go
+++ b/internal/api/handler_purchases.go
@@ -310,21 +310,33 @@ func (h *Handler) approvePurchase(ctx context.Context, req *events.LambdaFunctio
 		if err != nil {
 			return nil, err
 		}
+		// ApproveExecution now runs the purchase synchronously inside the
+		// same call (issue #372). When it returns nil the AWS API call
+		// has already happened, so the response surfaces "completed"
+		// instead of the transient "approved" the old no-op flow returned.
 		if err := h.purchase.ApproveExecution(ctx, execID, token, actor); err != nil {
 			return nil, err
 		}
-		return map[string]string{"status": "approved"}, nil
+		return map[string]string{"status": "completed"}, nil
 	}
 
 	return h.approvePurchaseViaSession(ctx, req, execution)
 }
 
 // approvePurchaseViaSession is the session-authed branch of approvePurchase.
-// Enforces the approve-any/approve-own RBAC matrix, validates the execution
-// is in an approvable state (pending|notified), flips the row to "approved"
-// and stamps session.Email onto ApprovedBy. Mirrors cancelPurchaseViaSession
-// minus the suppressions cleanup (approve doesn't drop suppressions —
-// suppressions persist through the approval and only clear on cancel/expiry).
+// Enforces the approve-any/approve-own RBAC matrix, then hands off to
+// purchase.Manager.ApproveAndExecute which atomically flips the row to
+// "approved" (stamping session.Email onto ApprovedBy) and runs the
+// purchase synchronously. The synchronous-execute is what closes the gap
+// from issue #372 — pre-fix, approval was a no-op beyond the status flip
+// because no scheduler picked the "approved" row up for the Lambda
+// deployment.
+//
+// Concurrency: ApproveAndExecute uses an atomic transition, so two
+// in-flight Approve clicks on the same execution see exactly one win.
+// Approvals across different executions run independently — each HTTP
+// invocation drives its own executeAndFinalize, which already fans out
+// per-account in parallel via executeMultiAccount.
 func (h *Handler) approvePurchaseViaSession(ctx context.Context, req *events.LambdaFunctionURLRequest, execution *config.PurchaseExecution) (any, error) {
 	session, err := h.requireSession(ctx, req)
 	if err != nil {
@@ -339,20 +351,16 @@ func (h *Handler) approvePurchaseViaSession(ctx context.Context, req *events.Lam
 		return nil, err
 	}
 
-	// Flip status + stamp ApprovedBy. The optimistic-locking guard inside
-	// the tx (status IN ('pending','notified')) prevents a concurrent
-	// cancel from landing on top of us — if the status drifted, the
-	// UPDATE 0-rows the row count and we 409 cleanly.
-	execution.Status = "approved"
-	if session.Email != "" {
-		actor := session.Email
-		execution.ApprovedBy = &actor
-	}
-	if err := h.config.SavePurchaseExecution(ctx, execution); err != nil {
-		return nil, NewClientError(409, fmt.Sprintf("execution %s cannot be approved: %v", execution.ExecutionID, err))
+	if err := h.purchase.ApproveAndExecute(ctx, execution.ExecutionID, session.Email); err != nil {
+		// ApproveAndExecute returns either a transition error (the row
+		// drifted out of pending/notified between our check and the UPDATE
+		// — race with cancel/expire) or an execution error (AWS API failed,
+		// status is now "failed" on disk). Both surface as 409 to the
+		// caller; the History view shows the resulting row state.
+		return nil, NewClientError(409, fmt.Sprintf("execution %s could not be approved: %v", execution.ExecutionID, err))
 	}
 
-	return map[string]string{"status": "approved"}, nil
+	return map[string]string{"status": "completed"}, nil
 }
 
 // authorizeSessionApprove returns nil when the session is permitted to

--- a/internal/api/handler_purchases_test.go
+++ b/internal/api/handler_purchases_test.go
@@ -70,8 +70,11 @@ func TestHandler_approvePurchase(t *testing.T) {
 	result, err := handler.approvePurchase(ctx, req, execID, "valid-token")
 	require.NoError(t, err)
 
+	// Issue #372: approve now also executes synchronously, so the JSON
+	// response surfaces the final state instead of the transient
+	// "approved" the old no-op flow returned.
 	resultMap := result.(map[string]string)
-	assert.Equal(t, "approved", resultMap["status"])
+	assert.Equal(t, "completed", resultMap["status"])
 }
 
 func TestHandler_cancelPurchase(t *testing.T) {
@@ -267,7 +270,93 @@ func TestHandler_approvePurchase_AcceptsContactEmailSession(t *testing.T) {
 	}
 	result, err := handler.approvePurchase(ctx, req, execID, "valid-token")
 	require.NoError(t, err)
-	assert.Equal(t, "approved", result.(map[string]string)["status"])
+	// Issue #372: response now reflects post-execute state.
+	assert.Equal(t, "completed", result.(map[string]string)["status"])
+}
+
+// TestHandler_approvePurchase_SessionApproveAnyChainsToExecute pins the
+// session-authed branch added by issue #286 + made functional by issue
+// #372: when an admin / approve-any session clicks Approve from the
+// dashboard, the handler must call ApproveAndExecute (NOT
+// ApproveExecution), and the JSON response must surface the post-execute
+// status. This is the regression test for the bug where approval was a
+// no-op beyond the status flip on the Lambda deployment.
+func TestHandler_approvePurchase_SessionApproveAnyChainsToExecute(t *testing.T) {
+	ctx := context.Background()
+	execID := "12345678-1234-1234-1234-123456789abc"
+	adminEmail := "admin@example.com"
+
+	mockConfig := new(MockConfigStore)
+	exec := &config.PurchaseExecution{
+		ExecutionID:   execID,
+		ApprovalToken: "valid-token",
+		Status:        "pending",
+		Recommendations: []config.RecommendationRecord{
+			{ID: "r1"},
+		},
+	}
+	mockConfig.On("GetExecutionByID", ctx, execID).Return(exec, nil)
+
+	mockAuth := new(MockAuthService)
+	mockAuth.On("ValidateSession", ctx, "sess-tok").Return(&Session{Email: adminEmail, Role: "admin"}, nil)
+
+	mockPurchase := new(MockPurchaseManager)
+	// CRITICAL ASSERTION: session-authed approve goes through
+	// ApproveAndExecute, not ApproveExecution. The token-only path runs
+	// ApproveExecution; the dashboard click runs ApproveAndExecute. Both
+	// converge inside the Manager.
+	mockPurchase.On("ApproveAndExecute", ctx, execID, adminEmail).Return(nil)
+
+	handler := &Handler{purchase: mockPurchase, config: mockConfig, auth: mockAuth}
+
+	req := &events.LambdaFunctionURLRequest{
+		Headers: map[string]string{"authorization": "Bearer sess-tok"},
+	}
+	// Empty token forces the dashboard branch.
+	result, err := handler.approvePurchase(ctx, req, execID, "")
+	require.NoError(t, err)
+	assert.Equal(t, "completed", result.(map[string]string)["status"])
+	mockPurchase.AssertExpectations(t)
+	mockPurchase.AssertNotCalled(t, "ApproveExecution")
+}
+
+// TestHandler_approvePurchase_SessionExecuteFailureSurfacesAs409 pins the
+// failure shape: when ApproveAndExecute returns an error (e.g. the AWS
+// purchase fails or the row drifted out of pending/notified mid-flight),
+// the session handler surfaces it as a 409 instead of the optimistic
+// "approved" the pre-fix flow returned. Mirrors the rationale in
+// approvePurchaseViaSession.
+func TestHandler_approvePurchase_SessionExecuteFailureSurfacesAs409(t *testing.T) {
+	ctx := context.Background()
+	execID := "12345678-1234-1234-1234-123456789abc"
+	adminEmail := "admin@example.com"
+
+	mockConfig := new(MockConfigStore)
+	exec := &config.PurchaseExecution{
+		ExecutionID:     execID,
+		ApprovalToken:   "valid-token",
+		Status:          "pending",
+		Recommendations: []config.RecommendationRecord{{ID: "r1"}},
+	}
+	mockConfig.On("GetExecutionByID", ctx, execID).Return(exec, nil)
+
+	mockAuth := new(MockAuthService)
+	mockAuth.On("ValidateSession", ctx, "sess-tok").Return(&Session{Email: adminEmail, Role: "admin"}, nil)
+
+	mockPurchase := new(MockPurchaseManager)
+	mockPurchase.On("ApproveAndExecute", ctx, execID, adminEmail).Return(errors.New("AWS RI purchase failed"))
+
+	handler := &Handler{purchase: mockPurchase, config: mockConfig, auth: mockAuth}
+
+	req := &events.LambdaFunctionURLRequest{
+		Headers: map[string]string{"authorization": "Bearer sess-tok"},
+	}
+	_, err := handler.approvePurchase(ctx, req, execID, "")
+	require.Error(t, err)
+	ce, ok := IsClientError(err)
+	require.True(t, ok, "expected a clientError")
+	assert.Equal(t, 409, ce.code)
+	assert.Contains(t, ce.Error(), "could not be approved")
 }
 
 func TestHandler_approvePurchase_RejectsGlobalNotifyWhenContactSet(t *testing.T) {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -759,7 +759,9 @@ func TestHandler_HandleRequest_ApprovePurchase(t *testing.T) {
 	var body map[string]string
 	err = json.Unmarshal([]byte(resp.Body), &body)
 	require.NoError(t, err)
-	assert.Equal(t, "approved", body["status"])
+	// Issue #372: approve now executes synchronously; response reports
+	// the post-execute state.
+	assert.Equal(t, "completed", body["status"])
 }
 
 func TestHandler_HandleRequest_CancelPurchase(t *testing.T) {

--- a/internal/api/mocks_test.go
+++ b/internal/api/mocks_test.go
@@ -577,6 +577,11 @@ func (m *MockPurchaseManager) ApproveExecution(ctx context.Context, execID, toke
 	return args.Error(0)
 }
 
+func (m *MockPurchaseManager) ApproveAndExecute(ctx context.Context, execID, actor string) error {
+	args := m.Called(ctx, execID, actor)
+	return args.Error(0)
+}
+
 func (m *MockPurchaseManager) CancelExecution(ctx context.Context, execID, token, actor string) error {
 	args := m.Called(ctx, execID, token, actor)
 	return args.Error(0)

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -134,6 +134,7 @@ type BreakdownValue struct {
 // the notification email at render time.
 type PurchaseManagerInterface interface {
 	ApproveExecution(ctx context.Context, execID, token, actor string) error
+	ApproveAndExecute(ctx context.Context, execID, actor string) error
 	CancelExecution(ctx context.Context, execID, token, actor string) error
 }
 

--- a/internal/purchase/approvals.go
+++ b/internal/purchase/approvals.go
@@ -10,19 +10,19 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
-// ApproveExecution approves a pending execution. actor carries the email
-// of the session-authenticated user who clicked approve (from the
-// HTTP route gated by authorizeApprovalAction) or the actor_email
-// carried by an SQS approve message after verifyAsyncApprovalActor has
-// validated it against the per-account contact_email approver list.
-// Both call paths now enforce the approver gate before reaching this
-// function — actor is empty only on legacy in-process callers (tests,
-// older code paths) and is recorded as nil so we don't claim "approved
+// ApproveExecution is the token-authenticated approve entry point used by
+// the legacy email-link flow and the SQS approve worker. After validating
+// the approval token it hands off to ApproveAndExecute, which performs the
+// atomic status transition and runs the AWS purchase synchronously.
+//
+// actor carries the email of the operator who triggered the approval
+// (session-authed click on the HTTP path; verified actor_email on the SQS
+// path) so it can be stamped onto ApprovedBy. Empty actor is recorded as
+// NULL — the column is nullable TEXT and we don't want to claim "approved
 // by nobody".
 func (m *Manager) ApproveExecution(ctx context.Context, executionID, token, actor string) error {
 	logging.Infof("Approving execution: %s", executionID)
 
-	// Get the execution
 	execution, err := m.config.GetExecutionByID(ctx, executionID)
 	if err != nil {
 		return fmt.Errorf("failed to get execution: %w", err)
@@ -31,7 +31,7 @@ func (m *Manager) ApproveExecution(ctx context.Context, executionID, token, acto
 		return fmt.Errorf("execution not found: %s", executionID)
 	}
 
-	// Validate token using constant-time comparison to prevent timing attacks
+	// Validate token using constant-time comparison to prevent timing attacks.
 	if execution.ApprovalToken == "" || token == "" {
 		return fmt.Errorf("invalid approval token")
 	}
@@ -39,25 +39,43 @@ func (m *Manager) ApproveExecution(ctx context.Context, executionID, token, acto
 		return fmt.Errorf("invalid approval token")
 	}
 
-	// Check status
-	if execution.Status != "pending" && execution.Status != "notified" {
-		return fmt.Errorf("execution cannot be approved, current status: %s", execution.Status)
+	return m.ApproveAndExecute(ctx, executionID, actor)
+}
+
+// ApproveAndExecute atomically flips a pending/notified execution to
+// "approved" (stamping ApprovedBy) and then runs the purchase
+// synchronously, returning the final outcome. Callers MUST have already
+// authorized the actor — this method does no RBAC or token validation; it
+// is shared between:
+//
+//   - ApproveExecution (token path: token validated by the caller)
+//   - approvePurchaseViaSession (session path: RBAC validated by the caller)
+//
+// Concurrency: TransitionExecutionStatus uses an atomic UPDATE WHERE status
+// IN ('pending','notified'). Two callers racing to approve the same row
+// will see exactly one win — the loser receives a clear "cannot
+// transition" error. Cross-execution concurrency is unaffected: each
+// approval drives its own executeAndFinalize, which already fans out
+// per-account in parallel via executeMultiAccount.
+func (m *Manager) ApproveAndExecute(ctx context.Context, executionID, actor string) error {
+	updated, err := m.config.TransitionExecutionStatus(ctx, executionID, []string{"pending", "notified"}, "approved")
+	if err != nil {
+		return fmt.Errorf("approve: %w", err)
 	}
 
-	// Update status + attribution (nil when actor is empty — the store
-	// column is nullable TEXT and we don't want to record an empty string
-	// as "approved by nobody").
-	execution.Status = "approved"
 	if actor != "" {
 		a := actor
-		execution.ApprovedBy = &a
-	}
-	if err := m.config.SavePurchaseExecution(ctx, execution); err != nil {
-		return fmt.Errorf("failed to save execution: %w", err)
+		updated.ApprovedBy = &a
+		if saveErr := m.config.SavePurchaseExecution(ctx, updated); saveErr != nil {
+			// Attribution is best-effort once the atomic flip has landed —
+			// dropping ApprovedBy must not stop the purchase from firing.
+			// Log loudly so the audit gap is visible.
+			logging.Errorf("AUDIT GAP: failed to stamp approved_by on %s: %v", executionID, saveErr)
+		}
 	}
 
-	logging.Infof("Execution %s approved", executionID)
-	return nil
+	logging.Infof("Execution %s approved, executing synchronously", executionID)
+	return m.executeAndFinalize(ctx, updated)
 }
 
 // CancelExecution cancels a pending execution. actor carries the email of

--- a/internal/purchase/approvals_test.go
+++ b/internal/purchase/approvals_test.go
@@ -11,10 +11,46 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestManager_ApproveExecution(t *testing.T) {
+// approveFromStatuses mirrors the value Manager.ApproveAndExecute passes to
+// TransitionExecutionStatus. Centralized so a future change to the
+// allowed-from set updates every test in one place.
+var approveFromStatuses = []string{"pending", "notified"}
+
+// newApproveManager wires a Manager backed by a fresh MockConfigStore +
+// MockEmailSender. Returns both mocks so tests can register expectations
+// per scenario without re-stating the boilerplate.
+func newApproveManager(t *testing.T) (*Manager, *MockConfigStore, *MockEmailSender) {
+	t.Helper()
+	store := new(MockConfigStore)
+	sender := new(MockEmailSender)
+	return &Manager{
+		config:       store,
+		email:        sender,
+		dashboardURL: "https://dashboard.example.com",
+	}, store, sender
+}
+
+// stubExecuteChain wires the mocks that Manager.executeAndFinalize touches
+// when the execution has no work to do (empty Recommendations, no plan
+// accounts). GetPlanAccounts uses the Fn-override pattern in this mock,
+// not testify's .On; left at its nil default it returns (nil, nil) which
+// drops us into the single-account branch with no recs.
+func stubExecuteChain(t *testing.T, store *MockConfigStore, sender *MockEmailSender, planID string) {
+	t.Helper()
+	plan := &config.PurchasePlan{ID: planID, Name: "test-plan"}
+	store.On("GetPurchasePlan", mock.Anything, planID).Return(plan, nil)
+	// Empty Recommendations means processPurchaseRecommendations is a
+	// no-op; totals stay zero but sendPurchaseNotification still fires.
+	sender.On("SendPurchaseConfirmation", mock.Anything, mock.Anything).Return(nil)
+	// finalizeExecution writes status=completed via SavePurchaseExecution.
+	store.On("SavePurchaseExecution", mock.Anything, mock.AnythingOfType("*config.PurchaseExecution")).Return(nil)
+	// updatePlanProgress fetches+updates the plan.
+	store.On("UpdatePurchasePlan", mock.Anything, mock.AnythingOfType("*config.PurchasePlan")).Return(nil)
+}
+
+func TestManager_ApproveExecution_Success(t *testing.T) {
 	ctx := context.Background()
-	mockStore := new(MockConfigStore)
-	mockEmail := new(MockEmailSender)
+	manager, store, sender := newApproveManager(t)
 
 	execution := &config.PurchaseExecution{
 		ExecutionID:   "exec-123",
@@ -22,26 +58,26 @@ func TestManager_ApproveExecution(t *testing.T) {
 		Status:        "pending",
 		ApprovalToken: "valid-token",
 	}
-
-	mockStore.On("GetExecutionByID", ctx, "exec-123").Return(execution, nil)
-	mockStore.On("SavePurchaseExecution", ctx, mock.AnythingOfType("*config.PurchaseExecution")).Return(nil)
-
-	manager := &Manager{
-		config:       mockStore,
-		email:        mockEmail,
-		dashboardURL: "https://dashboard.example.com",
+	updated := &config.PurchaseExecution{
+		ExecutionID:   "exec-123",
+		PlanID:        "plan-456",
+		Status:        "approved",
+		ApprovalToken: "valid-token",
 	}
+
+	store.On("GetExecutionByID", ctx, "exec-123").Return(execution, nil)
+	store.On("TransitionExecutionStatus", ctx, "exec-123", approveFromStatuses, "approved").Return(updated, nil)
+	stubExecuteChain(t, store, sender, "plan-456")
 
 	err := manager.ApproveExecution(ctx, "exec-123", "valid-token", "")
 	require.NoError(t, err)
-
-	mockStore.AssertExpectations(t)
+	store.AssertExpectations(t)
+	sender.AssertExpectations(t)
 }
 
-func TestManager_ApproveExecution_InvalidToken(t *testing.T) {
+func TestManager_ApproveExecution_StampsApprovedBy(t *testing.T) {
 	ctx := context.Background()
-	mockStore := new(MockConfigStore)
-	mockEmail := new(MockEmailSender)
+	manager, store, sender := newApproveManager(t)
 
 	execution := &config.PurchaseExecution{
 		ExecutionID:   "exec-123",
@@ -49,93 +85,32 @@ func TestManager_ApproveExecution_InvalidToken(t *testing.T) {
 		Status:        "pending",
 		ApprovalToken: "valid-token",
 	}
-
-	mockStore.On("GetExecutionByID", ctx, "exec-123").Return(execution, nil)
-
-	manager := &Manager{
-		config:       mockStore,
-		email:        mockEmail,
-		dashboardURL: "https://dashboard.example.com",
-	}
-
-	err := manager.ApproveExecution(ctx, "exec-123", "invalid-token", "")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid approval token")
-
-	mockStore.AssertExpectations(t)
-}
-
-func TestManager_ApproveExecution_NotFound(t *testing.T) {
-	ctx := context.Background()
-	mockStore := new(MockConfigStore)
-	mockEmail := new(MockEmailSender)
-
-	mockStore.On("GetExecutionByID", ctx, "exec-123").Return(nil, nil)
-
-	manager := &Manager{
-		config:       mockStore,
-		email:        mockEmail,
-		dashboardURL: "https://dashboard.example.com",
-	}
-
-	err := manager.ApproveExecution(ctx, "exec-123", "token", "")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "execution not found")
-
-	mockStore.AssertExpectations(t)
-}
-
-func TestManager_ApproveExecution_AlreadyCompleted(t *testing.T) {
-	ctx := context.Background()
-	mockStore := new(MockConfigStore)
-	mockEmail := new(MockEmailSender)
-
-	execution := &config.PurchaseExecution{
+	updated := &config.PurchaseExecution{
 		ExecutionID:   "exec-123",
 		PlanID:        "plan-456",
-		Status:        "completed",
+		Status:        "approved",
 		ApprovalToken: "valid-token",
 	}
 
-	mockStore.On("GetExecutionByID", ctx, "exec-123").Return(execution, nil)
+	store.On("GetExecutionByID", ctx, "exec-123").Return(execution, nil)
+	store.On("TransitionExecutionStatus", ctx, "exec-123", approveFromStatuses, "approved").Return(updated, nil)
+	stubExecuteChain(t, store, sender, "plan-456")
 
-	manager := &Manager{
-		config:       mockStore,
-		email:        mockEmail,
-		dashboardURL: "https://dashboard.example.com",
-	}
+	err := manager.ApproveExecution(ctx, "exec-123", "valid-token", "operator@example.com")
+	require.NoError(t, err)
 
-	err := manager.ApproveExecution(ctx, "exec-123", "valid-token", "")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "execution cannot be approved")
-
-	mockStore.AssertExpectations(t)
-}
-
-func TestManager_ApproveExecution_GetError(t *testing.T) {
-	ctx := context.Background()
-	mockStore := new(MockConfigStore)
-	mockEmail := new(MockEmailSender)
-
-	mockStore.On("GetExecutionByID", ctx, "exec-123").Return(nil, errors.New("database error"))
-
-	manager := &Manager{
-		config:       mockStore,
-		email:        mockEmail,
-		dashboardURL: "https://dashboard.example.com",
-	}
-
-	err := manager.ApproveExecution(ctx, "exec-123", "token", "")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to get execution")
-
-	mockStore.AssertExpectations(t)
+	// Two SavePurchaseExecution calls land on the same pointer (the
+	// transitioned row): once for the ApprovedBy stamp, once at the end
+	// of executeAndFinalize. Both should reflect the actor.
+	require.NotNil(t, updated.ApprovedBy)
+	assert.Equal(t, "operator@example.com", *updated.ApprovedBy)
+	store.AssertExpectations(t)
+	sender.AssertExpectations(t)
 }
 
 func TestManager_ApproveExecution_NotifiedStatus(t *testing.T) {
 	ctx := context.Background()
-	mockStore := new(MockConfigStore)
-	mockEmail := new(MockEmailSender)
+	manager, store, sender := newApproveManager(t)
 
 	execution := &config.PurchaseExecution{
 		ExecutionID:   "exec-123",
@@ -143,20 +118,136 @@ func TestManager_ApproveExecution_NotifiedStatus(t *testing.T) {
 		Status:        "notified",
 		ApprovalToken: "valid-token",
 	}
-
-	mockStore.On("GetExecutionByID", ctx, "exec-123").Return(execution, nil)
-	mockStore.On("SavePurchaseExecution", ctx, mock.AnythingOfType("*config.PurchaseExecution")).Return(nil)
-
-	manager := &Manager{
-		config:       mockStore,
-		email:        mockEmail,
-		dashboardURL: "https://dashboard.example.com",
+	updated := &config.PurchaseExecution{
+		ExecutionID:   "exec-123",
+		PlanID:        "plan-456",
+		Status:        "approved",
+		ApprovalToken: "valid-token",
 	}
+
+	store.On("GetExecutionByID", ctx, "exec-123").Return(execution, nil)
+	store.On("TransitionExecutionStatus", ctx, "exec-123", approveFromStatuses, "approved").Return(updated, nil)
+	stubExecuteChain(t, store, sender, "plan-456")
 
 	err := manager.ApproveExecution(ctx, "exec-123", "valid-token", "")
 	require.NoError(t, err)
+	store.AssertExpectations(t)
+	sender.AssertExpectations(t)
+}
 
-	mockStore.AssertExpectations(t)
+func TestManager_ApproveExecution_InvalidToken(t *testing.T) {
+	ctx := context.Background()
+	manager, store, _ := newApproveManager(t)
+
+	execution := &config.PurchaseExecution{
+		ExecutionID:   "exec-123",
+		PlanID:        "plan-456",
+		Status:        "pending",
+		ApprovalToken: "valid-token",
+	}
+
+	store.On("GetExecutionByID", ctx, "exec-123").Return(execution, nil)
+
+	err := manager.ApproveExecution(ctx, "exec-123", "invalid-token", "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid approval token")
+	// Critically: TransitionExecutionStatus and SavePurchaseExecution must
+	// NOT have been called. A token-validation bypass is exactly what the
+	// constant-time comparison guards against.
+	store.AssertNotCalled(t, "TransitionExecutionStatus", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	store.AssertNotCalled(t, "SavePurchaseExecution", mock.Anything, mock.Anything)
+	store.AssertExpectations(t)
+}
+
+func TestManager_ApproveExecution_EmptyToken(t *testing.T) {
+	ctx := context.Background()
+	manager, store, _ := newApproveManager(t)
+
+	execution := &config.PurchaseExecution{
+		ExecutionID:   "exec-123",
+		Status:        "pending",
+		ApprovalToken: "valid-token",
+	}
+	store.On("GetExecutionByID", ctx, "exec-123").Return(execution, nil)
+
+	err := manager.ApproveExecution(ctx, "exec-123", "", "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid approval token")
+	store.AssertNotCalled(t, "TransitionExecutionStatus", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestManager_ApproveExecution_NotFound(t *testing.T) {
+	ctx := context.Background()
+	manager, store, _ := newApproveManager(t)
+
+	store.On("GetExecutionByID", ctx, "exec-123").Return(nil, nil)
+
+	err := manager.ApproveExecution(ctx, "exec-123", "token", "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "execution not found")
+	store.AssertExpectations(t)
+}
+
+func TestManager_ApproveExecution_GetError(t *testing.T) {
+	ctx := context.Background()
+	manager, store, _ := newApproveManager(t)
+
+	store.On("GetExecutionByID", ctx, "exec-123").Return(nil, errors.New("database error"))
+
+	err := manager.ApproveExecution(ctx, "exec-123", "token", "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get execution")
+	store.AssertExpectations(t)
+}
+
+func TestManager_ApproveExecution_TransitionFails(t *testing.T) {
+	// Closes the race-with-cancel/expire path: token is valid but the row
+	// drifted out of pending/notified between fetch and atomic UPDATE.
+	// TransitionExecutionStatus 0-rows; the caller surfaces a clean error
+	// and never enters the execute chain.
+	ctx := context.Background()
+	manager, store, _ := newApproveManager(t)
+
+	execution := &config.PurchaseExecution{
+		ExecutionID:   "exec-123",
+		PlanID:        "plan-456",
+		Status:        "pending",
+		ApprovalToken: "valid-token",
+	}
+	store.On("GetExecutionByID", ctx, "exec-123").Return(execution, nil)
+	store.On("TransitionExecutionStatus", ctx, "exec-123", approveFromStatuses, "approved").
+		Return(nil, errors.New(`execution exec-123 cannot transition from "cancelled" to "approved"`))
+
+	err := manager.ApproveExecution(ctx, "exec-123", "valid-token", "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot transition")
+	// Execute chain must not run after a failed transition.
+	store.AssertNotCalled(t, "GetPurchasePlan", mock.Anything, mock.Anything)
+	store.AssertExpectations(t)
+}
+
+func TestManager_ApproveAndExecute_SkipsTokenCheck(t *testing.T) {
+	// Session-authed path: ApproveAndExecute is called directly without a
+	// token, after the caller has run RBAC. Verifies the entry point works
+	// independently of the token branch.
+	ctx := context.Background()
+	manager, store, sender := newApproveManager(t)
+
+	updated := &config.PurchaseExecution{
+		ExecutionID:   "exec-456",
+		PlanID:        "plan-789",
+		Status:        "approved",
+		ApprovalToken: "tok",
+	}
+	store.On("TransitionExecutionStatus", ctx, "exec-456", approveFromStatuses, "approved").Return(updated, nil)
+	stubExecuteChain(t, store, sender, "plan-789")
+
+	err := manager.ApproveAndExecute(ctx, "exec-456", "session-user@example.com")
+	require.NoError(t, err)
+	require.NotNil(t, updated.ApprovedBy)
+	assert.Equal(t, "session-user@example.com", *updated.ApprovedBy)
+	store.AssertExpectations(t)
+	sender.AssertExpectations(t)
 }
 
 func TestManager_CancelExecution(t *testing.T) {

--- a/internal/purchase/coverage_extra_test.go
+++ b/internal/purchase/coverage_extra_test.go
@@ -266,8 +266,14 @@ func TestProcessMessage_ApproveHappyPath(t *testing.T) {
 	mockEmail := new(MockEmailSender)
 
 	accountID := "acct-1"
+	// Non-empty PlanID exercises the plan-id propagation through the
+	// approve→execute chain. Earlier versions of this test used "" and
+	// would have silently passed even if the approve handler dropped or
+	// substituted the plan id en route to GetPurchasePlan.
+	planID := "plan-appv"
 	exec := &config.PurchaseExecution{
 		ExecutionID:   "exec-appv",
+		PlanID:        planID,
 		Status:        "pending",
 		ApprovalToken: "correct-token",
 		// Recommendations are non-Selected, so processPurchaseRecommendations
@@ -278,6 +284,7 @@ func TestProcessMessage_ApproveHappyPath(t *testing.T) {
 	}
 	approved := &config.PurchaseExecution{
 		ExecutionID:     "exec-appv",
+		PlanID:          planID,
 		Status:          "approved",
 		ApprovalToken:   "correct-token",
 		Recommendations: exec.Recommendations,
@@ -290,10 +297,12 @@ func TestProcessMessage_ApproveHappyPath(t *testing.T) {
 	mockStore.On("GetCloudAccount", ctx, accountID).Return(account, nil)
 	// Atomic approve transition (issue #372 fix).
 	mockStore.On("TransitionExecutionStatus", ctx, "exec-appv", []string{"pending", "notified"}, "approved").Return(approved, nil)
-	// Synchronous execute chain: empty plan, no accounts → single-account
-	// no-op path, then notification + final save + plan-progress update.
-	plan := &config.PurchasePlan{ID: "", Name: "test-plan"}
-	mockStore.On("GetPurchasePlan", ctx, "").Return(plan, nil)
+	// Synchronous execute chain: GetPurchasePlan is called with the
+	// approved execution's PlanID — pinning the non-empty id here means a
+	// regression that drops it (e.g. passes "" or exec.ExecutionID by
+	// mistake) would mismatch the mock expectation and fail the test.
+	plan := &config.PurchasePlan{ID: planID, Name: "test-plan"}
+	mockStore.On("GetPurchasePlan", ctx, planID).Return(plan, nil)
 	mockEmail.On("SendPurchaseConfirmation", ctx, mock.Anything).Return(nil)
 	mockStore.On("SavePurchaseExecution", ctx, mock.AnythingOfType("*config.PurchaseExecution")).Return(nil)
 	mockStore.On("UpdatePurchasePlan", ctx, mock.AnythingOfType("*config.PurchasePlan")).Return(nil)

--- a/internal/purchase/coverage_extra_test.go
+++ b/internal/purchase/coverage_extra_test.go
@@ -270,9 +270,17 @@ func TestProcessMessage_ApproveHappyPath(t *testing.T) {
 		ExecutionID:   "exec-appv",
 		Status:        "pending",
 		ApprovalToken: "correct-token",
+		// Recommendations are non-Selected, so processPurchaseRecommendations
+		// is a no-op and no AWS API call is made.
 		Recommendations: []config.RecommendationRecord{
 			{CloudAccountID: &accountID},
 		},
+	}
+	approved := &config.PurchaseExecution{
+		ExecutionID:     "exec-appv",
+		Status:          "approved",
+		ApprovalToken:   "correct-token",
+		Recommendations: exec.Recommendations,
 	}
 	account := &config.CloudAccount{ID: accountID, ContactEmail: "owner@example.com"}
 
@@ -280,7 +288,15 @@ func TestProcessMessage_ApproveHappyPath(t *testing.T) {
 	// execution; mock returns it twice.
 	mockStore.On("GetExecutionByID", ctx, "exec-appv").Return(exec, nil).Twice()
 	mockStore.On("GetCloudAccount", ctx, accountID).Return(account, nil)
+	// Atomic approve transition (issue #372 fix).
+	mockStore.On("TransitionExecutionStatus", ctx, "exec-appv", []string{"pending", "notified"}, "approved").Return(approved, nil)
+	// Synchronous execute chain: empty plan, no accounts → single-account
+	// no-op path, then notification + final save + plan-progress update.
+	plan := &config.PurchasePlan{ID: "", Name: "test-plan"}
+	mockStore.On("GetPurchasePlan", ctx, "").Return(plan, nil)
+	mockEmail.On("SendPurchaseConfirmation", ctx, mock.Anything).Return(nil)
 	mockStore.On("SavePurchaseExecution", ctx, mock.AnythingOfType("*config.PurchaseExecution")).Return(nil)
+	mockStore.On("UpdatePurchasePlan", ctx, mock.AnythingOfType("*config.PurchasePlan")).Return(nil)
 
 	manager := &Manager{
 		config:       mockStore,
@@ -291,6 +307,7 @@ func TestProcessMessage_ApproveHappyPath(t *testing.T) {
 	err := manager.ProcessMessage(ctx, `{"type":"approve","execution_id":"exec-appv","token":"correct-token","actor_email":"owner@example.com"}`)
 	require.NoError(t, err)
 	mockStore.AssertExpectations(t)
+	mockEmail.AssertExpectations(t)
 }
 
 func TestProcessMessage_CancelHappyPath(t *testing.T) {

--- a/internal/purchase/execution.go
+++ b/internal/purchase/execution.go
@@ -235,7 +235,18 @@ func (m *Manager) processPurchaseRecommendations(ctx context.Context, exec *conf
 	// outer account fan-out and this inner rec fan-out.
 	results := execution.FanOutWithConcurrency(ctx, indexKeys(selected),
 		func(ctx context.Context, key string) (recPurchaseOutcome, error) {
-			i, _ := strconv.Atoi(key)
+			// indexKeys() builds these keys from selectedIndices(), so parse +
+			// bounds errors are not expected at runtime. Surface them as
+			// closure-level errors anyway so the aggregator can correlate
+			// them via execution.Result.Err and never silently dereference a
+			// zero-valued outcome at index 0.
+			i, parseErr := strconv.Atoi(key)
+			if parseErr != nil {
+				return recPurchaseOutcome{}, fmt.Errorf("invalid fan-out key %q: %w", key, parseErr)
+			}
+			if i < 0 || i >= len(exec.Recommendations) {
+				return recPurchaseOutcome{}, fmt.Errorf("fan-out index %d out of range for %d recommendations", i, len(exec.Recommendations))
+			}
 			rec := exec.Recommendations[i]
 			logging.Infof("Purchasing: %dx %s in %s (%s/%s)", rec.Count, rec.ResourceType, rec.Region, rec.Provider, rec.Service)
 			purchaseResult, err := m.executeSinglePurchase(ctx, rec, provCfg, opts)
@@ -255,8 +266,26 @@ func (m *Manager) aggregatePurchaseOutcomes(ctx context.Context, exec *config.Pu
 	var totalSavings, totalUpfront float64
 	var purchaseErrors []string
 	for _, r := range results {
+		// Closure-level error (parse / bounds / framework). r.Value is the
+		// zero recPurchaseOutcome here — its index is 0 and would mis-target
+		// exec.Recommendations[0] if blindly trusted. Record it as a
+		// generic execution failure and skip the per-rec writes.
+		if r.Err != nil {
+			logging.Errorf("Internal fan-out failure during purchase execution: %v", r.Err)
+			purchaseErrors = append(purchaseErrors, fmt.Sprintf("internal fan-out error: %v", r.Err))
+			continue
+		}
 		v := r.Value
 		i := v.index
+		// Defence-in-depth: even with the closure's bounds check, never
+		// index past exec.Recommendations here (a future refactor that
+		// mutates the slice between fan-out and aggregation would corrupt
+		// this otherwise).
+		if i < 0 || i >= len(exec.Recommendations) {
+			logging.Errorf("Aggregator received out-of-range index %d (len=%d)", i, len(exec.Recommendations))
+			purchaseErrors = append(purchaseErrors, fmt.Sprintf("aggregator index %d out of range", i))
+			continue
+		}
 		rec := exec.Recommendations[i]
 		if v.err != nil {
 			logging.Errorf("Failed to purchase %s: %v", rec.ResourceType, v.err)

--- a/internal/purchase/execution.go
+++ b/internal/purchase/execution.go
@@ -3,6 +3,7 @@ package purchase
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -203,56 +204,113 @@ func getMaxAccountParallelism() int {
 	return execution.ConcurrencyFromEnv()
 }
 
+// recPurchaseOutcome carries the result of a single fan-out unit so the
+// aggregator can write back into exec.Recommendations and call
+// savePurchaseHistory from a single goroutine (no concurrent map / slice
+// mutation). The index field is the position in exec.Recommendations.
+type recPurchaseOutcome struct {
+	index    int
+	purchase common.PurchaseResult
+	err      error
+}
+
 func (m *Manager) processPurchaseRecommendations(ctx context.Context, exec *config.PurchaseExecution, plan *config.PurchasePlan, accountID string, provCfg *provider.ProviderConfig) (float64, float64, []string) {
+	opts := common.PurchaseOptions{Source: m.normalizePurchaseSource(exec)}
+
+	// Build the list of selected indices once so the fan-out closure only
+	// has to look up rec[i] (no second pass over the full slice).
+	selected := selectedIndices(exec.Recommendations)
+	if len(selected) == 0 {
+		return 0, 0, nil
+	}
+
+	// Each rec runs in its own goroutine so a multi-rec execution that
+	// spans providers (AWS RI + Azure reservation + GCP CUD) or services
+	// (EC2 + RDS + ElastiCache + OpenSearch within AWS) makes its cloud
+	// API calls in parallel rather than blocking on the slowest one.
+	// Provider client construction inside executeSinglePurchase is
+	// independent per call, so cross-provider parallelism is safe.
+	// Concurrency is capped at getMaxAccountParallelism so the same
+	// operator-level CUDLY_MAX_ACCOUNT_PARALLELISM knob covers both the
+	// outer account fan-out and this inner rec fan-out.
+	results := execution.FanOutWithConcurrency(ctx, indexKeys(selected),
+		func(ctx context.Context, key string) (recPurchaseOutcome, error) {
+			i, _ := strconv.Atoi(key)
+			rec := exec.Recommendations[i]
+			logging.Infof("Purchasing: %dx %s in %s (%s/%s)", rec.Count, rec.ResourceType, rec.Region, rec.Provider, rec.Service)
+			purchaseResult, err := m.executeSinglePurchase(ctx, rec, provCfg, opts)
+			return recPurchaseOutcome{index: i, purchase: purchaseResult, err: err}, nil
+		}, getMaxAccountParallelism())
+
+	return m.aggregatePurchaseOutcomes(ctx, exec, plan, accountID, results)
+}
+
+// aggregatePurchaseOutcomes walks the fan-out results serially and writes
+// each rec's outcome back to exec.Recommendations + savePurchaseHistory.
+// Extracted so processPurchaseRecommendations stays under gocyclo:10 and
+// so the aggregation logic is single-threaded — no concurrent writes to
+// totals, purchaseErrors, or exec.Recommendations[i] regardless of how
+// many recs ran in parallel.
+func (m *Manager) aggregatePurchaseOutcomes(ctx context.Context, exec *config.PurchaseExecution, plan *config.PurchasePlan, accountID string, results []execution.Result[recPurchaseOutcome]) (float64, float64, []string) {
 	var totalSavings, totalUpfront float64
 	var purchaseErrors []string
-
-	// Source is set once per execution (web handler writes cudly-web; approval
-	// flow preserves it through the DB round-trip) and propagates into every
-	// per-account/per-rec purchase so the tag is stamped consistently.
-	//
-	// Defence-in-depth: NormalizeSource rejects anything outside the allowed
-	// whitelist. If the DB has been tampered with (or a future code path
-	// assigns an unexpected value), we don't want arbitrary strings landing
-	// on cloud commitments where they'd be expensive to retract. Fall back to
-	// untagged rather than failing the already-approved execution.
-	source := exec.Source
-	if source != "" {
-		normalized, err := common.NormalizeSource(source)
-		if err != nil {
-			logging.Warnf("Invalid purchase source %q on execution %s: %v — proceeding untagged", source, exec.ExecutionID, err)
-			source = ""
-		} else {
-			source = normalized
-		}
-	}
-	opts := common.PurchaseOptions{Source: source}
-
-	for i, rec := range exec.Recommendations {
-		if !rec.Selected {
+	for _, r := range results {
+		v := r.Value
+		i := v.index
+		rec := exec.Recommendations[i]
+		if v.err != nil {
+			logging.Errorf("Failed to purchase %s: %v", rec.ResourceType, v.err)
+			exec.Recommendations[i].Error = v.err.Error()
+			purchaseErrors = append(purchaseErrors, fmt.Sprintf("%s: %v", rec.ResourceType, v.err))
 			continue
 		}
-
-		logging.Infof("Purchasing: %dx %s in %s", rec.Count, rec.ResourceType, rec.Region)
-
-		purchaseResult, err := m.executeSinglePurchase(ctx, rec, provCfg, opts)
-		if err != nil {
-			logging.Errorf("Failed to purchase %s: %v", rec.ResourceType, err)
-			exec.Recommendations[i].Error = err.Error()
-			purchaseErrors = append(purchaseErrors, fmt.Sprintf("%s: %v", rec.ResourceType, err))
-			continue
-		}
-
 		exec.Recommendations[i].Purchased = true
-		exec.Recommendations[i].PurchaseID = purchaseResult.CommitmentID
-
+		exec.Recommendations[i].PurchaseID = v.purchase.CommitmentID
 		totalSavings += rec.Savings
 		totalUpfront += rec.UpfrontCost
-
-		m.savePurchaseHistory(ctx, exec, plan, rec, purchaseResult, accountID)
+		m.savePurchaseHistory(ctx, exec, plan, rec, v.purchase, accountID)
 	}
-
 	return totalSavings, totalUpfront, purchaseErrors
+}
+
+// normalizePurchaseSource canonicalizes exec.Source for downstream tag
+// stamping. Defence-in-depth: NormalizeSource rejects anything outside
+// the allowed whitelist; an unexpected value (DB tampering, future
+// code path) is dropped to "" rather than fed onto a cloud commitment
+// where it would be expensive to retract.
+func (m *Manager) normalizePurchaseSource(exec *config.PurchaseExecution) string {
+	source := exec.Source
+	if source == "" {
+		return ""
+	}
+	normalized, err := common.NormalizeSource(source)
+	if err != nil {
+		logging.Warnf("Invalid purchase source %q on execution %s: %v, proceeding untagged", source, exec.ExecutionID, err)
+		return ""
+	}
+	return normalized
+}
+
+// selectedIndices returns the positions of recs with Selected=true,
+// preserving slice order so the aggregator's pass over the fan-out
+// results writes back to exec.Recommendations deterministically.
+func selectedIndices(recs []config.RecommendationRecord) []int {
+	out := make([]int, 0, len(recs))
+	for i, rec := range recs {
+		if rec.Selected {
+			out = append(out, i)
+		}
+	}
+	return out
+}
+
+// indexKeys formats a slice of indices as string keys for FanOut.
+func indexKeys(idx []int) []string {
+	out := make([]string, len(idx))
+	for i, n := range idx {
+		out[i] = strconv.Itoa(n)
+	}
+	return out
 }
 
 func (m *Manager) savePurchaseHistory(ctx context.Context, exec *config.PurchaseExecution, plan *config.PurchasePlan, rec config.RecommendationRecord, result common.PurchaseResult, accountID string) {

--- a/internal/server/interfaces.go
+++ b/internal/server/interfaces.go
@@ -20,6 +20,7 @@ type PurchaseManagerInterface interface {
 	SendUpcomingPurchaseNotifications(ctx context.Context) (*purchase.NotificationResult, error)
 	ProcessMessage(ctx context.Context, body string) error
 	ApproveExecution(ctx context.Context, execID, token, actor string) error
+	ApproveAndExecute(ctx context.Context, execID, actor string) error
 	CancelExecution(ctx context.Context, execID, token, actor string) error
 }
 

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -34,6 +34,7 @@ type MockPurchaseManager struct {
 	SendUpcomingPurchaseNotificationsFunc func(ctx context.Context) (*purchase.NotificationResult, error)
 	ProcessMessageFunc                    func(ctx context.Context, body string) error
 	ApproveExecutionFunc                  func(ctx context.Context, execID, token, actor string) error
+	ApproveAndExecuteFunc                 func(ctx context.Context, execID, actor string) error
 	CancelExecutionFunc                   func(ctx context.Context, execID, token, actor string) error
 }
 
@@ -61,6 +62,13 @@ func (m *MockPurchaseManager) ProcessMessage(ctx context.Context, body string) e
 func (m *MockPurchaseManager) ApproveExecution(ctx context.Context, execID, token, actor string) error {
 	if m.ApproveExecutionFunc != nil {
 		return m.ApproveExecutionFunc(ctx, execID, token, actor)
+	}
+	return nil
+}
+
+func (m *MockPurchaseManager) ApproveAndExecute(ctx context.Context, execID, actor string) error {
+	if m.ApproveAndExecuteFunc != nil {
+		return m.ApproveAndExecuteFunc(ctx, execID, actor)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Closes #372 (P0). Pre-fix, clicking Approve only flipped `purchase_executions.status` to `approved` and stopped. No scheduler in the Lambda deployment picked the row up, so the AWS RI / SP / Azure reservation / GCP CUD was never purchased and the approval never reached Purchase History. The History view's `historyExecutionStatuses` list excluded `approved` on the assumption that the scheduler would materialize the row into `purchase_history`, which completed the invisibility.

This PR makes Approve run the purchase synchronously inside the same HTTP invocation:

- **Atomic transition** `pending|notified -> approved` via the existing `TransitionExecutionStatus`. Two concurrent approves on the same execution see exactly one win; the loser gets a clean 409.
- **ApprovedBy** stamped on the returned row for attribution.
- **executeAndFinalize** drives the cloud API calls and lands the row on `completed` or `failed` before the HTTP response returns.

## Parallel-purchase guarantees (per follow-up reqs)

- **Concurrent approvals** stay parallel by Lambda design - each HTTP/SQS invocation drives its own `executeAndFinalize`.
- **Multi-cloud-account** fan-out unchanged: outer `executeMultiAccount` still spawns one goroutine per account up to `CUDLY_MAX_ACCOUNT_PARALLELISM`.
- **Multi-rec within one account** is now parallel too: `processPurchaseRecommendations` fans out via `execution.FanOutWithConcurrency`, so a single approval that covers AWS RI + Azure reservation + GCP CUD (or EC2 + RDS + ElastiCache + OpenSearch within AWS) runs the cloud API calls concurrently. Aggregation stays single-threaded so writes to `exec.Recommendations[i]`, error accumulation, and `savePurchaseHistory` are race-free regardless of how many recs are in flight.

## File-level changes

- `internal/purchase/approvals.go` - new `ApproveAndExecute` (atomic flip + execute), token-path `ApproveExecution` now delegates to it.
- `internal/purchase/execution.go` - `processPurchaseRecommendations` parallelizes across recs; aggregation extracted to `aggregatePurchaseOutcomes`; small `normalizePurchaseSource` / `selectedIndices` / `indexKeys` helpers added.
- `internal/api/handler_purchases.go` - session-authed branch now calls `ApproveAndExecute` instead of doing an inline non-atomic flip; response returns `completed` (the post-execute state) instead of `approved`.
- `internal/api/handler_history.go` - obsolete "scheduler will materialize approved" comment updated.
- Interface + mock plumbing: `internal/api/types.go`, `internal/api/mocks_test.go`, `internal/server/interfaces.go`, `internal/testutil/mocks.go`.

## Test plan

- [x] `go test ./...` passes (4440 / 4440)
- [x] `internal/purchase/approvals_test.go` rewritten to cover the new transition + execute chain (happy path, ApprovedBy stamp, notified->approved, invalid token, empty token, not found, get error, transition fails, ApproveAndExecute bypasses token).
- [x] `internal/purchase/coverage_extra_test.go` - `TestProcessMessage_ApproveHappyPath` extended with the now-chained mocks.
- [x] `internal/api/handler_purchases_test.go` - existing token-path test asserts response is now `completed`; two new tests pin (a) session-auth uses `ApproveAndExecute` and (b) execute failure surfaces as 409.
- [ ] Manual verification on dev once deployed: approve a real RI from the dashboard, confirm row lands on `completed`, confirm it shows in Purchase History, confirm the RI shows up in AWS billing.

## Stranded rows

Any existing `purchase_executions` row already stuck at `status='approved'` won't be auto-rescued by this PR. Operator action: `UPDATE purchase_executions SET status='pending' WHERE status='approved'` and re-click Approve. Filing a separate small chore to add a one-shot reaper for stranded rows.

## Out of scope (deferred to separate issues)

- Pre-purchase modal UX: showing service / instance type / count / region instead of just the execution ID.
- Stranded-`approved` reaper for legacy rows.
- The Fargate-only `ProcessScheduledPurchases` cron still runs against `pending|notified` only - intentional; the synchronous path handles the common case and the scheduler stays as a backstop.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Approvals now complete synchronously in a single request; responses show completed status.
  * Session-based admin approval path added.

* **Bug Fixes**
  * Failed execution errors surface as client 409 responses with clearer messages.
  * History/status docs clarified to avoid duplicate or “ghost” rows.

* **Performance**
  * Purchase recommendation processing optimized to run concurrently.

* **Tests**
  * Added regression tests covering synchronous approve-and-execute flows and error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/373)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->