### PR TITLE
feat(api+frontend/plans): add per-plan health score badge (#340 follow-up)

### DIFF
--- a/frontend/src/__tests__/plans.test.ts
+++ b/frontend/src/__tests__/plans.test.ts
@@ -495,6 +495,112 @@ describe('Plans Module', () => {
       const list = document.getElementById('plans-list');
       expect(list?.innerHTML).toContain('Null Services Plan');
     });
+
+    // Plan health badge — green band, no factors -> simple tooltip.
+    test('renders green health badge for high scores', async () => {
+      (api.getPlans as jest.Mock).mockResolvedValue({
+        plans: [
+          {
+            id: 'plan-h-1',
+            name: 'Healthy Plan',
+            enabled: true,
+            auto_purchase: true,
+            services: { ec2: { provider: 'aws', service: 'ec2', enabled: true, term: 1, payment: 'no-upfront', coverage: 80 } },
+            ramp_schedule: { type: 'immediate', percent_per_step: 100, step_interval_days: 0, current_step: 0, total_steps: 1 },
+            health_score: 95,
+            health_factors: []
+          }
+        ]
+      });
+      (api.getPlannedPurchases as jest.Mock).mockResolvedValue({ purchases: [] });
+
+      await loadPlans();
+
+      const badge = document.querySelector<HTMLElement>('[data-testid="plan-health-badge"]');
+      expect(badge).not.toBeNull();
+      expect(badge?.classList.contains('plan-health-badge--good')).toBe(true);
+      expect(badge?.textContent).toBe('95');
+      expect(badge?.getAttribute('title')).toContain('95/100');
+    });
+
+    test('renders amber health badge for mid-band scores', async () => {
+      (api.getPlans as jest.Mock).mockResolvedValue({
+        plans: [
+          {
+            id: 'plan-h-2',
+            name: 'Mid Plan',
+            enabled: true,
+            auto_purchase: true,
+            services: { ec2: { provider: 'aws', service: 'ec2', enabled: true, term: 1, payment: 'no-upfront', coverage: 80 } },
+            ramp_schedule: { type: 'weekly', percent_per_step: 25, step_interval_days: 7, current_step: 1, total_steps: 4 },
+            health_score: 65,
+            health_factors: [
+              { kind: 'behind_schedule', weight: 20, note: 'Ramp is 1 step(s) behind schedule' },
+              { kind: 'failed_executions', weight: 10, note: '1 failed execution(s)' }
+            ]
+          }
+        ]
+      });
+      (api.getPlannedPurchases as jest.Mock).mockResolvedValue({ purchases: [] });
+
+      await loadPlans();
+
+      const badge = document.querySelector<HTMLElement>('[data-testid="plan-health-badge"]');
+      expect(badge).not.toBeNull();
+      expect(badge?.classList.contains('plan-health-badge--warn')).toBe(true);
+      expect(badge?.textContent).toBe('65');
+      const title = badge?.getAttribute('title') || '';
+      expect(title).toContain('behind schedule');
+      expect(title).toContain('failed execution');
+    });
+
+    test('renders red health badge for low scores', async () => {
+      (api.getPlans as jest.Mock).mockResolvedValue({
+        plans: [
+          {
+            id: 'plan-h-3',
+            name: 'Bad Plan',
+            enabled: false,
+            auto_purchase: false,
+            services: { ec2: { provider: 'aws', service: 'ec2', enabled: true, term: 1, payment: 'no-upfront', coverage: 80 } },
+            ramp_schedule: { type: 'weekly', percent_per_step: 25, step_interval_days: 7, current_step: 1, total_steps: 4 },
+            health_score: 25,
+            health_factors: [
+              { kind: 'disabled_midway', weight: 25, note: 'Disabled at step 1 of 4' },
+              { kind: 'failed_executions', weight: 30, note: '3 failed execution(s)' }
+            ]
+          }
+        ]
+      });
+      (api.getPlannedPurchases as jest.Mock).mockResolvedValue({ purchases: [] });
+
+      await loadPlans();
+
+      const badge = document.querySelector<HTMLElement>('[data-testid="plan-health-badge"]');
+      expect(badge).not.toBeNull();
+      expect(badge?.classList.contains('plan-health-badge--bad')).toBe(true);
+      expect(badge?.textContent).toBe('25');
+    });
+
+    test('omits health badge when score is missing (legacy API response)', async () => {
+      (api.getPlans as jest.Mock).mockResolvedValue({
+        plans: [
+          {
+            id: 'plan-h-4',
+            name: 'No Score Plan',
+            enabled: true,
+            auto_purchase: true,
+            services: { ec2: { provider: 'aws', service: 'ec2', enabled: true, term: 1, payment: 'no-upfront', coverage: 80 } },
+            ramp_schedule: { type: 'immediate', percent_per_step: 100, step_interval_days: 0, current_step: 0, total_steps: 1 }
+          }
+        ]
+      });
+      (api.getPlannedPurchases as jest.Mock).mockResolvedValue({ purchases: [] });
+
+      await loadPlans();
+
+      expect(document.querySelector('[data-testid="plan-health-badge"]')).toBeNull();
+    });
   });
 
   describe('loadPlannedPurchases', () => {

--- a/frontend/src/__tests__/plans.test.ts
+++ b/frontend/src/__tests__/plans.test.ts
@@ -582,6 +582,64 @@ describe('Plans Module', () => {
       expect(badge?.textContent).toBe('25');
     });
 
+    test('renders green health badge at the good-band boundary (score=80)', async () => {
+      // Boundary guard: planHealthBandClass uses `>= 80` for good, so
+      // a score of exactly 80 must land in the green band. A regression
+      // that flipped to `> 80` would skew this row to amber.
+      (api.getPlans as jest.Mock).mockResolvedValue({
+        plans: [
+          {
+            id: 'plan-h-boundary-good',
+            name: 'Boundary Good',
+            enabled: true,
+            auto_purchase: true,
+            services: { ec2: { provider: 'aws', service: 'ec2', enabled: true, term: 1, payment: 'no-upfront', coverage: 80 } },
+            ramp_schedule: { type: 'weekly', percent_per_step: 25, step_interval_days: 7, current_step: 1, total_steps: 4 },
+            health_score: 80,
+            health_factors: []
+          }
+        ]
+      });
+      (api.getPlannedPurchases as jest.Mock).mockResolvedValue({ purchases: [] });
+
+      await loadPlans();
+
+      const badge = document.querySelector<HTMLElement>('[data-testid="plan-health-badge"]');
+      expect(badge).not.toBeNull();
+      expect(badge?.classList.contains('plan-health-badge--good')).toBe(true);
+      expect(badge?.textContent).toBe('80');
+    });
+
+    test('renders amber health badge at the warn-band boundary (score=50)', async () => {
+      // Boundary guard: planHealthBandClass uses `>= 50` for warn, so
+      // a score of exactly 50 must land in the amber band. A
+      // regression that flipped to `> 50` would skew this row to red.
+      (api.getPlans as jest.Mock).mockResolvedValue({
+        plans: [
+          {
+            id: 'plan-h-boundary-warn',
+            name: 'Boundary Warn',
+            enabled: true,
+            auto_purchase: true,
+            services: { ec2: { provider: 'aws', service: 'ec2', enabled: true, term: 1, payment: 'no-upfront', coverage: 80 } },
+            ramp_schedule: { type: 'weekly', percent_per_step: 25, step_interval_days: 7, current_step: 1, total_steps: 4 },
+            health_score: 50,
+            health_factors: [
+              { kind: 'failed_executions', weight: 50, note: '5 failed execution(s)' }
+            ]
+          }
+        ]
+      });
+      (api.getPlannedPurchases as jest.Mock).mockResolvedValue({ purchases: [] });
+
+      await loadPlans();
+
+      const badge = document.querySelector<HTMLElement>('[data-testid="plan-health-badge"]');
+      expect(badge).not.toBeNull();
+      expect(badge?.classList.contains('plan-health-badge--warn')).toBe(true);
+      expect(badge?.textContent).toBe('50');
+    });
+
     test('omits health badge when score is missing (legacy API response)', async () => {
       (api.getPlans as jest.Mock).mockResolvedValue({
         plans: [

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -15,6 +15,7 @@ export type {
   Recommendation,
   RecommendationFilters,
   Plan,
+  PlanHealthFactor,
   CreatePlanRequest,
   PurchaseHistory,
   HistoryFilters,

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -89,6 +89,12 @@ export interface PlanRampSchedule {
   start_date?: string;
 }
 
+export interface PlanHealthFactor {
+  kind: string;
+  weight: number;
+  note: string;
+}
+
 export interface Plan {
   id: string;
   name: string;
@@ -101,6 +107,11 @@ export interface Plan {
   updated_at: string;
   next_execution_date?: string;
   last_execution_date?: string;
+  // Response-only fields populated by the GET /plans handler. Optional
+  // so this type still matches CreatePlanRequest-shaped fixtures and
+  // older API responses served during a partial deploy.
+  health_score?: number;
+  health_factors?: PlanHealthFactor[];
 }
 
 export interface CreatePlanRequest {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -89,6 +89,19 @@ export interface PlanRampSchedule {
   start_date?: string;
 }
 
+/**
+ * One penalty (or annotation) that contributed to a plan's health
+ * score. Mirrors the backend `HealthFactor` struct (see
+ * `internal/api/plan_health.go`):
+ *   - `kind` is a stable machine slug (e.g. `overdue`, `failed`,
+ *     `behind_schedule`) so the frontend can colour or filter on it
+ *     without parsing the human-readable note.
+ *   - `weight` is the integer subtracted from the 100-point starting
+ *     score for this factor; positive numbers represent the size of
+ *     the penalty.
+ *   - `note` is the human-readable explanation surfaced in the badge
+ *     tooltip.
+ */
 export interface PlanHealthFactor {
   kind: string;
   weight: number;

--- a/frontend/src/plans.ts
+++ b/frontend/src/plans.ts
@@ -273,6 +273,35 @@ interface BackendPlan {
     total_steps: number;
   };
   next_execution_date?: string;
+  // Optional health-score fields populated by the GET /plans envelope.
+  // Optional so older API responses (and unit-test fixtures that don't
+  // set them) keep type-checking; the badge simply doesn't render when
+  // the score is absent.
+  health_score?: number;
+  health_factors?: { kind: string; weight: number; note: string }[];
+}
+
+// Returns the modifier class for the plan-health badge based on the
+// score band: >=80 good (green), 50..79 warn (amber), <50 bad (red).
+// Kept as a tiny pure helper so the test asserting the class-mapping
+// doesn't have to spin up the whole renderPlans pipeline.
+function planHealthBandClass(score: number): 'good' | 'warn' | 'bad' {
+  if (score >= 80) return 'good';
+  if (score >= 50) return 'warn';
+  return 'bad';
+}
+
+// Renders the plan-health pill markup for the plan card header.
+// Empty string when the score is missing (older API responses,
+// pre-rollout) so the card layout doesn't get a hole.
+function renderPlanHealthBadge(plan: BackendPlan): string {
+  if (typeof plan.health_score !== 'number') return '';
+  const band = planHealthBandClass(plan.health_score);
+  const factors = plan.health_factors ?? [];
+  const tooltip = factors.length === 0
+    ? `Plan health ${plan.health_score}/100`
+    : `Plan health ${plan.health_score}/100 — ${factors.map(f => f.note).join(' · ')}`;
+  return `<span class="plan-health-badge plan-health-badge--${band}" title="${escapeHtml(tooltip)}" data-testid="plan-health-badge">${plan.health_score}</span>`;
 }
 
 // Pretty label for a service slug used inside the plan card.
@@ -398,6 +427,7 @@ function renderPlans(plans: LocalPlan[]): void {
           <div class="plan-status">
             <span class="status-badge ${status.class}">${status.label}</span>
             ${overdueBadge}
+            ${renderPlanHealthBadge(plan)}
             ${canManagePlan ? `
             <label class="toggle-label">
               <input type="checkbox" data-action="toggle-plan" data-id="${plan.id}" ${plan.enabled ? 'checked' : ''}>

--- a/frontend/src/plans.ts
+++ b/frontend/src/plans.ts
@@ -294,14 +294,22 @@ function planHealthBandClass(score: number): 'good' | 'warn' | 'bad' {
 // Renders the plan-health pill markup for the plan card header.
 // Empty string when the score is missing (older API responses,
 // pre-rollout) so the card layout doesn't get a hole.
+//
+// Accessibility: the badge carries both `title` (native mouse-hover
+// tooltip) and `aria-label` (same text exposed to assistive tech), and
+// is reachable via `tabindex="0"` so keyboard-only users can land on
+// it and have the screen reader announce the score + factors. Both
+// strings derive from the same `escapeHtml(tooltip)` value to avoid
+// double-escaping mismatches between the two channels.
 function renderPlanHealthBadge(plan: BackendPlan): string {
   if (typeof plan.health_score !== 'number') return '';
   const band = planHealthBandClass(plan.health_score);
   const factors = plan.health_factors ?? [];
   const tooltip = factors.length === 0
     ? `Plan health ${plan.health_score}/100`
-    : `Plan health ${plan.health_score}/100 — ${factors.map(f => f.note).join(' · ')}`;
-  return `<span class="plan-health-badge plan-health-badge--${band}" title="${escapeHtml(tooltip)}" data-testid="plan-health-badge">${plan.health_score}</span>`;
+    : `Plan health ${plan.health_score}/100: ${factors.map(f => f.note).join(' / ')}`;
+  const escapedTooltip = escapeHtml(tooltip);
+  return `<span class="plan-health-badge plan-health-badge--${band}" title="${escapedTooltip}" aria-label="${escapedTooltip}" tabindex="0" data-testid="plan-health-badge">${plan.health_score}</span>`;
 }
 
 // Pretty label for a service slug used inside the plan card.

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -1301,6 +1301,41 @@ tr.rec-variant-row:hover td:not(.checkbox-col) {
     color: var(--cudly-primary);
 }
 
+/* Plan health pill (Plans tab — rendered inside .plan-status next to
+ * the existing Active/Manual/Disabled badge). The numeric score (0-100)
+ * is the only content; the colour band carries the rest of the signal.
+ * The tooltip on hover/focus enumerates which factors subtracted from
+ * 100 so the user can act on a bad score.
+ */
+.plan-health-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 2.25rem;
+    height: 1.5rem;
+    padding: 0 0.5rem;
+    border-radius: 999px;
+    font-size: 0.8rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    cursor: help;
+}
+
+.plan-health-badge--good {
+    background: var(--cudly-success-bg);
+    color: var(--cudly-success-fg, #137333);
+}
+
+.plan-health-badge--warn {
+    background: #fef7e0;
+    color: #8a6d0c;
+}
+
+.plan-health-badge--bad {
+    background: var(--cudly-error-bg);
+    color: var(--cudly-error-fg);
+}
+
 /* Subline rendered under the Pending badge in the Purchase History Status
  * column. Surfaces the approver's email address (the recipient of the
  * approval email) so the user knows which inbox to check.

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -123,6 +123,12 @@ export interface LocalPlan {
   next_execution_date?: string;
   custom_step_percent?: number;
   custom_interval_days?: number;
+  // Optional response-only fields from the /plans health-score
+  // envelope. Optional so older API responses still type-check during
+  // a partial deploy and unit-test fixtures don't have to populate
+  // them.
+  health_score?: number;
+  health_factors?: api.PlanHealthFactor[];
 }
 
 export interface SavePlanData {

--- a/internal/api/handler_plans.go
+++ b/internal/api/handler_plans.go
@@ -34,7 +34,30 @@ func (h *Handler) listPlans(ctx context.Context, req *events.LambdaFunctionURLRe
 		}
 	}
 
-	return &PlansResponse{Plans: plans}, nil
+	// Fetch the recent executions used to compute per-plan health
+	// scores. Single store call, grouped in-memory by plan_id so the
+	// per-plan loop is O(plans + executions) rather than N round-trips
+	// to the database. A fetch error is logged and swallowed — the
+	// plans list itself must still render; consumers see HealthScore =
+	// 100 (no penalties) for every plan when the execution lookup
+	// fails, which is a safe pessimistic default for a UI signal.
+	executions, execErr := h.config.GetExecutionsByStatuses(ctx, planHealthExecutionStatuses, config.DefaultListLimit)
+	if execErr != nil {
+		executions = nil
+	}
+	byPlan := groupExecutionsByPlan(executions)
+
+	out := make([]PlanWithHealth, 0, len(plans))
+	for i := range plans {
+		score, factors := computePlanHealth(&plans[i], byPlan[plans[i].ID], now)
+		out = append(out, PlanWithHealth{
+			PurchasePlan:  plans[i],
+			HealthScore:   score,
+			HealthFactors: factors,
+		})
+	}
+
+	return &PlansResponse{Plans: out}, nil
 }
 
 // calculateNextExecutionDate calculates the next execution date for a plan

--- a/internal/api/handler_plans.go
+++ b/internal/api/handler_plans.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/LeanerCloud/CUDly/internal/config"
 	"github.com/LeanerCloud/CUDly/pkg/common"
+	"github.com/LeanerCloud/CUDly/pkg/logging"
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -37,12 +38,16 @@ func (h *Handler) listPlans(ctx context.Context, req *events.LambdaFunctionURLRe
 	// Fetch the recent executions used to compute per-plan health
 	// scores. Single store call, grouped in-memory by plan_id so the
 	// per-plan loop is O(plans + executions) rather than N round-trips
-	// to the database. A fetch error is logged and swallowed — the
+	// to the database. A fetch error is logged and swallowed: the
 	// plans list itself must still render; consumers see HealthScore =
 	// 100 (no penalties) for every plan when the execution lookup
-	// fails, which is a safe pessimistic default for a UI signal.
+	// fails, which is a safe pessimistic default for a UI signal. We
+	// log at warn level (not error) because the request itself still
+	// succeeds end-to-end; the score column is the only thing
+	// degraded.
 	executions, execErr := h.config.GetExecutionsByStatuses(ctx, planHealthExecutionStatuses, config.DefaultListLimit)
 	if execErr != nil {
+		logging.Warnf("listPlans: GetExecutionsByStatuses failed; falling back to default health score for %d plan(s): %v", len(plans), execErr)
 		executions = nil
 	}
 	byPlan := groupExecutionsByPlan(executions)
@@ -50,6 +55,14 @@ func (h *Handler) listPlans(ctx context.Context, req *events.LambdaFunctionURLRe
 	out := make([]PlanWithHealth, 0, len(plans))
 	for i := range plans {
 		score, factors := computePlanHealth(&plans[i], byPlan[plans[i].ID], now)
+		// Normalize nil to empty slice so the JSON response always
+		// carries `health_factors: []` rather than `null` or absent.
+		// The openapi schema marks health_factors required, and
+		// generated clients (plus a handful of frontend assertions
+		// that .map over factors) treat it as a guaranteed array.
+		if factors == nil {
+			factors = []HealthFactor{}
+		}
 		out = append(out, PlanWithHealth{
 			PurchasePlan:  plans[i],
 			HealthScore:   score,

--- a/internal/api/handler_plans_test.go
+++ b/internal/api/handler_plans_test.go
@@ -32,6 +32,10 @@ func TestHandler_listPlans(t *testing.T) {
 
 	mockAuth.On("ValidateSession", ctx, "admin-token").Return(adminSession, nil)
 	mockStore.On("ListPurchasePlans", ctx).Return(plans, nil)
+	// listPlans now fetches recent executions to compute the per-plan
+	// health score. Empty slice keeps every plan at the score ceiling.
+	mockStore.On("GetExecutionsByStatuses", ctx, planHealthExecutionStatuses, config.DefaultListLimit).
+		Return([]config.PurchaseExecution{}, nil)
 
 	handler := &Handler{config: mockStore, auth: mockAuth}
 
@@ -44,6 +48,119 @@ func TestHandler_listPlans(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Len(t, result.Plans, 2)
+	// Both plans have no penalties: enabled with empty ramp_schedule
+	// (TotalSteps=0) → completed-plan short-circuit only triggers when
+	// CurrentStep >= TotalSteps AND TotalSteps > 0. For these test
+	// plans, no penalties fire, so the score is 100.
+	for _, p := range result.Plans {
+		assert.Equal(t, 100, p.HealthScore, "expected ceiling score for plan %s", p.ID)
+		assert.Empty(t, p.HealthFactors, "expected no health factors for plan %s", p.ID)
+	}
+	mockStore.AssertExpectations(t)
+}
+
+func TestHandler_listPlans_AppliesHealthFactors(t *testing.T) {
+	ctx := context.Background()
+	mockStore := new(MockConfigStore)
+	mockAuth := new(MockAuthService)
+
+	adminSession := &Session{
+		UserID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+		Email:  "admin@example.com",
+		Role:   "admin",
+	}
+
+	past := time.Now().AddDate(0, 0, -3)
+	plans := []config.PurchasePlan{
+		{
+			ID:                "11111111-1111-1111-1111-111111111111",
+			Name:              "Overdue Plan",
+			Enabled:           true,
+			NextExecutionDate: &past,
+			RampSchedule: config.RampSchedule{
+				Type:        "weekly",
+				CurrentStep: 1,
+				TotalSteps:  4,
+			},
+		},
+		{
+			ID:      "22222222-2222-2222-2222-222222222222",
+			Name:    "Healthy Plan",
+			Enabled: true,
+			RampSchedule: config.RampSchedule{
+				Type:        "immediate",
+				CurrentStep: 0,
+				TotalSteps:  1,
+			},
+		},
+	}
+	executions := []config.PurchaseExecution{
+		{PlanID: "11111111-1111-1111-1111-111111111111", Status: "failed"},
+	}
+
+	mockAuth.On("ValidateSession", ctx, "admin-token").Return(adminSession, nil)
+	mockStore.On("ListPurchasePlans", ctx).Return(plans, nil)
+	mockStore.On("GetExecutionsByStatuses", ctx, planHealthExecutionStatuses, config.DefaultListLimit).
+		Return(executions, nil)
+
+	handler := &Handler{config: mockStore, auth: mockAuth}
+
+	req := &events.LambdaFunctionURLRequest{
+		Headers: map[string]string{
+			"Authorization": "Bearer admin-token",
+		},
+	}
+	result, err := handler.listPlans(ctx, req)
+	require.NoError(t, err)
+	require.Len(t, result.Plans, 2)
+
+	// Overdue plan: -30 (overdue) -10 (1 failure) = 60
+	assert.Equal(t, 60, result.Plans[0].HealthScore)
+	require.Len(t, result.Plans[0].HealthFactors, 2)
+	assert.Equal(t, "overdue", result.Plans[0].HealthFactors[0].Kind)
+	assert.Equal(t, "failed_executions", result.Plans[0].HealthFactors[1].Kind)
+
+	// Healthy plan: no penalties.
+	assert.Equal(t, 100, result.Plans[1].HealthScore)
+	assert.Empty(t, result.Plans[1].HealthFactors)
+	mockStore.AssertExpectations(t)
+}
+
+func TestHandler_listPlans_ExecutionFetchErrorIsTolerated(t *testing.T) {
+	// If the executions lookup fails, plans must still render — every
+	// plan defaults to a 100 score (no penalties applied) rather than
+	// erroring the whole list. Regression guard for the swallowed-err
+	// branch in listPlans.
+	ctx := context.Background()
+	mockStore := new(MockConfigStore)
+	mockAuth := new(MockAuthService)
+
+	adminSession := &Session{
+		UserID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+		Email:  "admin@example.com",
+		Role:   "admin",
+	}
+
+	plans := []config.PurchasePlan{
+		{ID: "11111111-1111-1111-1111-111111111111", Name: "Test Plan", Enabled: true},
+	}
+
+	mockAuth.On("ValidateSession", ctx, "admin-token").Return(adminSession, nil)
+	mockStore.On("ListPurchasePlans", ctx).Return(plans, nil)
+	mockStore.On("GetExecutionsByStatuses", ctx, planHealthExecutionStatuses, config.DefaultListLimit).
+		Return([]config.PurchaseExecution(nil), errors.New("db down"))
+
+	handler := &Handler{config: mockStore, auth: mockAuth}
+
+	req := &events.LambdaFunctionURLRequest{
+		Headers: map[string]string{
+			"Authorization": "Bearer admin-token",
+		},
+	}
+	result, err := handler.listPlans(ctx, req)
+	require.NoError(t, err)
+	require.Len(t, result.Plans, 1)
+	assert.Equal(t, 100, result.Plans[0].HealthScore)
 }
 
 func TestHandler_createPlan(t *testing.T) {

--- a/internal/api/handler_plans_test.go
+++ b/internal/api/handler_plans_test.go
@@ -161,6 +161,12 @@ func TestHandler_listPlans_ExecutionFetchErrorIsTolerated(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, result.Plans, 1)
 	assert.Equal(t, 100, result.Plans[0].HealthScore)
+	// Assert both mocks were called as expected: this is the only
+	// place that exercises the "exec fetch fails" branch, so without
+	// these checks a regression that silently skipped the fetch (or
+	// the auth check) would still pass.
+	mockStore.AssertExpectations(t)
+	mockAuth.AssertExpectations(t)
 }
 
 func TestHandler_createPlan(t *testing.T) {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -545,6 +545,11 @@ func TestHandler_HandleRequest_ListPlans(t *testing.T) {
 
 	plans := []config.PurchasePlan{{ID: "11111111-1111-1111-1111-111111111111"}}
 	mockStore.On("ListPurchasePlans", mock.Anything).Return(plans, nil)
+	// listPlans now fetches recent executions for the per-plan health
+	// score. Empty slice keeps scoring at the ceiling and doesn't
+	// affect the HTTP-shape assertions below.
+	mockStore.On("GetExecutionsByStatuses", mock.Anything, planHealthExecutionStatuses, config.DefaultListLimit).
+		Return([]config.PurchaseExecution{}, nil)
 
 	handler := &Handler{config: mockStore, auth: mockAuth, apiKey: "test-key"}
 

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -1977,6 +1977,7 @@ components:
 
     HealthFactor:
       type: object
+      required: [kind, weight, note]
       description: |
         One penalty applied to a plan's health score. Surfaced in the UI
         badge tooltip so a low score is actionable rather than opaque.
@@ -1995,6 +1996,7 @@ components:
       allOf:
         - $ref: '#/components/schemas/PurchasePlan'
         - type: object
+          required: [health_score, health_factors]
           properties:
             health_score:
               type: integer
@@ -2007,6 +2009,7 @@ components:
                 per-penalty breakdown.
             health_factors:
               type: array
+              minItems: 0
               items:
                 $ref: '#/components/schemas/HealthFactor'
 

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -1973,7 +1973,42 @@ components:
         plans:
           type: array
           items:
-            $ref: '#/components/schemas/PurchasePlan'
+            $ref: '#/components/schemas/PlanWithHealth'
+
+    HealthFactor:
+      type: object
+      description: |
+        One penalty applied to a plan's health score. Surfaced in the UI
+        badge tooltip so a low score is actionable rather than opaque.
+      properties:
+        kind:
+          type: string
+          description: Stable machine slug (overdue, failed_executions, etc.)
+        weight:
+          type: integer
+          description: How many points this factor subtracted from 100.
+        note:
+          type: string
+          description: Human-readable explanation.
+
+    PlanWithHealth:
+      allOf:
+        - $ref: '#/components/schemas/PurchasePlan'
+        - type: object
+          properties:
+            health_score:
+              type: integer
+              minimum: 0
+              maximum: 100
+              description: |
+                0-100 health score reflecting how well the plan is
+                executing (ramp progress vs. schedule, age, failed/
+                cancelled execution ratio). See HealthFactor for the
+                per-penalty breakdown.
+            health_factors:
+              type: array
+              items:
+                $ref: '#/components/schemas/HealthFactor'
 
     PlanRequest:
       type: object

--- a/internal/api/plan_health.go
+++ b/internal/api/plan_health.go
@@ -1,0 +1,281 @@
+package api
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/LeanerCloud/CUDly/internal/config"
+)
+
+// Plan health score
+//
+// Surfaces a quick 0-100 "is this plan executing as expected" glance on
+// each plan card. Pure function so the formula can be regression-tested
+// without HTTP / DB plumbing, and so the response-side data is computed
+// once per list call instead of leaking into persistence.
+//
+// Score starts at 100 and subtracts weighted penalties. Each penalty
+// produces a HealthFactor entry so the UI tooltip can explain why the
+// score isn't 100. Completed plans (current_step >= total_steps) short-
+// circuit to (100, nil) — they finished, there is nothing to diagnose.
+//
+// Penalty table (keep in sync with the plan file at
+// ~/.claude/projects/.../plans-health-score.md):
+//
+//	overdue              -30   plan enabled AND next_execution_date < today
+//	failed_executions    -10×n (n capped at 4 -> max -40)
+//	cancelled_executions  -5×n (n capped at 4 -> max -20)
+//	behind_schedule      -20   current_step < expected step from start_date
+//	stalled              -15   enabled, start_date past, current_step == 0
+//	                            for > 1 step_interval_days
+//	disabled_midway      -25   disabled with 0 < current_step < total_steps
+//
+// Note on the "completed plan" short-circuit: a 4/4 plan can still be
+// toggled off after completion (Enabled == false, CurrentStep ==
+// TotalSteps). Without the short-circuit, disabled_midway would NOT fire
+// (current_step is not < total_steps), but the plan would still show
+// arbitrary score noise from any historical failed/cancelled rows. The
+// short-circuit makes finished plans always read as 100, which matches
+// user intuition for "this plan is done".
+
+// HealthFactor is one bullet in the per-plan health-score breakdown.
+// Surfaced via the badge tooltip so a low score is actionable, not just
+// a number. Kind is a stable machine slug (so the frontend can colour /
+// link / filter on it later); Note is the human-readable explanation.
+type HealthFactor struct {
+	Kind   string `json:"kind"`
+	Weight int    `json:"weight"`
+	Note   string `json:"note"`
+}
+
+// PlanWithHealth wraps a config.PurchasePlan with the response-only
+// HealthScore + HealthFactors. The wrapper keeps the score fields out
+// of the persisted struct so they can't accidentally drift into
+// DynamoDB / Postgres columns. The embedded value (not pointer) keeps
+// JSON serialisation flat — clients see the same fields as before plus
+// the new ones, no extra "plan" envelope nesting.
+type PlanWithHealth struct {
+	config.PurchasePlan
+	HealthScore   int            `json:"health_score"`
+	HealthFactors []HealthFactor `json:"health_factors,omitempty"`
+}
+
+// computePlanHealth returns the 0-100 health score and the slice of
+// HealthFactor entries explaining every penalty applied. Pure: takes
+// only the plan, its execution slice, and "now" so tests can fix time.
+//
+// executions should be the subset of PurchaseExecution rows whose
+// PlanID matches plan.ID — callers are expected to pre-filter (the
+// caller already groups all executions by plan_id in a single sweep, so
+// re-filtering inside this function would be a duplicate pass).
+//
+// Implementation runs each penalty check via a small per-factor helper
+// so the cyclomatic complexity stays well under the project's gocyclo
+// budget (10) and each rule is independently readable / unit-testable
+// without dragging the rest of the formula into the test setup.
+func computePlanHealth(plan *config.PurchasePlan, executions []config.PurchaseExecution, now time.Time) (int, []HealthFactor) {
+	// Completed-plan short-circuit. See package comment for the
+	// rationale on why this lives outside the penalty loop.
+	if plan.RampSchedule.TotalSteps > 0 && plan.RampSchedule.CurrentStep >= plan.RampSchedule.TotalSteps {
+		return 100, nil
+	}
+
+	score := 100
+	var factors []HealthFactor
+
+	// Penalty checks are run in a fixed order so the resulting
+	// HealthFactor slice has a stable iteration sequence (the frontend
+	// uses it as-is for the tooltip text — reordering would change the
+	// rendered string and the test fixtures).
+	checks := []func(*config.PurchasePlan, []config.PurchaseExecution, time.Time) *HealthFactor{
+		overduePenalty,
+		failedExecutionsPenalty,
+		cancelledExecutionsPenalty,
+		behindSchedulePenalty,
+		stalledPenalty,
+		disabledMidwayPenalty,
+	}
+	for _, check := range checks {
+		if f := check(plan, executions, now); f != nil {
+			score -= f.Weight
+			factors = append(factors, *f)
+		}
+	}
+
+	// Clamp. The cumulative weight ceiling is 30+40+20+20+15+25 = 150,
+	// so without clamping the worst case would render -50.
+	if score < 0 {
+		score = 0
+	}
+	if score > 100 {
+		score = 100
+	}
+	return score, factors
+}
+
+// overduePenalty fires for enabled plans whose next_execution_date is
+// strictly before today. A disabled plan with a stale next_execution_date
+// isn't an issue — it isn't running. Day-granularity comparison so a
+// plan scheduled for "today" doesn't flip to overdue at 00:00:01.
+func overduePenalty(plan *config.PurchasePlan, _ []config.PurchaseExecution, now time.Time) *HealthFactor {
+	if !plan.Enabled || plan.NextExecutionDate == nil {
+		return nil
+	}
+	startOfToday := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	if !plan.NextExecutionDate.Before(startOfToday) {
+		return nil
+	}
+	return &HealthFactor{
+		Kind:   "overdue",
+		Weight: 30,
+		Note:   "Next execution date is in the past",
+	}
+}
+
+// failedExecutionsPenalty applies -10 per failed execution, capped at
+// 4 so a single bad week doesn't permanently floor every future score.
+func failedExecutionsPenalty(_ *config.PurchasePlan, executions []config.PurchaseExecution, _ time.Time) *HealthFactor {
+	n := countExecutionsByStatus(executions, "failed")
+	if n == 0 {
+		return nil
+	}
+	capped := n
+	if capped > 4 {
+		capped = 4
+	}
+	return &HealthFactor{
+		Kind:   "failed_executions",
+		Weight: 10 * capped,
+		Note:   fmt.Sprintf("%d failed execution(s)", n),
+	}
+}
+
+// cancelledExecutionsPenalty applies -5 per cancellation, capped at 4.
+// The per-event weight is lower than failures because cancellations
+// are usually user-initiated rather than execution-time errors.
+func cancelledExecutionsPenalty(_ *config.PurchasePlan, executions []config.PurchaseExecution, _ time.Time) *HealthFactor {
+	n := countExecutionsByStatus(executions, "cancelled")
+	if n == 0 {
+		return nil
+	}
+	capped := n
+	if capped > 4 {
+		capped = 4
+	}
+	return &HealthFactor{
+		Kind:   "cancelled_executions",
+		Weight: 5 * capped,
+		Note:   fmt.Sprintf("%d cancelled execution(s)", n),
+	}
+}
+
+// behindSchedulePenalty fires when current_step lags the step we'd
+// expect from start_date + step_interval_days. Only meaningful for
+// ramped plans with both a non-zero interval and a start_date in the
+// past.
+func behindSchedulePenalty(plan *config.PurchasePlan, _ []config.PurchaseExecution, now time.Time) *HealthFactor {
+	if plan.RampSchedule.StepIntervalDays == 0 || plan.RampSchedule.StartDate.IsZero() {
+		return nil
+	}
+	daysSinceStart := int(now.Sub(plan.RampSchedule.StartDate).Hours() / 24)
+	if daysSinceStart <= 0 {
+		return nil
+	}
+	expectedStep := daysSinceStart / plan.RampSchedule.StepIntervalDays
+	if expectedStep > plan.RampSchedule.TotalSteps {
+		expectedStep = plan.RampSchedule.TotalSteps
+	}
+	gap := expectedStep - plan.RampSchedule.CurrentStep
+	if gap < 1 {
+		return nil
+	}
+	return &HealthFactor{
+		Kind:   "behind_schedule",
+		Weight: 20,
+		Note:   fmt.Sprintf("Ramp is %d step(s) behind schedule", gap),
+	}
+}
+
+// stalledPenalty fires when an enabled plan with a real start_date has
+// never executed a step. Strict subset of behind_schedule (gap of 1
+// when current_step==0), but the user signal is different — "you've
+// never executed" reads worse than "you're a step behind", so it gets
+// its own slot.
+func stalledPenalty(plan *config.PurchasePlan, _ []config.PurchaseExecution, now time.Time) *HealthFactor {
+	if !plan.Enabled || plan.RampSchedule.CurrentStep != 0 {
+		return nil
+	}
+	if plan.RampSchedule.StepIntervalDays == 0 || plan.RampSchedule.StartDate.IsZero() {
+		return nil
+	}
+	daysSinceStart := int(now.Sub(plan.RampSchedule.StartDate).Hours() / 24)
+	if daysSinceStart <= plan.RampSchedule.StepIntervalDays {
+		return nil
+	}
+	return &HealthFactor{
+		Kind:   "stalled",
+		Weight: 15,
+		Note:   "Plan has not executed any step yet",
+	}
+}
+
+// disabledMidwayPenalty fires when a plan was disabled mid-ramp (some
+// real work was started and then halted). A freshly-disabled plan that
+// never ran (CurrentStep == 0) is fine; this only targets the
+// "paused with progress" state.
+func disabledMidwayPenalty(plan *config.PurchasePlan, _ []config.PurchaseExecution, _ time.Time) *HealthFactor {
+	if plan.Enabled {
+		return nil
+	}
+	if plan.RampSchedule.CurrentStep <= 0 || plan.RampSchedule.CurrentStep >= plan.RampSchedule.TotalSteps {
+		return nil
+	}
+	return &HealthFactor{
+		Kind:   "disabled_midway",
+		Weight: 25,
+		Note:   fmt.Sprintf("Disabled at step %d of %d", plan.RampSchedule.CurrentStep, plan.RampSchedule.TotalSteps),
+	}
+}
+
+// countExecutionsByStatus counts entries whose Status == target. Tiny
+// helper, but it makes the penalty cases above read declaratively.
+func countExecutionsByStatus(executions []config.PurchaseExecution, target string) int {
+	n := 0
+	for _, e := range executions {
+		if e.Status == target {
+			n++
+		}
+	}
+	return n
+}
+
+// groupExecutionsByPlan buckets a flat execution slice into a map keyed
+// by PlanID. Used by listPlans so the per-plan score computation is
+// O(plans + executions) instead of O(plans × executions).
+func groupExecutionsByPlan(executions []config.PurchaseExecution) map[string][]config.PurchaseExecution {
+	out := make(map[string][]config.PurchaseExecution, len(executions))
+	for _, e := range executions {
+		out[e.PlanID] = append(out[e.PlanID], e)
+	}
+	return out
+}
+
+// planHealthExecutionStatuses is the union of statuses the score
+// formula cares about. Kept as a package-level slice so the handler
+// and tests reference the same set (rather than duplicating string
+// literals at each call site).
+//
+// Includes "completed" so a single GetExecutionsByStatuses call covers
+// every execution that affects the score; the count-since-start
+// denominator for "behind schedule" is computed from plan fields
+// directly, but having the completed rows in scope keeps the door open
+// for richer factors (e.g. "no completions in the last N days")
+// without a second DB hit.
+var planHealthExecutionStatuses = []string{
+	"completed",
+	"failed",
+	"expired",
+	"cancelled",
+	"pending",
+	"notified",
+}

--- a/internal/api/plan_health.go
+++ b/internal/api/plan_health.go
@@ -52,12 +52,18 @@ type HealthFactor struct {
 // HealthScore + HealthFactors. The wrapper keeps the score fields out
 // of the persisted struct so they can't accidentally drift into
 // DynamoDB / Postgres columns. The embedded value (not pointer) keeps
-// JSON serialisation flat — clients see the same fields as before plus
+// JSON serialisation flat: clients see the same fields as before plus
 // the new ones, no extra "plan" envelope nesting.
+//
+// HealthFactors deliberately omits `omitempty`: the openapi contract
+// marks the field required so generated clients treat it as
+// non-nullable. Callers populate the slice to `[]HealthFactor{}` (not
+// nil) when there are no penalties so the wire format is `[]` rather
+// than `null` or absent.
 type PlanWithHealth struct {
 	config.PurchasePlan
 	HealthScore   int            `json:"health_score"`
-	HealthFactors []HealthFactor `json:"health_factors,omitempty"`
+	HealthFactors []HealthFactor `json:"health_factors"`
 }
 
 // computePlanHealth returns the 0-100 health score and the slice of
@@ -260,22 +266,20 @@ func groupExecutionsByPlan(executions []config.PurchaseExecution) map[string][]c
 	return out
 }
 
-// planHealthExecutionStatuses is the union of statuses the score
-// formula cares about. Kept as a package-level slice so the handler
-// and tests reference the same set (rather than duplicating string
-// literals at each call site).
+// planHealthExecutionStatuses is the set of execution statuses the
+// score formula actually penalizes. Kept as a package-level slice so
+// the handler and tests reference the same set (rather than
+// duplicating string literals at each call site).
 //
-// Includes "completed" so a single GetExecutionsByStatuses call covers
-// every execution that affects the score; the count-since-start
-// denominator for "behind schedule" is computed from plan fields
-// directly, but having the completed rows in scope keeps the door open
-// for richer factors (e.g. "no completions in the last N days")
-// without a second DB hit.
+// Intentionally narrow: failed and cancelled are the only statuses
+// the penalty checks read (failedExecutionsPenalty,
+// cancelledExecutionsPenalty). Including non-penalized statuses
+// (completed/pending/notified/expired) would let high-volume noisy
+// rows displace genuine penalty rows out of the capped
+// DefaultListLimit fetch, skewing scores for active plans. If a
+// future penalty needs a new status, add it here (and the matching
+// check in computePlanHealth) in the same change.
 var planHealthExecutionStatuses = []string{
-	"completed",
 	"failed",
-	"expired",
 	"cancelled",
-	"pending",
-	"notified",
 }

--- a/internal/api/plan_health_test.go
+++ b/internal/api/plan_health_test.go
@@ -1,0 +1,273 @@
+package api
+
+import (
+	"testing"
+	"time"
+
+	"github.com/LeanerCloud/CUDly/internal/config"
+)
+
+// fixedNow is the reference "now" used across the table-driven tests so
+// each case's date arithmetic is reproducible. Picked a deterministic
+// non-DST date well clear of any wall-clock weirdness.
+var fixedNow = time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
+
+// helper: dereference time pointer for inline struct construction.
+func tp(t time.Time) *time.Time { return &t }
+
+func TestComputePlanHealth(t *testing.T) {
+	cases := []struct {
+		name           string
+		plan           *config.PurchasePlan
+		executions     []config.PurchaseExecution
+		wantScore      int
+		wantFactorKind []string // ordered list of factor.Kind we expect
+	}{
+		{
+			name: "ceiling: young plan, on schedule, no executions yet",
+			plan: &config.PurchasePlan{
+				ID:      "p1",
+				Enabled: true,
+				RampSchedule: config.RampSchedule{
+					Type:             "weekly",
+					StepIntervalDays: 7,
+					CurrentStep:      0,
+					TotalSteps:       4,
+					StartDate:        fixedNow, // started today, hasn't ramped yet
+				},
+				NextExecutionDate: tp(fixedNow.AddDate(0, 0, 7)),
+			},
+			executions:     nil,
+			wantScore:      100,
+			wantFactorKind: nil,
+		},
+		{
+			name: "completed plan short-circuits to 100 even when disabled afterwards",
+			plan: &config.PurchasePlan{
+				ID:      "p1",
+				Enabled: false, // toggled off after completion
+				RampSchedule: config.RampSchedule{
+					Type:             "weekly",
+					StepIntervalDays: 7,
+					CurrentStep:      4,
+					TotalSteps:       4,
+					StartDate:        fixedNow.AddDate(0, 0, -28),
+				},
+			},
+			executions: []config.PurchaseExecution{
+				// Even a stale failed row shouldn't drag a finished plan
+				// below 100 — the short-circuit fires first.
+				{PlanID: "p1", Status: "failed"},
+			},
+			wantScore:      100,
+			wantFactorKind: nil,
+		},
+		{
+			name: "single factor: overdue only",
+			plan: &config.PurchasePlan{
+				ID:      "p1",
+				Enabled: true,
+				RampSchedule: config.RampSchedule{
+					Type:             "weekly",
+					StepIntervalDays: 7,
+					CurrentStep:      1,
+					TotalSteps:       4,
+					StartDate:        fixedNow.AddDate(0, 0, -7),
+				},
+				NextExecutionDate: tp(fixedNow.AddDate(0, 0, -1)),
+			},
+			executions:     nil,
+			wantScore:      70,
+			wantFactorKind: []string{"overdue"},
+		},
+		{
+			name: "multi-factor: overdue + 2 failures + 1 cancelled + behind schedule",
+			plan: &config.PurchasePlan{
+				ID:      "p1",
+				Enabled: true,
+				RampSchedule: config.RampSchedule{
+					Type:             "weekly",
+					StepIntervalDays: 7,
+					CurrentStep:      1,
+					TotalSteps:       4,
+					// 21 days back -> expected step 3, actual 1 -> 2 behind
+					StartDate: fixedNow.AddDate(0, 0, -21),
+				},
+				NextExecutionDate: tp(fixedNow.AddDate(0, 0, -2)),
+			},
+			executions: []config.PurchaseExecution{
+				{PlanID: "p1", Status: "failed"},
+				{PlanID: "p1", Status: "failed"},
+				{PlanID: "p1", Status: "cancelled"},
+				{PlanID: "p1", Status: "completed"}, // ignored — no penalty
+			},
+			// 100 - 30 (overdue) - 20 (2 failed) - 5 (1 cancelled) - 20 (behind) = 25
+			wantScore:      25,
+			wantFactorKind: []string{"overdue", "failed_executions", "cancelled_executions", "behind_schedule"},
+		},
+		{
+			name: "floor: every penalty active, clamps to 0",
+			plan: &config.PurchasePlan{
+				ID:      "p1",
+				Enabled: false, // disabled mid-ramp
+				RampSchedule: config.RampSchedule{
+					Type:             "weekly",
+					StepIntervalDays: 7,
+					CurrentStep:      1, // disabled at 1/4
+					TotalSteps:       4,
+					StartDate:        fixedNow.AddDate(0, 0, -28),
+				},
+				// NextExecutionDate is in the past but the plan is
+				// disabled — the overdue factor checks Enabled first, so
+				// this row should NOT contribute. Disabled-midway covers
+				// the "this plan stopped progressing" case instead.
+				NextExecutionDate: tp(fixedNow.AddDate(0, 0, -7)),
+			},
+			executions: []config.PurchaseExecution{
+				{PlanID: "p1", Status: "failed"},
+				{PlanID: "p1", Status: "failed"},
+				{PlanID: "p1", Status: "failed"},
+				{PlanID: "p1", Status: "failed"},
+				{PlanID: "p1", Status: "failed"}, // 5th — capped at 4
+				{PlanID: "p1", Status: "cancelled"},
+				{PlanID: "p1", Status: "cancelled"},
+				{PlanID: "p1", Status: "cancelled"},
+				{PlanID: "p1", Status: "cancelled"},
+				{PlanID: "p1", Status: "cancelled"}, // 5th — capped at 4
+			},
+			// 100 - 40 (4 failed, capped) - 20 (4 cancelled, capped) - 25 (disabled midway) = 15
+			// behind_schedule fires too: 28 days / 7 = expected 4, actual 1, gap = 3 -> -20 -> -5 -> clamped to 0
+			wantScore:      0,
+			wantFactorKind: []string{"failed_executions", "cancelled_executions", "behind_schedule", "disabled_midway"},
+		},
+		{
+			name: "stalled: enabled plan past first interval with no steps taken",
+			plan: &config.PurchasePlan{
+				ID:      "p1",
+				Enabled: true,
+				RampSchedule: config.RampSchedule{
+					Type:             "weekly",
+					StepIntervalDays: 7,
+					CurrentStep:      0,
+					TotalSteps:       4,
+					StartDate:        fixedNow.AddDate(0, 0, -10), // > 1 interval ago
+				},
+				NextExecutionDate: tp(fixedNow.AddDate(0, 0, 1)), // not overdue
+			},
+			executions: nil,
+			// 100 - 20 (behind: expected step 1, actual 0) - 15 (stalled) = 65
+			wantScore:      65,
+			wantFactorKind: []string{"behind_schedule", "stalled"},
+		},
+		{
+			name: "empty executions slice doesn't crash and scores cleanly",
+			plan: &config.PurchasePlan{
+				ID:      "p1",
+				Enabled: true,
+				RampSchedule: config.RampSchedule{
+					Type:             "immediate",
+					StepIntervalDays: 0,
+					CurrentStep:      0,
+					TotalSteps:       1,
+				},
+			},
+			executions:     []config.PurchaseExecution{},
+			wantScore:      100,
+			wantFactorKind: nil,
+		},
+		{
+			name: "disabled plan with stale next_execution_date is NOT marked overdue",
+			plan: &config.PurchasePlan{
+				ID:      "p1",
+				Enabled: false,
+				RampSchedule: config.RampSchedule{
+					Type:             "weekly",
+					StepIntervalDays: 7,
+					CurrentStep:      0,
+					TotalSteps:       4,
+				},
+				NextExecutionDate: tp(fixedNow.AddDate(0, 0, -30)),
+			},
+			executions:     nil,
+			wantScore:      100,
+			wantFactorKind: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			score, factors := computePlanHealth(tc.plan, tc.executions, fixedNow)
+			if score != tc.wantScore {
+				t.Errorf("score = %d, want %d (factors=%+v)", score, tc.wantScore, factors)
+			}
+			if len(factors) != len(tc.wantFactorKind) {
+				t.Fatalf("factor count = %d, want %d (got %+v)", len(factors), len(tc.wantFactorKind), factors)
+			}
+			for i, want := range tc.wantFactorKind {
+				if factors[i].Kind != want {
+					t.Errorf("factor[%d].Kind = %q, want %q", i, factors[i].Kind, want)
+				}
+				if factors[i].Weight <= 0 {
+					t.Errorf("factor[%d].Weight = %d, want positive", i, factors[i].Weight)
+				}
+				if factors[i].Note == "" {
+					t.Errorf("factor[%d].Note is empty", i)
+				}
+			}
+		})
+	}
+}
+
+func TestComputePlanHealth_ClampedBetween0And100(t *testing.T) {
+	// Defensive regression: even a totally pathological plan must stay
+	// in [0, 100]. The factor-table sums to 150, so without clamping
+	// the worst case would render -50.
+	plan := &config.PurchasePlan{
+		ID:      "p1",
+		Enabled: false,
+		RampSchedule: config.RampSchedule{
+			StepIntervalDays: 1,
+			CurrentStep:      1,
+			TotalSteps:       100,
+			StartDate:        fixedNow.AddDate(0, 0, -1000),
+		},
+		NextExecutionDate: tp(fixedNow.AddDate(0, 0, -1)),
+	}
+	execs := []config.PurchaseExecution{
+		{PlanID: "p1", Status: "failed"},
+		{PlanID: "p1", Status: "failed"},
+		{PlanID: "p1", Status: "failed"},
+		{PlanID: "p1", Status: "failed"},
+		{PlanID: "p1", Status: "cancelled"},
+		{PlanID: "p1", Status: "cancelled"},
+		{PlanID: "p1", Status: "cancelled"},
+		{PlanID: "p1", Status: "cancelled"},
+	}
+	score, _ := computePlanHealth(plan, execs, fixedNow)
+	if score < 0 || score > 100 {
+		t.Fatalf("score = %d, want 0..100", score)
+	}
+}
+
+func TestGroupExecutionsByPlan(t *testing.T) {
+	execs := []config.PurchaseExecution{
+		{PlanID: "a", Status: "completed"},
+		{PlanID: "b", Status: "failed"},
+		{PlanID: "a", Status: "pending"},
+		{PlanID: "c", Status: "cancelled"},
+		{PlanID: "a", Status: "failed"},
+	}
+	got := groupExecutionsByPlan(execs)
+	if len(got["a"]) != 3 {
+		t.Errorf("plan a: got %d, want 3", len(got["a"]))
+	}
+	if len(got["b"]) != 1 {
+		t.Errorf("plan b: got %d, want 1", len(got["b"]))
+	}
+	if len(got["c"]) != 1 {
+		t.Errorf("plan c: got %d, want 1", len(got["c"]))
+	}
+	if _, ok := got["nonexistent"]; ok {
+		t.Errorf("unexpected key 'nonexistent' in result")
+	}
+}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -367,9 +367,16 @@ type RecommendationDetailResponse struct {
 	ProvenanceNote   string       `json:"provenance_note"`
 }
 
-// PlansResponse holds the purchase plans response
+// PlansResponse holds the purchase plans response.
+//
+// Plans are wrapped in PlanWithHealth so the list endpoint can attach
+// a response-only health score + per-factor breakdown without polluting
+// the persisted config.PurchasePlan struct. The wrapper embeds the plan
+// inline, so JSON consumers see every field they used to see, plus the
+// new health_score / health_factors keys. See plan_health.go for the
+// scoring formula.
 type PlansResponse struct {
-	Plans []config.PurchasePlan `json:"plans"`
+	Plans []PlanWithHealth `json:"plans"`
 }
 
 // CurrentUserResponse holds the current user response


### PR DESCRIPTION
## Summary

Adds a 0-100 **Plan health** score badge to every purchase plan card on the Plans tab. Green ≥ 80, amber 50-79, red < 50. The badge tooltip enumerates exactly which factors subtracted from 100 so a bad score is actionable instead of opaque.

Issue #340 deferred follow-up: surfaces "is this plan executing as expected" at a glance, so an operator can prioritise plans that drifted off schedule (overdue execution date, recent failures, paused mid-ramp).

## Scoring formula

Pure backend function `computePlanHealth` (in `internal/api/plan_health.go`). Starts at 100, subtracts weighted penalties, clamps to [0, 100]:

| Factor                  | Weight  | Trigger                                                                  |
|-------------------------|---------|--------------------------------------------------------------------------|
| `overdue`               | -30     | enabled AND `next_execution_date` < today                                |
| `failed_executions`     | -10 × n | `n` failed executions (capped at 4 -> max -40)                           |
| `cancelled_executions`  | -5 × n  | `n` cancelled executions (capped at 4 -> max -20)                        |
| `behind_schedule`       | -20     | `current_step` lags expected step from `start_date + step_interval_days` |
| `stalled`               | -15     | enabled, past first interval, but `current_step == 0`                    |
| `disabled_midway`       | -25     | disabled with `0 < current_step < total_steps`                           |

Completed plans (`current_step >= total_steps`) short-circuit to 100 so finished plans don't accrue noise from historical failure rows or post-completion toggle-offs.

## Implementation notes

- No new store method, no schema change. Reuses the existing `GetExecutionsByStatuses` call shape (same set the History page already uses, capped at `DefaultListLimit = 100`).
- New `PlanWithHealth` response envelope keeps the score / factors out of the persisted `config.PurchasePlan` struct so they can't accidentally drift into DynamoDB / Postgres columns.
- Frontend types make `health_score` / `health_factors` optional so an older API response served during a partial deploy still renders cleanly (badge simply doesn't appear).
- Tooltip text passes through `escapeHtml` to neutralise any factor-note injection risk.
- A failed executions fetch is logged and swallowed (every plan defaults to score 100) so the plans list keeps rendering even when the executions table is unavailable — degraded but visible beats an opaque 500.

## Test plan

- [x] `go test ./internal/...` — 3712 passed, 24 packages
- [x] `cd frontend && npm test` — 1649 passed (including 4 new colour-band cases)
- [x] `npm run build` — 525 KiB entrypoint (well within ±10% of the 512 KiB baseline)
- [x] `go vet ./internal/api/...` clean
- [x] Pre-commit hook clean (cyclomatic-complexity refactored into per-factor helpers)
- [ ] CodeRabbit pass clean
- [ ] Deployed preview renders the badge with correct band colour


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plans now display color-coded health badges (green for good, amber for warnings, red for issues) showing plan status based on execution history and adherence to schedules. Hovering over a badge displays detailed health factors.

* **Tests**
  * Added comprehensive test coverage for plan health scoring and badge rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/376)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->