### PR TITLE
fix(auth): auto-assign bootstrap admin to Administrators group (closes #351)

### DIFF
--- a/internal/database/postgres/migrations/ensure_admin_user_test.go
+++ b/internal/database/postgres/migrations/ensure_admin_user_test.go
@@ -1,0 +1,165 @@
+//go:build integration
+// +build integration
+
+package migrations_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/LeanerCloud/CUDly/internal/database/postgres/migrations"
+	"github.com/LeanerCloud/CUDly/internal/database/postgres/testhelpers"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// defaultAdminGroupIDTest mirrors the literal in
+// internal/database/postgres/migrations/migrate.go (defaultAdminGroupID)
+// and 000024_seed_default_groups.up.sql. Duplicated as a test-local
+// constant because the production constant is package-private.
+const defaultAdminGroupIDTest = "00000000-0000-5000-8000-000000000001"
+
+// queryAdminGroupIDs returns the group_ids array for the admin user
+// with the given email, as a []string of UUID strings. Helper for the
+// sub-cases below so the assertions stay readable.
+func queryAdminGroupIDs(t *testing.T, ctx context.Context, pool *pgxpool.Pool, email string) []string {
+	t.Helper()
+	var ids []string
+	err := pool.QueryRow(ctx, `
+		SELECT COALESCE(ARRAY(
+			SELECT id::text FROM unnest(group_ids) AS id
+		), '{}')
+		FROM users WHERE email = $1
+	`, email).Scan(&ids)
+	require.NoError(t, err, "user row for %s must exist", email)
+	return ids
+}
+
+// TestEnsureAdminUser_GroupAssignment covers the five scenarios from
+// issue #351: every code path that inserts an admin row must produce
+// group_ids containing the Administrators group, post-migration
+// drift must self-heal on the next boot, and operator-customised
+// group_ids must be preserved.
+func TestEnsureAdminUser_GroupAssignment(t *testing.T) {
+	ctx := context.Background()
+	migrationsPath := getMigrationsPath()
+	const adminEmail = "admin@test.example"
+
+	t.Run("fresh insert no password", func(t *testing.T) {
+		container, err := testhelpers.SetupPostgresContainer(ctx, t)
+		require.NoError(t, err)
+		defer container.Cleanup(ctx)
+		pool := container.DB.Pool()
+
+		require.NoError(t, migrations.RunMigrations(ctx, pool, migrationsPath, adminEmail, ""))
+
+		got := queryAdminGroupIDs(t, ctx, pool, adminEmail)
+		assert.Equal(t, []string{defaultAdminGroupIDTest}, got,
+			"fresh bootstrap admin (no-password path) must have the Administrators group assigned")
+	})
+
+	t.Run("fresh insert with password", func(t *testing.T) {
+		container, err := testhelpers.SetupPostgresContainer(ctx, t)
+		require.NoError(t, err)
+		defer container.Cleanup(ctx)
+		pool := container.DB.Pool()
+
+		require.NoError(t, migrations.RunMigrations(ctx, pool, migrationsPath, adminEmail, "TestPass!9aF"))
+
+		got := queryAdminGroupIDs(t, ctx, pool, adminEmail)
+		assert.Equal(t, []string{defaultAdminGroupIDTest}, got,
+			"fresh bootstrap admin (with-password path) must have the Administrators group assigned")
+	})
+
+	t.Run("post-migration drift repair", func(t *testing.T) {
+		container, err := testhelpers.SetupPostgresContainer(ctx, t)
+		require.NoError(t, err)
+		defer container.Cleanup(ctx)
+		pool := container.DB.Pool()
+
+		// First pass: run migrations only, no admin yet. Migration 000024
+		// seeds the Administrators group row but does not insert any
+		// admin user.
+		require.NoError(t, migrations.RunMigrations(ctx, pool, migrationsPath, "", ""))
+
+		// Simulate an out-of-band manual DB seed that inserted an admin
+		// without group_ids (the bug pattern from issue #351 - happens
+		// when an operator runs INSERT INTO users directly).
+		_, err = pool.Exec(ctx, `
+			INSERT INTO users (id, email, password_hash, salt, role, active, group_ids, created_at, updated_at)
+			VALUES (gen_random_uuid(), $1, '', '', 'admin', false, '{}', NOW(), NOW())
+		`, adminEmail)
+		require.NoError(t, err)
+
+		// Verify the drift state before re-running RunMigrations.
+		drifted := queryAdminGroupIDs(t, ctx, pool, adminEmail)
+		require.Empty(t, drifted, "test setup: admin should start with empty group_ids")
+
+		// Second pass: re-run RunMigrations with the admin email. The
+		// m.Up() inside is a no-op (already at head, returns
+		// ErrNoChange) but ensureAdminUser still fires and triggers
+		// the code-level backfill via assignAdminGroupAndWarn.
+		require.NoError(t, migrations.RunMigrations(ctx, pool, migrationsPath, adminEmail, ""))
+
+		got := queryAdminGroupIDs(t, ctx, pool, adminEmail)
+		assert.Equal(t, []string{defaultAdminGroupIDTest}, got,
+			"post-migration drift must self-heal on the next ensureAdminUser run")
+	})
+
+	t.Run("idempotency", func(t *testing.T) {
+		container, err := testhelpers.SetupPostgresContainer(ctx, t)
+		require.NoError(t, err)
+		defer container.Cleanup(ctx)
+		pool := container.DB.Pool()
+
+		// Two consecutive RunMigrations calls must not duplicate the
+		// admin group in group_ids - DISTINCT(unnest(...)) dedupes
+		// and the WHERE clause skips already-populated rows.
+		require.NoError(t, migrations.RunMigrations(ctx, pool, migrationsPath, adminEmail, ""))
+		require.NoError(t, migrations.RunMigrations(ctx, pool, migrationsPath, adminEmail, ""))
+
+		got := queryAdminGroupIDs(t, ctx, pool, adminEmail)
+		assert.Equal(t, []string{defaultAdminGroupIDTest}, got,
+			"calling RunMigrations twice must not duplicate the admin group ID")
+		assert.Len(t, got, 1, "group_ids must contain exactly one entry after two runs")
+	})
+
+	t.Run("operator customisation preserved", func(t *testing.T) {
+		container, err := testhelpers.SetupPostgresContainer(ctx, t)
+		require.NoError(t, err)
+		defer container.Cleanup(ctx)
+		pool := container.DB.Pool()
+
+		// First pass: create the admin via the normal path.
+		require.NoError(t, migrations.RunMigrations(ctx, pool, migrationsPath, adminEmail, ""))
+
+		// Simulate an operator who deliberately scoped this admin to a
+		// custom group only - removing the default Administrators
+		// group. The backfill must NOT undo this customisation on
+		// subsequent boots (issue body: "leave existing group_ids
+		// alone").
+		const customGroupID = "11111111-1111-5111-8111-111111111111"
+		_, err = pool.Exec(ctx, `
+			INSERT INTO groups (id, name, description, permissions, allowed_accounts)
+			VALUES ($1::UUID, 'OperatorCustom', 'test', '[]'::jsonb, ARRAY['*'])
+			ON CONFLICT DO NOTHING
+		`, customGroupID)
+		require.NoError(t, err)
+
+		_, err = pool.Exec(ctx, `
+			UPDATE users SET group_ids = ARRAY[$1]::UUID[]
+			WHERE email = $2 AND role = 'admin'
+		`, customGroupID, adminEmail)
+		require.NoError(t, err)
+
+		// Second pass: re-run RunMigrations. ensureAdminUser fires
+		// again, but the backfill's WHERE cardinality=0 clause skips
+		// the customised row.
+		require.NoError(t, migrations.RunMigrations(ctx, pool, migrationsPath, adminEmail, ""))
+
+		got := queryAdminGroupIDs(t, ctx, pool, adminEmail)
+		assert.Equal(t, []string{customGroupID}, got,
+			"operator-customised group_ids (non-empty, no default admin group) must be preserved across boots")
+	})
+}

--- a/internal/database/postgres/migrations/migrate.go
+++ b/internal/database/postgres/migrations/migrate.go
@@ -18,6 +18,15 @@ import (
 // bcryptCost matches the cost used in internal/auth/service_password.go
 const bcryptCost = 12
 
+// defaultAdminGroupID is the fixed UUID of the Administrators group
+// seeded by migration 000024_seed_default_groups.up.sql. Duplicated
+// here as a literal (rather than imported from internal/auth) because
+// the migrations package must not depend on the auth package -
+// auth depends on the DB, not the reverse. Keep in sync with
+// auth.DefaultAdminGroupID (internal/auth/types.go) and the literal
+// inside the 000024 migration SQL.
+const defaultAdminGroupID = "00000000-0000-5000-8000-000000000001"
+
 // RunMigrations runs database migrations using golang-migrate
 // adminEmail is optional - if provided, admin user will be created after migrations complete
 // adminPassword is optional - if provided, admin is created with hashed password and active=true
@@ -74,6 +83,13 @@ func RunMigrations(ctx context.Context, pool *pgxpool.Pool, migrationsPath strin
 // ensureAdminUser creates the admin user if it doesn't exist.
 // When password is provided, the admin is created with a bcrypt-hashed password and active=true.
 // When password is empty, the admin is created inactive and must use password reset to log in.
+//
+// The INSERT seeds group_ids with the Administrators group so the user
+// has full group-based permissions from the first boot. After the
+// insert, assignAdminGroupAndWarn runs an idempotent backfill on any
+// admin row whose group_ids drifted to empty (e.g. from an out-of-band
+// manual DB seed), and warns operators if the drift cannot be repaired
+// (e.g. groups table not yet populated). See issue #351.
 func ensureAdminUser(ctx context.Context, pool *pgxpool.Pool, email string, password string) error {
 	if password != "" {
 		return ensureAdminUserWithPassword(ctx, pool, email, password)
@@ -81,16 +97,18 @@ func ensureAdminUser(ctx context.Context, pool *pgxpool.Pool, email string, pass
 
 	fmt.Printf("Ensuring admin user exists: %s (user will need to reset password to login)\n", email)
 
-	// Create admin user with no password - account is inactive until password is set via reset flow
-	// Use ON CONFLICT to prevent race conditions when multiple instances run migrations
+	// Create admin user with no password - account is inactive until password is set via reset flow.
+	// Use ON CONFLICT to prevent race conditions when multiple instances run migrations.
+	// group_ids is seeded with the Administrators group so a fresh bootstrap admin
+	// has group-based permissions from the start (issue #351).
 	result, err := pool.Exec(ctx, `
 		INSERT INTO users (
-			id, email, password_hash, salt, role, active, created_at, updated_at
+			id, email, password_hash, salt, role, active, group_ids, created_at, updated_at
 		) VALUES (
-			gen_random_uuid(), $1, '', '', 'admin', false, NOW(), NOW()
+			gen_random_uuid(), $1, '', '', 'admin', false, ARRAY[$2]::UUID[], NOW(), NOW()
 		)
 		ON CONFLICT (email) DO NOTHING
-	`, email)
+	`, email, defaultAdminGroupID)
 
 	if err != nil {
 		return fmt.Errorf("failed to insert admin user: %w", err)
@@ -101,11 +119,25 @@ func ensureAdminUser(ctx context.Context, pool *pgxpool.Pool, email string, pass
 	} else {
 		fmt.Printf("Admin user already exists: %s\n", email)
 	}
+
+	// Idempotent backfill + invariant check on any pre-existing admin
+	// row whose group_ids drifted to empty after migration 000024's
+	// one-shot backfill already ran.
+	if err := assignAdminGroupAndWarn(ctx, pool, defaultAdminGroupID); err != nil {
+		return fmt.Errorf("failed to assign admin group: %w", err)
+	}
 	return nil
 }
 
 // ensureAdminUserWithPassword creates or updates the admin with a hashed password and active=true.
 // If the admin already exists with an empty password_hash, the password and active flag are updated.
+//
+// The INSERT seeds group_ids with the Administrators group so the user
+// has full group-based permissions from the first boot. The DO UPDATE
+// clause is deliberately NOT extended to touch group_ids - the
+// post-insert assignAdminGroupAndWarn handles drift uniformly without
+// coupling that semantics to the password-empty WHERE clause. See
+// issue #351.
 func ensureAdminUserWithPassword(ctx context.Context, pool *pgxpool.Pool, email string, password string) error {
 	fmt.Printf("Ensuring admin user exists with password: %s\n", email)
 
@@ -117,16 +149,17 @@ func ensureAdminUserWithPassword(ctx context.Context, pool *pgxpool.Pool, email 
 	// Insert new admin or update existing one that has no password set yet.
 	// Only overwrite password_hash/active when the existing hash is empty,
 	// so we never clobber a password that was already set via the UI.
+	// group_ids is seeded with the Administrators group on insert (issue #351).
 	result, err := pool.Exec(ctx, `
 		INSERT INTO users (
-			id, email, password_hash, salt, role, active, created_at, updated_at
+			id, email, password_hash, salt, role, active, group_ids, created_at, updated_at
 		) VALUES (
-			gen_random_uuid(), $1, $2, '', 'admin', true, NOW(), NOW()
+			gen_random_uuid(), $1, $2, '', 'admin', true, ARRAY[$3]::UUID[], NOW(), NOW()
 		)
 		ON CONFLICT (email) DO UPDATE
 			SET password_hash = $2, active = true, updated_at = NOW()
 			WHERE users.password_hash = ''
-	`, email, string(hashedPassword))
+	`, email, string(hashedPassword), defaultAdminGroupID)
 
 	if err != nil {
 		return fmt.Errorf("failed to upsert admin user: %w", err)
@@ -136,6 +169,63 @@ func ensureAdminUserWithPassword(ctx context.Context, pool *pgxpool.Pool, email 
 		fmt.Printf("Admin user created/activated with password: %s\n", email)
 	} else {
 		fmt.Printf("Admin user already has a password set: %s (skipping)\n", email)
+	}
+
+	// Idempotent backfill + invariant check on any pre-existing admin
+	// row whose group_ids drifted to empty after migration 000024's
+	// one-shot backfill already ran.
+	if err := assignAdminGroupAndWarn(ctx, pool, defaultAdminGroupID); err != nil {
+		return fmt.Errorf("failed to assign admin group: %w", err)
+	}
+	return nil
+}
+
+// assignAdminGroupAndWarn runs an idempotent backfill that appends
+// groupID to any admin row whose group_ids is empty (NULL or
+// zero-length). The DISTINCT(unnest(...)) dedupe makes the UPDATE
+// safe to run repeatedly. After the backfill, a defensive SELECT
+// counts any admin rows still showing empty group_ids and logs a
+// WARN so operators see drift in container logs rather than only via
+// a broken UI. This is the "defence-in-depth invariant" described
+// in issue #351.
+//
+// The EXISTS guard on the groups table makes the backfill a no-op
+// when migration 000024 hasn't yet seeded the Administrators group -
+// defence-in-depth, since in practice this function is invoked
+// after RunMigrations -> m.Up() completes.
+func assignAdminGroupAndWarn(ctx context.Context, pool *pgxpool.Pool, groupID string) error {
+	res, err := pool.Exec(ctx, `
+		UPDATE users
+		SET group_ids = ARRAY(
+			SELECT DISTINCT unnest(
+				COALESCE(group_ids, '{}') || ARRAY[$1]::UUID[]
+			)
+		),
+			updated_at = NOW()
+		WHERE role = 'admin'
+		  AND (group_ids IS NULL OR cardinality(group_ids) = 0)
+		  AND EXISTS (SELECT 1 FROM groups WHERE id = $1::UUID)
+	`, groupID)
+	if err != nil {
+		return fmt.Errorf("failed to backfill admin group_ids: %w", err)
+	}
+	if n := res.RowsAffected(); n > 0 {
+		fmt.Printf("Backfilled group_ids for %d admin user(s) to include Administrators group\n", n)
+	}
+
+	// Invariant check: any admin still missing group_ids after the
+	// backfill (e.g. EXISTS guard failed because the Administrators
+	// group is missing) is logged loudly so operators notice.
+	var remaining int
+	if err := pool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM users
+		WHERE role = 'admin'
+		  AND (group_ids IS NULL OR cardinality(group_ids) = 0)
+	`).Scan(&remaining); err != nil {
+		return fmt.Errorf("failed to check admin group_ids invariant: %w", err)
+	}
+	if remaining > 0 {
+		log.Printf("WARN: %d admin user(s) have empty group_ids and the Administrators group could not be assigned. Permissions may not work as expected. Check that migration 000024_seed_default_groups has run successfully.", remaining)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Closes #351.

`ensureAdminUser` and `ensureAdminUserWithPassword`
(`internal/database/postgres/migrations/migrate.go`) insert admin
rows without populating `group_ids`. A bootstrap admin (via
`ADMIN_EMAIL` + `ADMIN_PASSWORD_SECRET`) ended up with
`role='admin'` but empty `group_ids`, so the permissions system saw
no group memberships and group-based features broke.

Migration `000024_seed_default_groups` already backfills existing
admins at migration time, but it runs only once. The bootstrap path
fires on every container boot, AFTER migrations are at head, so any
admin inserted by `ensureAdminUser` bypassed the backfill entirely.

### What changed

- Both `ensureAdminUser` variants now seed `group_ids` with the
  Administrators group UUID on `INSERT`. `ON CONFLICT (email) DO NOTHING`
  / `DO UPDATE WHERE password_hash = ''` semantics are preserved so
  an operator's customised `group_ids` is never overwritten.
- New helper `assignAdminGroupAndWarn` runs an idempotent backfill
  on any admin row whose `group_ids` drifted to empty. The
  `DISTINCT(unnest(...))` dedupe makes the UPDATE safe to run on
  every boot. Operator customisation (non-empty `group_ids` that
  deliberately omits the default admin group) is preserved via the
  `cardinality(group_ids) = 0` guard.
- After the backfill, a defensive `SELECT` counts admins still
  showing empty `group_ids` and logs a `WARN` so operators see
  drift in container logs rather than only via a broken UI. This
  is the "defence-in-depth invariant" described in the issue body.

### Notes

- `defaultAdminGroupID` is duplicated as a package-private literal
  in `migrate.go` rather than imported from `internal/auth`, because
  the migrations package must not depend on the auth package
  (`auth` depends on the DB, not the reverse). Kept in sync with
  `auth.DefaultAdminGroupID` and the literal in the `000024`
  migration via cross-referencing comments.
- The `DO UPDATE` clause in `ensureAdminUserWithPassword` is
  deliberately NOT extended to touch `group_ids` - the post-insert
  `assignAdminGroupAndWarn` handles drift uniformly without
  coupling that semantics to the password-empty `WHERE` clause.

## Test plan

Integration test `ensure_admin_user_test.go` (build tag
`integration`) covers five sub-cases against a `postgres:16-alpine`
testcontainer:

- [x] Fresh insert (no-password): admin has
      `group_ids = [DefaultAdminGroupID]`.
- [x] Fresh insert (with-password): same.
- [x] Post-migration drift repair: simulate an admin inserted
      out-of-band with empty `group_ids`, run `RunMigrations` again,
      assert the row self-heals.
- [x] Idempotency: two consecutive `RunMigrations` calls do not
      duplicate the admin group ID.
- [x] Operator customisation preserved: admin manually scoped to a
      custom group (deliberately removing the default admin group)
      survives subsequent boots unchanged.

All five pass locally:

```
=== RUN   TestEnsureAdminUser_GroupAssignment
--- PASS: TestEnsureAdminUser_GroupAssignment (... fresh insert no password / with password / post-migration drift repair / idempotency / operator customisation preserved)
ok  ...migrations  (integration tag)
```

`go build ./...` and `go vet ./...` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive integration test for admin user group assignment validation across multiple scenarios, including fresh installations, self-healing of misconfigured records, duplicate prevention, and custom configuration preservation.

* **Bug Fixes**
  * Improved admin user group assignment consistency with automatic self-healing for any pre-existing admin records with missing group membership.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/393)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->