### PR TITLE
feat(settings): inline edit Term/Coverage + Enabled toggle on override rows (closes #110)

### DIFF
--- a/frontend/src/__tests__/settings-accounts.test.ts
+++ b/frontend/src/__tests__/settings-accounts.test.ts
@@ -662,6 +662,300 @@ describe('Overrides panel — AWS payment selector', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Inline edit on existing override rows: Term, Coverage, Enabled (issue #110)
+// ---------------------------------------------------------------------------
+
+describe('Overrides panel: inline Term/Coverage/Enabled (issue #110)', () => {
+  /**
+   * Render the AWS accounts list and open the per-account overrides modal,
+   * mirroring openOverridesPanel from the Payment-selector describe block.
+   * The body element is what loadOverridesPanel renders into.
+   */
+  async function openOverridesPanel(accountId = 'acc-1'): Promise<HTMLElement> {
+    (api.listAccounts as jest.Mock).mockResolvedValue([
+      { id: accountId, name: 'Prod', provider: 'aws', external_id: '111', enabled: true },
+    ]);
+    await loadAccountsForProvider('aws');
+    const overridesBtn = document.querySelector(
+      `button[aria-label="Service overrides for Prod (111)"]`,
+    ) as HTMLButtonElement | null;
+    expect(overridesBtn).not.toBeNull();
+    overridesBtn!.click();
+    await new Promise(r => setTimeout(r, 0));
+    const panel = document.getElementById('account-overrides-modal-body') as HTMLElement | null;
+    expect(panel).not.toBeNull();
+    return panel!;
+  }
+
+  beforeEach(() => {
+    buildAccountsDOM();
+    jest.clearAllMocks();
+  });
+
+  // ----- Term cell -----
+
+  test('Term: renders <select> with Inherit + 1yr/3yr options for an AWS EC2 row', async () => {
+    (api.listAccountServiceOverrides as jest.Mock).mockResolvedValue([
+      { id: 'o1', account_id: 'acc-1', provider: 'aws', service: 'ec2' },
+    ]);
+
+    const panel = await openOverridesPanel('acc-1');
+    const sel = panel.querySelector('select.override-term-select') as HTMLSelectElement | null;
+    expect(sel).not.toBeNull();
+    const values = Array.from(sel!.options).map(o => o.value);
+    expect(values).toEqual(['', '1', '3']);
+    expect(sel!.value).toBe(''); // Inherit by default when no term set
+    expect(sel!.options[0]!.disabled).toBe(false);
+  });
+
+  test('Term: change from Inherit calls saveAccountServiceOverride with only {term}', async () => {
+    (api.listAccountServiceOverrides as jest.Mock).mockResolvedValue([
+      { id: 'o1', account_id: 'acc-1', provider: 'aws', service: 'ec2' },
+    ]);
+    (api.saveAccountServiceOverride as jest.Mock).mockResolvedValue({
+      id: 'o1', account_id: 'acc-1', provider: 'aws', service: 'ec2', term: 3,
+    });
+
+    const panel = await openOverridesPanel('acc-1');
+    const sel = panel.querySelector('select.override-term-select') as HTMLSelectElement;
+    sel.value = '3';
+    sel.dispatchEvent(new Event('change'));
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(api.saveAccountServiceOverride).toHaveBeenCalledTimes(1);
+    expect(api.saveAccountServiceOverride).toHaveBeenCalledWith(
+      'acc-1', 'aws', 'ec2', { term: 3 },
+    );
+  });
+
+  test('Term: RDS row with payment=no-upfront hides term=3 (commitmentOptions parity)', async () => {
+    // RDS has the only AWS hard rule: no 3yr/no-upfront combination. The
+    // Term dropdown for an RDS row currently set to no-upfront must omit
+    // the 3yr option, same way the inline Payment selector omits no-upfront
+    // for RDS term=3 rows.
+    (api.listAccountServiceOverrides as jest.Mock).mockResolvedValue([
+      { id: 'o1', account_id: 'acc-1', provider: 'aws', service: 'rds', payment: 'no-upfront' },
+    ]);
+
+    const panel = await openOverridesPanel('acc-1');
+    const sel = panel.querySelector('select.override-term-select') as HTMLSelectElement;
+    const values = Array.from(sel.options).map(o => o.value);
+    expect(values).toEqual(['', '1']);
+    expect(values).not.toContain('3');
+  });
+
+  test('Term: Inherit is disabled when term already set (no clear-field channel)', async () => {
+    (api.listAccountServiceOverrides as jest.Mock).mockResolvedValue([
+      { id: 'o1', account_id: 'acc-1', provider: 'aws', service: 'ec2', term: 1 },
+    ]);
+
+    const panel = await openOverridesPanel('acc-1');
+    const sel = panel.querySelector('select.override-term-select') as HTMLSelectElement;
+    expect(sel.value).toBe('1');
+    expect(sel.options[0]!.disabled).toBe(true);
+    expect(api.saveAccountServiceOverride).not.toHaveBeenCalled();
+  });
+
+  test('Term: save failure reverts the cell and shows an error toast', async () => {
+    (api.listAccountServiceOverrides as jest.Mock).mockResolvedValue([
+      { id: 'o1', account_id: 'acc-1', provider: 'aws', service: 'ec2' },
+    ]);
+    (api.saveAccountServiceOverride as jest.Mock).mockRejectedValueOnce(new Error('boom'));
+
+    const panel = await openOverridesPanel('acc-1');
+    const sel = panel.querySelector('select.override-term-select') as HTMLSelectElement;
+    sel.value = '3';
+    sel.dispatchEvent(new Event('change'));
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(sel.value).toBe(''); // reverted to previous
+    const toastCalls = mockShowToast.mock.calls.map(c => c[0]) as Array<{ kind?: string; message?: string }>;
+    expect(toastCalls.some(t => t.kind === 'error' && t.message?.includes('term'))).toBe(true);
+  });
+
+  // ----- Coverage cell -----
+
+  test('Coverage: renders numeric <input> with value=50 for preset, placeholder when absent', async () => {
+    (api.listAccountServiceOverrides as jest.Mock).mockResolvedValue([
+      { id: 'o1', account_id: 'acc-1', provider: 'aws', service: 'ec2', coverage: 50 },
+      { id: 'o2', account_id: 'acc-1', provider: 'aws', service: 'rds' },
+    ]);
+
+    const panel = await openOverridesPanel('acc-1');
+    const inputs = panel.querySelectorAll<HTMLInputElement>('input.override-coverage-input');
+    expect(inputs.length).toBe(2);
+    expect(inputs[0]!.type).toBe('number');
+    expect(inputs[0]!.value).toBe('50');
+    expect(inputs[1]!.value).toBe('');
+    expect(inputs[1]!.placeholder).toBe('Inherit');
+  });
+
+  test('Coverage: change to 75 calls saveAccountServiceOverride with only {coverage: 75}', async () => {
+    (api.listAccountServiceOverrides as jest.Mock).mockResolvedValue([
+      { id: 'o1', account_id: 'acc-1', provider: 'aws', service: 'ec2', coverage: 50 },
+    ]);
+    (api.saveAccountServiceOverride as jest.Mock).mockResolvedValue({
+      id: 'o1', account_id: 'acc-1', provider: 'aws', service: 'ec2', coverage: 75,
+    });
+
+    const panel = await openOverridesPanel('acc-1');
+    const inp = panel.querySelector('input.override-coverage-input') as HTMLInputElement;
+    inp.value = '75';
+    inp.dispatchEvent(new Event('change'));
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(api.saveAccountServiceOverride).toHaveBeenCalledTimes(1);
+    expect(api.saveAccountServiceOverride).toHaveBeenCalledWith(
+      'acc-1', 'aws', 'ec2', { coverage: 75 },
+    );
+  });
+
+  test('Coverage: out-of-range value (150) does NOT call save, reverts, and posts error toast', async () => {
+    (api.listAccountServiceOverrides as jest.Mock).mockResolvedValue([
+      { id: 'o1', account_id: 'acc-1', provider: 'aws', service: 'ec2', coverage: 50 },
+    ]);
+
+    const panel = await openOverridesPanel('acc-1');
+    const inp = panel.querySelector('input.override-coverage-input') as HTMLInputElement;
+    inp.value = '150';
+    inp.dispatchEvent(new Event('change'));
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(api.saveAccountServiceOverride).not.toHaveBeenCalled();
+    expect(inp.value).toBe('50');
+    const toastCalls = mockShowToast.mock.calls.map(c => c[0]) as Array<{ kind?: string; message?: string }>;
+    expect(toastCalls.some(t => t.kind === 'error' && t.message?.includes('between 0 and 100'))).toBe(true);
+  });
+
+  test('Coverage: negative value does NOT call save, reverts, and posts error toast', async () => {
+    (api.listAccountServiceOverrides as jest.Mock).mockResolvedValue([
+      { id: 'o1', account_id: 'acc-1', provider: 'aws', service: 'ec2', coverage: 50 },
+    ]);
+
+    const panel = await openOverridesPanel('acc-1');
+    const inp = panel.querySelector('input.override-coverage-input') as HTMLInputElement;
+    inp.value = '-5';
+    inp.dispatchEvent(new Event('change'));
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(api.saveAccountServiceOverride).not.toHaveBeenCalled();
+    expect(inp.value).toBe('50');
+  });
+
+  test('Coverage: clearing a preset value reverts (no clear-field channel) and posts info toast', async () => {
+    (api.listAccountServiceOverrides as jest.Mock).mockResolvedValue([
+      { id: 'o1', account_id: 'acc-1', provider: 'aws', service: 'ec2', coverage: 50 },
+    ]);
+
+    const panel = await openOverridesPanel('acc-1');
+    const inp = panel.querySelector('input.override-coverage-input') as HTMLInputElement;
+    inp.value = '';
+    inp.dispatchEvent(new Event('change'));
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(api.saveAccountServiceOverride).not.toHaveBeenCalled();
+    expect(inp.value).toBe('50');
+    const toastCalls = mockShowToast.mock.calls.map(c => c[0]) as Array<{ kind?: string; message?: string }>;
+    expect(toastCalls.some(t => t.kind === 'info' && t.message?.includes('Delete'))).toBe(true);
+  });
+
+  // ----- Enabled toggle -----
+
+  test('Enabled: checkbox is checked by default for legacy rows (enabled === undefined)', async () => {
+    (api.listAccountServiceOverrides as jest.Mock).mockResolvedValue([
+      { id: 'o1', account_id: 'acc-1', provider: 'aws', service: 'ec2' },
+    ]);
+
+    const panel = await openOverridesPanel('acc-1');
+    const cb = panel.querySelector('input.override-enabled-toggle') as HTMLInputElement;
+    expect(cb).not.toBeNull();
+    expect(cb.type).toBe('checkbox');
+    expect(cb.checked).toBe(true);
+    const tr = cb.closest('tr')!;
+    expect(tr.classList.contains('override-disabled')).toBe(false);
+  });
+
+  test('Enabled: rows with enabled=false render unchecked with .override-disabled dim', async () => {
+    (api.listAccountServiceOverrides as jest.Mock).mockResolvedValue([
+      { id: 'o1', account_id: 'acc-1', provider: 'aws', service: 'ec2', enabled: false },
+    ]);
+
+    const panel = await openOverridesPanel('acc-1');
+    const cb = panel.querySelector('input.override-enabled-toggle') as HTMLInputElement;
+    expect(cb.checked).toBe(false);
+    const tr = cb.closest('tr')!;
+    expect(tr.classList.contains('override-disabled')).toBe(true);
+  });
+
+  test('Enabled: toggle off calls save with {enabled: false} and dims the row', async () => {
+    (api.listAccountServiceOverrides as jest.Mock).mockResolvedValue([
+      { id: 'o1', account_id: 'acc-1', provider: 'aws', service: 'ec2' },
+    ]);
+    (api.saveAccountServiceOverride as jest.Mock).mockResolvedValue({
+      id: 'o1', account_id: 'acc-1', provider: 'aws', service: 'ec2', enabled: false,
+    });
+
+    const panel = await openOverridesPanel('acc-1');
+    const cb = panel.querySelector('input.override-enabled-toggle') as HTMLInputElement;
+    const tr = cb.closest('tr')!;
+    cb.checked = false;
+    cb.dispatchEvent(new Event('change'));
+    // After the optimistic visual update, the row should already be dimmed
+    // even before the network roundtrip completes.
+    expect(tr.classList.contains('override-disabled')).toBe(true);
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(api.saveAccountServiceOverride).toHaveBeenCalledTimes(1);
+    expect(api.saveAccountServiceOverride).toHaveBeenCalledWith(
+      'acc-1', 'aws', 'ec2', { enabled: false },
+    );
+  });
+
+  test('Enabled: toggle on calls save with {enabled: true} and removes dim', async () => {
+    (api.listAccountServiceOverrides as jest.Mock).mockResolvedValue([
+      { id: 'o1', account_id: 'acc-1', provider: 'aws', service: 'ec2', enabled: false },
+    ]);
+    (api.saveAccountServiceOverride as jest.Mock).mockResolvedValue({
+      id: 'o1', account_id: 'acc-1', provider: 'aws', service: 'ec2', enabled: true,
+    });
+
+    const panel = await openOverridesPanel('acc-1');
+    const cb = panel.querySelector('input.override-enabled-toggle') as HTMLInputElement;
+    const tr = cb.closest('tr')!;
+    expect(tr.classList.contains('override-disabled')).toBe(true);
+    cb.checked = true;
+    cb.dispatchEvent(new Event('change'));
+    expect(tr.classList.contains('override-disabled')).toBe(false);
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(api.saveAccountServiceOverride).toHaveBeenCalledTimes(1);
+    expect(api.saveAccountServiceOverride).toHaveBeenCalledWith(
+      'acc-1', 'aws', 'ec2', { enabled: true },
+    );
+  });
+
+  // ----- Non-AWS rows -----
+
+  test('Non-AWS rows: term/coverage render as text, enabled checkbox is disabled with tooltip', async () => {
+    (api.listAccountServiceOverrides as jest.Mock).mockResolvedValue([
+      { id: 'o1', account_id: 'acc-1', provider: 'azure', service: 'vm', term: 1, coverage: 80 },
+    ]);
+
+    const panel = await openOverridesPanel('acc-1');
+    expect(panel.querySelector('select.override-term-select')).toBeNull();
+    expect(panel.querySelector('input.override-coverage-input')).toBeNull();
+    const cb = panel.querySelector('input.override-enabled-toggle') as HTMLInputElement;
+    expect(cb).not.toBeNull();
+    expect(cb.disabled).toBe(true);
+    expect(cb.title).toContain('AWS-only');
+    // Read-only fallbacks for term and coverage on non-AWS rows.
+    expect(panel.textContent).toContain('1yr');
+    expect(panel.textContent).toContain('80%');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Override creation modal — issue #104
 // ---------------------------------------------------------------------------
 

--- a/frontend/src/settings.ts
+++ b/frontend/src/settings.ts
@@ -9,7 +9,7 @@ import { initFederationPanel } from './federation';
 import { confirmDialog } from './confirmDialog';
 import { reflectDirtyState } from './settings-subnav';
 import { showToast } from './toast';
-import { isValidCombination, getValidPaymentOptions, getPaymentLabel } from './commitmentOptions';
+import { isValidCombination, getValidPaymentOptions, getValidTermOptions, getPaymentLabel } from './commitmentOptions';
 import { openModal, closeModal } from './modal';
 import { loadRecommendations } from './recommendations';
 
@@ -635,6 +635,306 @@ async function handlePaymentOverrideChange(
 }
 
 /**
+ * Build the per-row Term <select> for the overrides panel. Issue #110.
+ *
+ * Mirrors buildPaymentOverrideSelect (#23) verbatim: Inherit option +
+ * provider/service-specific valid options + sparse PUT on change. The
+ * options are filtered by the row's CURRENT payment via
+ * `getValidTermOptions('aws', service, payment)`, so an RDS row with
+ * payment=no-upfront does not list term=3 (the one hard AWS rule per
+ * commitmentOptions.ts).
+ *
+ * When `term` is already set on the row, the Inherit option is disabled
+ * for the same reason as Payment's Inherit: the backend has no
+ * clear-field channel, so reverting to "no term" would require Delete.
+ */
+function buildTermOverrideSelect(
+  accountId: string,
+  override: api.AccountServiceOverride,
+  panel: HTMLElement,
+): HTMLSelectElement {
+  const select = document.createElement('select');
+  select.className = 'override-term-select';
+  select.setAttribute(
+    'aria-label',
+    `Term for ${override.provider}/${override.service} override`,
+  );
+
+  const inheritOpt = document.createElement('option');
+  inheritOpt.value = '';
+  inheritOpt.textContent = 'Inherit (default)';
+  select.appendChild(inheritOpt);
+
+  // Filter the term dropdown to the (term, payment) combinations AWS
+  // supports for THIS service given the row's CURRENT payment. e.g. an
+  // RDS row with payment=no-upfront cannot upgrade to term=3.
+  // When payment is unset, getValidTermOptions falls back to the
+  // service's full term list (the underlying `getValidTermOptions`
+  // returns all terms whose invalidCombinations don't match the given
+  // payment; with payment='' nothing matches, so all terms are valid).
+  const currentPayment = override.payment ?? '';
+  const validTerms = getValidTermOptions(override.provider, override.service, currentPayment);
+
+  for (const { value, label } of validTerms) {
+    const opt = document.createElement('option');
+    opt.value = String(value);
+    opt.textContent = label;
+    select.appendChild(opt);
+  }
+
+  const initial = override.term !== undefined && override.term > 0 ? String(override.term) : '';
+
+  // If the row's CURRENT term isn't in the valid set (e.g., the row was
+  // saved before the filter shipped, or AWS tightened the rules), still
+  // render the current value so the row isn't silently mutated, but
+  // mark it as a problem.
+  const currentIsValid = initial === '' || validTerms.some(t => String(t.value) === initial);
+  if (!currentIsValid) {
+    const stale = document.createElement('option');
+    stale.value = initial;
+    stale.textContent = `${initial}yr (invalid for current payment — Delete the override and recreate)`;
+    stale.dataset['stale'] = 'true';
+    select.appendChild(stale);
+  }
+
+  select.value = initial;
+  select.dataset['previous'] = initial;
+
+  // If a term is already set, "Inherit" is not a clean transition (the
+  // backend has no clear-field channel). Same rationale as Payment.
+  if (initial !== '') {
+    inheritOpt.disabled = true;
+    inheritOpt.title = 'Use Delete to remove the override entirely (clears all fields including term)';
+  }
+
+  select.addEventListener('change', () => {
+    void handleTermOverrideChange(accountId, override, select, panel);
+  });
+
+  return select;
+}
+
+async function handleTermOverrideChange(
+  accountId: string,
+  override: api.AccountServiceOverride,
+  select: HTMLSelectElement,
+  panel: HTMLElement,
+): Promise<void> {
+  const previous = select.dataset['previous'] ?? '';
+  const next = select.value;
+  if (next === previous) return;
+  if (next === '') {
+    // Reverting to Inherit while a term is set is blocked above; defensive
+    // no-op here keeps types narrow if the option becomes selectable later.
+    select.value = previous;
+    return;
+  }
+  const termNum = parseInt(next, 10);
+  if (Number.isNaN(termNum)) {
+    select.value = previous;
+    return;
+  }
+  select.disabled = true;
+  try {
+    await api.saveAccountServiceOverride(accountId, override.provider, override.service, {
+      term: termNum,
+    });
+    select.dataset['previous'] = next;
+    showToast({
+      message: `Term override updated for ${override.provider}/${override.service}.`,
+      kind: 'success',
+    });
+    await loadOverridesPanel(accountId, panel, override.provider as AccountProvider);
+    await refreshRecommendationsAfterOverrideChange();
+  } catch (err) {
+    select.value = previous;
+    showToast({
+      message: `Failed to update term override: ${(err as Error).message}`,
+      kind: 'error',
+    });
+  } finally {
+    select.disabled = false;
+  }
+}
+
+/**
+ * Build the per-row Coverage <input> for the overrides panel. Issue #110.
+ *
+ * Numeric input bound to the row's coverage % (0–100, integer). PUT
+ * fires on the 'change' event (blur or Enter), not 'input', so we don't
+ * issue one PUT per keystroke. Out-of-range or non-numeric input
+ * reverts to the previous value with an error toast.
+ *
+ * Empty value when no coverage is set: placeholder shows "Inherit".
+ * Clearing a previously-set value reverts (same no-clear-field
+ * rationale as Term and Payment).
+ */
+function buildCoverageOverrideInput(
+  accountId: string,
+  override: api.AccountServiceOverride,
+  panel: HTMLElement,
+): HTMLInputElement {
+  const input = document.createElement('input');
+  input.type = 'number';
+  input.min = '0';
+  input.max = '100';
+  input.step = '1';
+  input.className = 'override-coverage-input';
+  input.setAttribute(
+    'aria-label',
+    `Coverage for ${override.provider}/${override.service} override`,
+  );
+
+  const initial = override.coverage !== undefined ? String(override.coverage) : '';
+  input.value = initial;
+  input.dataset['previous'] = initial;
+  if (initial === '') {
+    input.placeholder = 'Inherit';
+  }
+
+  input.addEventListener('change', () => {
+    void handleCoverageOverrideChange(accountId, override, input, panel);
+  });
+
+  return input;
+}
+
+async function handleCoverageOverrideChange(
+  accountId: string,
+  override: api.AccountServiceOverride,
+  input: HTMLInputElement,
+  panel: HTMLElement,
+): Promise<void> {
+  const previous = input.dataset['previous'] ?? '';
+  const raw = input.value.trim();
+  if (raw === previous) return;
+  if (raw === '') {
+    // No clear-field channel — clearing a coverage value would leave the
+    // override row in a no-op state. Revert and tell the user.
+    input.value = previous;
+    showToast({
+      message: 'Use Delete to remove the override entirely (clears all fields including coverage).',
+      kind: 'info',
+    });
+    return;
+  }
+  const n = Number(raw);
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n < 0 || n > 100) {
+    input.value = previous;
+    showToast({
+      message: 'Coverage must be an integer between 0 and 100.',
+      kind: 'error',
+    });
+    return;
+  }
+  input.disabled = true;
+  try {
+    await api.saveAccountServiceOverride(accountId, override.provider, override.service, {
+      coverage: n,
+    });
+    input.dataset['previous'] = String(n);
+    showToast({
+      message: `Coverage override updated for ${override.provider}/${override.service}.`,
+      kind: 'success',
+    });
+    await loadOverridesPanel(accountId, panel, override.provider as AccountProvider);
+    await refreshRecommendationsAfterOverrideChange();
+  } catch (err) {
+    input.value = previous;
+    showToast({
+      message: `Failed to update coverage override: ${(err as Error).message}`,
+      kind: 'error',
+    });
+  } finally {
+    input.disabled = false;
+  }
+}
+
+/**
+ * Build the per-row Enabled checkbox for the overrides panel. Issue #110.
+ *
+ * Toggles the `enabled` column on `account_service_overrides`. When
+ * unchecked, the override row exists but does not influence
+ * recommendations (the backend's read path filters by `enabled`). The
+ * UI dims the row to make the inactive state obvious.
+ *
+ * Default state: an override with `enabled === undefined` (legacy rows,
+ * or rows never explicitly toggled) is treated as ACTIVE. Only explicit
+ * `enabled: false` renders as unchecked.
+ *
+ * Non-AWS rows render the checkbox disabled with an explanatory tooltip
+ * to preserve column alignment between provider types — Azure/GCP
+ * editing is tracked separately under the provider-aware modal work.
+ */
+function buildEnabledOverrideCheckbox(
+  accountId: string,
+  override: api.AccountServiceOverride,
+  panel: HTMLElement,
+  row: HTMLTableRowElement,
+): HTMLInputElement {
+  const input = document.createElement('input');
+  input.type = 'checkbox';
+  input.className = 'override-enabled-toggle';
+  input.checked = override.enabled !== false;
+  input.dataset['previous'] = input.checked ? 'true' : 'false';
+  input.setAttribute(
+    'aria-label',
+    `Enable ${override.provider}/${override.service} override`,
+  );
+
+  if (override.provider !== 'aws') {
+    input.disabled = true;
+    input.title = 'Per-provider override editing is AWS-only — Azure/GCP coming with the provider-aware modal';
+    return input;
+  }
+
+  input.addEventListener('change', () => {
+    void handleEnabledOverrideChange(accountId, override, input, panel, row);
+  });
+
+  return input;
+}
+
+async function handleEnabledOverrideChange(
+  accountId: string,
+  override: api.AccountServiceOverride,
+  input: HTMLInputElement,
+  panel: HTMLElement,
+  row: HTMLTableRowElement,
+): Promise<void> {
+  const next = input.checked;
+  const previousStr = input.dataset['previous'] ?? 'true';
+  const previous = previousStr === 'true';
+  if (next === previous) return;
+  input.disabled = true;
+  // Optimistically reflect the new state in the row's visual treatment
+  // so the user sees feedback before the network round-trip completes;
+  // we revert on error below.
+  row.classList.toggle('override-disabled', !next);
+  try {
+    await api.saveAccountServiceOverride(accountId, override.provider, override.service, {
+      enabled: next,
+    });
+    input.dataset['previous'] = next ? 'true' : 'false';
+    showToast({
+      message: `${override.provider}/${override.service} override ${next ? 'enabled' : 'disabled'}.`,
+      kind: 'success',
+    });
+    await loadOverridesPanel(accountId, panel, override.provider as AccountProvider);
+    await refreshRecommendationsAfterOverrideChange();
+  } catch (err) {
+    input.checked = previous;
+    row.classList.toggle('override-disabled', !previous);
+    showToast({
+      message: `Failed to update enabled state: ${(err as Error).message}`,
+      kind: 'error',
+    });
+  } finally {
+    input.disabled = false;
+  }
+}
+
+/**
  * Load and render the service overrides panel for an account.
  *
  * Empty state (no overrides yet for this account) auto-opens the create
@@ -735,7 +1035,11 @@ export async function loadOverridesPanel(accountId: string, panel: HTMLElement, 
     table.className = 'overrides-table';
     const thead = table.createTHead();
     const hrow = thead.insertRow();
-    ['Service', 'Term', 'Payment', 'Coverage', ''].forEach(h => {
+    // Column order: Service | Term | Payment | Coverage | Enabled | <action>
+    // Enabled is second-to-last (immediately before the action cell) so the
+    // descriptive columns keep the layout users learned from PR #72/#23.
+    // Issue #110.
+    ['Service', 'Term', 'Payment', 'Coverage', 'Enabled', ''].forEach(h => {
       const th = document.createElement('th');
       th.textContent = h;
       hrow.appendChild(th);
@@ -743,13 +1047,23 @@ export async function loadOverridesPanel(accountId: string, panel: HTMLElement, 
     const tbody = table.createTBody();
     overrides.forEach(o => {
       const tr = tbody.insertRow();
-      [
-        `${o.provider}/${o.service}`,
-        o.term !== undefined ? `${o.term}yr` : '\u2014',
-      ].forEach(text => {
-        const td = tr.insertCell();
-        td.textContent = text;
-      });
+      // Reflect the row's enabled state visually from the initial render so
+      // disabled overrides are obvious without waiting for a toggle event.
+      if (o.enabled === false) {
+        tr.classList.add('override-disabled');
+      }
+
+      const serviceTd = tr.insertCell();
+      serviceTd.textContent = `${o.provider}/${o.service}`;
+
+      // Term cell: editable <select> for AWS (issue #110); read-only text
+      // for Azure/GCP until the provider-aware modal lands.
+      const termTd = tr.insertCell();
+      if (o.provider === 'aws') {
+        termTd.appendChild(buildTermOverrideSelect(accountId, o, panel));
+      } else {
+        termTd.textContent = o.term !== undefined ? `${o.term}yr` : '\u2014';
+      }
 
       // Payment cell: editable <select> for AWS (the only provider whose
       // reservations support distinct payment options); read-only text for
@@ -761,8 +1075,20 @@ export async function loadOverridesPanel(accountId: string, panel: HTMLElement, 
         paymentTd.textContent = o.payment ?? '\u2014';
       }
 
+      // Coverage cell: editable numeric <input> for AWS (issue #110);
+      // read-only text for Azure/GCP.
       const coverageTd = tr.insertCell();
-      coverageTd.textContent = o.coverage !== undefined ? `${o.coverage}%` : '\u2014';
+      if (o.provider === 'aws') {
+        coverageTd.appendChild(buildCoverageOverrideInput(accountId, o, panel));
+      } else {
+        coverageTd.textContent = o.coverage !== undefined ? `${o.coverage}%` : '\u2014';
+      }
+
+      // Enabled cell: per-row checkbox toggling account_service_overrides.enabled.
+      // AWS-editable, disabled (with tooltip) for non-AWS to keep the column
+      // alignment consistent across provider types. Issue #110.
+      const enabledTd = tr.insertCell();
+      enabledTd.appendChild(buildEnabledOverrideCheckbox(accountId, o, panel, tr));
 
       const actionTd = tr.insertCell();
       const resetBtn = document.createElement('button');

--- a/frontend/src/styles/settings.css
+++ b/frontend/src/styles/settings.css
@@ -589,3 +589,12 @@ select.dirty {
     padding: 0.5rem;
     margin: 0;
 }
+
+/* Issue #110: inline-editable override cells on the per-account
+   overrides panel. */
+.override-coverage-input {
+    width: 5em;
+}
+tr.override-disabled {
+    opacity: 0.55;
+}


### PR DESCRIPTION
## Summary

V2 of #72. PR #72 made the Payment cell on existing override rows
editable; this extends the same sparse-PUT pattern to the remaining
editable scalars on `account_service_overrides` so users no longer
have to Delete and re-create the row just to bump a single field.

Changes (AWS rows only; Azure/GCP inline editing tracked under the
provider-aware modal work):

- **Term cell**: inline `<select>` (Inherit / 1yr / 3yr) filtered by
  `getValidTermOptions(provider, service, payment)` so RDS rows with
  payment=no-upfront do not list term=3 (the one hard AWS rule per
  `commitmentOptions.ts`). Inherit is disabled when term is already set
  (no clear-field channel; same rationale as Payment's Inherit).
- **Coverage cell**: inline numeric `<input>` (0..100, integer). Fires on
  `change` (blur or Enter), not `input`, so a single PUT per finished edit.
  Out-of-range or non-integer input reverts to the previous value with an
  error toast; clearing a preset value reverts with an info toast pointing
  the user at Delete.
- **Enabled toggle**: per-row checkbox, second-to-last column. Toggling
  disabled adds `.override-disabled` to the row (CSS `opacity: 0.55`) so
  the inactive state is visually obvious. Legacy rows with
  `enabled === undefined` render as ACTIVE; only explicit `enabled: false`
  renders unchecked + dimmed.

For non-AWS rows the new column slot keeps the layout consistent: the
Enabled checkbox renders disabled with an explanatory tooltip; Term and
Coverage stay as read-only text cells.

Each handler mirrors `handlePaymentOverrideChange`'s shape verbatim:
sparse PUT of just the touched field (backend's `applyOverrideScalars`
treats unset request fields as "leave alone"), `loadOverridesPanel`
reload + `refreshRecommendationsAfterOverrideChange` on success,
revert-and-toast on failure.

## Test plan

- [x] `npx jest --testPathPattern settings-accounts` -- 61 tests pass
  (46 existing + 15 new for issue #110).
- [x] `npx jest --testPathPattern settings` -- 5 suites, 141 tests, green.
- [x] `npx jest` (full frontend suite) -- 46 suites, 1660 passing
  (1 pre-existing skip, unchanged by this PR).
- [x] `npx tsc --noEmit` -- clean.
- [x] `npx webpack --mode production` -- build green.
- [x] pre-commit hooks run on the commit; all enabled checks pass.
- [ ] After deploy: smoke test in the deployed dashboard -- open
  Settings -> Accounts -> Overrides on an AWS account with at least
  one override, edit Term / Coverage / Enabled in-place, confirm each
  change persists across a reload, and confirm a disabled row renders
  dimmed.

## Reuse / no-duplication notes

The three new builders share the same template as
`buildPaymentOverrideSelect` + `handlePaymentOverrideChange` (added by
#72). Extracting a common helper would also touch the existing Payment
code path; doing so here would expand the scope of this PR. Filing a
follow-up refactor issue after this lands.

Closes #110
