### PR TITLE
feat(frontend/purchases): approval queue card at top of Purchases tab (#340 sub-task)

### DIFF
--- a/frontend/src/__tests__/history-approval-queue.test.ts
+++ b/frontend/src/__tests__/history-approval-queue.test.ts
@@ -224,17 +224,24 @@ describe('Approval queue card (issue #340 sub-task)', () => {
       summary: {},
       purchases: [makeRow({ purchase_id: 'p-pending', created_by_user_id: ADMIN_USER.id })],
     });
-    console.error = jest.fn();
+    // CR-feedback (PR #387): stub console.error via jest.spyOn so the
+    // mock auto-restores after the test, instead of leaking a permanent
+    // override into sibling tests.
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
-    await loadHistory();
-    const queue = document.getElementById('purchases-approval-queue')!;
-    const btn = queue.querySelector<HTMLButtonElement>('.history-approve-btn');
-    btn?.click();
-    await new Promise((r) => setTimeout(r, 10));
+    try {
+      await loadHistory();
+      const queue = document.getElementById('purchases-approval-queue')!;
+      const btn = queue.querySelector<HTMLButtonElement>('.history-approve-btn');
+      btn?.click();
+      await new Promise((r) => setTimeout(r, 10));
 
-    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ kind: 'error' }));
-    // No reload after failure.
-    expect(api.getHistory).toHaveBeenCalledTimes(1);
+      expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ kind: 'error' }));
+      // No reload after failure.
+      expect(api.getHistory).toHaveBeenCalledTimes(1);
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
   });
 
   test('pending row appears in BOTH the queue card and the history table (extraction did not drop a view)', async () => {

--- a/frontend/src/__tests__/history-approval-queue.test.ts
+++ b/frontend/src/__tests__/history-approval-queue.test.ts
@@ -1,0 +1,259 @@
+/**
+ * History approval queue card tests (issue #340 sub-task).
+ *
+ * The queue card sits above the Purchase History table inside
+ * #purchases-tab and surfaces pending|notified purchases in a dedicated
+ * action-focused view. Approve / Cancel buttons reuse the existing
+ * history.ts helpers (renderPendingActionButtons + wireRowActionHandlers)
+ * so the click flow is the SAME as approving from the history table.
+ *
+ * Tested matrix:
+ *   1. Queue renders only pending|notified rows; skips completed,
+ *      cancelled, failed, expired.
+ *   2. Queue empty-state copy when no pending rows exist.
+ *   3. Approve click on a queue row goes through confirmDialog →
+ *      api.approvePurchase → showToast → reload.
+ *   4. Cancel click on a queue row goes through confirmDialog →
+ *      api.cancelPurchase → showToast → reload.
+ *   5. The SAME fixture row renders in BOTH the queue card and the
+ *      history table, proving the helper extraction kept the two
+ *      views in sync rather than dropping one.
+ */
+
+import { loadHistory } from '../history';
+
+jest.mock('../api', () => ({
+  getHistory: jest.fn(),
+  approvePurchase: jest.fn(),
+  cancelPurchase: jest.fn(),
+}));
+
+jest.mock('../navigation', () => ({
+  switchTab: jest.fn(),
+}));
+
+jest.mock('../utils', () => ({
+  formatCurrency: jest.fn((val) => `$${val || 0}`),
+  formatDate: jest.fn((val) => (val ? new Date(val).toLocaleDateString() : '')),
+  formatTerm: jest.fn((years) => (years == null ? '' : `${years} Year${years === 1 ? '' : 's'}`)),
+  escapeHtml: jest.fn((str) => str || ''),
+  populateAccountFilter: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('../confirmDialog', () => ({
+  confirmDialog: jest.fn(),
+}));
+
+jest.mock('../toast', () => ({
+  showToast: jest.fn(),
+}));
+
+jest.mock('../state', () => ({
+  getCurrentUser: jest.fn(),
+  getCurrentProvider: jest.fn().mockReturnValue(''),
+  setCurrentProvider: jest.fn(),
+  getCurrentAccountIDs: jest.fn().mockReturnValue([]),
+  setCurrentAccountIDs: jest.fn(),
+  subscribeProvider: jest.fn().mockReturnValue(() => {}),
+  subscribeAccount: jest.fn().mockReturnValue(() => {}),
+}));
+
+import * as api from '../api';
+import { confirmDialog } from '../confirmDialog';
+import { showToast } from '../toast';
+import { getCurrentUser } from '../state';
+
+const ADMIN_USER = { id: 'admin-uuid', email: 'admin@example.com', role: 'admin' };
+
+function setupDOM(): void {
+  while (document.body.firstChild) document.body.removeChild(document.body.firstChild);
+
+  const mkInput = (id: string): HTMLInputElement => {
+    const el = document.createElement('input');
+    el.type = 'date';
+    el.id = id;
+    return el;
+  };
+  const mkDiv = (id: string): HTMLDivElement => {
+    const el = document.createElement('div');
+    el.id = id;
+    return el;
+  };
+
+  document.body.appendChild(mkInput('history-start'));
+  document.body.appendChild(mkInput('history-end'));
+  document.body.appendChild(mkDiv('history-summary'));
+  document.body.appendChild(mkDiv('history-list'));
+  document.body.appendChild(mkDiv('purchases-approval-queue'));
+}
+
+function makeRow(overrides: Record<string, unknown>) {
+  return {
+    purchase_id: 'exec-1',
+    timestamp: '2024-01-15T00:00:00Z',
+    provider: 'aws',
+    service: 'ec2',
+    resource_type: 't3.medium',
+    region: 'us-east-1',
+    count: 1,
+    term: 1,
+    upfront_cost: 100,
+    estimated_savings: 50,
+    plan_name: '',
+    status: 'pending',
+    ...overrides,
+  };
+}
+
+describe('Approval queue card (issue #340 sub-task)', () => {
+  beforeEach(() => {
+    setupDOM();
+    jest.clearAllMocks();
+  });
+
+  test('renders only pending|notified rows; skips completed / cancelled / failed / expired', async () => {
+    (getCurrentUser as jest.Mock).mockReturnValue(ADMIN_USER);
+    (api.getHistory as jest.Mock).mockResolvedValue({
+      summary: {},
+      purchases: [
+        makeRow({ purchase_id: 'p-pending', status: 'pending', created_by_user_id: ADMIN_USER.id }),
+        makeRow({ purchase_id: 'p-notified', status: 'notified', created_by_user_id: ADMIN_USER.id }),
+        makeRow({ purchase_id: 'p-completed', status: 'completed' }),
+        makeRow({ purchase_id: 'p-cancelled', status: 'cancelled' }),
+        makeRow({ purchase_id: 'p-failed', status: 'failed' }),
+        makeRow({ purchase_id: 'p-expired', status: 'expired' }),
+      ],
+    });
+
+    await loadHistory();
+
+    const queue = document.getElementById('purchases-approval-queue');
+    expect(queue).toBeTruthy();
+    const queueRows = queue!.querySelectorAll('tr[data-execution-id]');
+    const ids = Array.from(queueRows).map((r) => r.getAttribute('data-execution-id'));
+    expect(ids).toEqual(expect.arrayContaining(['p-pending', 'p-notified']));
+    expect(ids).toHaveLength(2);
+    // Negative assertions on the queue.
+    for (const skipped of ['p-completed', 'p-cancelled', 'p-failed', 'p-expired']) {
+      expect(ids).not.toContain(skipped);
+    }
+  });
+
+  test('shows empty-state copy when no pending rows', async () => {
+    (getCurrentUser as jest.Mock).mockReturnValue(ADMIN_USER);
+    (api.getHistory as jest.Mock).mockResolvedValue({
+      summary: {},
+      purchases: [
+        makeRow({ purchase_id: 'p-completed', status: 'completed' }),
+        makeRow({ purchase_id: 'p-cancelled', status: 'cancelled' }),
+      ],
+    });
+
+    await loadHistory();
+
+    const queue = document.getElementById('purchases-approval-queue');
+    expect(queue?.textContent || '').toMatch(/no pending approvals/i);
+    expect(queue?.querySelectorAll('tr[data-execution-id]').length).toBe(0);
+  });
+
+  test('shows empty-state copy when the full history is empty', async () => {
+    (getCurrentUser as jest.Mock).mockReturnValue(ADMIN_USER);
+    (api.getHistory as jest.Mock).mockResolvedValue({ summary: {}, purchases: [] });
+
+    await loadHistory();
+
+    const queue = document.getElementById('purchases-approval-queue');
+    expect(queue?.textContent || '').toMatch(/no pending approvals/i);
+  });
+
+  test('Approve click on a queue row runs confirm + api.approvePurchase + toast + reload', async () => {
+    (getCurrentUser as jest.Mock).mockReturnValue(ADMIN_USER);
+    (confirmDialog as jest.Mock).mockResolvedValue(true);
+    (api.approvePurchase as jest.Mock).mockResolvedValue(undefined);
+    (api.getHistory as jest.Mock).mockResolvedValue({
+      summary: {},
+      purchases: [makeRow({ purchase_id: 'p-pending', created_by_user_id: ADMIN_USER.id })],
+    });
+
+    await loadHistory();
+    expect(api.getHistory).toHaveBeenCalledTimes(1);
+
+    // Pick the Approve button INSIDE the queue card specifically.
+    const queue = document.getElementById('purchases-approval-queue')!;
+    const btn = queue.querySelector<HTMLButtonElement>('.history-approve-btn[data-approve-id="p-pending"]');
+    expect(btn).toBeTruthy();
+    btn?.click();
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(confirmDialog).toHaveBeenCalled();
+    expect(api.approvePurchase).toHaveBeenCalledWith('p-pending');
+    // Reload triggers a second getHistory call.
+    expect(api.getHistory).toHaveBeenCalledTimes(2);
+    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ kind: 'success' }));
+  });
+
+  test('Cancel click on a queue row runs confirm + api.cancelPurchase + toast + reload', async () => {
+    (getCurrentUser as jest.Mock).mockReturnValue(ADMIN_USER);
+    (confirmDialog as jest.Mock).mockResolvedValue(true);
+    (api.cancelPurchase as jest.Mock).mockResolvedValue(undefined);
+    (api.getHistory as jest.Mock).mockResolvedValue({
+      summary: {},
+      purchases: [makeRow({ purchase_id: 'p-pending', created_by_user_id: ADMIN_USER.id })],
+    });
+
+    await loadHistory();
+    expect(api.getHistory).toHaveBeenCalledTimes(1);
+
+    const queue = document.getElementById('purchases-approval-queue')!;
+    const btn = queue.querySelector<HTMLButtonElement>('.history-cancel-btn[data-cancel-id="p-pending"]');
+    expect(btn).toBeTruthy();
+    btn?.click();
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(confirmDialog).toHaveBeenCalled();
+    expect(api.cancelPurchase).toHaveBeenCalledWith('p-pending');
+    expect(api.getHistory).toHaveBeenCalledTimes(2);
+    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ kind: 'success' }));
+  });
+
+  test('approve API failure on a queue row surfaces error toast (no reload)', async () => {
+    (getCurrentUser as jest.Mock).mockReturnValue(ADMIN_USER);
+    (confirmDialog as jest.Mock).mockResolvedValue(true);
+    (api.approvePurchase as jest.Mock).mockRejectedValue(new Error('boom'));
+    (api.getHistory as jest.Mock).mockResolvedValue({
+      summary: {},
+      purchases: [makeRow({ purchase_id: 'p-pending', created_by_user_id: ADMIN_USER.id })],
+    });
+    console.error = jest.fn();
+
+    await loadHistory();
+    const queue = document.getElementById('purchases-approval-queue')!;
+    const btn = queue.querySelector<HTMLButtonElement>('.history-approve-btn');
+    btn?.click();
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ kind: 'error' }));
+    // No reload after failure.
+    expect(api.getHistory).toHaveBeenCalledTimes(1);
+  });
+
+  test('pending row appears in BOTH the queue card and the history table (extraction did not drop a view)', async () => {
+    (getCurrentUser as jest.Mock).mockReturnValue(ADMIN_USER);
+    (api.getHistory as jest.Mock).mockResolvedValue({
+      summary: {},
+      purchases: [makeRow({ purchase_id: 'p-pending', status: 'pending', created_by_user_id: ADMIN_USER.id })],
+    });
+
+    await loadHistory();
+
+    const queue = document.getElementById('purchases-approval-queue')!;
+    const list = document.getElementById('history-list')!;
+    const queueRow = queue.querySelector('tr[data-execution-id="p-pending"]');
+    const listRow = list.querySelector('tr[data-execution-id="p-pending"]');
+    expect(queueRow).toBeTruthy();
+    expect(listRow).toBeTruthy();
+    // Approve button in BOTH views.
+    expect(queue.querySelectorAll('.history-approve-btn[data-approve-id="p-pending"]').length).toBe(1);
+    expect(list.querySelectorAll('.history-approve-btn[data-approve-id="p-pending"]').length).toBe(1);
+  });
+});

--- a/frontend/src/__tests__/history-approve-button.test.ts
+++ b/frontend/src/__tests__/history-approve-button.test.ts
@@ -98,6 +98,10 @@ function setupDOM(): void {
   document.body.appendChild(mkSelect('history-account-filter'));
   document.body.appendChild(mkDiv('history-summary'));
   document.body.appendChild(mkDiv('history-list'));
+  // Issue #340 sub-task: loadHistory now also paints the approval-queue
+  // card. The container must exist so renderApprovalQueue's
+  // getElementById lookup succeeds.
+  document.body.appendChild(mkDiv('purchases-approval-queue'));
 }
 
 function makeRow(overrides: Record<string, unknown>) {
@@ -137,7 +141,11 @@ describe('History inline Approve button (issue #286)', () => {
 
     await loadHistory();
 
-    const buttons = document.querySelectorAll<HTMLButtonElement>('.history-approve-btn');
+    // Scope to the Purchase History table only. The Approval queue
+    // card (issue #340 sub-task) ALSO renders Approve buttons for
+    // pending rows, so a document-wide query would double-count.
+    const list = document.getElementById('history-list')!;
+    const buttons = list.querySelectorAll<HTMLButtonElement>('.history-approve-btn');
     const ids = Array.from(buttons).map((b) => b.dataset['approveId']);
     expect(ids).toEqual(expect.arrayContaining(['exec-mine', 'exec-other', 'exec-legacy']));
     expect(ids).toHaveLength(3);
@@ -156,7 +164,11 @@ describe('History inline Approve button (issue #286)', () => {
 
     await loadHistory();
 
-    const buttons = document.querySelectorAll<HTMLButtonElement>('.history-approve-btn');
+    // Scope to the Purchase History table only. The Approval queue
+    // card (issue #340 sub-task) ALSO renders Approve buttons for
+    // pending rows, so a document-wide query would double-count.
+    const list = document.getElementById('history-list')!;
+    const buttons = list.querySelectorAll<HTMLButtonElement>('.history-approve-btn');
     const ids = Array.from(buttons).map((b) => b.dataset['approveId']);
     expect(ids).toEqual(['exec-mine']);
   });
@@ -188,7 +200,10 @@ describe('History inline Approve button (issue #286)', () => {
 
     await loadHistory();
 
-    const ids = Array.from(document.querySelectorAll<HTMLButtonElement>('.history-approve-btn'))
+    // Scope to history-list. The queue card also paints the same
+    // notified row, but this test is about the table-side filter.
+    const list = document.getElementById('history-list')!;
+    const ids = Array.from(list.querySelectorAll<HTMLButtonElement>('.history-approve-btn'))
       .map((b) => b.dataset['approveId']);
     expect(ids).toEqual(['exec-notified']);
   });
@@ -202,8 +217,10 @@ describe('History inline Approve button (issue #286)', () => {
 
     await loadHistory();
 
-    const approveBtns = document.querySelectorAll<HTMLButtonElement>('.history-approve-btn[data-approve-id]');
-    const cancelBtns = document.querySelectorAll<HTMLButtonElement>('.history-cancel-btn[data-cancel-id]');
+    // Scope to history-list. The queue card also renders the pair.
+    const list = document.getElementById('history-list')!;
+    const approveBtns = list.querySelectorAll<HTMLButtonElement>('.history-approve-btn[data-approve-id]');
+    const cancelBtns = list.querySelectorAll<HTMLButtonElement>('.history-cancel-btn[data-cancel-id]');
     expect(approveBtns).toHaveLength(1);
     expect(cancelBtns).toHaveLength(1);
     expect(approveBtns[0]?.dataset['approveId']).toBe('exec-1');
@@ -285,8 +302,13 @@ describe('History inline Approve button (issue #286)', () => {
     });
 
     await loadHistory();
-    const approveBtn = document.querySelector<HTMLButtonElement>('.history-approve-btn');
-    const cancelBtn = document.querySelector<HTMLButtonElement>('.history-cancel-btn');
+    // Scope to history-list for the disable assertion. The click
+    // handler scopes its disable to the clicked button's containing
+    // <td> (sameRowActions), so we need both buttons from the SAME row
+    // of the SAME view to verify the pair-disable behaviour.
+    const list = document.getElementById('history-list')!;
+    const approveBtn = list.querySelector<HTMLButtonElement>('.history-approve-btn');
+    const cancelBtn = list.querySelector<HTMLButtonElement>('.history-cancel-btn');
     expect(approveBtn).not.toBeNull();
     expect(cancelBtn).not.toBeNull();
     expect(approveBtn?.disabled).toBe(false);

--- a/frontend/src/__tests__/history-cancel-button.test.ts
+++ b/frontend/src/__tests__/history-cancel-button.test.ts
@@ -98,6 +98,10 @@ function setupDOM(): void {
   document.body.appendChild(mkSelect('history-account-filter'));
   document.body.appendChild(mkDiv('history-summary'));
   document.body.appendChild(mkDiv('history-list'));
+  // Issue #340 sub-task: loadHistory now also paints the approval-queue
+  // card. The container must exist so renderApprovalQueue's
+  // getElementById lookup succeeds.
+  document.body.appendChild(mkDiv('purchases-approval-queue'));
 }
 
 function makeRow(overrides: Record<string, unknown>) {
@@ -137,7 +141,10 @@ describe('History inline Cancel button (issue #46)', () => {
 
     await loadHistory();
 
-    const buttons = document.querySelectorAll<HTMLButtonElement>('.history-cancel-btn');
+    // Scope to history-list. The queue card (issue #340 sub-task)
+    // also renders Cancel buttons for pending rows.
+    const list = document.getElementById('history-list')!;
+    const buttons = list.querySelectorAll<HTMLButtonElement>('.history-cancel-btn');
     const ids = Array.from(buttons).map((b) => b.dataset['cancelId']);
     expect(ids).toEqual(expect.arrayContaining(['exec-mine', 'exec-other', 'exec-legacy']));
     expect(ids).toHaveLength(3);
@@ -156,7 +163,10 @@ describe('History inline Cancel button (issue #46)', () => {
 
     await loadHistory();
 
-    const buttons = document.querySelectorAll<HTMLButtonElement>('.history-cancel-btn');
+    // Scope to history-list. The queue card (issue #340 sub-task)
+    // also renders Cancel buttons for pending rows.
+    const list = document.getElementById('history-list')!;
+    const buttons = list.querySelectorAll<HTMLButtonElement>('.history-cancel-btn');
     const ids = Array.from(buttons).map((b) => b.dataset['cancelId']);
     expect(ids).toEqual(['exec-mine']);
   });
@@ -188,7 +198,10 @@ describe('History inline Cancel button (issue #46)', () => {
 
     await loadHistory();
 
-    const ids = Array.from(document.querySelectorAll<HTMLButtonElement>('.history-cancel-btn'))
+    // Scope to history-list. The queue card also paints the same
+    // notified row.
+    const list = document.getElementById('history-list')!;
+    const ids = Array.from(list.querySelectorAll<HTMLButtonElement>('.history-cancel-btn'))
       .map((b) => b.dataset['cancelId']);
     expect(ids).toEqual(['exec-notified']);
   });

--- a/frontend/src/__tests__/history-retry-button.test.ts
+++ b/frontend/src/__tests__/history-retry-button.test.ts
@@ -101,6 +101,10 @@ function setupDOM(): void {
   document.body.appendChild(mkSelect('history-account-filter'));
   document.body.appendChild(mkDiv('history-summary'));
   document.body.appendChild(mkDiv('history-list'));
+  // Issue #340 sub-task: loadHistory now also paints the approval-queue
+  // card. The container must exist so renderApprovalQueue's
+  // getElementById lookup succeeds.
+  document.body.appendChild(mkDiv('purchases-approval-queue'));
 }
 
 function makeRow(overrides: Record<string, unknown>) {

--- a/frontend/src/__tests__/history.test.ts
+++ b/frontend/src/__tests__/history.test.ts
@@ -48,6 +48,7 @@ describe('History Module', () => {
       <input type="date" id="history-end">
       <div id="history-summary"></div>
       <div id="history-list"></div>
+      <div id="purchases-approval-queue"></div>
     `;
 
     jest.clearAllMocks();

--- a/frontend/src/__tests__/html.test.ts
+++ b/frontend/src/__tests__/html.test.ts
@@ -215,6 +215,17 @@ describe('HTML Structure', () => {
       const list = document.getElementById('history-list');
       expect(list).toBeTruthy();
     });
+
+    // Issue #340 sub-task: the Approval queue card sits ABOVE the
+    // Savings History + Purchase History sections so pending
+    // approvals jump out without scrolling. Verify both the wrapper
+    // section and the inner mount point are present.
+    test('has approval queue section + mount point', () => {
+      const section = document.getElementById('purchases-approval-queue-section');
+      const mount = document.getElementById('purchases-approval-queue');
+      expect(section).toBeTruthy();
+      expect(mount).toBeTruthy();
+    });
   });
 
   describe('Settings Tab', () => {

--- a/frontend/src/__tests__/html.test.ts
+++ b/frontend/src/__tests__/html.test.ts
@@ -219,12 +219,24 @@ describe('HTML Structure', () => {
     // Issue #340 sub-task: the Approval queue card sits ABOVE the
     // Savings History + Purchase History sections so pending
     // approvals jump out without scrolling. Verify both the wrapper
-    // section and the inner mount point are present.
-    test('has approval queue section + mount point', () => {
+    // section and the inner mount point are present, AND that the
+    // queue card precedes both history sections in document order.
+    // CR-feedback (PR #387): existence alone doesn't guard the
+    // "at the top of the Purchases tab" requirement.
+    test('has approval queue section + mount point + appears before history sections', () => {
       const section = document.getElementById('purchases-approval-queue-section');
       const mount = document.getElementById('purchases-approval-queue');
+      const savings = document.getElementById('savings-history-section');
+      const history = document.getElementById('purchase-history-section');
       expect(section).toBeTruthy();
       expect(mount).toBeTruthy();
+      expect(savings).toBeTruthy();
+      expect(history).toBeTruthy();
+      // compareDocumentPosition returns a bitmask; FOLLOWING means
+      // the argument is positioned AFTER the receiver in document order.
+      const FOLLOWING = Node.DOCUMENT_POSITION_FOLLOWING;
+      expect(section!.compareDocumentPosition(savings!) & FOLLOWING).toBeTruthy();
+      expect(section!.compareDocumentPosition(history!) & FOLLOWING).toBeTruthy();
     });
   });
 

--- a/frontend/src/__tests__/navigation.test.ts
+++ b/frontend/src/__tests__/navigation.test.ts
@@ -14,7 +14,12 @@ jest.mock('../plans', () => ({
   loadPlans: jest.fn().mockResolvedValue(undefined)
 }));
 jest.mock('../history', () => ({
-  initHistoryDateRange: jest.fn()
+  initHistoryDateRange: jest.fn(),
+  // Issue #340 sub-task: switchTab('purchases') now auto-loads
+  // history so the Approval queue card populates without waiting for
+  // the "Load History" button click. Stub it so the navigation tests
+  // don't make real fetch calls.
+  loadHistory: jest.fn().mockResolvedValue(undefined),
 }));
 jest.mock('../settings', () => ({
   loadGlobalSettings: jest.fn().mockResolvedValue(undefined),

--- a/frontend/src/__tests__/navigation.test.ts
+++ b/frontend/src/__tests__/navigation.test.ts
@@ -37,7 +37,7 @@ jest.mock('../auth', () => ({
 import { loadDashboard } from '../dashboard';
 import { loadRecommendations } from '../recommendations';
 import { loadPlans } from '../plans';
-import { initHistoryDateRange } from '../history';
+import { initHistoryDateRange, loadHistory } from '../history';
 import { loadGlobalSettings } from '../settings';
 import { loadAutomationSettings } from '../riexchange';
 
@@ -121,7 +121,7 @@ describe('Navigation Module', () => {
       expect(loadPlans).toHaveBeenCalled();
     });
 
-    test('switches to history tab and initializes date range', () => {
+    test('switches to history tab and initializes date range + auto-loads history', () => {
       switchTab('purchases');
 
       const historyBtn = document.querySelector('[data-tab="purchases"]');
@@ -131,6 +131,11 @@ describe('Navigation Module', () => {
       expect(historyContent?.classList.contains('active')).toBe(true);
 
       expect(initHistoryDateRange).toHaveBeenCalled();
+      // Issue #340 sub-task: switchTab('purchases') auto-loads
+      // history so the Approval queue card and the Purchase History
+      // table populate on first visit. Guards against a regression
+      // that re-introduces "user must click Load History" friction.
+      expect(loadHistory).toHaveBeenCalled();
     });
 
     test('switches to settings tab and loads settings', () => {

--- a/frontend/src/history.ts
+++ b/frontend/src/history.ts
@@ -122,6 +122,7 @@ export async function viewPlanHistory(planId: string): Promise<void> {
     const data = await api.getHistory({ planId }) as unknown as HistoryResponse;
     renderHistorySummary(data.summary || {});
     const purchases = data.purchases || [];
+    renderApprovalQueue(purchases);
     renderHistoryList(purchases);
     snapDateInputsToPurchases(purchases);
   } catch (error) {
@@ -166,6 +167,13 @@ export async function loadHistory(): Promise<void> {
   // Term / Upfront Cost / Monthly Savings / Plan.
   const listEl = document.getElementById('history-list');
   if (listEl) showSkeletonRows(listEl, 8, 11);
+  // Pending-approval queue card (issue #340 sub-task): 3 rows x 8
+  // cols matches the queue table shape (Date / Provider / Service /
+  // Count / Upfront / Monthly Savings / Created by / Actions). The
+  // queue is typically much shorter than the full history list, so
+  // 3 rows is a sensible skeleton size.
+  const queueEl = document.getElementById('purchases-approval-queue');
+  if (queueEl) showSkeletonRows(queueEl, 3, 8);
 
   try {
     // Provider/account filters live in state.ts now (mutated by topbar chips).
@@ -185,14 +193,21 @@ export async function loadHistory(): Promise<void> {
     };
     const data = await api.getHistory(filters) as unknown as HistoryResponse;
     renderHistorySummary(data.summary || {});
-    renderHistoryList(data.purchases || []);
+    const purchases = data.purchases || [];
+    renderApprovalQueue(purchases);
+    renderHistoryList(purchases);
   } catch (error) {
     console.error('Failed to load history:', error);
+    const err = error as Error;
     const list = document.getElementById('history-list');
     if (list) {
       teardownSkeleton(list);
-      const err = error as Error;
       list.innerHTML = `<p class="error">Failed to load history: ${escapeHtml(err.message)}</p>`;
+    }
+    const queue = document.getElementById('purchases-approval-queue');
+    if (queue) {
+      teardownSkeleton(queue);
+      queue.innerHTML = `<p class="error">Failed to load approval queue: ${escapeHtml(err.message)}</p>`;
     }
   }
 }
@@ -421,6 +436,26 @@ function sameRowActions(btn: HTMLButtonElement): HTMLButtonElement[] {
   );
 }
 
+// renderPendingActionButtons returns the inline Approve / Cancel
+// button HTML for a pending|notified row, or "" when neither verb is
+// available to the current session. Extracted from renderActionCell
+// so the approval-queue card can emit identical buttons without
+// duplicating the predicate logic or the DOM contract. Each predicate
+// is checked independently so a custom role with only one of the
+// verbs renders just that button; Approve sits to the left as the
+// affirmative action.
+function renderPendingActionButtons(p: HistoryPurchase): string {
+  if (!p.purchase_id) return '';
+  const buttons: string[] = [];
+  if (canApprovePendingRow(p)) {
+    buttons.push(`<button type="button" class="btn-link history-approve-btn" data-approve-id="${escapeHtml(p.purchase_id)}">Approve</button>`);
+  }
+  if (canCancelPendingRow(p)) {
+    buttons.push(`<button type="button" class="btn-link history-cancel-btn" data-cancel-id="${escapeHtml(p.purchase_id)}">Cancel</button>`);
+  }
+  return buttons.join(' ');
+}
+
 // renderActionCell returns the HTML for the Plan / action column on a
 // single history row. The column doubles as the per-row action surface
 // because pending / failed rows rarely have a meaningful plan_name (the
@@ -438,21 +473,9 @@ function renderActionCell(p: HistoryPurchase): string {
   // Pending → render Approve + Cancel side-by-side when the session
   // qualifies for both (the typical case after issue #286 — the same
   // approve-own / cancel-own grant lives in DefaultUserPermissions).
-  // Each predicate is checked independently so a custom role with only
-  // one of the verbs renders just that button. Approve sits to the
-  // left as the affirmative action; Cancel keeps its existing class
-  // and styling so the cancel-button click handler keeps working.
-  if (p.purchase_id) {
-    const buttons: string[] = [];
-    if (canApprovePendingRow(p)) {
-      buttons.push(`<button type="button" class="btn-link history-approve-btn" data-approve-id="${escapeHtml(p.purchase_id)}">Approve</button>`);
-    }
-    if (canCancelPendingRow(p)) {
-      buttons.push(`<button type="button" class="btn-link history-cancel-btn" data-cancel-id="${escapeHtml(p.purchase_id)}">Cancel</button>`);
-    }
-    if (buttons.length > 0) {
-      return buttons.join(' ');
-    }
+  const pendingButtons = renderPendingActionButtons(p);
+  if (pendingButtons) {
+    return pendingButtons;
   }
 
   // Failed → either ops-hint (no retry possible), Retry (with optional
@@ -590,18 +613,26 @@ function renderHistoryList(purchases: HistoryPurchase[]): void {
     });
   });
 
-  // Wire the inline Cancel button on pending/notified rows the current
-  // session may cancel (issue #46). confirmDialog → POST → reload. The
-  // backend remains the security boundary; the canCancelPendingRow
-  // helper above is a UX gate that hides the button when the call would
-  // 403, but a stale cache could still surface a 403 — handle it the
-  // same way as any other failure.
-  //
-  // The cancel POST and the follow-up reload are split into separate
-  // try/catch blocks: a successful cancel + failed reload must not show
-  // a "Failed to cancel" toast (the purchase IS cancelled), and the
-  // user should see success-toast first so they don't think their
-  // click was lost while we re-fetch the table.
+  wireRowActionHandlers(container);
+
+  // Scroll + flash the deep-link target if the URL hash carries a
+  // ?execution=<id>. The suppression badge on the Recommendations
+  // view links here so the user lands on the relevant row without
+  // scrolling through the whole list.
+  applyExecutionDeepLink();
+}
+
+// wireRowActionHandlers binds the Approve / Cancel / Retry click handlers
+// against the buttons inside `container`. Scoped to the container (NOT
+// the document) so multiple mounted lists (Purchase History table +
+// Approval queue card) don't cross-fire: clicking the queue's Approve
+// button binds and dispatches against the queue's button instance only.
+//
+// All three handlers terminate with a `loadHistory()` reload on success,
+// which re-renders BOTH the history table and the queue card from the
+// same fetched dataset. That means a successful approve from the queue
+// card removes the row from BOTH views in one shot.
+function wireRowActionHandlers(container: HTMLElement): void {
   // Wire the inline Approve button on pending rows the current session
   // may approve (issue #286). One flow: confirmDialog → POST /approve
   // (no token — bearer-session auth on apiRequest) → reload + toast.
@@ -645,6 +676,18 @@ function renderHistoryList(purchases: HistoryPurchase[]): void {
     });
   });
 
+  // Wire the inline Cancel button on pending/notified rows the current
+  // session may cancel (issue #46). confirmDialog → POST → reload. The
+  // backend remains the security boundary; the canCancelPendingRow
+  // helper above is a UX gate that hides the button when the call would
+  // 403, but a stale cache could still surface a 403 — handle it the
+  // same way as any other failure.
+  //
+  // The cancel POST and the follow-up reload are split into separate
+  // try/catch blocks: a successful cancel + failed reload must not show
+  // a "Failed to cancel" toast (the purchase IS cancelled), and the
+  // user should see success-toast first so they don't think their
+  // click was lost while we re-fetch the table.
   container.querySelectorAll<HTMLButtonElement>('.history-cancel-btn[data-cancel-id]').forEach(btn => {
     btn.addEventListener('click', async () => {
       const id = btn.dataset['cancelId'];
@@ -740,10 +783,80 @@ function renderHistoryList(purchases: HistoryPurchase[]): void {
       }
     });
   });
+}
 
-  // Scroll + flash the deep-link target if the URL hash carries a
-  // ?execution=<id>. The suppression badge on the Recommendations
-  // view links here so the user lands on the relevant row without
-  // scrolling through the whole list.
-  applyExecutionDeepLink();
+// isPendingRow returns true when a history row represents a purchase
+// awaiting approval. The Approval queue card filters on this predicate.
+// Mirrors the badge / button-eligibility logic elsewhere in this file:
+// "pending" is the freshly-created state, "notified" is the post-SES
+// state; both render the same Approve / Cancel affordances.
+function isPendingRow(p: HistoryPurchase): boolean {
+  const s = (p.status || '').toLowerCase();
+  return s === 'pending' || s === 'notified';
+}
+
+// renderApprovalQueue paints the pending-approval card at the top of the
+// Purchases tab (issue #340 sub-task). Filters the full history slice
+// down to pending|notified rows and renders a compact action-focused
+// table. When the filtered slice is empty, the card shows a friendly
+// "No pending approvals" message so the section stays visible (stable
+// layout, screen-reader-discoverable) without rendering an empty table.
+//
+// The row-action buttons reuse renderPendingActionButtons and the click
+// handlers are wired by the shared wireRowActionHandlers helper, so
+// approving from the queue card runs the exact same flow as approving
+// from the history table (confirmDialog → API → toast → reload). The
+// reload re-renders both views from one fetch, which removes the
+// approved row from BOTH lists in one shot.
+export function renderApprovalQueue(purchases: HistoryPurchase[]): void {
+  const container = document.getElementById('purchases-approval-queue');
+  if (!container) return;
+
+  const pending = (purchases || []).filter(isPendingRow);
+
+  if (pending.length === 0) {
+    container.innerHTML = '<p class="empty">No pending approvals.</p>';
+    return;
+  }
+
+  const rows = pending.map(p => {
+    const actions = renderPendingActionButtons(p);
+    const actionsCell = actions || '<span class="muted">-</span>';
+    const createdBy = p.created_by_user_id ? escapeHtml(p.created_by_user_id) : '<span class="muted">-</span>';
+    const execIdAttr = p.purchase_id ? ` data-execution-id="${escapeHtml(p.purchase_id)}"` : '';
+    return `
+      <tr${execIdAttr}>
+        <td>${formatDate(p.timestamp)}</td>
+        <td>${providerCell(p)}</td>
+        <td>${escapeHtml(p.service)}</td>
+        <td>${p.count}</td>
+        <td>${formatCurrency(p.upfront_cost)}</td>
+        <td class="savings">${formatCurrency(p.estimated_savings)}</td>
+        <td>${createdBy}</td>
+        <td>${actionsCell}</td>
+      </tr>
+    `;
+  }).join('');
+
+  container.innerHTML = `
+    <table class="approval-queue-table">
+      <thead>
+        <tr>
+          <th>Date</th>
+          <th>Provider</th>
+          <th>Service</th>
+          <th>Count</th>
+          <th>Upfront Cost</th>
+          <th>Monthly Savings</th>
+          <th>Created by</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${rows}
+      </tbody>
+    </table>
+  `;
+
+  wireRowActionHandlers(container);
 }

--- a/frontend/src/history.ts
+++ b/frontend/src/history.ts
@@ -127,10 +127,17 @@ export async function viewPlanHistory(planId: string): Promise<void> {
     snapDateInputsToPurchases(purchases);
   } catch (error) {
     console.error('Failed to load plan history:', error);
+    const err = error as Error;
     const list = document.getElementById('history-list');
     if (list) {
-      const err = error as Error;
       list.innerHTML = `<p class="error">Failed to load plan history: ${escapeHtml(err.message)}</p>`;
+    }
+    // Mirror the loadHistory catch: clear the approval queue on error
+    // so stale pending rows from a previous render don't sit on screen
+    // alongside the failure message and tempt clicks on outdated state.
+    const queue = document.getElementById('purchases-approval-queue');
+    if (queue) {
+      queue.innerHTML = `<p class="error">Failed to load approval queue: ${escapeHtml(err.message)}</p>`;
     }
   }
 }

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -129,6 +129,20 @@
 
             <!-- History Tab -->
             <div id="purchases-tab" class="tab-content" role="tabpanel" aria-labelledby="purchases-tab-btn">
+                <!-- Approval Queue Card (issue #340 sub-task): surfaces
+                     pending-approval purchases at the top of the Purchases
+                     tab so users don't have to scan the full Purchase
+                     History table for them. Rows render with inline
+                     Approve / Cancel buttons (issues #46 + #286) and the
+                     same click flow as the history table. Auto-loaded on
+                     tab switch via loadHistory(); also re-rendered after
+                     any Approve / Cancel from either view. -->
+                <section id="purchases-approval-queue-section" class="card page-hero">
+                    <h2>Approval queue</h2>
+                    <p class="help-text page-hero-description">Purchases awaiting approval. Review and approve or cancel each one. The same actions are available from the Purchase History table below.</p>
+                    <section id="purchases-approval-queue"></section>
+                </section>
+
                 <!-- Savings History Chart Section -->
                 <section id="savings-history-section" class="card page-hero">
                     <div class="section-header">

--- a/frontend/src/navigation.ts
+++ b/frontend/src/navigation.ts
@@ -5,7 +5,7 @@
 import { loadDashboard } from './dashboard';
 import { loadRecommendations } from './recommendations';
 import { loadPlans } from './plans';
-import { initHistoryDateRange } from './history';
+import { initHistoryDateRange, loadHistory } from './history';
 import { loadGlobalSettings, isUnsavedChanges, loadAccountsTab } from './settings';
 import { loadUsers } from './users';
 import { loadApiKeys } from './apikeys';
@@ -105,6 +105,12 @@ export function switchTab(tabName: string, opts: SwitchTabOptions = {}): void {
     case 'purchases':
       initHistoryDateRange();
       void loadSavingsHistory();
+      // Auto-load history so the Approval queue card and the Purchase
+      // History table populate on first visit, without requiring the
+      // user to click "Load History" just to see pending approvals.
+      // Matches the loadSavingsHistory pattern above. Both fetch
+      // small, fast, scope-already-filtered payloads.
+      void loadHistory();
       break;
     case 'admin':
       switchSettingsSubTab(getSettingsSubTabFromPath(), { push: false });


### PR DESCRIPTION
## Summary

- Adds an Approval queue card at the top of the Purchases tab that surfaces pending|notified purchases with inline Approve / Cancel buttons, so users don't have to scan the full Purchase History table for pending approvals (issue #340 sub-task).
- Extracts two helpers from `history.ts`: `renderPendingActionButtons(p)` and `wireRowActionHandlers(container)`. Both views (the queue card and the history table) emit identical button DOM and share one click flow, so an Approve from either reload-refreshes both lists in one shot.
- No backend change. `GET /api/history` already returns every non-completed execution status via `fetchExecutionsAsHistory`; the queue card filters client-side from the same payload, which keeps the queue and the history table consistent on every reload.

## What's new

- New section `#purchases-approval-queue-section` in `index.html`, mounted above `#savings-history-section` inside `#purchases-tab`.
- `navigation.ts` `case 'purchases'` now also calls `loadHistory()` so the queue populates on first tab visit (same pattern as `loadSavingsHistory`).
- Skeleton paint via `showSkeletonRows(queueEl, 3, 8)`, error-state copy ("Failed to load approval queue: ..."), friendly empty state ("No pending approvals.").

## Files touched

- `frontend/src/history.ts` (refactor + new `renderApprovalQueue`)
- `frontend/src/index.html` (new section)
- `frontend/src/navigation.ts` (auto-load on tab switch)
- `frontend/src/__tests__/history-approval-queue.test.ts` (new)
- `frontend/src/__tests__/history-{approve,cancel,retry}-button.test.ts` (DOM fixture + selector scoping)
- `frontend/src/__tests__/history.test.ts` (DOM fixture)
- `frontend/src/__tests__/html.test.ts` (regression guard for the new section)
- `frontend/src/__tests__/navigation.test.ts` (stub `loadHistory` mock)

## Test plan

- [x] `cd frontend && npx jest` - 1653 pass, 0 fail
- [x] `cd frontend && npx tsc --noEmit` - no errors
- [x] `cd frontend && npm run build` - bundle 526 KiB (unchanged vs base)
- [x] `go test ./internal/api/...` - 1081 pass
- [ ] Verify in a deployed environment: pending row created via the dashboard renders in the new queue card AND in the history table; Approve from the queue card removes the row from both views.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Approval Queue card at the top of the Purchases tab displaying pending and notified purchases requiring action.
  * Users can approve or cancel pending purchases directly from the queue with real-time confirmation and automatic history updates.
  * Empty state message displays when there are no pending approvals.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/387)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->