### PR TITLE
feat(api+frontend/admin): surface API key usage stats (closes #344 deferred)

### DIFF
--- a/frontend/src/__tests__/api-apikeys.test.ts
+++ b/frontend/src/__tests__/api-apikeys.test.ts
@@ -5,6 +5,7 @@
 import { fetchMock } from './setup';
 import {
   getApiKeys,
+  getApiKeysUsageStats,
   createApiKey,
   revokeApiKey,
   deleteApiKey
@@ -53,6 +54,46 @@ describe('API Keys API Module', () => {
       });
 
       await expect(getApiKeys()).rejects.toThrow('Unauthorized');
+    });
+  });
+
+  describe('getApiKeysUsageStats', () => {
+    test('fetches section-level usage summary', async () => {
+      const mockResponse = {
+        total_active: 2,
+        total_requests_24h: 42,
+        total_requests_lifetime: 1234,
+        top_keys: [
+          { id: 'key-1', name: 'Busy', key_prefix: 'abc12345', request_count_24h: 30 },
+        ],
+      };
+
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      });
+
+      const result = await getApiKeysUsageStats();
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/api-keys/usage-stats',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'X-Authorization': 'Bearer test-token',
+          }),
+        })
+      );
+      expect(result).toEqual(mockResponse);
+    });
+
+    test('throws error on API failure', async () => {
+      fetchMock.mockResolvedValue({
+        ok: false,
+        status: 401,
+        json: () => Promise.resolve({ error: 'Unauthorized' }),
+      });
+
+      await expect(getApiKeysUsageStats()).rejects.toThrow('Unauthorized');
     });
   });
 

--- a/frontend/src/__tests__/apikeys.test.ts
+++ b/frontend/src/__tests__/apikeys.test.ts
@@ -17,6 +17,7 @@ import {
 // Mock the api module
 jest.mock('../api', () => ({
   getApiKeys: jest.fn(),
+  getApiKeysUsageStats: jest.fn(),
   createApiKey: jest.fn(),
   revokeApiKey: jest.fn(),
   deleteApiKey: jest.fn()
@@ -36,6 +37,7 @@ describe('API Keys Module', () => {
   beforeEach(() => {
     // Reset DOM
     document.body.innerHTML = `
+      <div id="apikeys-usage-summary"></div>
       <div id="apikeys-list"></div>
       <button id="create-apikey-btn"></button>
       <div id="create-apikey-modal" class="hidden">
@@ -59,6 +61,15 @@ describe('API Keys Module', () => {
     // clears call history, not the mockResolvedValueOnce queue.
     mockConfirmDialog.mockReset();
     mockConfirmDialog.mockImplementation(() => Promise.resolve(true));
+    // Default the usage-stats endpoint to an empty response so the
+    // parallel-load path in loadApiKeys doesn't reject in tests that
+    // only set up `getApiKeys`. Individual tests can override.
+    (api.getApiKeysUsageStats as jest.Mock).mockResolvedValue({
+      total_active: 0,
+      total_requests_24h: 0,
+      total_requests_lifetime: 0,
+      top_keys: [],
+    });
   });
 
   describe('loadApiKeys', () => {
@@ -926,6 +937,134 @@ describe('API Keys Module', () => {
       const container = document.getElementById('apikeys-list');
       // The exact format depends on locale, but it should contain date parts
       expect(container?.innerHTML).toContain('2024');
+    });
+  });
+
+  // Usage stats (issue #344 deferred sub-task) — section-level summary
+  // card above the table + per-row request count columns.
+  describe('Usage stats', () => {
+    test('renders summary tiles when stats load successfully', async () => {
+      (api.getApiKeys as jest.Mock).mockResolvedValue({ api_keys: [] });
+      (api.getApiKeysUsageStats as jest.Mock).mockResolvedValue({
+        total_active: 2,
+        total_requests_24h: 42,
+        total_requests_lifetime: 1234,
+        top_keys: [
+          { id: 'key-1', name: 'Busy', key_prefix: 'aaaa1111', request_count_24h: 30 },
+          { id: 'key-2', name: 'Medium', key_prefix: 'bbbb2222', request_count_24h: 12 },
+        ],
+      });
+
+      await loadApiKeys();
+      // Allow the parallel stats fetch to resolve.
+      await new Promise((r) => setTimeout(r, 0));
+
+      const summary = document.getElementById('apikeys-usage-summary');
+      expect(summary?.textContent).toContain('Active keys');
+      expect(summary?.textContent).toContain('2');
+      expect(summary?.textContent).toContain('Requests (24h)');
+      expect(summary?.textContent).toContain('42');
+      expect(summary?.textContent).toContain('Requests (lifetime)');
+      // formatCount abbreviates large numbers in the summary tiles to
+      // fit the tile width — table cells keep the exact integer.
+      expect(summary?.textContent).toContain('1.2k');
+      expect(summary?.textContent).toContain('Most active (24h)');
+      expect(summary?.textContent).toContain('Busy');
+      expect(summary?.textContent).toContain('aaaa1111');
+    });
+
+    test('omits top-list when no key has 24h activity', async () => {
+      (api.getApiKeys as jest.Mock).mockResolvedValue({ api_keys: [] });
+      (api.getApiKeysUsageStats as jest.Mock).mockResolvedValue({
+        total_active: 1,
+        total_requests_24h: 0,
+        total_requests_lifetime: 7,
+        top_keys: [],
+      });
+
+      await loadApiKeys();
+      await new Promise((r) => setTimeout(r, 0));
+
+      const summary = document.getElementById('apikeys-usage-summary');
+      expect(summary?.textContent).not.toContain('Most active (24h)');
+    });
+
+    test('shows inline error when stats endpoint fails, table still renders', async () => {
+      (api.getApiKeys as jest.Mock).mockResolvedValue({
+        api_keys: [
+          { id: 'key-1', name: 'k', key_prefix: 'abc12345', is_active: true, created_at: '2024-01-15T10:00:00Z' },
+        ],
+      });
+      (api.getApiKeysUsageStats as jest.Mock).mockRejectedValue(new Error('boom'));
+
+      await loadApiKeys();
+      await new Promise((r) => setTimeout(r, 0));
+
+      const summary = document.getElementById('apikeys-usage-summary');
+      expect(summary?.querySelector('.error')?.textContent).toBe('Failed to load usage summary');
+      // The table itself still renders despite the summary failure.
+      const list = document.getElementById('apikeys-list');
+      expect(list?.innerHTML).toContain('abc12345');
+    });
+
+    test('renders Requests (24h) and Requests (total) columns per row', async () => {
+      (api.getApiKeys as jest.Mock).mockResolvedValue({
+        api_keys: [
+          {
+            id: 'key-1',
+            name: 'k1',
+            key_prefix: 'abc12345',
+            is_active: true,
+            created_at: '2024-01-15T10:00:00Z',
+            request_count_24h: 12,
+            request_count_total: 1234,
+          },
+        ],
+      });
+
+      await loadApiKeys();
+
+      const container = document.getElementById('apikeys-list');
+      expect(container?.innerHTML).toContain('Requests (24h)');
+      expect(container?.innerHTML).toContain('Requests (total)');
+      // Counts render with thousands separator for readability.
+      expect(container?.innerHTML).toContain('1,234');
+      expect(container?.innerHTML).toContain('apikeys-count-cell');
+    });
+
+    test('falls back to 0 when counter fields are missing from the response', async () => {
+      (api.getApiKeys as jest.Mock).mockResolvedValue({
+        api_keys: [
+          // No request_count_* fields — simulates a cached older response.
+          { id: 'key-1', name: 'k1', key_prefix: 'abc12345', is_active: true, created_at: '2024-01-15T10:00:00Z' },
+        ],
+      });
+
+      await loadApiKeys();
+
+      const container = document.getElementById('apikeys-list');
+      const cells = container?.querySelectorAll('.apikeys-count-cell');
+      expect(cells?.length).toBe(2);
+      expect(cells?.[0]?.textContent).toBe('0');
+      expect(cells?.[1]?.textContent).toBe('0');
+    });
+
+    test('list-fetch failure clears summary skeleton and shows error', async () => {
+      (api.getApiKeys as jest.Mock).mockRejectedValue(new Error('list boom'));
+      (api.getApiKeysUsageStats as jest.Mock).mockResolvedValue({
+        total_active: 0,
+        total_requests_24h: 0,
+        total_requests_lifetime: 0,
+        top_keys: [],
+      });
+
+      await loadApiKeys();
+      await new Promise((r) => setTimeout(r, 0));
+
+      const list = document.getElementById('apikeys-list');
+      expect(list?.querySelector('.error')?.textContent).toBe('Failed to load API keys');
+      // The skeleton-active marker is gone (success/error both clear it).
+      expect(list?.dataset['skeletonActive']).toBeUndefined();
     });
   });
 });

--- a/frontend/src/api/apikeys.ts
+++ b/frontend/src/api/apikeys.ts
@@ -3,13 +3,27 @@
  */
 
 import { apiRequest } from './client';
-import type { GetAPIKeysResponse, CreateAPIKeyRequest, CreateAPIKeyResponse } from './types';
+import type {
+  GetAPIKeysResponse,
+  CreateAPIKeyRequest,
+  CreateAPIKeyResponse,
+  APIKeysUsageStats,
+} from './types';
 
 /**
  * Get all API keys
  */
 export async function getApiKeys(): Promise<GetAPIKeysResponse> {
   return apiRequest<GetAPIKeysResponse>('/api-keys');
+}
+
+/**
+ * Get section-level API keys usage stats (issue #344 deferred sub-task).
+ * Returns the per-section summary card — totals + top keys by 24h
+ * activity. Scoped to the calling user's own keys.
+ */
+export async function getApiKeysUsageStats(): Promise<APIKeysUsageStats> {
+  return apiRequest<APIKeysUsageStats>('/api-keys/usage-stats');
 }
 
 /**

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -36,6 +36,8 @@ export type {
   CreateAPIKeyRequest,
   CreateAPIKeyResponse,
   GetAPIKeysResponse,
+  APIKeysUsageStats,
+  APIKeysUsageStatsTopKey,
   SavingsAnalyticsResponse,
   SavingsAnalyticsSummary,
   SavingsDataPoint,
@@ -147,6 +149,7 @@ export {
 // Re-export apikeys functions
 export {
   getApiKeys,
+  getApiKeysUsageStats,
   createApiKey,
   revokeApiKey,
   deleteApiKey

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -343,6 +343,26 @@ export interface APIKeyInfo {
   created_at: string;
   last_used_at?: string;
   permissions?: Permission[];
+  // Usage counters (issue #344 deferred sub-task).
+  // Optional in the type so older mock data / cached responses without
+  // the columns don't blow up the renderer — but the backend always
+  // sends them as of migration 000051.
+  request_count_total?: number;
+  request_count_24h?: number;
+}
+
+export interface APIKeysUsageStatsTopKey {
+  id: string;
+  name: string;
+  key_prefix: string;
+  request_count_24h: number;
+}
+
+export interface APIKeysUsageStats {
+  total_active: number;
+  total_requests_24h: number;
+  total_requests_lifetime: number;
+  top_keys: APIKeysUsageStatsTopKey[];
 }
 
 export interface CreateAPIKeyRequest {

--- a/frontend/src/apikeys.ts
+++ b/frontend/src/apikeys.ts
@@ -4,10 +4,12 @@
 
 import * as api from './api';
 import type { APIKeyInfo, CreateAPIKeyResponse } from './types';
+import type { APIKeysUsageStats } from './api/types';
 import { formatDateTime } from './utils';
 import { confirmDialog } from './confirmDialog';
 import { showToast } from './toast';
 import { openModal, closeModal } from './modal';
+import { showSkeletonRows, showSkeletonBlock, teardownSkeleton } from './lib/skeleton';
 
 // State for modal management
 let currentApiKeys: APIKeyInfo[] = [];
@@ -22,8 +24,20 @@ let currentApiKeys: APIKeyInfo[] = [];
  * Read the documented `api_keys` field, then fall back to a bare array
  * (some other deployments/proxies might unwrap) and finally to `[]` so
  * a contract drift can never crash the page.
+ *
+ * The usage-stats summary loads in parallel — a failure in either path
+ * only takes down its own region, never both. See loadApiKeysUsageStats
+ * for the section header's lifecycle.
  */
 export async function loadApiKeys(): Promise<void> {
+  const listContainer = document.getElementById('apikeys-list');
+  if (listContainer) {
+    showSkeletonRows(listContainer, 3, 7);
+  }
+  // Kick the summary off in parallel — it has its own container + error
+  // path so we don't await it inside the list flow.
+  void loadApiKeysUsageStats();
+
   try {
     const response = await api.getApiKeys();
     const list = (response as { api_keys?: APIKeyInfo[] } | undefined)?.api_keys
@@ -33,8 +47,124 @@ export async function loadApiKeys(): Promise<void> {
     renderApiKeysList();
   } catch (error) {
     console.error('Failed to load API keys:', error);
+    if (listContainer) teardownSkeleton(listContainer);
+    renderApiKeysListError(listContainer, 'Failed to load API keys');
     showError('Failed to load API keys');
   }
+}
+
+/**
+ * Replace the API keys list region with an inline error message so the
+ * shimmer skeleton doesn't sit beside a stale empty table after a
+ * failed fetch. Uses textContent (no innerHTML) to stay XSS-safe and
+ * matches the patterns used by other modules (e.g. dashboard.ts).
+ */
+function renderApiKeysListError(container: HTMLElement | null, message: string): void {
+  if (!container) return;
+  container.replaceChildren();
+  const p = document.createElement('p');
+  p.className = 'error';
+  p.textContent = message;
+  container.appendChild(p);
+}
+
+/**
+ * Load and render the section-level usage summary (totals + top keys).
+ * Fails closed: on error the summary slot shows an inline message and
+ * the rest of the section still works.
+ */
+export async function loadApiKeysUsageStats(): Promise<void> {
+  const container = document.getElementById('apikeys-usage-summary');
+  if (!container) return;
+  showSkeletonBlock(container, '100%', '4rem');
+  try {
+    const stats = await api.getApiKeysUsageStats();
+    renderApiKeysUsageSummary(stats);
+  } catch (error) {
+    console.error('Failed to load API keys usage stats:', error);
+    teardownSkeleton(container);
+    const p = document.createElement('p');
+    p.className = 'error';
+    p.textContent = 'Failed to load usage summary';
+    container.appendChild(p);
+  }
+}
+
+/**
+ * Render the section-level summary card: total active keys, total
+ * requests (24h + lifetime), and a top-3 most-active row. Built with
+ * createElement only (no innerHTML) to match the codebase XSS posture.
+ */
+export function renderApiKeysUsageSummary(stats: APIKeysUsageStats): void {
+  const container = document.getElementById('apikeys-usage-summary');
+  if (!container) return;
+  container.replaceChildren();
+  delete container.dataset['skeletonActive'];
+
+  const card = document.createElement('div');
+  card.className = 'apikeys-usage-summary card';
+
+  const tiles = document.createElement('div');
+  tiles.className = 'apikeys-usage-tiles';
+  tiles.appendChild(buildSummaryTile('Active keys', String(stats.total_active)));
+  tiles.appendChild(buildSummaryTile('Requests (24h)', formatCount(stats.total_requests_24h)));
+  tiles.appendChild(buildSummaryTile('Requests (lifetime)', formatCount(stats.total_requests_lifetime)));
+  card.appendChild(tiles);
+
+  if (stats.top_keys && stats.top_keys.length > 0) {
+    const heading = document.createElement('h5');
+    heading.className = 'apikeys-usage-top-heading';
+    heading.textContent = 'Most active (24h)';
+    card.appendChild(heading);
+
+    const list = document.createElement('ul');
+    list.className = 'apikeys-usage-top-list';
+    for (const top of stats.top_keys) {
+      const li = document.createElement('li');
+      const name = document.createElement('strong');
+      name.textContent = top.name;
+      const code = document.createElement('code');
+      code.textContent = `${top.key_prefix}...`;
+      const count = document.createElement('span');
+      count.className = 'apikeys-usage-top-count';
+      count.textContent = `${formatCount(top.request_count_24h)} req`;
+      li.appendChild(name);
+      li.appendChild(document.createTextNode(' '));
+      li.appendChild(code);
+      li.appendChild(document.createTextNode(' — '));
+      li.appendChild(count);
+      list.appendChild(li);
+    }
+    card.appendChild(list);
+  }
+
+  container.appendChild(card);
+}
+
+function buildSummaryTile(label: string, value: string): HTMLElement {
+  const tile = document.createElement('div');
+  tile.className = 'apikeys-usage-tile';
+  const labelEl = document.createElement('div');
+  labelEl.className = 'apikeys-usage-tile-label';
+  labelEl.textContent = label;
+  const valueEl = document.createElement('div');
+  valueEl.className = 'apikeys-usage-tile-value';
+  valueEl.textContent = value;
+  tile.appendChild(labelEl);
+  tile.appendChild(valueEl);
+  return tile;
+}
+
+/**
+ * Format a request count for display. Uses the standard "k" / "M"
+ * abbreviation for large values so the summary tile doesn't have to
+ * fit "1,234,567" — the table still shows the exact number.
+ */
+function formatCount(n: number): string {
+  if (!Number.isFinite(n) || n < 0) return '0';
+  if (n < 1000) return String(Math.trunc(n));
+  if (n < 1_000_000) return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0)}k`;
+  return `${(n / 1_000_000).toFixed(n < 10_000_000 ? 1 : 0)}M`;
 }
 
 /**
@@ -69,6 +199,8 @@ export function renderApiKeysList(): void {
           <th>Status</th>
           <th>Created</th>
           <th>Last Used</th>
+          <th>Requests (24h)</th>
+          <th>Requests (total)</th>
           <th>Expires</th>
           <th>Actions</th>
         </tr>
@@ -78,6 +210,8 @@ export function renderApiKeysList(): void {
           const isExpired = key.expires_at && new Date(key.expires_at) < new Date();
           const statusClass = !key.is_active ? 'badge-danger' : isExpired ? 'badge-warning' : 'badge-success';
           const statusText = !key.is_active ? 'Revoked' : isExpired ? 'Expired' : 'Active';
+          const count24h = formatRequestCount(key.request_count_24h);
+          const countTotal = formatRequestCount(key.request_count_total);
 
           return `
             <tr>
@@ -86,6 +220,8 @@ export function renderApiKeysList(): void {
               <td><span class="badge ${statusClass}">${statusText}</span></td>
               <td>${formatDateTime(key.created_at)}</td>
               <td>${key.last_used_at ? formatDateTime(key.last_used_at) : '<span class="text-muted">Never</span>'}</td>
+              <td class="apikeys-count-cell">${count24h}</td>
+              <td class="apikeys-count-cell">${countTotal}</td>
               <td>${key.expires_at ? formatDateTime(key.expires_at) : '<span class="text-muted">Never</span>'}</td>
               <td>
                 ${key.is_active && !isExpired ? `<button class="btn-small btn-warning revoke-key-btn" data-key-id="${escapeHtml(key.id)}">Revoke</button>` : ''}
@@ -98,6 +234,11 @@ export function renderApiKeysList(): void {
     </table>
   `;
 
+  // Clear the skeleton marker before the render — the existing
+  // innerHTML write (kept intact for diff minimality) replaces all
+  // children, and we don't want a stale `data-skeleton-active`
+  // attribute lingering on the live table.
+  delete container.dataset['skeletonActive'];
   container.innerHTML = table;
 
   // Add event delegation after rendering
@@ -397,4 +538,19 @@ function escapeHtml(text: string): string {
   const div = document.createElement('div');
   div.textContent = text;
   return div.innerHTML;
+}
+
+/**
+ * Format a per-row request count for display in the table cells.
+ * Renders the exact integer (no abbreviation) so a row with "1,234,567"
+ * is unambiguous — the section-level summary card uses a separate
+ * `formatCount` that abbreviates large values to fit the tile width.
+ *
+ * Defends against missing fields (older cached responses without the
+ * counters from migration 000051) and non-finite inputs by coercing
+ * to 0 — never returns "undefined" or "NaN" to the rendered table.
+ */
+function formatRequestCount(n: number | undefined): string {
+  if (typeof n !== 'number' || !Number.isFinite(n) || n < 0) return '0';
+  return Math.trunc(n).toLocaleString('en-US');
 }

--- a/frontend/src/apikeys.ts
+++ b/frontend/src/apikeys.ts
@@ -163,7 +163,13 @@ function buildSummaryTile(label: string, value: string): HTMLElement {
 function formatCount(n: number): string {
   if (!Number.isFinite(n) || n < 0) return '0';
   if (n < 1000) return String(Math.trunc(n));
-  if (n < 1_000_000) return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0)}k`;
+  if (n < 1_000_000) {
+    // Round to the chosen precision FIRST so we can detect the
+    // 999,500..999,999 band that rounds up to 1000k and promote
+    // it to the M branch instead of emitting "1000k".
+    const k = Number((n / 1000).toFixed(n < 10_000 ? 1 : 0));
+    if (k < 1000) return `${k}k`;
+  }
   return `${(n / 1_000_000).toFixed(n < 10_000_000 ? 1 : 0)}M`;
 }
 

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -664,6 +664,9 @@
                         <div class="section-header">
                             <button type="button" id="create-apikey-btn" class="primary">Create API Key</button>
                         </div>
+                        <!-- Section-level usage summary (issue #344 deferred sub-task).
+                             Populated by apikeys.ts:loadApiKeysUsageStats(). -->
+                        <div id="apikeys-usage-summary" class="mt-3"></div>
                         <div id="apikeys-list" class="mt-3"></div>
                     </fieldset>
                 </section>

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -1481,3 +1481,70 @@ tr.rec-variant-row:hover td:not(.checkbox-col) {
     font-size: var(--cudly-fs-sm);
     font-style: italic;
 }
+
+/* ---------------------------------------------------------------------------
+ * API keys usage summary (issue #344 deferred sub-task).
+ * Three-tile summary card + top-3 most-active list. Sits above the
+ * api-keys table inside #apikeys-section. Tiles reuse the design-token
+ * stack from .kpi-tile but stay flat (no spark-area grid) — this is a
+ * settings-page card, not a dashboard headline.
+ * ------------------------------------------------------------------------- */
+.apikeys-usage-summary {
+    padding: var(--cudly-sp-4);
+}
+
+.apikeys-usage-tiles {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: var(--cudly-sp-3);
+}
+
+.apikeys-usage-tile {
+    padding: var(--cudly-sp-3);
+    border-radius: var(--cudly-r-md);
+    border: 1px solid var(--cudly-border);
+    background: var(--cudly-bg-elevated, white);
+}
+
+.apikeys-usage-tile-label {
+    font-size: var(--cudly-fs-sm);
+    color: var(--cudly-text-muted);
+    margin-bottom: var(--cudly-sp-1);
+}
+
+.apikeys-usage-tile-value {
+    font-size: var(--cudly-fs-xl);
+    font-weight: var(--cudly-fw-semibold);
+    color: var(--cudly-text);
+}
+
+.apikeys-usage-top-heading {
+    margin: var(--cudly-sp-4) 0 var(--cudly-sp-2);
+    font-size: var(--cudly-fs-sm);
+    color: var(--cudly-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.apikeys-usage-top-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--cudly-sp-1);
+}
+
+.apikeys-usage-top-list li {
+    padding: var(--cudly-sp-1) 0;
+    font-size: var(--cudly-fs-sm);
+}
+
+.apikeys-usage-top-count {
+    color: var(--cudly-text-muted);
+}
+
+.apikeys-count-cell {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -316,6 +316,10 @@ export interface APIKeyInfo {
   created_at: string;
   last_used_at?: string;
   permissions?: api.Permission[];
+  // Usage counters (issue #344 deferred sub-task). Optional for the
+  // same reason as in api/types.ts — see comment there.
+  request_count_total?: number;
+  request_count_24h?: number;
 }
 
 export interface CreateAPIKeyResponse {

--- a/internal/api/handler_apikeys.go
+++ b/internal/api/handler_apikeys.go
@@ -35,6 +35,27 @@ func (h *Handler) listAPIKeys(ctx context.Context, req *events.LambdaFunctionURL
 	return keys, nil
 }
 
+// listAPIKeysUsageStats handles GET /api/api-keys/usage-stats.
+//
+// Returns a section-level summary scoped to the calling user's own keys:
+// total active, total requests (24h + lifetime), and the top-3 keys by
+// 24h activity. Scope is identical to listAPIKeys — both gate on the
+// same view-api-keys permission so the section header and the row list
+// can never disagree about visibility.
+func (h *Handler) listAPIKeysUsageStats(ctx context.Context, req *events.LambdaFunctionURLRequest) (any, error) {
+	session, err := h.requirePermission(ctx, req, "view", "api-keys")
+	if err != nil {
+		return nil, err
+	}
+
+	stats, err := h.auth.GetAPIKeysUsageStatsAPI(ctx, session.UserID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load API key usage stats: %w", err)
+	}
+
+	return stats, nil
+}
+
 // createAPIKey handles POST /api/api-keys
 func (h *Handler) createAPIKey(ctx context.Context, req *events.LambdaFunctionURLRequest) (any, error) {
 	session, err := h.requirePermission(ctx, req, "create", "api-keys")

--- a/internal/api/handler_apikeys_test.go
+++ b/internal/api/handler_apikeys_test.go
@@ -616,6 +616,91 @@ func TestHandler_revokeAPIKey_PermissionDenied(t *testing.T) {
 	mockAuth.AssertNotCalled(t, "RevokeAPIKeyAPI", mock.Anything, mock.Anything, mock.Anything)
 }
 
+// listAPIKeysUsageStats handler — section-level summary (issue #344
+// deferred sub-task). Mirrors the listAPIKeys test layout: happy path
+// for an admin session, a no-auth-service failure, a service-error
+// passthrough, and a permission-denied path for a non-admin without
+// the view-api-keys permission.
+
+func TestHandler_listAPIKeysUsageStats_Success(t *testing.T) {
+	ctx := context.Background()
+	mockAuth := new(MockAuthService)
+
+	session := &Session{UserID: "user-123", Email: "user@example.com", Role: "admin"}
+	mockAuth.On("ValidateSession", ctx, "test-token").Return(session, nil)
+
+	expectedStats := map[string]any{
+		"total_active":            2,
+		"total_requests_24h":      int64(15),
+		"total_requests_lifetime": int64(120),
+		"top_keys":                []map[string]any{{"id": "key-1", "name": "k1", "key_prefix": "abc12345", "request_count_24h": int64(10)}},
+	}
+	mockAuth.On("GetAPIKeysUsageStatsAPI", ctx, "user-123").Return(expectedStats, nil)
+
+	handler := &Handler{auth: mockAuth}
+
+	req := &events.LambdaFunctionURLRequest{
+		Headers: map[string]string{"Authorization": "Bearer test-token"},
+	}
+
+	result, err := handler.listAPIKeysUsageStats(ctx, req)
+	require.NoError(t, err)
+	got, ok := result.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, 2, got["total_active"])
+	mockAuth.AssertCalled(t, "GetAPIKeysUsageStatsAPI", ctx, "user-123")
+}
+
+func TestHandler_listAPIKeysUsageStats_NoAuthService(t *testing.T) {
+	ctx := context.Background()
+	handler := &Handler{}
+
+	req := &events.LambdaFunctionURLRequest{}
+
+	_, err := handler.listAPIKeysUsageStats(ctx, req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "authentication service not configured")
+}
+
+func TestHandler_listAPIKeysUsageStats_ServiceError(t *testing.T) {
+	ctx := context.Background()
+	mockAuth := new(MockAuthService)
+
+	session := &Session{UserID: "user-123", Email: "user@example.com", Role: "admin"}
+	mockAuth.On("ValidateSession", ctx, "test-token").Return(session, nil)
+	mockAuth.On("GetAPIKeysUsageStatsAPI", ctx, "user-123").Return(nil, errors.New("database error"))
+
+	handler := &Handler{auth: mockAuth}
+
+	req := &events.LambdaFunctionURLRequest{
+		Headers: map[string]string{"Authorization": "Bearer test-token"},
+	}
+
+	_, err := handler.listAPIKeysUsageStats(ctx, req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load API key usage stats")
+}
+
+func TestHandler_listAPIKeysUsageStats_PermissionDenied(t *testing.T) {
+	ctx := context.Background()
+	mockAuth := new(MockAuthService)
+
+	session := &Session{UserID: "viewer-1", Email: "viewer@example.com", Role: "viewer"}
+	mockAuth.On("ValidateSession", ctx, "viewer-token").Return(session, nil)
+	mockAuth.On("HasPermissionAPI", ctx, "viewer-1", "view", "api-keys").Return(false, nil)
+
+	handler := &Handler{auth: mockAuth}
+
+	req := &events.LambdaFunctionURLRequest{
+		Headers: map[string]string{"Authorization": "Bearer viewer-token"},
+	}
+
+	_, err := handler.listAPIKeysUsageStats(ctx, req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "permission denied")
+	mockAuth.AssertNotCalled(t, "GetAPIKeysUsageStatsAPI", mock.Anything, mock.Anything)
+}
+
 func TestFormatTimePtr(t *testing.T) {
 	t.Run("nil pointer returns empty string", func(t *testing.T) {
 		result := formatTimePtr(nil)

--- a/internal/api/handler_ri_exchange_test.go
+++ b/internal/api/handler_ri_exchange_test.go
@@ -509,6 +509,9 @@ func (m *mockAuthForExchange) CreateAPIKeyAPI(_ context.Context, _ string, _ any
 func (m *mockAuthForExchange) ListUserAPIKeysAPI(_ context.Context, _ string) (any, error) {
 	return nil, nil
 }
+func (m *mockAuthForExchange) GetAPIKeysUsageStatsAPI(_ context.Context, _ string) (any, error) {
+	return nil, nil
+}
 func (m *mockAuthForExchange) DeleteAPIKeyAPI(_ context.Context, _, _ string) error { return nil }
 func (m *mockAuthForExchange) RevokeAPIKeyAPI(_ context.Context, _, _ string) error { return nil }
 func (m *mockAuthForExchange) ValidateUserAPIKeyAPI(_ context.Context, _ string) (any, any, error) {

--- a/internal/api/mocks_test.go
+++ b/internal/api/mocks_test.go
@@ -746,6 +746,11 @@ func (m *MockAuthService) ListUserAPIKeysAPI(ctx context.Context, userID string)
 	return args.Get(0), args.Error(1)
 }
 
+func (m *MockAuthService) GetAPIKeysUsageStatsAPI(ctx context.Context, userID string) (interface{}, error) {
+	args := m.Called(ctx, userID)
+	return args.Get(0), args.Error(1)
+}
+
 func (m *MockAuthService) DeleteAPIKeyAPI(ctx context.Context, userID, keyID string) error {
 	args := m.Called(ctx, userID, keyID)
 	return args.Error(0)

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -928,6 +928,25 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
 
+  /api/api-keys/usage-stats:
+    get:
+      operationId: getAPIKeysUsageStats
+      tags: [APIKeys]
+      summary: Section-level usage summary for the caller's API keys
+      description: |
+        Aggregates per-key counters into a single summary card: number of
+        active keys, total requests (24h + lifetime), and the top-3 keys
+        by 24h request count. Scoped to the calling user's own keys.
+      responses:
+        '200':
+          description: API keys usage stats
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIKeysUsageStats'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
   /api/api-keys/{id}/revoke:
     parameters:
       - $ref: '#/components/parameters/ResourceID'
@@ -1716,6 +1735,49 @@ components:
           format: date-time
         is_active:
           type: boolean
+        request_count_total:
+          type: integer
+          format: int64
+          description: Lifetime request count since the key was created.
+        request_count_24h:
+          type: integer
+          format: int64
+          description: |
+            Rolling 24h request count. Resets when the previous window
+            crosses 24h since its first request — the value is "requests
+            in the last 24h", not "requests today".
+
+    APIKeysUsageStats:
+      type: object
+      properties:
+        total_active:
+          type: integer
+          description: Number of currently-active API keys for the caller.
+        total_requests_24h:
+          type: integer
+          format: int64
+          description: Sum of request_count_24h across the caller's keys.
+        total_requests_lifetime:
+          type: integer
+          format: int64
+          description: Sum of request_count_total across the caller's keys.
+        top_keys:
+          type: array
+          description: |
+            Top keys by 24h request count (lifetime count as tiebreaker).
+            At most 3 entries; keys with zero 24h activity are omitted.
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              name:
+                type: string
+              key_prefix:
+                type: string
+              request_count_24h:
+                type: integer
+                format: int64
 
     # -- Configuration ------------------------------------------------------
     ConfigResponse:

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -201,7 +201,10 @@ func (r *Router) registerRoutes() {
 		{ExactPath: "/api/auth/profile", Method: "PUT", Handler: r.updateProfileHandler, Auth: AuthUser},
 		{ExactPath: "/api/auth/change-password", Method: "POST", Handler: r.changePasswordHandler, Auth: AuthUser},
 
-		// API Key endpoints (self-service — any authenticated user)
+		// API Key endpoints (self-service — any authenticated user).
+		// Usage-stats route is declared before the generic prefix
+		// matches so the more-specific path wins.
+		{ExactPath: "/api/api-keys/usage-stats", Method: "GET", Handler: r.listAPIKeysUsageStatsHandler, Auth: AuthUser},
 		{ExactPath: "/api/api-keys", Method: "GET", Handler: r.listAPIKeysHandler, Auth: AuthUser},
 		{ExactPath: "/api/api-keys", Method: "POST", Handler: r.createAPIKeyHandler, Auth: AuthUser},
 		{PathPrefix: "/api/api-keys/", PathSuffix: "/revoke", Method: "POST", Handler: r.revokeAPIKeyHandler, Auth: AuthUser},
@@ -536,6 +539,10 @@ func (r *Router) changePasswordHandler(ctx context.Context, req *events.LambdaFu
 
 func (r *Router) listAPIKeysHandler(ctx context.Context, req *events.LambdaFunctionURLRequest, params map[string]string) (any, error) {
 	return r.h.listAPIKeys(ctx, req)
+}
+
+func (r *Router) listAPIKeysUsageStatsHandler(ctx context.Context, req *events.LambdaFunctionURLRequest, params map[string]string) (any, error) {
+	return r.h.listAPIKeysUsageStats(ctx, req)
 }
 
 func (r *Router) createAPIKeyHandler(ctx context.Context, req *events.LambdaFunctionURLRequest, params map[string]string) (any, error) {

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -175,6 +175,7 @@ type AuthServiceInterface interface {
 	// API Key management
 	CreateAPIKeyAPI(ctx context.Context, userID string, req any) (any, error)
 	ListUserAPIKeysAPI(ctx context.Context, userID string) (any, error)
+	GetAPIKeysUsageStatsAPI(ctx context.Context, userID string) (any, error)
 	DeleteAPIKeyAPI(ctx context.Context, userID, keyID string) error
 	RevokeAPIKeyAPI(ctx context.Context, userID, keyID string) error
 	ValidateUserAPIKeyAPI(ctx context.Context, apiKey string) (any, any, error)

--- a/internal/auth/interfaces.go
+++ b/internal/auth/interfaces.go
@@ -45,6 +45,11 @@ type StoreInterface interface {
 	ListAPIKeysByUser(ctx context.Context, userID string) ([]*UserAPIKey, error)
 	UpdateAPIKey(ctx context.Context, key *UserAPIKey) error
 	UpdateAPIKeyLastUsed(ctx context.Context, keyID string) error
+	// RecordAPIKeyUsage atomically updates last_used_at and increments
+	// request_count_total + request_count_24h. The 24h counter resets
+	// (along with its window-start) when the existing window is older
+	// than 24h. See migration 000051 for the column shape.
+	RecordAPIKeyUsage(ctx context.Context, keyID string) error
 	DeleteAPIKey(ctx context.Context, keyID string) error
 
 	// Health check

--- a/internal/auth/service_apikeys.go
+++ b/internal/auth/service_apikeys.go
@@ -275,21 +275,32 @@ func (s *Service) ValidateUserAPIKey(ctx context.Context, apiKey string) (*UserA
 		return nil, nil, err
 	}
 
-	// Update last used timestamp (async to avoid blocking)
+	// Record usage (last_used_at + counters) async so request latency is
+	// unaffected. The store does an atomic single-row UPDATE — see
+	// PostgresStore.RecordAPIKeyUsage for the rolling-24h-window logic.
 	go func() {
 		updateCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		if err := s.UpdateLastUsed(updateCtx, key.ID); err != nil {
-			logging.Warnf("Failed to update API key last used timestamp: %v", err)
+		if err := s.RecordUsage(updateCtx, key.ID); err != nil {
+			logging.Warnf("Failed to record API key usage: %v", err)
 		}
 	}()
 
 	return key, user, nil
 }
 
-// UpdateLastUsed updates the last used timestamp for an API key atomically
+// UpdateLastUsed updates only the last used timestamp for an API key.
+// Retained for backwards compatibility; new code paths should use
+// RecordUsage so the request_count_* counters stay current.
 func (s *Service) UpdateLastUsed(ctx context.Context, keyID string) error {
 	return s.store.UpdateAPIKeyLastUsed(ctx, keyID)
+}
+
+// RecordUsage updates last_used_at and increments both the lifetime and
+// rolling-24h request counters for the key. See
+// PostgresStore.RecordAPIKeyUsage for the atomic SQL.
+func (s *Service) RecordUsage(ctx context.Context, keyID string) error {
+	return s.store.RecordAPIKeyUsage(ctx, keyID)
 }
 
 // ComputeEffectivePermissions computes the intersection of API key permissions and user permissions

--- a/internal/auth/service_apikeys_api.go
+++ b/internal/auth/service_apikeys_api.go
@@ -3,8 +3,21 @@ package auth
 import (
 	"context"
 	"fmt"
+	"sort"
 	"time"
 )
+
+// sortAPIKeysByActivity sorts in place by request_count_24h desc, with
+// request_count_total desc as the tiebreaker. Exported as a helper so
+// it can be unit-tested without going through the full service.
+func sortAPIKeysByActivity(keys []*UserAPIKey) {
+	sort.SliceStable(keys, func(i, j int) bool {
+		if keys[i].RequestCount24h != keys[j].RequestCount24h {
+			return keys[i].RequestCount24h > keys[j].RequestCount24h
+		}
+		return keys[i].RequestCountTotal > keys[j].RequestCountTotal
+	})
+}
 
 // API wrapper methods for API key operations
 // These methods return API-friendly types and handle type conversions
@@ -26,6 +39,29 @@ type APIKeyInfo struct {
 	CreatedAt   time.Time    `json:"created_at"`
 	LastUsedAt  *time.Time   `json:"last_used_at,omitempty"`
 	IsActive    bool         `json:"is_active"`
+	// Usage counters (issue #344 deferred sub-task).
+	RequestCountTotal int64 `json:"request_count_total"`
+	RequestCount24h   int64 `json:"request_count_24h"`
+}
+
+// APIKeysUsageStatsTopKey is one entry in the top-keys list returned by
+// GetAPIKeysUsageStatsAPI. Trimmed to identifier + 24h count so the UI
+// doesn't have to re-derive anything from the full APIKeyInfo blob.
+type APIKeysUsageStatsTopKey struct {
+	ID              string `json:"id"`
+	Name            string `json:"name"`
+	KeyPrefix       string `json:"key_prefix"`
+	RequestCount24h int64  `json:"request_count_24h"`
+}
+
+// APIKeysUsageStatsResponse is the summary payload for the API keys
+// section header (issue #344 deferred sub-task). Scoped to the calling
+// user's own keys — same scope as ListUserAPIKeysAPI.
+type APIKeysUsageStatsResponse struct {
+	TotalActive           int                       `json:"total_active"`
+	TotalRequests24h      int64                     `json:"total_requests_24h"`
+	TotalRequestsLifetime int64                     `json:"total_requests_lifetime"`
+	TopKeys               []APIKeysUsageStatsTopKey `json:"top_keys"`
 }
 
 // APICreateAPIKeyResponse represents the API response for creating an API key
@@ -59,14 +95,16 @@ func (s *Service) CreateAPIKeyAPI(ctx context.Context, userID string, req any) (
 		APIKey: apiKey,
 		KeyID:  keyInfo.ID,
 		Info: &APIKeyInfo{
-			ID:          keyInfo.ID,
-			Name:        keyInfo.Name,
-			KeyPrefix:   keyInfo.KeyPrefix,
-			Permissions: keyInfo.Permissions,
-			ExpiresAt:   keyInfo.ExpiresAt,
-			CreatedAt:   keyInfo.CreatedAt,
-			LastUsedAt:  keyInfo.LastUsedAt,
-			IsActive:    keyInfo.IsActive,
+			ID:                keyInfo.ID,
+			Name:              keyInfo.Name,
+			KeyPrefix:         keyInfo.KeyPrefix,
+			Permissions:       keyInfo.Permissions,
+			ExpiresAt:         keyInfo.ExpiresAt,
+			CreatedAt:         keyInfo.CreatedAt,
+			LastUsedAt:        keyInfo.LastUsedAt,
+			IsActive:          keyInfo.IsActive,
+			RequestCountTotal: keyInfo.RequestCountTotal,
+			RequestCount24h:   keyInfo.RequestCount24h,
 		},
 	}, nil
 }
@@ -82,20 +120,76 @@ func (s *Service) ListUserAPIKeysAPI(ctx context.Context, userID string) (any, e
 	apiKeys := make([]*APIKeyInfo, 0, len(keys))
 	for _, key := range keys {
 		apiKeys = append(apiKeys, &APIKeyInfo{
-			ID:          key.ID,
-			Name:        key.Name,
-			KeyPrefix:   key.KeyPrefix,
-			Permissions: key.Permissions,
-			ExpiresAt:   key.ExpiresAt,
-			CreatedAt:   key.CreatedAt,
-			LastUsedAt:  key.LastUsedAt,
-			IsActive:    key.IsActive,
+			ID:                key.ID,
+			Name:              key.Name,
+			KeyPrefix:         key.KeyPrefix,
+			Permissions:       key.Permissions,
+			ExpiresAt:         key.ExpiresAt,
+			CreatedAt:         key.CreatedAt,
+			LastUsedAt:        key.LastUsedAt,
+			IsActive:          key.IsActive,
+			RequestCountTotal: key.RequestCountTotal,
+			RequestCount24h:   key.RequestCount24h,
 		})
 	}
 
 	return &APIListAPIKeysResponse{
 		APIKeys: apiKeys,
 	}, nil
+}
+
+// GetAPIKeysUsageStatsAPI computes section-level usage stats for the
+// calling user's own API keys. Aggregated in-process so we don't need
+// a separate DB round-trip — ListUserAPIKeys already returns the
+// per-key counters from migration 000051.
+//
+// The "top keys" list is sorted by request_count_24h descending, with
+// total-lifetime as the tiebreaker so a long-running idle key doesn't
+// outrank an active one with the same 24h count. Up to 3 entries are
+// surfaced; the UI clarifies this is "top by 24h activity".
+func (s *Service) GetAPIKeysUsageStatsAPI(ctx context.Context, userID string) (any, error) {
+	keys, err := s.ListUserAPIKeys(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := &APIKeysUsageStatsResponse{
+		TopKeys: []APIKeysUsageStatsTopKey{},
+	}
+	for _, k := range keys {
+		if k.IsActive {
+			resp.TotalActive++
+		}
+		resp.TotalRequests24h += k.RequestCount24h
+		resp.TotalRequestsLifetime += k.RequestCountTotal
+	}
+
+	// Sort by 24h count desc, then lifetime desc.
+	sorted := make([]*UserAPIKey, len(keys))
+	copy(sorted, keys)
+	sortAPIKeysByActivity(sorted)
+
+	const topN = 3
+	limit := topN
+	if len(sorted) < limit {
+		limit = len(sorted)
+	}
+	for i := 0; i < limit; i++ {
+		k := sorted[i]
+		// Skip keys with zero 24h activity — surfacing a "top key"
+		// with 0 requests is confusing rather than informative.
+		if k.RequestCount24h == 0 {
+			break
+		}
+		resp.TopKeys = append(resp.TopKeys, APIKeysUsageStatsTopKey{
+			ID:              k.ID,
+			Name:            k.Name,
+			KeyPrefix:       k.KeyPrefix,
+			RequestCount24h: k.RequestCount24h,
+		})
+	}
+
+	return resp, nil
 }
 
 // DeleteAPIKeyAPI deletes an API key

--- a/internal/auth/service_apikeys_api_test.go
+++ b/internal/auth/service_apikeys_api_test.go
@@ -293,14 +293,25 @@ func TestService_ValidateUserAPIKeyAPI(t *testing.T) {
 
 		mockStore.On("GetAPIKeyByHash", ctx, keyHash).Return(apiKeyRecord, nil)
 		mockStore.On("GetUserByID", ctx, "user-123").Return(user, nil)
-		mockStore.On("RecordAPIKeyUsage", mock.Anything, "key-1").Return(nil).Maybe()
+		// Use a signalling channel + .Once() so the test fails (rather than
+		// silently passes) if ValidateUserAPIKeyAPI ever stops recording
+		// usage, and so we don't have to busy-sleep waiting for the async
+		// goroutine that runs inside ValidateUserAPIKey.
+		usageRecorded := make(chan struct{}, 1)
+		mockStore.On("RecordAPIKeyUsage", mock.Anything, "key-1").
+			Run(func(mock.Arguments) { usageRecorded <- struct{}{} }).
+			Return(nil).Once()
 
 		resultKey, resultUser, err := service.ValidateUserAPIKeyAPI(ctx, apiKey)
 
 		require.NoError(t, err)
 		assert.Equal(t, apiKeyRecord, resultKey)
 		assert.Equal(t, user, resultUser)
-		time.Sleep(10 * time.Millisecond) // Allow goroutine to complete
+		select {
+		case <-usageRecorded:
+		case <-time.After(500 * time.Millisecond):
+			t.Fatal("expected RecordAPIKeyUsage to be called")
+		}
 		mockStore.AssertExpectations(t)
 	})
 

--- a/internal/auth/service_apikeys_api_test.go
+++ b/internal/auth/service_apikeys_api_test.go
@@ -293,7 +293,7 @@ func TestService_ValidateUserAPIKeyAPI(t *testing.T) {
 
 		mockStore.On("GetAPIKeyByHash", ctx, keyHash).Return(apiKeyRecord, nil)
 		mockStore.On("GetUserByID", ctx, "user-123").Return(user, nil)
-		mockStore.On("UpdateAPIKeyLastUsed", mock.Anything, "key-1").Return(nil).Maybe()
+		mockStore.On("RecordAPIKeyUsage", mock.Anything, "key-1").Return(nil).Maybe()
 
 		resultKey, resultUser, err := service.ValidateUserAPIKeyAPI(ctx, apiKey)
 
@@ -346,4 +346,86 @@ func TestService_ValidateUserAPIKeyAPI(t *testing.T) {
 		assert.Nil(t, resultUser)
 		mockStore.AssertExpectations(t)
 	})
+}
+
+func TestService_GetAPIKeysUsageStatsAPI(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now()
+
+	t.Run("aggregates totals and surfaces top keys by 24h", func(t *testing.T) {
+		mockStore := new(MockStore)
+		service := &Service{store: mockStore}
+
+		user := &User{ID: "user-123", Email: "test@example.com", Active: true}
+		keys := []*UserAPIKey{
+			{ID: "key-a", UserID: "user-123", Name: "Quiet", KeyPrefix: "qaaaaaaa", IsActive: true, CreatedAt: now, RequestCount24h: 0, RequestCountTotal: 50},
+			{ID: "key-b", UserID: "user-123", Name: "Busy", KeyPrefix: "bbbbbbbb", IsActive: true, CreatedAt: now, RequestCount24h: 25, RequestCountTotal: 1000},
+			{ID: "key-c", UserID: "user-123", Name: "Medium", KeyPrefix: "ccccccccc", IsActive: true, CreatedAt: now, RequestCount24h: 5, RequestCountTotal: 200},
+			{ID: "key-d", UserID: "user-123", Name: "Inactive", KeyPrefix: "dddddddd", IsActive: false, CreatedAt: now, RequestCount24h: 0, RequestCountTotal: 12},
+		}
+
+		mockStore.On("GetUserByID", ctx, "user-123").Return(user, nil)
+		mockStore.On("ListAPIKeysByUser", ctx, "user-123").Return(keys, nil)
+
+		result, err := service.GetAPIKeysUsageStatsAPI(ctx, "user-123")
+		require.NoError(t, err)
+		resp := result.(*APIKeysUsageStatsResponse)
+
+		assert.Equal(t, 3, resp.TotalActive)
+		assert.Equal(t, int64(30), resp.TotalRequests24h)
+		assert.Equal(t, int64(1262), resp.TotalRequestsLifetime)
+		require.Len(t, resp.TopKeys, 2, "only keys with non-zero 24h count appear in top list")
+		assert.Equal(t, "key-b", resp.TopKeys[0].ID)
+		assert.Equal(t, int64(25), resp.TopKeys[0].RequestCount24h)
+		assert.Equal(t, "key-c", resp.TopKeys[1].ID)
+		mockStore.AssertExpectations(t)
+	})
+
+	t.Run("returns empty top-keys when no usage at all", func(t *testing.T) {
+		mockStore := new(MockStore)
+		service := &Service{store: mockStore}
+
+		user := &User{ID: "user-123", Email: "test@example.com", Active: true}
+		keys := []*UserAPIKey{
+			{ID: "key-a", UserID: "user-123", Name: "k", KeyPrefix: "aaaa", IsActive: true, CreatedAt: now},
+		}
+
+		mockStore.On("GetUserByID", ctx, "user-123").Return(user, nil)
+		mockStore.On("ListAPIKeysByUser", ctx, "user-123").Return(keys, nil)
+
+		result, err := service.GetAPIKeysUsageStatsAPI(ctx, "user-123")
+		require.NoError(t, err)
+		resp := result.(*APIKeysUsageStatsResponse)
+
+		assert.Equal(t, 1, resp.TotalActive)
+		assert.Equal(t, int64(0), resp.TotalRequests24h)
+		assert.Equal(t, int64(0), resp.TotalRequestsLifetime)
+		assert.Empty(t, resp.TopKeys)
+	})
+
+	t.Run("propagates store error", func(t *testing.T) {
+		mockStore := new(MockStore)
+		service := &Service{store: mockStore}
+
+		user := &User{ID: "user-123", Email: "test@example.com", Active: true}
+		mockStore.On("GetUserByID", ctx, "user-123").Return(user, nil)
+		mockStore.On("ListAPIKeysByUser", ctx, "user-123").Return([]*UserAPIKey(nil), assert.AnError)
+
+		result, err := service.GetAPIKeysUsageStatsAPI(ctx, "user-123")
+		assert.Error(t, err)
+		assert.Nil(t, result)
+	})
+}
+
+func TestSortAPIKeysByActivity(t *testing.T) {
+	a := &UserAPIKey{ID: "a", RequestCount24h: 10, RequestCountTotal: 100}
+	b := &UserAPIKey{ID: "b", RequestCount24h: 25, RequestCountTotal: 50}
+	c := &UserAPIKey{ID: "c", RequestCount24h: 10, RequestCountTotal: 500}
+	d := &UserAPIKey{ID: "d", RequestCount24h: 0, RequestCountTotal: 1000}
+
+	in := []*UserAPIKey{a, b, c, d}
+	sortAPIKeysByActivity(in)
+
+	assert.Equal(t, []string{"b", "c", "a", "d"}, []string{in[0].ID, in[1].ID, in[2].ID, in[3].ID},
+		"24h desc first, then lifetime desc as tiebreaker")
 }

--- a/internal/auth/service_apikeys_test.go
+++ b/internal/auth/service_apikeys_test.go
@@ -492,7 +492,7 @@ func TestService_ValidateUserAPIKey(t *testing.T) {
 
 		mockStore.On("GetAPIKeyByHash", ctx, keyHash).Return(apiKeyRecord, nil)
 		mockStore.On("GetUserByID", ctx, "user-123").Return(user, nil)
-		mockStore.On("UpdateAPIKeyLastUsed", mock.Anything, "key-1").Return(nil).Maybe()
+		mockStore.On("RecordAPIKeyUsage", mock.Anything, "key-1").Return(nil).Maybe()
 
 		resultKey, resultUser, err := service.ValidateUserAPIKey(ctx, apiKey)
 
@@ -658,6 +658,32 @@ func TestService_UpdateLastUsed(t *testing.T) {
 
 		err := service.UpdateLastUsed(ctx, "key-1")
 
+		assert.Error(t, err)
+		mockStore.AssertExpectations(t)
+	})
+}
+
+func TestService_RecordUsage(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("delegates to store RecordAPIKeyUsage", func(t *testing.T) {
+		mockStore := new(MockStore)
+		service := &Service{store: mockStore}
+
+		mockStore.On("RecordAPIKeyUsage", ctx, "key-1").Return(nil)
+
+		err := service.RecordUsage(ctx, "key-1")
+		require.NoError(t, err)
+		mockStore.AssertExpectations(t)
+	})
+
+	t.Run("propagates store error", func(t *testing.T) {
+		mockStore := new(MockStore)
+		service := &Service{store: mockStore}
+
+		mockStore.On("RecordAPIKeyUsage", ctx, "key-1").Return(assert.AnError)
+
+		err := service.RecordUsage(ctx, "key-1")
 		assert.Error(t, err)
 		mockStore.AssertExpectations(t)
 	})

--- a/internal/auth/service_apikeys_test.go
+++ b/internal/auth/service_apikeys_test.go
@@ -492,14 +492,24 @@ func TestService_ValidateUserAPIKey(t *testing.T) {
 
 		mockStore.On("GetAPIKeyByHash", ctx, keyHash).Return(apiKeyRecord, nil)
 		mockStore.On("GetUserByID", ctx, "user-123").Return(user, nil)
-		mockStore.On("RecordAPIKeyUsage", mock.Anything, "key-1").Return(nil).Maybe()
+		// Use a signalling channel + .Once() so the test fails (rather than
+		// silently passes) if ValidateUserAPIKey ever stops recording usage,
+		// and so we don't have to busy-sleep waiting for the async goroutine.
+		usageRecorded := make(chan struct{}, 1)
+		mockStore.On("RecordAPIKeyUsage", mock.Anything, "key-1").
+			Run(func(mock.Arguments) { usageRecorded <- struct{}{} }).
+			Return(nil).Once()
 
 		resultKey, resultUser, err := service.ValidateUserAPIKey(ctx, apiKey)
 
 		require.NoError(t, err)
 		assert.Equal(t, user, resultUser)
 		assert.Equal(t, apiKeyRecord, resultKey)
-		time.Sleep(10 * time.Millisecond) // Allow goroutine to complete
+		select {
+		case <-usageRecorded:
+		case <-time.After(500 * time.Millisecond):
+			t.Fatal("expected RecordAPIKeyUsage to be called")
+		}
 		mockStore.AssertExpectations(t)
 	})
 

--- a/internal/auth/store_postgres.go
+++ b/internal/auth/store_postgres.go
@@ -621,6 +621,9 @@ func (s *PostgresStore) CreateAPIKey(ctx context.Context, key *UserAPIKey) error
 		return fmt.Errorf("failed to marshal permissions: %w", err)
 	}
 
+	// Counter columns default to 0 in the schema, so we don't have to
+	// pass them explicitly on create. The 24h-window-start stays NULL
+	// until the first request lands.
 	query := `
 		INSERT INTO api_keys (
 			id, user_id, name, key_prefix, key_hash, permissions,
@@ -652,7 +655,8 @@ func (s *PostgresStore) CreateAPIKey(ctx context.Context, key *UserAPIKey) error
 func (s *PostgresStore) GetAPIKeyByID(ctx context.Context, keyID string) (*UserAPIKey, error) {
 	query := `
 		SELECT id, user_id, name, key_prefix, key_hash, permissions,
-		       is_active, expires_at, created_at, last_used_at
+		       is_active, expires_at, created_at, last_used_at,
+		       request_count_total, request_count_24h
 		FROM api_keys
 		WHERE id = $1
 	`
@@ -664,7 +668,8 @@ func (s *PostgresStore) GetAPIKeyByID(ctx context.Context, keyID string) (*UserA
 func (s *PostgresStore) GetAPIKeyByHash(ctx context.Context, keyHash string) (*UserAPIKey, error) {
 	query := `
 		SELECT id, user_id, name, key_prefix, key_hash, permissions,
-		       is_active, expires_at, created_at, last_used_at
+		       is_active, expires_at, created_at, last_used_at,
+		       request_count_total, request_count_24h
 		FROM api_keys
 		WHERE key_hash = $1 AND is_active = true
 		  AND (expires_at IS NULL OR expires_at > NOW())
@@ -677,7 +682,8 @@ func (s *PostgresStore) GetAPIKeyByHash(ctx context.Context, keyHash string) (*U
 func (s *PostgresStore) ListAPIKeysByUser(ctx context.Context, userID string) ([]*UserAPIKey, error) {
 	query := `
 		SELECT id, user_id, name, key_prefix, key_hash, permissions,
-		       is_active, expires_at, created_at, last_used_at
+		       is_active, expires_at, created_at, last_used_at,
+		       request_count_total, request_count_24h
 		FROM api_keys
 		WHERE user_id = $1
 		ORDER BY created_at DESC
@@ -742,12 +748,56 @@ func (s *PostgresStore) UpdateAPIKey(ctx context.Context, key *UserAPIKey) error
 	return nil
 }
 
-// UpdateAPIKeyLastUsed atomically updates the last_used_at timestamp for an API key
+// UpdateAPIKeyLastUsed atomically updates the last_used_at timestamp for an API key.
+// Retained for backwards compatibility with callers that only need the
+// timestamp update — production code routes through RecordAPIKeyUsage,
+// which additionally maintains the usage counters from migration 000051.
 func (s *PostgresStore) UpdateAPIKeyLastUsed(ctx context.Context, keyID string) error {
 	query := `UPDATE api_keys SET last_used_at = NOW() WHERE id = $1`
 	result, err := s.db.Exec(ctx, query, keyID)
 	if err != nil {
 		return fmt.Errorf("failed to update API key last used: %w", err)
+	}
+	if result.RowsAffected() == 0 {
+		return fmt.Errorf("API key not found: %s", keyID)
+	}
+	return nil
+}
+
+// RecordAPIKeyUsage atomically updates last_used_at, increments
+// request_count_total, and increments-or-resets request_count_24h
+// based on whether the rolling 24h window is still current.
+//
+// The single UPDATE does the window decision inline:
+//   - if window_start IS NULL OR (NOW() - window_start) > 24h, start a
+//     fresh window (window_start = NOW(), count = 1).
+//   - otherwise increment the existing count.
+//
+// Doing it in one statement keeps the update atomic per row, so two
+// concurrent calls can't both see "stale window" and reset to 1 in
+// parallel — pgx serialises updates to the same row.
+func (s *PostgresStore) RecordAPIKeyUsage(ctx context.Context, keyID string) error {
+	query := `
+		UPDATE api_keys
+		SET last_used_at = NOW(),
+		    request_count_total = request_count_total + 1,
+		    request_count_24h = CASE
+		        WHEN request_count_24h_window_start IS NULL
+		             OR NOW() - request_count_24h_window_start > INTERVAL '24 hours'
+		        THEN 1
+		        ELSE request_count_24h + 1
+		    END,
+		    request_count_24h_window_start = CASE
+		        WHEN request_count_24h_window_start IS NULL
+		             OR NOW() - request_count_24h_window_start > INTERVAL '24 hours'
+		        THEN NOW()
+		        ELSE request_count_24h_window_start
+		    END
+		WHERE id = $1
+	`
+	result, err := s.db.Exec(ctx, query, keyID)
+	if err != nil {
+		return fmt.Errorf("failed to record API key usage: %w", err)
 	}
 	if result.RowsAffected() == 0 {
 		return fmt.Errorf("API key not found: %s", keyID)
@@ -898,6 +948,8 @@ func (s *PostgresStore) scanAPIKey(scanner Scanner) (*UserAPIKey, error) {
 		&expiresAt,
 		&key.CreatedAt,
 		&lastUsedAt,
+		&key.RequestCountTotal,
+		&key.RequestCount24h,
 	)
 
 	if err != nil {

--- a/internal/auth/store_postgres.go
+++ b/internal/auth/store_postgres.go
@@ -769,9 +769,13 @@ func (s *PostgresStore) UpdateAPIKeyLastUsed(ctx context.Context, keyID string) 
 // based on whether the rolling 24h window is still current.
 //
 // The single UPDATE does the window decision inline:
-//   - if window_start IS NULL OR (NOW() - window_start) > 24h, start a
+//   - if window_start IS NULL OR (NOW() - window_start) >= 24h, start a
 //     fresh window (window_start = NOW(), count = 1).
 //   - otherwise increment the existing count.
+//
+// `>=` (rather than `>`) makes the rollover trigger precisely at the
+// 24-hour boundary, matching the migration comment that says the
+// window resets "once the window age crosses 24h".
 //
 // Doing it in one statement keeps the update atomic per row, so two
 // concurrent calls can't both see "stale window" and reset to 1 in
@@ -783,13 +787,13 @@ func (s *PostgresStore) RecordAPIKeyUsage(ctx context.Context, keyID string) err
 		    request_count_total = request_count_total + 1,
 		    request_count_24h = CASE
 		        WHEN request_count_24h_window_start IS NULL
-		             OR NOW() - request_count_24h_window_start > INTERVAL '24 hours'
+		             OR NOW() - request_count_24h_window_start >= INTERVAL '24 hours'
 		        THEN 1
 		        ELSE request_count_24h + 1
 		    END,
 		    request_count_24h_window_start = CASE
 		        WHEN request_count_24h_window_start IS NULL
-		             OR NOW() - request_count_24h_window_start > INTERVAL '24 hours'
+		             OR NOW() - request_count_24h_window_start >= INTERVAL '24 hours'
 		        THEN NOW()
 		        ELSE request_count_24h_window_start
 		    END

--- a/internal/auth/test_helpers.go
+++ b/internal/auth/test_helpers.go
@@ -171,6 +171,11 @@ func (m *MockStore) UpdateAPIKeyLastUsed(ctx context.Context, keyID string) erro
 	return args.Error(0)
 }
 
+func (m *MockStore) RecordAPIKeyUsage(ctx context.Context, keyID string) error {
+	args := m.Called(ctx, keyID)
+	return args.Error(0)
+}
+
 func (m *MockStore) DeleteAPIKey(ctx context.Context, keyID string) error {
 	args := m.Called(ctx, keyID)
 	return args.Error(0)

--- a/internal/auth/types.go
+++ b/internal/auth/types.go
@@ -82,6 +82,12 @@ type UserAPIKey struct {
 	CreatedAt   time.Time    `json:"created_at" dynamodbav:"CreatedAt"`
 	LastUsedAt  *time.Time   `json:"last_used_at,omitempty" dynamodbav:"LastUsedAt"`
 	IsActive    bool         `json:"is_active" dynamodbav:"IsActive"`
+	// Usage counters (issue #344 deferred sub-task — migration 000051).
+	// Both default to 0 for legacy rows. RequestCount24h is reset by the
+	// store's RecordAPIKeyUsage path once its window-start is older than
+	// 24h, so it really is a "last 24h" number, not "last calendar day".
+	RequestCountTotal int64 `json:"request_count_total" dynamodbav:"RequestCountTotal"`
+	RequestCount24h   int64 `json:"request_count_24h" dynamodbav:"RequestCount24h"`
 }
 
 // AuthContext represents the complete authorization context for a user

--- a/internal/database/postgres/migrations/000051_api_keys_usage_counters.down.sql
+++ b/internal/database/postgres/migrations/000051_api_keys_usage_counters.down.sql
@@ -1,0 +1,5 @@
+-- Roll back API key usage counters (000051).
+ALTER TABLE api_keys
+    DROP COLUMN IF EXISTS request_count_24h_window_start,
+    DROP COLUMN IF EXISTS request_count_24h,
+    DROP COLUMN IF EXISTS request_count_total;

--- a/internal/database/postgres/migrations/000051_api_keys_usage_counters.up.sql
+++ b/internal/database/postgres/migrations/000051_api_keys_usage_counters.up.sql
@@ -1,0 +1,25 @@
+-- API key usage counters (deferred sub-task from #340 / #344).
+--
+-- Surface per-key request volume to the Admin → API Keys UI without
+-- introducing a separate audit-log table. Two counters live directly on
+-- the api_keys row, updated atomically by the same code path that
+-- already maintains last_used_at:
+--
+--   * request_count_total       — lifetime count since the key was created.
+--   * request_count_24h         — rolling 24-hour count; reset by the
+--                                 increment path once the window age
+--                                 crosses 24h (see store_postgres.go
+--                                 RecordAPIKeyUsage).
+--   * request_count_24h_window_start — the timestamp the current 24h
+--                                 window started at; NULL until the
+--                                 first request after this migration
+--                                 runs.
+--
+-- Counters default to 0 so all existing rows show "0 requests" rather
+-- than "(null)" in the UI. The window-start column is nullable because
+-- a row with zero-ever-usage shouldn't lie about when its window began.
+
+ALTER TABLE api_keys
+    ADD COLUMN request_count_total BIGINT NOT NULL DEFAULT 0,
+    ADD COLUMN request_count_24h BIGINT NOT NULL DEFAULT 0,
+    ADD COLUMN request_count_24h_window_start TIMESTAMPTZ;

--- a/internal/mocks/stores.go
+++ b/internal/mocks/stores.go
@@ -420,6 +420,12 @@ func (m *MockAuthStore) UpdateAPIKeyLastUsed(ctx context.Context, keyID string) 
 	return args.Error(0)
 }
 
+// RecordAPIKeyUsage mocks the RecordAPIKeyUsage operation
+func (m *MockAuthStore) RecordAPIKeyUsage(ctx context.Context, keyID string) error {
+	args := m.Called(ctx, keyID)
+	return args.Error(0)
+}
+
 // DeleteAPIKey mocks the DeleteAPIKey operation
 func (m *MockAuthStore) DeleteAPIKey(ctx context.Context, keyID string) error {
 	args := m.Called(ctx, keyID)

--- a/internal/server/app.go
+++ b/internal/server/app.go
@@ -997,6 +997,10 @@ func (a *authServiceAdapter) ListUserAPIKeysAPI(ctx context.Context, userID stri
 	return a.service.ListUserAPIKeysAPI(ctx, userID)
 }
 
+func (a *authServiceAdapter) GetAPIKeysUsageStatsAPI(ctx context.Context, userID string) (any, error) {
+	return a.service.GetAPIKeysUsageStatsAPI(ctx, userID)
+}
+
 func (a *authServiceAdapter) DeleteAPIKeyAPI(ctx context.Context, userID, keyID string) error {
 	return a.service.DeleteAPIKeyAPI(ctx, userID, keyID)
 }

--- a/internal/server/health_test.go
+++ b/internal/server/health_test.go
@@ -116,6 +116,10 @@ func (m *mockAuthStoreForHealth) UpdateAPIKeyLastUsed(ctx context.Context, keyID
 	return nil
 }
 
+func (m *mockAuthStoreForHealth) RecordAPIKeyUsage(ctx context.Context, keyID string) error {
+	return nil
+}
+
 func (m *mockAuthStoreForHealth) DeleteAPIKey(ctx context.Context, keyID string) error {
 	return nil
 }


### PR DESCRIPTION
## Summary

Closes the *"API keys usage stats"* deferred sub-task from #340 / #344.

- Backend: migration 000051 + atomic ``RecordAPIKeyUsage`` (last_used_at + lifetime + rolling-24h counter), new ``GET /api/api-keys/usage-stats`` for the section summary, OpenAPI updated.
- Frontend: Admin → API Keys now shows a 3-tile summary card (active keys, requests 24h, requests lifetime) + a top-3 most-active list, plus per-row ``Requests (24h)`` + ``Requests (total)`` columns. Loading skeletons via ``lib/skeleton``; summary errors stay isolated from list errors.
- Tests: backend handler + service + sort tests; frontend tests cover the summary render, empty top-list, partial-failure paths, and the missing-counter fallback. 3706 backend tests + 1653 frontend tests pass.

## Scope

Per-key ``last_used_ip`` / ``last_endpoint`` and historical time-series charting are explicitly out of scope — surfaced as separate follow-ups if useful.

## Test plan

- [ ] ``go test ./internal/...`` (backend, 3706 tests)
- [ ] ``cd frontend && npm test`` (1653 tests)
- [ ] ``cd frontend && npm run build`` (bundle 528 KiB)
- [ ] Migration 000051 applied + a single API-key-authenticated request bumps both counters; second-day request resets the 24h counter to 1
- [ ] In a browser: Admin → API Keys shows the new summary card + new columns; a zero-usage account shows totals of 0 with no top-list; a stats-endpoint failure leaves the table intact and shows an inline summary error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API Keys page: usage summary card (Active keys, Requests 24h, Requests lifetime) and "Most active (24h)" top-3.
  * API Keys table: new columns showing per-key Requests (24h) and Requests (total).

* **Style**
  * Added styling for usage summary tiles and right-aligned count cells.

* **Tests**
  * Expanded test coverage for usage summary, per-row counts, error states, and activity sorting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/380)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->