### PR TITLE
feat(api+frontend/inventory): per-commitment list endpoint + UI

### DIFF
--- a/frontend/src/__tests__/api-inventory.test.ts
+++ b/frontend/src/__tests__/api-inventory.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Tests for the inventory API module (issue #340 deferred sub-task).
+ *
+ * Verifies the wire format / envelope handling for
+ * GET /api/inventory/commitments. The backend handler logic is covered
+ * in handler_inventory_test.go; here we lock down the client adapter.
+ */
+
+import { apiRequest } from '../api/client';
+import { listActiveCommitments } from '../api/inventory';
+
+jest.mock('../api/client', () => ({
+  apiRequest: jest.fn(),
+}));
+
+describe('listActiveCommitments', () => {
+  beforeEach(() => {
+    (apiRequest as jest.Mock).mockReset();
+  });
+
+  test('calls /inventory/commitments without query string by default', async () => {
+    (apiRequest as jest.Mock).mockResolvedValue({ commitments: [] });
+
+    const result = await listActiveCommitments();
+
+    expect(apiRequest).toHaveBeenCalledWith('/inventory/commitments');
+    expect(result).toEqual([]);
+  });
+
+  test('appends URL-encoded account_id when scoped to one account', async () => {
+    (apiRequest as jest.Mock).mockResolvedValue({ commitments: [] });
+
+    await listActiveCommitments('acc/with special');
+
+    expect(apiRequest).toHaveBeenCalledWith('/inventory/commitments?account_id=acc%2Fwith%20special');
+  });
+
+  test('returns the commitments array unwrapped from the envelope', async () => {
+    const commitments = [
+      {
+        id: 'a:1',
+        provider: 'aws',
+        account_id: 'a',
+        service: 'ec2',
+        region: 'us-east-1',
+        count: 1,
+        term_years: 1,
+        start_date: '2025-01-01T00:00:00Z',
+        end_date: '2026-01-01T00:00:00Z',
+        upfront_cost: 0,
+        monthly_cost: 10,
+        estimated_savings: 2,
+        status: 'active',
+      },
+    ];
+    (apiRequest as jest.Mock).mockResolvedValue({ commitments });
+
+    const result = await listActiveCommitments();
+    expect(result).toEqual(commitments);
+  });
+
+  test('returns an empty array when the envelope is missing the commitments field', async () => {
+    // Defensive: a buggy/old backend could omit the field. The client
+    // adapter must default to [] so callers can safely call .length.
+    (apiRequest as jest.Mock).mockResolvedValue({});
+
+    const result = await listActiveCommitments();
+    expect(result).toEqual([]);
+  });
+});

--- a/frontend/src/__tests__/inventory.test.ts
+++ b/frontend/src/__tests__/inventory.test.ts
@@ -1,10 +1,10 @@
 /**
- * Inventory & Coverage section tests (issue #340 T4).
+ * Inventory & Coverage section tests (issue #340 T4 + deferred sub-task
+ * for the Active commitments table).
  *
- * Verifies the sub-tab switching machinery for the umbrella section that
- * folds the former top-level RI Exchange tab in. The RI Exchange sub-section
- * is the default and the only one with real backend data today; the other
- * two sub-sections are placeholders tracked as deferred sub-tasks in #340.
+ * Verifies the sub-tab switching machinery for the umbrella section AND
+ * the per-commitment table fetch+render flow (skeleton → table | empty |
+ * error). The coverage sub-section remains an intentional placeholder.
  */
 
 // loadRIExchange is a side-effect import from a module that touches the
@@ -14,14 +14,21 @@ jest.mock('../riexchange', () => ({
   loadRIExchange: jest.fn(),
 }));
 
-import { loadInventory, switchInventorySubSection } from '../inventory';
+// The active-commitments load path hits the API. Mock the entire api
+// barrel so we don't need to stand up fetch — tests exercise the render
+// machinery, not the network shape.
+jest.mock('../api', () => ({
+  listActiveCommitments: jest.fn(),
+}));
+
+import { loadInventory, switchInventorySubSection, loadActiveCommitments } from '../inventory';
 import { loadRIExchange } from '../riexchange';
+import * as api from '../api';
 
 function buildInventoryDOM(): void {
   // Build the inventory tab + sub-nav via DOM methods rather than an
   // innerHTML string. Matches the no-innerHTML-with-interpolated-data
-  // constraint from issue #340's plan; here there's no interpolation
-  // anyway, but the codebase prefers DOM construction in tests too.
+  // constraint from issue #340's plan.
   const tab = document.createElement('div');
   tab.id = 'inventory-tab';
   tab.classList.add('tab-content', 'active');
@@ -45,8 +52,21 @@ function buildInventoryDOM(): void {
   }
   tab.appendChild(subnav);
 
+  // active-commitments section: contains the real refresh button + list
+  // container (matches index.html shape).
+  const ac = document.createElement('section');
+  ac.id = 'inventory-active-commitments';
+  ac.classList.add('hidden');
+  const refresh = document.createElement('button');
+  refresh.id = 'active-commitments-refresh-btn';
+  refresh.textContent = 'Refresh';
+  ac.appendChild(refresh);
+  const list = document.createElement('div');
+  list.id = 'active-commitments-list';
+  ac.appendChild(list);
+  tab.appendChild(ac);
+
   for (const [id, hidden, body] of [
-    ['inventory-active-commitments', true, 'active'],
     ['inventory-coverage', true, 'coverage'],
     ['inventory-ri-exchange', false, 'ri-exchange'],
   ] as const) {
@@ -60,6 +80,28 @@ function buildInventoryDOM(): void {
   document.body.appendChild(tab);
 }
 
+function makeCommitment(overrides: Partial<api.InventoryCommitment> = {}): api.InventoryCommitment {
+  return {
+    id: 'acc-1:p-1',
+    provider: 'aws',
+    account_id: 'acc-1',
+    account_name: 'Prod Account',
+    service: 'ec2',
+    resource_type: 'm5.large',
+    region: 'us-east-1',
+    count: 4,
+    term_years: 1,
+    payment_option: 'no-upfront',
+    start_date: '2025-01-01T00:00:00Z',
+    end_date: '2026-01-01T00:00:00Z',
+    upfront_cost: 0,
+    monthly_cost: 240.5,
+    estimated_savings: 80.0,
+    status: 'active',
+    ...overrides,
+  };
+}
+
 function clearDOM(): void {
   while (document.body.firstChild) document.body.removeChild(document.body.firstChild);
 }
@@ -68,6 +110,11 @@ describe('Inventory & Coverage sub-section switching', () => {
   beforeEach(() => {
     buildInventoryDOM();
     (loadRIExchange as jest.Mock).mockClear();
+    // listActiveCommitments is invoked when switching to the
+    // active-commitments sub-tab; default to a resolved-empty so the
+    // switching tests don't need to care about the fetch outcome.
+    (api.listActiveCommitments as jest.Mock).mockReset();
+    (api.listActiveCommitments as jest.Mock).mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -84,6 +131,10 @@ describe('Inventory & Coverage sub-section switching', () => {
     const activeBtn = document.querySelector('[data-inv-subtab="active-commitments"]');
     expect(activeBtn?.classList.contains('active')).toBe(true);
     expect(activeBtn?.getAttribute('aria-selected')).toBe('true');
+
+    // Switching to active-commitments triggers the fetch — same shape
+    // as the ri-exchange sub-tab triggers loadRIExchange.
+    expect(api.listActiveCommitments).toHaveBeenCalledTimes(1);
   });
 
   test('switchInventorySubSection shows coverage and hides others', () => {
@@ -121,5 +172,95 @@ describe('Inventory & Coverage sub-section switching', () => {
     coverageBtn.click();
     expect(document.getElementById('inventory-coverage')?.classList.contains('hidden')).toBe(false);
     expect(document.getElementById('inventory-ri-exchange')?.classList.contains('hidden')).toBe(true);
+  });
+});
+
+describe('loadActiveCommitments — fetch + render flow', () => {
+  beforeEach(() => {
+    buildInventoryDOM();
+    (api.listActiveCommitments as jest.Mock).mockReset();
+  });
+
+  afterEach(() => {
+    clearDOM();
+  });
+
+  test('renders a table with header columns and one row per commitment', async () => {
+    (api.listActiveCommitments as jest.Mock).mockResolvedValue([
+      makeCommitment({ id: 'a:1', account_name: 'Prod', service: 'ec2', region: 'us-east-1', count: 4, term_years: 1, monthly_cost: 240.5 }),
+      makeCommitment({ id: 'a:2', account_name: 'Stg', service: 'rds', region: 'eu-west-1', count: 1, term_years: 3, monthly_cost: 60.0 }),
+    ]);
+
+    await loadActiveCommitments();
+
+    const list = document.getElementById('active-commitments-list')!;
+    const table = list.querySelector('table');
+    expect(table).not.toBeNull();
+
+    // Header columns lock the table shape so a refactor that re-orders
+    // (or drops) a column trips the test.
+    const headers = Array.from(list.querySelectorAll('thead th')).map(th => th.textContent);
+    expect(headers).toEqual([
+      'Provider', 'Account', 'Service', 'Resource type', 'Region', 'Count', 'Term', 'Payment', 'Monthly cost', 'Expires',
+    ]);
+
+    const rows = list.querySelectorAll('tbody tr');
+    expect(rows.length).toBe(2);
+    // Account cell contains the account name AND its monospaced ID.
+    expect(rows[0]!.textContent).toContain('Prod');
+    expect(rows[0]!.textContent).toContain('ec2');
+  });
+
+  test('renders an empty paragraph when no commitments are returned', async () => {
+    (api.listActiveCommitments as jest.Mock).mockResolvedValue([]);
+
+    await loadActiveCommitments();
+
+    const list = document.getElementById('active-commitments-list')!;
+    expect(list.querySelector('table')).toBeNull();
+    const empty = list.querySelector('.empty');
+    expect(empty).not.toBeNull();
+    expect(empty!.textContent).toMatch(/no active commitments/i);
+  });
+
+  test('renders an error paragraph when the API rejects, and tears down the skeleton', async () => {
+    (api.listActiveCommitments as jest.Mock).mockRejectedValue(new Error('boom'));
+
+    await loadActiveCommitments();
+
+    const list = document.getElementById('active-commitments-list')!;
+    expect(list.querySelector('table')).toBeNull();
+    // Skeleton marker should be gone — error path must call teardownSkeleton
+    // before rendering the error paragraph.
+    expect(list.dataset['skeletonActive']).toBeUndefined();
+    const err = list.querySelector('.error');
+    expect(err).not.toBeNull();
+    expect(err!.textContent).toContain('boom');
+  });
+
+  test('refresh button click re-invokes the fetch', async () => {
+    (api.listActiveCommitments as jest.Mock).mockResolvedValue([]);
+
+    await loadActiveCommitments();
+    expect(api.listActiveCommitments).toHaveBeenCalledTimes(1);
+
+    const btn = document.getElementById('active-commitments-refresh-btn')!;
+    btn.click();
+    // Click fires loadActiveCommitments; let the microtasks drain.
+    await Promise.resolve();
+    expect(api.listActiveCommitments).toHaveBeenCalledTimes(2);
+  });
+
+  test('falls back to monospaced account_id when account_name is missing', async () => {
+    (api.listActiveCommitments as jest.Mock).mockResolvedValue([
+      makeCommitment({ account_name: undefined, account_id: 'acc-no-name' }),
+    ]);
+
+    await loadActiveCommitments();
+
+    const list = document.getElementById('active-commitments-list')!;
+    const accountCell = list.querySelector('tbody tr td:nth-child(2)');
+    expect(accountCell?.textContent).toContain('acc-no-name');
+    expect(accountCell?.querySelector('.monospace')).not.toBeNull();
   });
 });

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -52,7 +52,8 @@ export type {
   ExchangeTarget,
   ExchangeResult,
   RIExchangeConfig,
-  RIExchangeHistoryRecord
+  RIExchangeHistoryRecord,
+  InventoryCommitment
 } from './types';
 
 // Re-export client functions
@@ -158,6 +159,11 @@ export {
   updateConfig,
   updateServiceConfig
 } from './settings';
+
+// Re-export inventory functions
+export {
+  listActiveCommitments
+} from './inventory';
 
 // Re-export RI exchange functions
 export {

--- a/frontend/src/api/inventory.ts
+++ b/frontend/src/api/inventory.ts
@@ -1,0 +1,23 @@
+/**
+ * Inventory & Coverage API functions.
+ *
+ * Per-commitment list view for the Inventory & Coverage → Active
+ * commitments sub-tab (issue #340 deferred sub-task). Reads aggregated
+ * purchase-history rows from `/api/inventory/commitments` and unwraps
+ * the `{commitments}` envelope so callers see a flat array.
+ */
+
+import { apiRequest } from './client';
+import type { InventoryCommitment } from './types';
+
+/**
+ * List active (non-expired) commitments across the user's accessible
+ * accounts. Pass `accountID` to scope the read to a single account; omit
+ * for the full cross-account list. The backend always filters expired
+ * rows out and sorts by soonest-expiring first.
+ */
+export async function listActiveCommitments(accountID?: string): Promise<InventoryCommitment[]> {
+  const qs = accountID ? `?account_id=${encodeURIComponent(accountID)}` : '';
+  const resp = await apiRequest<{ commitments: InventoryCommitment[] }>(`/inventory/commitments${qs}`);
+  return resp.commitments ?? [];
+}

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -546,6 +546,31 @@ export interface RIExchangeHistoryRecord {
   expires_at?: string;
 }
 
+// Inventory & Coverage types (issue #340 deferred sub-task — Active commitments)
+export interface InventoryCommitment {
+  id: string;
+  provider: string;
+  account_id: string;
+  account_name?: string;
+  service: string;
+  resource_type?: string;
+  region: string;
+  count: number;
+  term_years: number;
+  payment_option?: string;
+  start_date: string;
+  end_date: string;
+  upfront_cost: number;
+  monthly_cost: number;
+  estimated_savings: number;
+  /**
+   * Always "active" today — the backend filters expired rows before
+   * responding. The field stays in the shape so a future "expiring
+   * soon" sub-state can land without a breaking API change.
+   */
+  status: string;
+}
+
 // Internal types
 export interface ApiError extends Error {
   status?: number;

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -200,14 +200,24 @@
                     <button class="sub-tab-btn active" id="inv-subtab-ri-exchange" data-inv-subtab="ri-exchange" role="tab" aria-selected="true" aria-controls="inventory-ri-exchange">RI Exchange</button>
                 </div>
 
-                <!-- Active commitments — placeholder until T7 wires per-commitment list.
-                     Backend doesn't expose a dedicated list endpoint today; tracked in
-                     issue #340 sub-task list. -->
+                <!-- Active commitments — per-commitment list backed by
+                     /api/inventory/commitments (issue #340 deferred sub-task).
+                     The table is rendered into #active-commitments-list by
+                     loadActiveCommitments in inventory.ts. -->
                 <section id="inventory-active-commitments" class="hidden" role="tabpanel" aria-labelledby="inv-subtab-active-commitments">
-                    <div class="empty-state">
-                        <h3>Active commitments</h3>
-                        <p>Per-commitment inventory view is coming soon. For now, your active commitment count is on the Home dashboard, and RI exchange opportunities are in the RI Exchange tab.</p>
-                    </div>
+                    <section class="card page-hero">
+                        <div class="section-header">
+                            <h2>Active commitments</h2>
+                            <div class="section-header-actions">
+                                <button id="active-commitments-refresh-btn" class="btn btn-small">Refresh</button>
+                            </div>
+                        </div>
+                        <p class="settings-description">All non-expired Reserved Instances, Savings Plans, and Compute Units committed across your registered accounts. Soonest-expiring first.</p>
+                    </section>
+
+                    <section class="card">
+                        <div id="active-commitments-list"></div>
+                    </section>
                 </section>
 
                 <!-- Coverage — placeholder until T7 wires per-provider donuts. -->

--- a/frontend/src/inventory.ts
+++ b/frontend/src/inventory.ts
@@ -3,20 +3,20 @@
  *
  * Umbrella section that folds the former top-level "RI Exchange" tab into
  * a sub-section of a broader Inventory & Coverage view. Sub-sections:
- *   - active-commitments — placeholder until T7 wires the per-commitment list
- *   - coverage           — placeholder until T7 wires per-provider donuts
+ *   - active-commitments — per-commitment list backed by
+ *                          /api/inventory/commitments
+ *   - coverage           — placeholder until per-provider donuts land
  *   - ri-exchange        — hosts the existing RI Exchange UI unchanged
  *
- * The two placeholder sub-sections are intentional empty states — their
- * backend endpoints aren't in scope for #340. They're tracked as deferred
- * sub-tasks in #340 so the path forward stays visible.
- *
- * Default sub-section: ri-exchange. Once T7 lights up active-commitments
- * with real data, the default flips so the user lands on substantive
- * content first.
+ * The coverage sub-section is still an intentional empty state — its
+ * backend endpoint isn't in scope for #340 and remains a deferred
+ * sub-task.
  */
 
+import * as api from './api';
 import { loadRIExchange } from './riexchange';
+import { showSkeletonRows, teardownSkeleton } from './lib/skeleton';
+import { formatCurrency, formatDate } from './utils';
 
 type InventorySubSection = 'active-commitments' | 'coverage' | 'ri-exchange';
 
@@ -56,9 +56,159 @@ export function switchInventorySubSection(name: string): void {
 
   if (target === 'ri-exchange') {
     void loadRIExchange();
+  } else if (target === 'active-commitments') {
+    void loadActiveCommitments();
   }
 
   currentSubSection = target;
+}
+
+// ──────────────────────────────────────────────
+// Active commitments
+// ──────────────────────────────────────────────
+
+const ACTIVE_COMMITMENTS_LIST_ID = 'active-commitments-list';
+const ACTIVE_COMMITMENTS_REFRESH_BTN_ID = 'active-commitments-refresh-btn';
+const ACTIVE_COMMITMENTS_COLS = 10;
+
+/**
+ * Fetch and render the active-commitments table. Replaces #active-commitments-list
+ * children with a shimmer skeleton on entry, then either the rendered
+ * table or an empty-state / error paragraph on completion. Idempotent —
+ * safe to call on every sub-tab switch and on every refresh click.
+ */
+export async function loadActiveCommitments(): Promise<void> {
+  const container = document.getElementById(ACTIVE_COMMITMENTS_LIST_ID);
+  if (!container) return;
+
+  wireRefreshButton();
+
+  // 5 rows × 10 cols matches the rendered table shape (see
+  // renderActiveCommitmentsTable). The renderer wipes the container's
+  // children for a clean handoff from the skeleton.
+  showSkeletonRows(container, 5, ACTIVE_COMMITMENTS_COLS);
+
+  try {
+    const commitments = await api.listActiveCommitments();
+    renderActiveCommitmentsTable(container, commitments);
+  } catch (error) {
+    teardownSkeleton(container);
+    const err = error as Error;
+    renderErrorParagraph(container, `Failed to load active commitments: ${err.message}`);
+  }
+}
+
+function wireRefreshButton(): void {
+  // Idempotency is tracked on the element itself rather than a
+  // module-level flag — when the section is re-rendered (e.g. between
+  // tests, or after a hot-swap in dev), the new button is unwired and
+  // a stale flag would block the rebind. The dataset marker travels
+  // with the element so it can't drift out of sync.
+  const btn = document.getElementById(ACTIVE_COMMITMENTS_REFRESH_BTN_ID);
+  if (!btn) return;
+  if (btn.dataset['wired'] === '1') return;
+  btn.addEventListener('click', () => {
+    void loadActiveCommitments();
+  });
+  btn.dataset['wired'] = '1';
+}
+
+function clearChildren(el: HTMLElement): void {
+  while (el.firstChild) el.removeChild(el.firstChild);
+}
+
+function renderErrorParagraph(container: HTMLElement, message: string): void {
+  clearChildren(container);
+  const p = document.createElement('p');
+  p.className = 'error';
+  p.textContent = message;
+  container.appendChild(p);
+}
+
+function renderEmptyParagraph(container: HTMLElement, message: string): void {
+  clearChildren(container);
+  const p = document.createElement('p');
+  p.className = 'empty';
+  p.textContent = message;
+  container.appendChild(p);
+}
+
+/**
+ * Render the per-commitment table into `container`. Empty list yields
+ * an inline `.empty` paragraph instead of an empty table so the user
+ * gets a real message ("no active commitments"), not a blank header.
+ *
+ * All text uses textContent / DOM construction — no innerHTML — to
+ * keep the section safe by default against any unescaped backend
+ * field (issue #340 XSS posture).
+ */
+function renderActiveCommitmentsTable(container: HTMLElement, commitments: api.InventoryCommitment[]): void {
+  if (!commitments || commitments.length === 0) {
+    renderEmptyParagraph(container, 'No active commitments found across your registered accounts.');
+    return;
+  }
+
+  clearChildren(container);
+  const table = document.createElement('table');
+
+  const thead = document.createElement('thead');
+  const headerRow = document.createElement('tr');
+  const headers = ['Provider', 'Account', 'Service', 'Resource type', 'Region', 'Count', 'Term', 'Payment', 'Monthly cost', 'Expires'];
+  for (const label of headers) {
+    const th = document.createElement('th');
+    th.textContent = label;
+    headerRow.appendChild(th);
+  }
+  thead.appendChild(headerRow);
+  table.appendChild(thead);
+
+  const tbody = document.createElement('tbody');
+  for (const c of commitments) {
+    tbody.appendChild(buildCommitmentRow(c));
+  }
+  table.appendChild(tbody);
+
+  container.appendChild(table);
+}
+
+function buildCommitmentRow(c: api.InventoryCommitment): HTMLTableRowElement {
+  const tr = document.createElement('tr');
+
+  appendCell(tr, c.provider);
+  tr.appendChild(buildAccountCell(c));
+  appendCell(tr, c.service);
+  appendCell(tr, c.resource_type ?? '');
+  appendCell(tr, c.region);
+  appendCell(tr, String(c.count));
+  appendCell(tr, `${c.term_years}y`);
+  appendCell(tr, c.payment_option ?? '');
+  appendCell(tr, formatCurrency(c.monthly_cost));
+  appendCell(tr, formatDate(c.end_date));
+
+  return tr;
+}
+
+function appendCell(tr: HTMLTableRowElement, text: string): void {
+  const td = document.createElement('td');
+  td.textContent = text;
+  tr.appendChild(td);
+}
+
+function buildAccountCell(c: api.InventoryCommitment): HTMLTableCellElement {
+  const td = document.createElement('td');
+  if (c.account_name) {
+    td.appendChild(document.createTextNode(c.account_name + ' '));
+    const id = document.createElement('span');
+    id.className = 'monospace';
+    id.textContent = `(${c.account_id})`;
+    td.appendChild(id);
+  } else {
+    const id = document.createElement('span');
+    id.className = 'monospace';
+    id.textContent = c.account_id;
+    td.appendChild(id);
+  }
+  return td;
 }
 
 /**

--- a/internal/api/handler_dashboard.go
+++ b/internal/api/handler_dashboard.go
@@ -351,6 +351,27 @@ func (h *Handler) getPublicInfo(ctx context.Context, req *events.LambdaFunctionU
 	}, nil
 }
 
+// commitmentExpiry returns the moment a purchase's commitment term ends.
+// Computed from Timestamp + Term*365d. Extracted from
+// calculateCommitmentMetrics so the inventory handler can surface the
+// same date in its per-row response without re-deriving the math (and
+// so a future tweak to "what counts as expired" lands in exactly one
+// place). One year is approximated as 365 days — matches the original
+// dashboard arithmetic verbatim; leap-year precision isn't material for
+// a multi-year RI/SP/CUD term.
+func commitmentExpiry(p config.PurchaseHistoryRecord) time.Time {
+	termDuration := time.Duration(p.Term) * 365 * 24 * time.Hour
+	return p.Timestamp.Add(termDuration)
+}
+
+// isActiveCommitment reports whether the purchase's term has not yet
+// expired as of `now`. The boundary is strict (After): a commitment is
+// active right up to the instant its term ends. Same predicate shared
+// by the dashboard aggregate and the per-commitment inventory endpoint.
+func isActiveCommitment(p config.PurchaseHistoryRecord, now time.Time) bool {
+	return !now.After(commitmentExpiry(p))
+}
+
 // calculateCommitmentMetrics calculates active commitments and savings from purchase history
 func (h *Handler) calculateCommitmentMetrics(ctx context.Context, accountID string) (activeCommitments int, committedMonthly, ytdSavings float64) {
 	// Get purchase history (last 1000 purchases should be sufficient)
@@ -365,11 +386,7 @@ func (h *Handler) calculateCommitmentMetrics(ctx context.Context, accountID stri
 	yearStart := time.Date(currentTime.Year(), 1, 1, 0, 0, 0, 0, time.UTC)
 
 	for _, p := range purchases {
-		// Check if purchase is still active (within term)
-		termYears := time.Duration(p.Term) * 365 * 24 * time.Hour
-		expiryTime := p.Timestamp.Add(termYears)
-
-		if currentTime.After(expiryTime) {
+		if !isActiveCommitment(p, currentTime) {
 			continue // Skip expired commitments
 		}
 

--- a/internal/api/handler_inventory.go
+++ b/internal/api/handler_inventory.go
@@ -1,0 +1,102 @@
+// Package api provides the HTTP API handlers for the CUDly dashboard.
+package api
+
+import (
+	"context"
+	"sort"
+	"time"
+
+	"github.com/LeanerCloud/CUDly/internal/config"
+	"github.com/aws/aws-lambda-go/events"
+)
+
+// listActiveCommitments handles GET /api/inventory/commitments.
+//
+// Returns one row per *active* (non-expired) PurchaseHistoryRecord, with
+// the account name joined in for display and expiry computed via the
+// shared commitmentExpiry helper. Rows are sorted by EndDate ascending
+// so the most-actionable (soonest-expiring) commitments float to the
+// top — matches the dashboard's "what should I renew next?" framing
+// without forcing the UI to re-sort client-side.
+//
+// Auth: `view:purchases`. Purchase history is the same source we already
+// gate behind that permission for the /api/history page, so reusing the
+// resource keeps the role matrix consistent. The session's
+// allowed_accounts list is then applied via
+// filterPurchaseHistoryByAllowedAccounts so a restricted-access user
+// sees only the commitments belonging to accounts they're entitled to.
+func (h *Handler) listActiveCommitments(ctx context.Context, req *events.LambdaFunctionURLRequest, params map[string]string) (any, error) {
+	session, err := h.requirePermission(ctx, req, "view", "purchases")
+	if err != nil {
+		return nil, err
+	}
+
+	purchases, err := h.fetchCommitmentRecords(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+
+	purchases, err = h.filterPurchaseHistoryByAllowedAccounts(ctx, session, purchases)
+	if err != nil {
+		return nil, err
+	}
+
+	nameByID := h.resolveAccountNamesByID(ctx)
+	now := time.Now()
+
+	commitments := make([]InventoryCommitment, 0, len(purchases))
+	for _, p := range purchases {
+		if !isActiveCommitment(p, now) {
+			continue
+		}
+		commitments = append(commitments, buildInventoryCommitment(p, nameByID[p.AccountID]))
+	}
+
+	// Soonest-expiring first. The dashboard framing is "what do I need to
+	// renew next" — surfacing the imminent end_date on top means the
+	// frontend doesn't need to re-sort and the user's eye lands on the
+	// most-actionable rows immediately.
+	sort.SliceStable(commitments, func(i, j int) bool {
+		return commitments[i].EndDate.Before(commitments[j].EndDate)
+	})
+
+	return InventoryCommitmentsResponse{Commitments: commitments}, nil
+}
+
+// fetchCommitmentRecords reads purchase history from the store, honouring
+// an optional `account_id` query param the same way fetchPurchaseHistory
+// does for /api/history. Limit defaults to MaxListLimit — commitments
+// are a strict subset of purchase history (we drop expired rows before
+// returning) so a high cap is appropriate; an over-truncation here
+// would silently hide rows the user is entitled to see.
+func (h *Handler) fetchCommitmentRecords(ctx context.Context, params map[string]string) ([]config.PurchaseHistoryRecord, error) {
+	if accountID := params["account_id"]; accountID != "" {
+		return h.config.GetPurchaseHistory(ctx, accountID, config.MaxListLimit)
+	}
+	return h.config.GetAllPurchaseHistory(ctx, config.MaxListLimit)
+}
+
+// buildInventoryCommitment maps a PurchaseHistoryRecord to the
+// response-layer InventoryCommitment. The ID is namespaced by account so
+// the JSON payload is globally unique without a DB schema change —
+// purchase_id alone is only unique within an account.
+func buildInventoryCommitment(p config.PurchaseHistoryRecord, accountName string) InventoryCommitment {
+	return InventoryCommitment{
+		ID:               p.AccountID + ":" + p.PurchaseID,
+		Provider:         p.Provider,
+		AccountID:        p.AccountID,
+		AccountName:      accountName,
+		Service:          p.Service,
+		ResourceType:     p.ResourceType,
+		Region:           p.Region,
+		Count:            p.Count,
+		TermYears:        p.Term,
+		PaymentOption:    p.Payment,
+		StartDate:        p.Timestamp,
+		EndDate:          commitmentExpiry(p),
+		UpfrontCost:      p.UpfrontCost,
+		MonthlyCost:      p.MonthlyCost,
+		EstimatedSavings: p.EstimatedSavings,
+		Status:           "active",
+	}
+}

--- a/internal/api/handler_inventory_test.go
+++ b/internal/api/handler_inventory_test.go
@@ -1,0 +1,267 @@
+package api
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/LeanerCloud/CUDly/internal/config"
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// adminInventoryReq builds an admin-authed request and wires the auth mock so
+// requirePermission short-circuits. Mirrors adminHistoryReq from
+// handler_history_test.go — the inventory handler reuses the view:purchases
+// permission, so the request shape is the same.
+func adminInventoryReq(ctx context.Context) (*MockAuthService, *events.LambdaFunctionURLRequest) {
+	mockAuth := new(MockAuthService)
+	mockAuth.On("ValidateSession", ctx, "admin-token").Return(&Session{
+		UserID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+		Email:  "admin@example.com",
+		Role:   "admin",
+	}, nil)
+	req := &events.LambdaFunctionURLRequest{
+		Headers: map[string]string{"Authorization": "Bearer admin-token"},
+	}
+	return mockAuth, req
+}
+
+// TestHandler_listActiveCommitments_Empty verifies the empty-store path
+// returns a non-nil empty slice — the frontend renders `.empty` on
+// length==0, but a nil response would force a null check.
+func TestHandler_listActiveCommitments_Empty(t *testing.T) {
+	ctx := context.Background()
+	mockStore := new(MockConfigStore)
+
+	mockStore.On("GetAllPurchaseHistory", ctx, config.MaxListLimit).Return([]config.PurchaseHistoryRecord{}, nil)
+	mockStore.ListCloudAccountsFn = func(_ context.Context, _ config.CloudAccountFilter) ([]config.CloudAccount, error) {
+		return []config.CloudAccount{}, nil
+	}
+
+	mockAuth, req := adminInventoryReq(ctx)
+	handler := &Handler{auth: mockAuth, config: mockStore}
+
+	result, err := handler.listActiveCommitments(ctx, req, map[string]string{})
+	require.NoError(t, err)
+
+	resp, ok := result.(InventoryCommitmentsResponse)
+	require.True(t, ok, "response must be InventoryCommitmentsResponse envelope, not bare slice")
+	assert.NotNil(t, resp.Commitments, "commitments slice must be non-nil even when empty")
+	assert.Len(t, resp.Commitments, 0)
+}
+
+// TestHandler_listActiveCommitments_FiltersExpired verifies the term-expiry
+// predicate drops rows whose timestamp + term has elapsed and keeps the
+// in-term ones. Same predicate the dashboard aggregate uses; this test
+// guards the predicate's behaviour in the inventory-handler context so a
+// future refactor (e.g. moving to days-from-now) trips here too.
+func TestHandler_listActiveCommitments_FiltersExpired(t *testing.T) {
+	ctx := context.Background()
+	mockStore := new(MockConfigStore)
+
+	now := time.Now()
+	purchases := []config.PurchaseHistoryRecord{
+		// Active: bought 6 months ago, 1-year term — 6 months remaining.
+		{
+			AccountID:        "acc-active",
+			PurchaseID:       "p-active",
+			Provider:         "aws",
+			Service:          "ec2",
+			Region:           "us-east-1",
+			Count:            2,
+			Term:             1,
+			Payment:          "no-upfront",
+			Timestamp:        now.AddDate(0, -6, 0),
+			MonthlyCost:      100.0,
+			EstimatedSavings: 30.0,
+		},
+		// Expired: bought 2 years ago, 1-year term.
+		{
+			AccountID:        "acc-expired",
+			PurchaseID:       "p-expired",
+			Provider:         "aws",
+			Service:          "rds",
+			Region:           "us-east-1",
+			Count:            1,
+			Term:             1,
+			Timestamp:        now.AddDate(-2, 0, 0),
+			MonthlyCost:      50.0,
+			EstimatedSavings: 15.0,
+		},
+	}
+
+	mockStore.On("GetAllPurchaseHistory", ctx, config.MaxListLimit).Return(purchases, nil)
+	mockStore.ListCloudAccountsFn = func(_ context.Context, _ config.CloudAccountFilter) ([]config.CloudAccount, error) {
+		return []config.CloudAccount{
+			{ID: "acc-active", Name: "Active Account"},
+			{ID: "acc-expired", Name: "Expired Account"},
+		}, nil
+	}
+
+	mockAuth, req := adminInventoryReq(ctx)
+	handler := &Handler{auth: mockAuth, config: mockStore}
+
+	result, err := handler.listActiveCommitments(ctx, req, map[string]string{})
+	require.NoError(t, err)
+
+	resp := result.(InventoryCommitmentsResponse)
+	require.Len(t, resp.Commitments, 1, "expired commitment must be filtered out")
+	row := resp.Commitments[0]
+	assert.Equal(t, "acc-active:p-active", row.ID, "id namespaces account+purchase")
+	assert.Equal(t, "acc-active", row.AccountID)
+	assert.Equal(t, "Active Account", row.AccountName, "account name must be joined from ListCloudAccounts")
+	assert.Equal(t, "aws", row.Provider)
+	assert.Equal(t, "ec2", row.Service)
+	assert.Equal(t, 2, row.Count)
+	assert.Equal(t, 1, row.TermYears)
+	assert.Equal(t, "no-upfront", row.PaymentOption)
+	assert.Equal(t, 100.0, row.MonthlyCost)
+	assert.Equal(t, 30.0, row.EstimatedSavings)
+	assert.Equal(t, "active", row.Status)
+	assert.False(t, row.StartDate.IsZero())
+	assert.True(t, row.EndDate.After(row.StartDate), "end_date must follow start_date")
+}
+
+// TestHandler_listActiveCommitments_AccountFilter verifies the account_id
+// query param routes through GetPurchaseHistory (single-account read)
+// instead of GetAllPurchaseHistory, and the response respects the filter.
+func TestHandler_listActiveCommitments_AccountFilter(t *testing.T) {
+	ctx := context.Background()
+	mockStore := new(MockConfigStore)
+
+	now := time.Now()
+	purchases := []config.PurchaseHistoryRecord{
+		{
+			AccountID:        "acc-1",
+			PurchaseID:       "p-1",
+			Provider:         "aws",
+			Service:          "ec2",
+			Timestamp:        now.AddDate(0, -3, 0),
+			Term:             1,
+			Count:            1,
+			MonthlyCost:      80.0,
+			EstimatedSavings: 20.0,
+		},
+	}
+
+	mockStore.On("GetPurchaseHistory", ctx, "acc-1", config.MaxListLimit).Return(purchases, nil)
+	mockStore.ListCloudAccountsFn = func(_ context.Context, _ config.CloudAccountFilter) ([]config.CloudAccount, error) {
+		return []config.CloudAccount{{ID: "acc-1", Name: "Account One"}}, nil
+	}
+
+	mockAuth, req := adminInventoryReq(ctx)
+	handler := &Handler{auth: mockAuth, config: mockStore}
+
+	result, err := handler.listActiveCommitments(ctx, req, map[string]string{"account_id": "acc-1"})
+	require.NoError(t, err)
+
+	resp := result.(InventoryCommitmentsResponse)
+	require.Len(t, resp.Commitments, 1)
+	assert.Equal(t, "acc-1", resp.Commitments[0].AccountID)
+
+	// GetAllPurchaseHistory must NOT have been called when account_id is set.
+	mockStore.AssertNotCalled(t, "GetAllPurchaseHistory")
+}
+
+// TestHandler_listActiveCommitments_SortedByExpiry verifies soonest-expiring
+// is first — the dashboard framing is "what do I need to renew next?", so
+// surfacing the imminent end_date on top keeps the UI's order intuitive
+// without forcing the frontend to re-sort.
+func TestHandler_listActiveCommitments_SortedByExpiry(t *testing.T) {
+	ctx := context.Background()
+	mockStore := new(MockConfigStore)
+
+	now := time.Now()
+	// Three purchases with very different term remainders. Listed
+	// "out of order" so the sort step actually has work to do.
+	purchases := []config.PurchaseHistoryRecord{
+		// 30 months remaining (3y term, bought 6mo ago).
+		{
+			AccountID:  "acc-1",
+			PurchaseID: "p-long",
+			Provider:   "aws",
+			Service:    "ec2",
+			Timestamp:  now.AddDate(0, -6, 0),
+			Term:       3,
+			Count:      1,
+		},
+		// 6 months remaining (1y term, bought 6mo ago).
+		{
+			AccountID:  "acc-1",
+			PurchaseID: "p-short",
+			Provider:   "aws",
+			Service:    "rds",
+			Timestamp:  now.AddDate(0, -6, 0),
+			Term:       1,
+			Count:      1,
+		},
+		// 18 months remaining (3y term, bought 18mo ago).
+		{
+			AccountID:  "acc-1",
+			PurchaseID: "p-mid",
+			Provider:   "aws",
+			Service:    "elasticache",
+			Timestamp:  now.AddDate(0, -18, 0),
+			Term:       3,
+			Count:      1,
+		},
+	}
+
+	mockStore.On("GetAllPurchaseHistory", ctx, config.MaxListLimit).Return(purchases, nil)
+	mockStore.ListCloudAccountsFn = func(_ context.Context, _ config.CloudAccountFilter) ([]config.CloudAccount, error) {
+		return []config.CloudAccount{{ID: "acc-1", Name: "Account One"}}, nil
+	}
+
+	mockAuth, req := adminInventoryReq(ctx)
+	handler := &Handler{auth: mockAuth, config: mockStore}
+
+	result, err := handler.listActiveCommitments(ctx, req, map[string]string{})
+	require.NoError(t, err)
+
+	resp := result.(InventoryCommitmentsResponse)
+	require.Len(t, resp.Commitments, 3)
+	assert.Equal(t, "p-short", splitPurchaseID(resp.Commitments[0].ID), "shortest remaining term first")
+	assert.Equal(t, "p-mid", splitPurchaseID(resp.Commitments[1].ID))
+	assert.Equal(t, "p-long", splitPurchaseID(resp.Commitments[2].ID))
+}
+
+// splitPurchaseID strips the `{accountID}:` prefix from an
+// InventoryCommitment.ID so the sort-order assertion can compare on the
+// raw purchase ID without rebuilding the prefix in the test.
+func splitPurchaseID(id string) string {
+	for i := 0; i < len(id); i++ {
+		if id[i] == ':' {
+			return id[i+1:]
+		}
+	}
+	return id
+}
+
+// TestHandler_isActiveCommitment_Predicate exercises the extracted
+// predicate directly so the boundary case (term ends exactly at `now`)
+// is locked down by a test, not just by the integration tests above.
+// Stable boundary semantics matter because the dashboard aggregate and
+// the inventory handler now share this predicate — drift here would
+// cause the two views to disagree about which commitments are active.
+func TestHandler_isActiveCommitment_Predicate(t *testing.T) {
+	now := time.Now()
+	p := config.PurchaseHistoryRecord{
+		Timestamp: now.AddDate(-1, 0, 0),
+		Term:      1, // 1y term, started 1y ago — at the boundary.
+	}
+	// The 1y term is approximated as 365d. now.AddDate(-1, 0, 0) anchors
+	// on the calendar day, so on a leap-year boundary the predicate
+	// returns true (active) — we accept that; the dashboard's aggregate
+	// uses the same arithmetic.
+	assert.True(t, isActiveCommitment(p, now.Add(-time.Hour)),
+		"a commitment one hour before its expiry must still be active")
+
+	expired := config.PurchaseHistoryRecord{
+		Timestamp: now.AddDate(-2, 0, 0),
+		Term:      1,
+	}
+	assert.False(t, isActiveCommitment(expired, now),
+		"a commitment whose term ended a year ago must be inactive")
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -238,6 +238,13 @@ func (r *Router) registerRoutes() {
 		{PathPrefix: "/api/groups/", Method: "PUT", Handler: r.updateGroupHandler, Auth: AuthAdmin},
 		{PathPrefix: "/api/groups/", Method: "DELETE", Handler: r.deleteGroupHandler, Auth: AuthAdmin},
 
+		// Inventory & Coverage endpoints. Per-commitment list view for
+		// the Inventory & Coverage → Active commitments sub-tab (issue
+		// #340 deferred sub-task). AuthUser gates the read; the
+		// handler also filters by the session's allowed_accounts list
+		// so a restricted-access user sees only their entitled rows.
+		{ExactPath: "/api/inventory/commitments", Method: "GET", Handler: r.listInventoryCommitmentsHandler, Auth: AuthUser},
+
 		// RI Exchange endpoints — GETs are AuthUser (Convertible RIs,
 		// Reshape Recommendations, Exchange History pages all need this);
 		// quote / execute / config writes stay AuthAdmin.
@@ -600,6 +607,10 @@ func (r *Router) getPublicInfoHandler(ctx context.Context, req *events.LambdaFun
 
 func (r *Router) docsHandler(ctx context.Context, req *events.LambdaFunctionURLRequest, params map[string]string) (any, error) {
 	return r.h.docsHandler(ctx, req, params)
+}
+
+func (r *Router) listInventoryCommitmentsHandler(ctx context.Context, req *events.LambdaFunctionURLRequest, params map[string]string) (any, error) {
+	return r.h.listActiveCommitments(ctx, req, req.QueryStringParameters)
 }
 
 func (r *Router) listConvertibleRIsHandler(ctx context.Context, req *events.LambdaFunctionURLRequest, params map[string]string) (any, error) {

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -412,6 +412,46 @@ type ServiceSavings struct {
 	CurrentSavings   float64 `json:"current_savings"`
 }
 
+// InventoryCommitment is one row in the per-commitment Inventory &
+// Coverage view (issue #340 deferred sub-task — "Active commitments").
+// Aggregated from PurchaseHistoryRecord rows that are still within
+// their term; the inventory endpoint filters out expired commitments
+// before responding.
+//
+// ID is `{account_id}:{purchase_id}` so the row is uniquely identifiable
+// in the JSON payload without a DB schema change — purchase_id alone
+// is unique within an account but not globally across the table.
+//
+// Status is always `"active"` today (the handler drops expired rows).
+// The field stays in the response shape so a future "expiring soon"
+// sub-state has a slot without a breaking API change.
+type InventoryCommitment struct {
+	ID               string    `json:"id"`
+	Provider         string    `json:"provider"`
+	AccountID        string    `json:"account_id"`
+	AccountName      string    `json:"account_name,omitempty"`
+	Service          string    `json:"service"`
+	ResourceType     string    `json:"resource_type,omitempty"`
+	Region           string    `json:"region"`
+	Count            int       `json:"count"`
+	TermYears        int       `json:"term_years"`
+	PaymentOption    string    `json:"payment_option,omitempty"`
+	StartDate        time.Time `json:"start_date"`
+	EndDate          time.Time `json:"end_date"`
+	UpfrontCost      float64   `json:"upfront_cost"`
+	MonthlyCost      float64   `json:"monthly_cost"`
+	EstimatedSavings float64   `json:"estimated_savings"`
+	Status           string    `json:"status"`
+}
+
+// InventoryCommitmentsResponse is the envelope returned by
+// GET /api/inventory/commitments. Commitments is always a slice — never
+// nil — so the frontend can rely on `resp.commitments.length` without
+// a null check.
+type InventoryCommitmentsResponse struct {
+	Commitments []InventoryCommitment `json:"commitments"`
+}
+
 // UpcomingPurchaseResponse holds upcoming purchase data
 type UpcomingPurchaseResponse struct {
 	Purchases []UpcomingPurchase `json:"purchases"`


### PR DESCRIPTION
## Summary

- New `GET /api/inventory/commitments` endpoint backs the "Active commitments" sub-tab inside Inventory & Coverage. Reads from existing `PurchaseHistoryRecord` rows (no new cloud-API fetches), filters out expired rows via a shared `isActiveCommitment` predicate (extracted from the dashboard aggregate so the two views agree on what "active" means), joins account names, and sorts soonest-expiring first.
- New `frontend/src/inventory.ts::loadActiveCommitments` renders a 10-column table with skeleton + empty + error states. `index.html` empty-state placeholder is replaced with the table container + refresh button. Switching to the sub-tab triggers the load (matching the existing `ri-exchange` auto-load pattern).
- Auth reuses the existing `view:purchases` permission; the response is filtered through `filterPurchaseHistoryByAllowedAccounts` so restricted-access sessions see only their entitled rows.

Closes the "Active commitments inventory" deferred sub-task from #340.

## Test plan

- [x] Backend: `go test ./internal/api/...` — 1084 tests pass. New `handler_inventory_test.go` covers empty store, expired-row filtering, account_id scoping, soonest-expiring sort, response-envelope shape, predicate boundary.
- [x] Frontend: `npm test` — 1654 tests pass. New `inventory.test.ts` cases (render, empty, error+skeleton-teardown, refresh re-fetch, account_name fallback) + `api-inventory.test.ts` for the client adapter (URL shape, encoding, envelope unwrap).
- [x] `npm run build` — clean. Bundle 526 KiB (entrypoint warning is pre-existing).
- [x] Coverage parity: 81.05% stmts / 82.84% lines (≥ recent baseline).
- [ ] Manual smoke: visit Inventory & Coverage → Active commitments, verify table renders for an account with completed purchases; verify empty state renders for a fresh tenant; verify error renders when API returns 500.

## Notes for reviewers

- The `isActiveCommitment` / `commitmentExpiry` extraction is the only touch to the dashboard aggregate. Behaviour of `calculateCommitmentMetrics` is unchanged — existing dashboard tests still pass — and the predicate is now the single source of truth between the dashboard count and this per-row view.
- All frontend rendering uses DOM construction (no `innerHTML`) to match the project's XSS posture from #340.
- The `account_id` query param is accepted for parity with `/api/history`; the UI doesn't surface it yet — that's intentional follow-up scope.
