### PR TITLE
fix(frontend/ux): show per-rec details in pre-purchase approval modal (closes #374)

### DIFF
--- a/frontend/src/__tests__/approval-details.test.ts
+++ b/frontend/src/__tests__/approval-details.test.ts
@@ -154,6 +154,33 @@ describe('renderApprovalDetailsBody', () => {
     expect(rows[1]?.querySelectorAll('td')[11]?.textContent).toBe('—');
   });
 
+  it('annual-savings tooltip does NOT fire on floating-point rounding noise', () => {
+    // (0.1 + 0.2) === 0.30000000000000004 in IEEE-754. Sum the per-rec
+    // savings to that exact value but feed details.estimated_savings the
+    // "tidy" 0.3 the backend Math.Sum would produce. Strict !== would
+    // fire the tooltip on the 4e-17 mismatch; epsilon-tolerant compare
+    // must NOT.
+    const recs = [
+      makeRec({ id: 'r1', savings: 0.1 }),
+      makeRec({ id: 'r2', savings: 0.2 }),
+    ];
+    const details = makeDetails(recs, { estimated_savings: 0.3 });
+    const body = renderApprovalDetailsBody(details, new Map());
+    const stats = body.querySelectorAll('.approval-details-stat');
+    // Stat index 2 is Annual savings.
+    expect(stats[2]?.getAttribute('title')).toBeNull();
+  });
+
+  it('annual-savings tooltip DOES fire when backend and per-row sum genuinely disagree', () => {
+    const recs = [makeRec({ savings: 10 })];
+    // Backend says $5/mo but the per-rec sum says $10/mo. Honest
+    // mismatch — the tooltip should surface the per-row $120/yr.
+    const details = makeDetails(recs, { estimated_savings: 5 });
+    const body = renderApprovalDetailsBody(details, new Map());
+    const stats = body.querySelectorAll('.approval-details-stat');
+    expect(stats[2]?.getAttribute('title')).toBe('$120 from per-row sum');
+  });
+
   it('counts distinct providers and accounts in the header', () => {
     const recs = [
       makeRec({ id: 'r1', provider: 'aws', cloud_account_id: 'acct-1' }),

--- a/frontend/src/__tests__/approval-details.test.ts
+++ b/frontend/src/__tests__/approval-details.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Tests for the approval-details modal body builder (issue #374).
+ *
+ * The pure builder `renderApprovalDetailsBody` is tested directly with
+ * a stubbed accounts map and a hand-rolled PurchaseDetails fixture,
+ * since the wrapper `buildApprovalDetailsBody` is a thin shim over the
+ * network helpers (those are covered by api-* tests).
+ */
+
+import {
+  computeEffectiveSavingsPct,
+  formatAccountLabel,
+  renderApprovalDetailsBody,
+} from '../approval-details';
+import type { CloudAccount } from '../api/accounts';
+import type { PurchaseDetails, Recommendation } from '../api/types';
+
+function makeAccount(partial: Partial<CloudAccount> & Pick<CloudAccount, 'id' | 'name'>): CloudAccount {
+  return {
+    description: '',
+    provider: 'aws',
+    external_id: '',
+    contact_email: undefined,
+    enabled: true,
+    credentials_configured: true,
+    created_at: '',
+    updated_at: '',
+    ...partial,
+  } as CloudAccount;
+}
+
+function makeRec(partial: Partial<Recommendation>): Recommendation {
+  return {
+    id: 'rec-1',
+    provider: 'aws',
+    service: 'ec2',
+    region: 'us-east-1',
+    resource_type: 'm5.xlarge',
+    count: 1,
+    term: 1,
+    payment: 'all-upfront',
+    upfront_cost: 1000,
+    monthly_cost: 50,
+    savings: 20,
+    selected: true,
+    purchased: false,
+    ...partial,
+  };
+}
+
+function makeDetails(recs: Recommendation[], overrides: Partial<PurchaseDetails> = {}): PurchaseDetails {
+  return {
+    execution_id: 'exec-abc',
+    status: 'pending',
+    total_upfront_cost: recs.reduce((a, r) => a + (r.upfront_cost ?? 0), 0),
+    estimated_savings: recs.reduce((a, r) => a + r.savings, 0),
+    recommendations: recs,
+    ...overrides,
+  };
+}
+
+describe('renderApprovalDetailsBody', () => {
+  it('renders the aggregate header with total upfront, monthly + annual savings, and counts', () => {
+    const rec = makeRec({ provider: 'aws', cloud_account_id: 'acct-uuid-1', upfront_cost: 1200, savings: 30 });
+    const details = makeDetails([rec]);
+    const accountsById = new Map<string, CloudAccount>([
+      ['acct-uuid-1', makeAccount({ id: 'acct-uuid-1', name: 'Prod', external_id: '123456789012' })],
+    ]);
+    const body = renderApprovalDetailsBody(details, accountsById);
+
+    const stats = body.querySelectorAll('.approval-details-stat');
+    expect(stats.length).toBe(6);
+    const text = body.textContent || '';
+    expect(text).toContain('Upfront');
+    expect(text).toContain('$1,200');
+    expect(text).toContain('Monthly savings');
+    expect(text).toContain('$30');
+    expect(text).toContain('Annual savings');
+    expect(text).toContain('$360');
+    expect(text).toContain('Commitments');
+    expect(text).toContain('Providers');
+    expect(text).toContain('Accounts');
+  });
+
+  it('renders the per-rec table with all 12 columns', () => {
+    const rec = makeRec({});
+    const body = renderApprovalDetailsBody(makeDetails([rec]), new Map());
+    const headers = Array.from(body.querySelectorAll('.approval-details-table thead th')).map(th => th.textContent);
+    expect(headers).toEqual([
+      'Account', 'Provider', 'Service', 'Resource', 'Engine', 'Region',
+      'Count', 'Term', 'Payment', 'Upfront', 'Monthly savings', 'Eff. savings %',
+    ]);
+  });
+
+  it('resolves cloud_account_id to "Name (external_id)" when accounts are known', () => {
+    const rec = makeRec({ cloud_account_id: 'acct-uuid-1' });
+    const accountsById = new Map<string, CloudAccount>([
+      ['acct-uuid-1', makeAccount({ id: 'acct-uuid-1', name: 'Prod AWS', external_id: '999988887777' })],
+    ]);
+    const body = renderApprovalDetailsBody(makeDetails([rec]), accountsById);
+    const cells = body.querySelectorAll('.approval-details-table tbody td');
+    expect(cells[0]?.textContent).toBe('Prod AWS (999988887777)');
+  });
+
+  it('falls back to "acct <prefix>" when the rec carries a UUID we can\'t resolve', () => {
+    const rec = makeRec({ cloud_account_id: '11111111-2222-3333-4444-555555555555' });
+    const body = renderApprovalDetailsBody(makeDetails([rec]), new Map());
+    const cells = body.querySelectorAll('.approval-details-table tbody td');
+    expect(cells[0]?.textContent).toBe('acct 11111111…');
+  });
+
+  it('shows "(ambient)" for recs without a cloud_account_id', () => {
+    const rec = makeRec({});
+    delete rec.cloud_account_id;
+    const body = renderApprovalDetailsBody(makeDetails([rec]), new Map());
+    const cells = body.querySelectorAll('.approval-details-table tbody td');
+    expect(cells[0]?.textContent).toBe('(ambient)');
+  });
+
+  it('renders the engine column for RDS-shaped recs and "—" otherwise', () => {
+    const rdsRec = makeRec({ service: 'rds', engine: 'postgres' });
+    const ec2Rec = makeRec({ id: 'rec-2', service: 'ec2', engine: '' });
+    const body = renderApprovalDetailsBody(makeDetails([rdsRec, ec2Rec]), new Map());
+    const rows = body.querySelectorAll('.approval-details-table tbody tr');
+    expect(rows.length).toBe(2);
+    // Column index 4 is Engine (0-based).
+    expect(rows[0]?.querySelectorAll('td')[4]?.textContent).toBe('postgres');
+    expect(rows[1]?.querySelectorAll('td')[4]?.textContent).toBe('—');
+  });
+
+  it('renders Term via formatTerm ("1 Year" / "3 Years") for consistency with the rest of the dashboard', () => {
+    const rec1 = makeRec({ term: 1 });
+    const rec3 = makeRec({ id: 'rec-2', term: 3 });
+    const body = renderApprovalDetailsBody(makeDetails([rec1, rec3]), new Map());
+    const rows = body.querySelectorAll('.approval-details-table tbody tr');
+    expect(rows[0]?.querySelectorAll('td')[7]?.textContent).toBe('1 Year');
+    expect(rows[1]?.querySelectorAll('td')[7]?.textContent).toBe('3 Years');
+  });
+
+  it('formats upfront and monthly savings via formatCurrency (matches recs page rounding)', () => {
+    const rec = makeRec({ upfront_cost: 4567.89, savings: 12.5 });
+    const body = renderApprovalDetailsBody(makeDetails([rec]), new Map());
+    const cells = body.querySelectorAll('.approval-details-table tbody td');
+    expect(cells[9]?.textContent).toBe('$4,568');
+    expect(cells[10]?.textContent).toBe('$13');
+  });
+
+  it('computes effective savings % when on_demand_cost is set, "—" otherwise', () => {
+    const withBaseline = makeRec({ savings: 30, on_demand_cost: 100 });
+    const withoutBaseline = makeRec({ id: 'rec-2', savings: 30, on_demand_cost: null, monthly_cost: null });
+    const body = renderApprovalDetailsBody(makeDetails([withBaseline, withoutBaseline]), new Map());
+    const rows = body.querySelectorAll('.approval-details-table tbody tr');
+    expect(rows[0]?.querySelectorAll('td')[11]?.textContent).toBe('30.0%');
+    expect(rows[1]?.querySelectorAll('td')[11]?.textContent).toBe('—');
+  });
+
+  it('counts distinct providers and accounts in the header', () => {
+    const recs = [
+      makeRec({ id: 'r1', provider: 'aws', cloud_account_id: 'acct-1' }),
+      makeRec({ id: 'r2', provider: 'azure', cloud_account_id: 'acct-2' }),
+      makeRec({ id: 'r3', provider: 'gcp', cloud_account_id: 'acct-2' }),
+    ];
+    const body = renderApprovalDetailsBody(makeDetails(recs), new Map());
+    const stats = body.querySelectorAll('.approval-details-stat');
+    // Stat index 4 = Providers, index 5 = Accounts (post-Commitments).
+    expect(stats[3]?.querySelector('.approval-details-stat-value')?.textContent).toBe('3'); // Commitments
+    expect(stats[4]?.querySelector('.approval-details-stat-value')?.textContent).toBe('3'); // Providers
+    expect(stats[5]?.querySelector('.approval-details-stat-value')?.textContent).toBe('2'); // Accounts
+  });
+
+  it('falls back to a legacy text sentence when recommendations are empty', () => {
+    const details = makeDetails([]);
+    const body = renderApprovalDetailsBody(details, new Map());
+    expect(body.querySelector('.approval-details-fallback')).not.toBeNull();
+    expect(body.querySelector('.approval-details-table')).toBeNull();
+    expect(body.textContent).toContain('Cloud commitments will be charged');
+  });
+
+  it('escapes user-controlled string values in the table', () => {
+    const rec = makeRec({ resource_type: '<script>alert(1)</script>' });
+    const body = renderApprovalDetailsBody(makeDetails([rec]), new Map());
+    // After escapeHtml, the raw "<script>" must not appear as a script
+    // element inside the table; the literal angle brackets are
+    // escaped into entities and re-rendered as text content.
+    expect(body.querySelector('.approval-details-table script')).toBeNull();
+    const cells = body.querySelectorAll('.approval-details-table tbody td');
+    expect(cells[3]?.textContent).toBe('<script>alert(1)</script>');
+  });
+});
+
+describe('formatAccountLabel', () => {
+  it('returns "Name (external_id)" when both are present', () => {
+    const acct = makeAccount({ id: 'a', name: 'Prod', external_id: '999988887777' });
+    expect(formatAccountLabel(acct, 'a')).toBe('Prod (999988887777)');
+  });
+
+  it('returns just Name when external_id is empty', () => {
+    const acct = makeAccount({ id: 'a', name: 'Bastion', external_id: '' });
+    expect(formatAccountLabel(acct, 'a')).toBe('Bastion');
+  });
+
+  it('returns "acct <prefix>" when the UUID is unknown', () => {
+    expect(formatAccountLabel(undefined, 'aaaaaaaa-bbbb-cccc')).toBe('acct aaaaaaaa…');
+  });
+
+  it('returns "(ambient)" when no account id was carried', () => {
+    expect(formatAccountLabel(undefined, undefined)).toBe('(ambient)');
+  });
+});
+
+describe('computeEffectiveSavingsPct', () => {
+  it('uses on_demand_cost as the denominator when provided', () => {
+    const rec = makeRec({ savings: 30, on_demand_cost: 100 });
+    expect(computeEffectiveSavingsPct(rec)).toBeCloseTo(30, 5);
+  });
+
+  it('reconstructs from monthly_cost + savings when on_demand_cost is null', () => {
+    const rec = makeRec({ savings: 20, monthly_cost: 80, on_demand_cost: null });
+    expect(computeEffectiveSavingsPct(rec)).toBeCloseTo(20, 5);
+  });
+
+  it('returns null when neither denominator is available', () => {
+    const rec = makeRec({ savings: 10, monthly_cost: null, on_demand_cost: null });
+    expect(computeEffectiveSavingsPct(rec)).toBeNull();
+  });
+
+  it('returns null when on_demand_cost is zero (avoid divide by zero)', () => {
+    const rec = makeRec({ savings: 10, monthly_cost: 0, on_demand_cost: 0 });
+    expect(computeEffectiveSavingsPct(rec)).toBeNull();
+  });
+});

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -223,17 +223,27 @@ export interface PurchaseResult {
   }>;
 }
 
+// PurchaseDetails matches the shape produced by backend
+// buildPurchaseDetailsResponse (internal/api/handler_purchases.go).
+// `recommendations` carries the per-rec snapshot that was captured at
+// approval-request time so callers can render the deal without
+// re-querying provider APIs. plan_id / plan_name / scheduled_date are
+// only present when the execution belongs to a plan (direct-execute
+// purchases from the recommendations page have plan_id="" and
+// plan_name="").
 export interface PurchaseDetails {
   execution_id: string;
   status: string;
-  created_at: string;
+  plan_id?: string;
+  plan_name?: string;
+  step_number?: number;
+  scheduled_date?: string;
+  total_upfront_cost: number;
+  estimated_savings: number;
+  recommendations: Recommendation[];
+  notification_sent?: string;
   completed_at?: string;
-  results: Array<{
-    recommendation_id: string;
-    status: string;
-    confirmation_id?: string;
-    error?: string;
-  }>;
+  error?: string;
 }
 
 export interface PlannedPurchasesResponse {

--- a/frontend/src/approval-details.ts
+++ b/frontend/src/approval-details.ts
@@ -263,6 +263,9 @@ export function formatAccountLabel(acct: CloudAccount | undefined, recAccountId:
  * collection, so we don't re-add it here.
  */
 export function computeEffectiveSavingsPct(rec: Recommendation): number | null {
+  if (rec.savings === null || rec.savings === undefined) {
+    return null;
+  }
   if (rec.on_demand_cost !== undefined && rec.on_demand_cost !== null && rec.on_demand_cost > 0) {
     return (rec.savings / rec.on_demand_cost) * 100;
   }

--- a/frontend/src/approval-details.ts
+++ b/frontend/src/approval-details.ts
@@ -58,11 +58,9 @@ export function renderApprovalDetailsBody(details: PurchaseDetails, accountsById
     // Direct-execute paths (capacity_percent flow) can sometimes
     // race the JSONB write — surface the legacy sentence so the user
     // can still confirm rather than blocking the click on a missing
-    // payload.
-    const fallback = document.createElement('p');
-    fallback.className = 'approval-details-fallback';
-    fallback.textContent = 'This authorises the purchase to execute. Cloud commitments will be charged once the executor picks up the approved row.';
-    root.appendChild(fallback);
+    // payload. Shared helper keeps the fallback text identical to
+    // the network-failure branch.
+    root.appendChild(buildApprovalDetailsFallback());
     return root;
   }
 
@@ -93,7 +91,10 @@ function renderApprovalDetailsHeader(details: PurchaseDetails, recs: Recommendat
   for (const rec of recs) {
     if (rec.provider) providers.add(rec.provider);
     if (rec.cloud_account_id) accounts.add(rec.cloud_account_id);
-    totalMonthly += rec.savings;
+    // Defensive ?? 0: the wire type is wider than the TS one and a
+    // legacy row could carry null; a single NaN here would poison
+    // the entire header total.
+    totalMonthly += rec.savings ?? 0;
   }
   const totalAnnual = totalMonthly * 12;
 
@@ -103,9 +104,17 @@ function renderApprovalDetailsHeader(details: PurchaseDetails, recs: Recommendat
   // table footer stay numerically in sync with the per-row column.
   const monthly = details.estimated_savings ?? totalMonthly;
 
+  // Epsilon-tolerant comparison: strict !== on two floats that come
+  // from independent sums (backend estimated_savings vs frontend
+  // per-rec sum) will trigger on rounding noise as small as 1e-14,
+  // making the "from per-row sum" tooltip fire on rows that are
+  // conceptually equal. 0.005 keeps the tooltip silent up to the
+  // sub-cent level, well below the precision formatCurrency renders.
+  const annualMismatch = Math.abs(totalAnnual - monthly * 12) > 0.005;
+
   header.appendChild(headerStat('Upfront', formatCurrency(upfront)));
   header.appendChild(headerStat('Monthly savings', formatCurrency(monthly)));
-  header.appendChild(headerStat('Annual savings', formatCurrency(monthly * 12), undefined, totalAnnual !== monthly * 12 ? `${formatCurrency(totalAnnual)} from per-row sum` : undefined));
+  header.appendChild(headerStat('Annual savings', formatCurrency(monthly * 12), undefined, annualMismatch ? `${formatCurrency(totalAnnual)} from per-row sum` : undefined));
   header.appendChild(headerStat('Commitments', String(recs.length)));
   header.appendChild(headerStat('Providers', String(providers.size), Array.from(providers).join(', ')));
   header.appendChild(headerStat('Accounts', String(accounts.size)));
@@ -193,7 +202,9 @@ function renderRecRow(rec: Recommendation, accountsById: AccountsById): HTMLElem
   const row = document.createElement('tr');
   const acct = rec.cloud_account_id ? accountsById.get(rec.cloud_account_id) : undefined;
   const accountLabel = formatAccountLabel(acct, rec.cloud_account_id);
-  const engineLabel = rec.engine && rec.engine !== '' ? rec.engine : '—';
+  // rec.engine is a string for DB-shaped services and "" otherwise;
+  // both `undefined` and "" are falsy so the single check is enough.
+  const engineLabel = rec.engine ? rec.engine : '—';
   const effSavings = computeEffectiveSavingsPct(rec);
   // innerHTML is safe here because every interpolated value goes
   // through escapeHtml or is a numeric/preformatted constant. Using
@@ -273,18 +284,36 @@ export function computeEffectiveSavingsPct(rec: Recommendation): number | null {
  */
 export async function buildApprovalDetailsBody(executionId: string): Promise<HTMLElement> {
   try {
+    // listAccounts is caught inline so the modal still renders the
+    // full details when the accounts endpoint is unreachable; the
+    // per-rec table degrades to "acct xxxxxxxx…" stubs instead of
+    // failing the whole confirmation. console.warn keeps the failure
+    // traceable rather than silently dropping the error.
     const [details, accounts] = await Promise.all([
       api.getPurchaseDetails(executionId),
-      api.listAccounts().catch(() => [] as CloudAccount[]),
+      api.listAccounts().catch((err) => {
+        console.warn('Failed to load accounts for approval modal — falling back to UUID-prefixed labels:', err);
+        return [] as CloudAccount[];
+      }),
     ]);
     const accountsById = new Map<string, CloudAccount>();
     for (const acct of accounts) accountsById.set(acct.id, acct);
     return renderApprovalDetailsBody(details, accountsById);
   } catch (err) {
     console.error('Failed to load purchase details for approval modal:', err);
-    const fallback = document.createElement('div');
-    fallback.className = 'approval-details-fallback';
-    fallback.textContent = 'This authorises the purchase to execute. Cloud commitments will be charged once the executor picks up the approved row.';
-    return fallback;
+    return buildApprovalDetailsFallback();
   }
+}
+
+/**
+ * Build the legacy approval sentence as a standalone fallback
+ * element. Extracted so the two failure paths (empty recommendations
+ * + fetch failure) render identical text and class hooks; previously
+ * the literal string lived in two places and could drift.
+ */
+function buildApprovalDetailsFallback(): HTMLElement {
+  const fallback = document.createElement('div');
+  fallback.className = 'approval-details-fallback';
+  fallback.textContent = 'This authorises the purchase to execute. Cloud commitments will be charged once the executor picks up the approved row.';
+  return fallback;
 }

--- a/frontend/src/approval-details.ts
+++ b/frontend/src/approval-details.ts
@@ -71,6 +71,15 @@ export function renderApprovalDetailsBody(details: PurchaseDetails, accountsById
   return root;
 }
 
+/**
+ * Render the at-a-glance stat row that sits above the per-rec table.
+ * Each stat surfaces one number the user needs to weigh before
+ * clicking Approve: total upfront, monthly + annual savings,
+ * commitment count, distinct providers and distinct accounts touched.
+ * The annual figure is derived from monthly × 12; if it diverges from
+ * the sum of per-row monthly savings it's surfaced as a tooltip on
+ * the stat so the user has a path to the underlying numbers.
+ */
 function renderApprovalDetailsHeader(details: PurchaseDetails, recs: Recommendation[]): HTMLElement {
   const header = document.createElement('div');
   header.className = 'approval-details-header';
@@ -104,6 +113,13 @@ function renderApprovalDetailsHeader(details: PurchaseDetails, recs: Recommendat
   return header;
 }
 
+/**
+ * Build one label/value cell for the header grid. `hover` becomes the
+ * value's title attribute (used to surface the comma-joined provider
+ * list on the "Providers: 3" stat without crowding the visible cell);
+ * `title` is set on the wrapping container for stats whose deeper
+ * context belongs on the whole entry rather than just the value.
+ */
 function headerStat(label: string, value: string, hover?: string, title?: string): HTMLElement {
   const stat = document.createElement('div');
   stat.className = 'approval-details-stat';
@@ -120,6 +136,15 @@ function headerStat(label: string, value: string, hover?: string, title?: string
   return stat;
 }
 
+/**
+ * Render the per-recommendation table with sticky thead and one row
+ * per rec. Wrapped in a scrollable container so a 20-rec execution
+ * spanning AWS + Azure + GCP stays inside the modal viewport without
+ * pushing the action buttons off-screen. Columns mirror the order
+ * documented on issue #374: identity (account / provider / service /
+ * resource / engine / region) -> sizing (count / term / payment) ->
+ * money (upfront / monthly savings / effective savings %).
+ */
 function renderApprovalDetailsTable(recs: Recommendation[], accountsById: AccountsById): HTMLElement {
   const wrap = document.createElement('div');
   wrap.className = 'approval-details-table-wrap';
@@ -154,6 +179,16 @@ function renderApprovalDetailsTable(recs: Recommendation[], accountsById: Accoun
   return wrap;
 }
 
+/**
+ * Render one tbody row from a Recommendation. The account UUID is
+ * resolved against accountsById via formatAccountLabel; engine falls
+ * back to "—" for services that don't carry a DB engine (EC2, ALB);
+ * effective savings % follows the same baseline-preferred /
+ * reconstruction-fallback policy as the recommendations table (see
+ * computeEffectiveSavingsPct). Every interpolated string flows
+ * through escapeHtml so a tampered recommendation field can't inject
+ * markup.
+ */
 function renderRecRow(rec: Recommendation, accountsById: AccountsById): HTMLElement {
   const row = document.createElement('tr');
   const acct = rec.cloud_account_id ? accountsById.get(rec.cloud_account_id) : undefined;

--- a/frontend/src/approval-details.ts
+++ b/frontend/src/approval-details.ts
@@ -1,0 +1,255 @@
+/**
+ * Pre-purchase approval-confirmation modal body builder.
+ *
+ * Closes issue #374. Before this module existed, the confirm dialog
+ * shown when a user clicks Approve only carried a static sentence and
+ * the execution UUID — not informed consent for a financial commitment.
+ *
+ * This module fetches `/api/purchases/{id}` + `/api/accounts` and builds
+ * an HTMLElement carrying:
+ *   - An aggregate header (total upfront, total monthly + annual
+ *     savings, recommendation count, distinct providers, distinct
+ *     accounts touched).
+ *   - A per-recommendation table: account / provider / service /
+ *     resource type / engine / region / count / term + payment /
+ *     upfront / monthly savings / effective savings % when the rec
+ *     carries a non-null `on_demand_cost`.
+ *
+ * The pure builder `renderApprovalDetailsBody(details, accountsById)`
+ * is split out from the network-fetching wrapper
+ * `buildApprovalDetailsBody(executionId)` so unit tests can exercise
+ * the rendering without mocking fetch. Both code paths share the same
+ * fallback shape: when the GET fails (404, 403, network error) we
+ * return a plain-text element preserving the legacy behaviour so the
+ * dialog still opens and the Approve button still works — just without
+ * the details. Showing a half-built modal would be worse UX than
+ * gracefully falling back.
+ */
+
+import * as api from './api';
+import type { CloudAccount } from './api/accounts';
+import type { PurchaseDetails, Recommendation } from './api/types';
+import { escapeHtml, formatCurrency, formatTerm } from './utils';
+
+/**
+ * accountsById maps the internal CloudAccount UUID (the value carried
+ * on `Recommendation.cloud_account_id`) to the full CloudAccount
+ * record. Used to resolve "acct-uuid" -> "Production AWS
+ * (123456789012)" in the table without re-fetching the accounts list
+ * per row.
+ */
+export type AccountsById = Map<string, CloudAccount>;
+
+/**
+ * Build an HTMLElement to pass as `body` to confirmDialog when the
+ * user is about to approve a purchase. Renders the rich details from
+ * `details.recommendations`, falling back to a plain text element
+ * (with the legacy approval sentence) when no recs are present.
+ *
+ * Exported separately from `buildApprovalDetailsBody` so tests can
+ * render the body deterministically — no fetch mocking required.
+ */
+export function renderApprovalDetailsBody(details: PurchaseDetails, accountsById: AccountsById): HTMLElement {
+  const root = document.createElement('div');
+  root.className = 'approval-details';
+
+  const recs = details.recommendations ?? [];
+  if (recs.length === 0) {
+    // Direct-execute paths (capacity_percent flow) can sometimes
+    // race the JSONB write — surface the legacy sentence so the user
+    // can still confirm rather than blocking the click on a missing
+    // payload.
+    const fallback = document.createElement('p');
+    fallback.className = 'approval-details-fallback';
+    fallback.textContent = 'This authorises the purchase to execute. Cloud commitments will be charged once the executor picks up the approved row.';
+    root.appendChild(fallback);
+    return root;
+  }
+
+  root.appendChild(renderApprovalDetailsHeader(details, recs));
+  root.appendChild(renderApprovalDetailsTable(recs, accountsById));
+  return root;
+}
+
+function renderApprovalDetailsHeader(details: PurchaseDetails, recs: Recommendation[]): HTMLElement {
+  const header = document.createElement('div');
+  header.className = 'approval-details-header';
+
+  // Distinct provider / account counts give the user a quick
+  // "am I committing across N clouds and M accounts?" signal
+  // before they scroll the per-row table.
+  const providers = new Set<string>();
+  const accounts = new Set<string>();
+  let totalMonthly = 0;
+  for (const rec of recs) {
+    if (rec.provider) providers.add(rec.provider);
+    if (rec.cloud_account_id) accounts.add(rec.cloud_account_id);
+    totalMonthly += rec.savings;
+  }
+  const totalAnnual = totalMonthly * 12;
+
+  const upfront = details.total_upfront_cost ?? 0;
+  // estimated_savings on the response is monthly; aggregating the
+  // per-rec savings field above is identical math but lets the
+  // table footer stay numerically in sync with the per-row column.
+  const monthly = details.estimated_savings ?? totalMonthly;
+
+  header.appendChild(headerStat('Upfront', formatCurrency(upfront)));
+  header.appendChild(headerStat('Monthly savings', formatCurrency(monthly)));
+  header.appendChild(headerStat('Annual savings', formatCurrency(monthly * 12), undefined, totalAnnual !== monthly * 12 ? `${formatCurrency(totalAnnual)} from per-row sum` : undefined));
+  header.appendChild(headerStat('Commitments', String(recs.length)));
+  header.appendChild(headerStat('Providers', String(providers.size), Array.from(providers).join(', ')));
+  header.appendChild(headerStat('Accounts', String(accounts.size)));
+
+  return header;
+}
+
+function headerStat(label: string, value: string, hover?: string, title?: string): HTMLElement {
+  const stat = document.createElement('div');
+  stat.className = 'approval-details-stat';
+  const labelEl = document.createElement('div');
+  labelEl.className = 'approval-details-stat-label';
+  labelEl.textContent = label;
+  const valueEl = document.createElement('div');
+  valueEl.className = 'approval-details-stat-value';
+  valueEl.textContent = value;
+  if (hover) valueEl.setAttribute('title', hover);
+  if (title) stat.setAttribute('title', title);
+  stat.appendChild(labelEl);
+  stat.appendChild(valueEl);
+  return stat;
+}
+
+function renderApprovalDetailsTable(recs: Recommendation[], accountsById: AccountsById): HTMLElement {
+  const wrap = document.createElement('div');
+  wrap.className = 'approval-details-table-wrap';
+
+  const table = document.createElement('table');
+  table.className = 'approval-details-table';
+
+  const thead = document.createElement('thead');
+  thead.innerHTML = `
+    <tr>
+      <th>Account</th>
+      <th>Provider</th>
+      <th>Service</th>
+      <th>Resource</th>
+      <th>Engine</th>
+      <th>Region</th>
+      <th class="num">Count</th>
+      <th>Term</th>
+      <th>Payment</th>
+      <th class="num">Upfront</th>
+      <th class="num">Monthly savings</th>
+      <th class="num">Eff. savings %</th>
+    </tr>`;
+  table.appendChild(thead);
+
+  const tbody = document.createElement('tbody');
+  for (const rec of recs) {
+    tbody.appendChild(renderRecRow(rec, accountsById));
+  }
+  table.appendChild(tbody);
+  wrap.appendChild(table);
+  return wrap;
+}
+
+function renderRecRow(rec: Recommendation, accountsById: AccountsById): HTMLElement {
+  const row = document.createElement('tr');
+  const acct = rec.cloud_account_id ? accountsById.get(rec.cloud_account_id) : undefined;
+  const accountLabel = formatAccountLabel(acct, rec.cloud_account_id);
+  const engineLabel = rec.engine && rec.engine !== '' ? rec.engine : '—';
+  const effSavings = computeEffectiveSavingsPct(rec);
+  // innerHTML is safe here because every interpolated value goes
+  // through escapeHtml or is a numeric/preformatted constant. Using
+  // innerHTML rather than 12 createElement calls per row keeps the
+  // render code readable for the table layout, mirroring the
+  // recommendations.ts pattern.
+  row.innerHTML = `
+    <td>${escapeHtml(accountLabel)}</td>
+    <td>${escapeHtml(rec.provider ?? '')}</td>
+    <td>${escapeHtml(rec.service ?? '')}</td>
+    <td>${escapeHtml(rec.resource_type ?? '')}</td>
+    <td>${escapeHtml(engineLabel)}</td>
+    <td>${escapeHtml(rec.region ?? '')}</td>
+    <td class="num">${escapeHtml(String(rec.count ?? 0))}</td>
+    <td>${escapeHtml(formatTerm(rec.term))}</td>
+    <td>${escapeHtml(rec.payment ?? '')}</td>
+    <td class="num">${escapeHtml(formatCurrency(rec.upfront_cost ?? 0))}</td>
+    <td class="num">${escapeHtml(formatCurrency(rec.savings ?? 0))}</td>
+    <td class="num">${effSavings === null ? '—' : escapeHtml(`${effSavings.toFixed(1)}%`)}</td>`;
+  return row;
+}
+
+/**
+ * Compose the user-facing account label.
+ *
+ *   - When the account record is resolved, render "Name (external_id)".
+ *   - When only the UUID is on the rec (account not yet listed because
+ *     of a stale cache or a deletion race), show the first 8 chars of
+ *     the UUID so the user can still cross-reference.
+ *   - When the rec carries no account at all (ambient-credentials
+ *     direct-execute path), show "(ambient)" so the user knows it's
+ *     hitting whichever account the deployment runs in.
+ */
+export function formatAccountLabel(acct: CloudAccount | undefined, recAccountId: string | undefined): string {
+  if (acct) {
+    if (acct.external_id) return `${acct.name} (${acct.external_id})`;
+    return acct.name;
+  }
+  if (recAccountId) {
+    return `acct ${recAccountId.slice(0, 8)}…`;
+  }
+  return '(ambient)';
+}
+
+/**
+ * Compute the "effective savings %" the same way the recommendations
+ * table does (see recommendations.ts) — prefer the raw on_demand_cost
+ * baseline when the provider returned one. Returns null when we can't
+ * confidently compute (no on-demand baseline AND the reconstructed
+ * denominator would be zero or negative) so the table can render "—"
+ * instead of an inflated %.
+ *
+ * Formula: savings / on_demand_cost × 100, monthly-normalized.
+ * `savings` on the rec is already the monthly savings; the upfront
+ * cost is amortized into the rec.savings during recommendation
+ * collection, so we don't re-add it here.
+ */
+export function computeEffectiveSavingsPct(rec: Recommendation): number | null {
+  if (rec.on_demand_cost !== undefined && rec.on_demand_cost !== null && rec.on_demand_cost > 0) {
+    return (rec.savings / rec.on_demand_cost) * 100;
+  }
+  // Fallback: reconstruct on-demand from monthly + savings. Only valid
+  // when monthly_cost is present and positive — for all-upfront recs
+  // with monthly_cost = 0 the reconstruction collapses (see #274).
+  if (rec.monthly_cost !== null && rec.monthly_cost !== undefined && rec.monthly_cost > 0) {
+    const reconstructed = rec.monthly_cost + rec.savings;
+    if (reconstructed > 0) return (rec.savings / reconstructed) * 100;
+  }
+  return null;
+}
+
+/**
+ * Network-fetching wrapper. Fetches `/api/purchases/{id}` + the
+ * accounts list in parallel, builds the rich body, and returns it.
+ * Any fetch failure falls back to a plain-text element carrying the
+ * legacy approval sentence so confirmDialog still works.
+ */
+export async function buildApprovalDetailsBody(executionId: string): Promise<HTMLElement> {
+  try {
+    const [details, accounts] = await Promise.all([
+      api.getPurchaseDetails(executionId),
+      api.listAccounts().catch(() => [] as CloudAccount[]),
+    ]);
+    const accountsById = new Map<string, CloudAccount>();
+    for (const acct of accounts) accountsById.set(acct.id, acct);
+    return renderApprovalDetailsBody(details, accountsById);
+  } catch (err) {
+    console.error('Failed to load purchase details for approval modal:', err);
+    const fallback = document.createElement('div');
+    fallback.className = 'approval-details-fallback';
+    fallback.textContent = 'This authorises the purchase to execute. Cloud commitments will be charged once the executor picks up the approved row.';
+    return fallback;
+  }
+}

--- a/frontend/src/history.ts
+++ b/frontend/src/history.ts
@@ -8,6 +8,7 @@ import { formatCurrency, formatDate, formatTerm, escapeHtml } from './utils';
 import type { HistoryResponse, HistorySummary, HistoryPurchase } from './types';
 import { switchTab } from './navigation';
 import { confirmDialog } from './confirmDialog';
+import { buildApprovalDetailsBody } from './approval-details';
 import { showToast } from './toast';
 import { getCurrentUser } from './state';
 import { showSkeletonRows, teardownSkeleton } from './lib/skeleton';
@@ -611,9 +612,15 @@ function renderHistoryList(purchases: HistoryPurchase[]): void {
     btn.addEventListener('click', async () => {
       const id = btn.dataset['approveId'];
       if (!id) return;
+      // Issue #374: show the per-rec details (service / engine /
+      // resource / region / count / term + payment / costs) in the
+      // modal so the user has informed consent before authorising a
+      // financial commitment. buildApprovalDetailsBody falls back to
+      // the legacy text sentence if the GET fails.
+      const detailsBody = await buildApprovalDetailsBody(id);
       const ok = await confirmDialog({
         title: 'Approve this pending purchase?',
-        body: 'This authorises the purchase to execute. Cloud commitments will be charged once the executor picks up the approved row.',
+        body: detailsBody,
         confirmLabel: 'Approve purchase',
         destructive: false,
       });

--- a/frontend/src/purchases-deeplink.ts
+++ b/frontend/src/purchases-deeplink.ts
@@ -21,6 +21,7 @@
 import { apiRequest } from './api/client';
 import { showToast } from './toast';
 import { confirmDialog } from './confirmDialog';
+import { buildApprovalDetailsBody } from './approval-details';
 
 type DeeplinkAction = 'approve' | 'cancel';
 
@@ -75,9 +76,20 @@ export async function handlePurchaseDeeplink(): Promise<boolean> {
   const titleVerb = dl.action === 'approve' ? 'Approve' : 'Cancel';
   const gerund = dl.action === 'approve' ? 'approve' : 'cancel';
   const confirmLabel = dl.action === 'approve' ? 'Approve purchase' : 'Cancel purchase';
+  // Issue #374: on approve, show the per-rec details (service / engine
+  // / resource / region / count / term + payment / costs) so the user
+  // has informed consent before authorising a financial commitment.
+  // On cancel, the legacy sentence is enough — cancelling a pending
+  // approval is non-destructive to AWS.
+  let body: string | HTMLElement;
+  if (dl.action === 'approve') {
+    body = await buildApprovalDetailsBody(dl.id);
+  } else {
+    body = `You're about to ${gerund} purchase execution ${dl.id}. This action will be recorded against your logged-in account.`;
+  }
   const ok = await confirmDialog({
     title: `${titleVerb} purchase ${dl.id.slice(0, 8)}…?`,
-    body: `You're about to ${gerund} purchase execution ${dl.id}. This action will be recorded against your logged-in account.`,
+    body,
     confirmLabel,
     hideCancelButton: true,
     destructive: dl.action === 'cancel',

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -990,6 +990,100 @@ tr.rec-variant-row:hover td:not(.checkbox-col) {
     gap: 0.5rem;
 }
 
+/* Approval-details modal (issue #374): when the confirmDialog body
+ * carries an .approval-details element, widen the dialog so the 12-col
+ * per-rec table can breathe. The selector targets the parent modal via
+ * :has() so the rest of the confirmDialog callers (Cancel, etc.) keep
+ * the narrow 480px layout. */
+.modal-confirm:has(.approval-details) {
+    max-width: min(1100px, 95vw);
+    min-width: min(720px, 95vw);
+}
+
+.approval-details {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.approval-details-fallback {
+    margin: 0;
+    color: #444;
+    line-height: 1.5;
+    font-size: 0.95rem;
+}
+
+.approval-details-header {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 0.5rem 1rem;
+    padding: 0.75rem 1rem;
+    background: var(--cudly-surface-2, #f6f8fa);
+    border: 1px solid var(--cudly-border, #e1e4e8);
+    border-radius: 6px;
+}
+
+.approval-details-stat {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+}
+
+.approval-details-stat-label {
+    font-size: 0.78rem;
+    color: var(--cudly-text-muted, #6a737d);
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+
+.approval-details-stat-value {
+    font-size: 1rem;
+    font-weight: 600;
+    color: #222;
+}
+
+.approval-details-table-wrap {
+    overflow-x: auto;
+    max-height: 50vh;
+    border: 1px solid var(--cudly-border, #e1e4e8);
+    border-radius: 6px;
+}
+
+.approval-details-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.85rem;
+}
+
+.approval-details-table th,
+.approval-details-table td {
+    padding: 0.45rem 0.65rem;
+    text-align: left;
+    border-bottom: 1px solid var(--cudly-border, #eef0f2);
+    white-space: nowrap;
+}
+
+.approval-details-table thead th {
+    position: sticky;
+    top: 0;
+    background: var(--cudly-surface-2, #f6f8fa);
+    font-weight: 600;
+    color: var(--cudly-text-muted, #444);
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
+}
+
+.approval-details-table tbody tr:last-child td {
+    border-bottom: none;
+}
+
+.approval-details-table th.num,
+.approval-details-table td.num {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+}
+
 /* Provider badges */
 .provider-badge {
     display: inline-block;


### PR DESCRIPTION
## Summary

Closes #374. Pre-fix, the confirmation modal shown when a user clicks Approve only carried a static sentence and the execution UUID — not informed consent for a financial commitment.

This PR introduces a new `frontend/src/approval-details.ts` module that builds a rich modal body:

- **Aggregate header** — total upfront, total monthly + annual savings, commitment count, distinct providers, distinct accounts touched.
- **Per-rec table** (12 columns) — account (Name + external ID), provider, service, resource type, engine, region, count, term, payment, upfront, monthly savings, effective savings %.

## Per-rec field sources

| Column | Source |
|---|---|
| Account | `/api/accounts` lookup keyed off `rec.cloud_account_id` → `Name (external_id)` |
| Provider / Service / Resource / Region | direct from `rec` |
| Engine | `rec.engine`, present on RDS / Aurora / OpenSearch / ElastiCache; "—" otherwise |
| Term / Payment | direct from `rec` via existing `formatTerm` |
| Upfront / Monthly savings | direct from `rec` via existing `formatCurrency` |
| Effective savings % | `rec.savings / rec.on_demand_cost` when baseline present, falls back to `savings / (monthly + savings)` reconstruction, "—" when neither is usable |

The external-ID column does triple duty: AWS account number, Azure subscription ID, GCP project — all flow through the existing `CloudAccount.external_id` field. Recs without an account (ambient-credentials direct-execute path) render as `(ambient)`.

## Call sites wired

- `frontend/src/history.ts` — dashboard Approve button on pending rows.
- `frontend/src/purchases-deeplink.ts` — email-link approve flow.

The Cancel-purchase deep link keeps the legacy text body — cancelling a pending approval doesn't commit cloud spend, so the cost-of-error asymmetry doesn't justify the extra fetch.

## Resilience

`buildApprovalDetailsBody(executionId)` fetches details + accounts list in parallel and falls back to the legacy sentence if either GET fails. The Approve button keeps working on stale caches, 403s, or transient network failures — just without the details.

## CSS

`components.css` widens `.modal-confirm` to `min(1100px, 95vw)` only when it contains an `.approval-details` element (via `:has()`), so the other confirmDialog callers (Cancel, Delete, etc.) keep their 480px layout. The 12-col table is sticky-header + horizontally scrollable for narrow viewports, capped at 50vh.

## Tests

`frontend/src/__tests__/approval-details.test.ts` — 20 unit tests on `renderApprovalDetailsBody` + the pure helpers. Covers:

- Header aggregates (totals, distinct providers, distinct accounts)
- Full 12-column table headers
- Account UUID resolution: known → `Name (external_id)`, unknown → `acct <prefix>…`, missing → `(ambient)`
- Engine column for RDS-shaped recs, "—" otherwise
- Term and currency formatting matches existing dashboard conventions
- Effective savings % with baseline vs. reconstruction vs. neither
- Multi-provider / multi-account aggregate counts
- Empty-recs fallback
- HTML escaping of user-controlled string values
- `formatAccountLabel` and `computeEffectiveSavingsPct` edge cases (zero baseline, missing fields)

## Test plan

- [x] `npx jest` — 1666 tests pass (47 suites)
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: open the Approve modal on a pending row in dev, confirm: per-rec table renders, account name + external ID resolved, engine column shows for RDS / blank for EC2, effective savings % shows when baseline present.

## Backend changes

None. The backend's `buildPurchaseDetailsResponse` already returns the full `recommendations[]` array and `total_upfront_cost` / `estimated_savings`. Only the TypeScript `PurchaseDetails` type was stale — it has been brought into sync with the actual response shape.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Approval confirmation dialog now shows rich purchase details for approve flows and deep-links: aggregate upfront/monthly/annual savings, per-recommendation table with columns, resolved account labels, term/engine display, plan execution info, and effective savings percentages with legacy fallback when empty.

* **Style**
  * Responsive, expanded modal styling with stat blocks, sticky table header, numeric alignment, and overflow handling for the approval details view.

* **Tests**
  * Added unit tests for approval-details rendering, account label/term formatting, effective-savings computation, tooltip behavior, and HTML-escaping.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/375)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->