### PR TITLE
fix(purchases): persist & round-trip full ServiceDetails (closes #453)

### DIFF
--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -2,6 +2,7 @@
 package config
 
 import (
+	"encoding/json"
 	"time"
 )
 
@@ -258,16 +259,35 @@ type PurchaseExecution struct {
 
 // RecommendationRecord stores a recommendation with purchase status
 type RecommendationRecord struct {
-	ID           string  `json:"id" dynamodbav:"id"`
-	Provider     string  `json:"provider" dynamodbav:"provider"`
-	Service      string  `json:"service" dynamodbav:"service"`
-	Region       string  `json:"region" dynamodbav:"region"`
-	ResourceType string  `json:"resource_type" dynamodbav:"resource_type"`
-	Engine       string  `json:"engine,omitempty" dynamodbav:"engine,omitempty"`
-	Count        int     `json:"count" dynamodbav:"count"`
-	Term         int     `json:"term" dynamodbav:"term"`
-	Payment      string  `json:"payment" dynamodbav:"payment"`
-	UpfrontCost  float64 `json:"upfront_cost" dynamodbav:"upfront_cost"`
+	ID           string `json:"id" dynamodbav:"id"`
+	Provider     string `json:"provider" dynamodbav:"provider"`
+	Service      string `json:"service" dynamodbav:"service"`
+	Region       string `json:"region" dynamodbav:"region"`
+	ResourceType string `json:"resource_type" dynamodbav:"resource_type"`
+	Engine       string `json:"engine,omitempty" dynamodbav:"engine,omitempty"`
+	// Details preserves the full common.ServiceDetails payload from the
+	// source common.Recommendation so the purchase path can reconstruct
+	// the correct typed *Details pointer at execute time (issue #453).
+	// Stored as raw JSON because RecommendationRecord lives in the
+	// config package, which must NOT import pkg/common (the dependency
+	// graph is config <- common in callers, never the reverse). The
+	// scheduler populates this at collection time via
+	// common.MarshalServiceDetails; the purchase manager reads it via
+	// common.DecodeServiceDetailsFor when it builds the
+	// common.Recommendation handed to the cloud service client.
+	//
+	// Empty for rows persisted before #453 — DecodeServiceDetailsFor
+	// returns a zero-valued typed pointer in that case so the cloud
+	// client's findOfferingID type-assertion still succeeds (the
+	// service-side buildOfferingFilters substitutes default
+	// Platform / Tenancy / Scope / AZConfig values). New rows always
+	// carry the full Details, so non-default platforms (Windows EC2,
+	// Postgres RDS, etc.) round-trip correctly.
+	Details     json.RawMessage `json:"details,omitempty" dynamodbav:"-"`
+	Count       int             `json:"count" dynamodbav:"count"`
+	Term        int             `json:"term" dynamodbav:"term"`
+	Payment     string          `json:"payment" dynamodbav:"payment"`
+	UpfrontCost float64         `json:"upfront_cost" dynamodbav:"upfront_cost"`
 	// MonthlyCost is nil when the provider API did not return a monthly
 	// recurring breakdown (rendered as "—" in the UI, not "$0").
 	// Backward-compatible with DynamoDB: existing items with a numeric 0

--- a/internal/purchase/coverage_extra_test.go
+++ b/internal/purchase/coverage_extra_test.go
@@ -809,3 +809,395 @@ func TestManager_SavePurchaseHistory_Error(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, exec.Recommendations[0].Purchased)
 }
+
+// TestManager_ExecuteSinglePurchase_DetailsByService is the regression guard
+// for issue #453. Before the fix, executeSinglePurchase assigned a value-
+// typed common.DatabaseDetails (and only when rec.Engine was non-empty);
+// every AWS service client's findOfferingID type-asserts a *pointer*, so the
+// assertion failed and surfaced as "invalid service details for <Service>"
+// for every dashboard-driven purchase after #373 made approve synchronous.
+//
+// The revised fix (post-design-review) persists the full ServiceDetails
+// payload onto the RecommendationRecord at collection time and reconstructs
+// the correct typed *Details pointer in executeSinglePurchase. This table-
+// driven test:
+//
+//  1. Seeds a rec with the canonical Details JSON for each service (the
+//     "happy path" — new rows post-fix carry full details).
+//  2. Captures the rec.Details passed to the cloud client and asserts
+//     both the concrete pointer type AND that every field round-tripped
+//     intact (Platform=Windows must come through, not be silently
+//     defaulted to Linux/UNIX).
+//
+// A second sub-test below covers the legacy fallback (empty Details JSON).
+func TestManager_ExecuteSinglePurchase_DetailsByService(t *testing.T) {
+	cases := []struct {
+		name        string
+		service     string
+		serviceType common.ServiceType
+		region      string
+		resource    string
+		engine      string
+		details     common.ServiceDetails
+		// assertDetails inspects the rec.Details captured by the mock
+		// PurchaseCommitment call and asserts both the concrete pointer
+		// type and the per-service fields the AWS client reads.
+		assertDetails func(t *testing.T, d common.ServiceDetails)
+	}{
+		{
+			name:        "ec2_windows",
+			service:     "ec2",
+			serviceType: common.ServiceEC2,
+			region:      "us-east-1",
+			resource:    "t4g.nano",
+			details:     &common.ComputeDetails{InstanceType: "t4g.nano", Platform: "Windows", Tenancy: "dedicated", Scope: "Region"},
+			assertDetails: func(t *testing.T, d common.ServiceDetails) {
+				cd, ok := d.(*common.ComputeDetails)
+				if assert.True(t, ok, "EC2 details must be *common.ComputeDetails, got %T", d) {
+					// Platform must round-trip — silent fallback to
+					// Linux/UNIX is precisely the silent mis-purchase
+					// the revised fix exists to prevent.
+					assert.Equal(t, "Windows", cd.Platform)
+					assert.Equal(t, "dedicated", cd.Tenancy)
+					assert.Equal(t, "Region", cd.Scope)
+				}
+			},
+		},
+		{
+			name:        "rds_postgres",
+			service:     "rds",
+			serviceType: common.ServiceRDS,
+			region:      "us-east-1",
+			resource:    "db.r5.large",
+			engine:      "postgres",
+			details:     &common.DatabaseDetails{Engine: "postgres", AZConfig: "multi-az", InstanceClass: "db.r5.large"},
+			assertDetails: func(t *testing.T, d common.ServiceDetails) {
+				dd, ok := d.(*common.DatabaseDetails)
+				if assert.True(t, ok, "RDS details must be *common.DatabaseDetails, got %T", d) {
+					assert.Equal(t, "postgres", dd.Engine)
+					assert.Equal(t, "multi-az", dd.AZConfig)
+					assert.Equal(t, "db.r5.large", dd.InstanceClass)
+				}
+			},
+		},
+		{
+			name:        "elasticache_redis",
+			service:     "elasticache",
+			serviceType: common.ServiceElastiCache,
+			region:      "us-east-1",
+			resource:    "cache.r5.large",
+			engine:      "redis",
+			details:     &common.CacheDetails{Engine: "redis", NodeType: "cache.r5.large"},
+			assertDetails: func(t *testing.T, d common.ServiceDetails) {
+				cd, ok := d.(*common.CacheDetails)
+				if assert.True(t, ok, "ElastiCache details must be *common.CacheDetails, got %T", d) {
+					assert.Equal(t, "redis", cd.Engine)
+					assert.Equal(t, "cache.r5.large", cd.NodeType)
+				}
+			},
+		},
+		{
+			name:        "opensearch",
+			service:     "opensearch",
+			serviceType: common.ServiceOpenSearch,
+			region:      "us-west-2",
+			resource:    "r5.large.search",
+			details:     &common.SearchDetails{InstanceType: "r5.large.search"},
+			assertDetails: func(t *testing.T, d common.ServiceDetails) {
+				sd, ok := d.(*common.SearchDetails)
+				if assert.True(t, ok, "OpenSearch details must be *common.SearchDetails, got %T", d) {
+					assert.Equal(t, "r5.large.search", sd.InstanceType)
+				}
+			},
+		},
+		{
+			name:        "redshift",
+			service:     "redshift",
+			serviceType: common.ServiceRedshift,
+			region:      "us-east-1",
+			resource:    "ra3.xlplus",
+			details:     &common.DataWarehouseDetails{NodeType: "ra3.xlplus", NumberOfNodes: 2, ClusterType: "multi-node"},
+			assertDetails: func(t *testing.T, d common.ServiceDetails) {
+				dw, ok := d.(*common.DataWarehouseDetails)
+				if assert.True(t, ok, "Redshift details must be *common.DataWarehouseDetails, got %T", d) {
+					assert.Equal(t, "ra3.xlplus", dw.NodeType)
+					assert.Equal(t, 2, dw.NumberOfNodes)
+				}
+			},
+		},
+		{
+			name:        "sp_compute",
+			service:     "savings-plans-compute",
+			serviceType: common.ServiceSavingsPlansCompute,
+			region:      "us-east-1",
+			resource:    "ComputeSP",
+			details:     &common.SavingsPlanDetails{PlanType: "Compute", HourlyCommitment: 1.50},
+			assertDetails: func(t *testing.T, d common.ServiceDetails) {
+				sp, ok := d.(*common.SavingsPlanDetails)
+				if assert.True(t, ok, "SP-Compute details must be *common.SavingsPlanDetails, got %T", d) {
+					assert.Equal(t, "Compute", sp.PlanType)
+					assert.InDelta(t, 1.50, sp.HourlyCommitment, 0.001)
+				}
+			},
+		},
+		{
+			name:        "sp_ec2instance",
+			service:     "savings-plans-ec2instance",
+			serviceType: common.ServiceSavingsPlansEC2Instance,
+			region:      "us-east-1",
+			resource:    "EC2InstanceSP",
+			details:     &common.SavingsPlanDetails{PlanType: "EC2Instance", HourlyCommitment: 2.0},
+			assertDetails: func(t *testing.T, d common.ServiceDetails) {
+				sp, ok := d.(*common.SavingsPlanDetails)
+				if assert.True(t, ok, "SP-EC2Instance details must be *common.SavingsPlanDetails, got %T", d) {
+					assert.Equal(t, "EC2Instance", sp.PlanType)
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			mockStore := new(MockConfigStore)
+			mockEmail := new(MockEmailSender)
+			mockFactory := new(MockProviderFactory)
+			mockProvider := new(MockProvider)
+			mockServiceClient := new(MockServiceClient)
+			mockSTS := new(MockSTSClient)
+
+			// Marshal the canonical Details into the RecommendationRecord
+			// — this is exactly what the scheduler does at collection
+			// time via common.MarshalServiceDetails, so the round-trip
+			// here is the same one a real purchase exercises.
+			detailsBlob, err := common.MarshalServiceDetails(tc.details)
+			require.NoError(t, err)
+			require.NotNil(t, detailsBlob, "test seed must produce a non-empty Details blob")
+
+			plan := &config.PurchasePlan{ID: "plan-" + tc.name, Name: "Plan"}
+			exec := &config.PurchaseExecution{
+				ExecutionID: "exec-" + tc.name,
+				PlanID:      "plan-" + tc.name,
+				Recommendations: []config.RecommendationRecord{
+					{
+						Provider:     "aws",
+						Service:      tc.service,
+						ResourceType: tc.resource,
+						Engine:       tc.engine,
+						Details:      detailsBlob,
+						Region:       tc.region,
+						Count:        1,
+						Term:         1,
+						Payment:      "All Upfront",
+						Savings:      10.0,
+						UpfrontCost:  100.0,
+						Selected:     true,
+					},
+				},
+			}
+
+			// Capture the rec passed to PurchaseCommitment so we can
+			// inspect Details after the call.
+			var capturedRec common.Recommendation
+			mockStore.On("GetPurchasePlan", ctx, plan.ID).Return(plan, nil)
+			mockStore.On("SavePurchaseHistory", ctx, mock.AnythingOfType("*config.PurchaseHistoryRecord")).Return(nil)
+			mockEmail.On("SendPurchaseConfirmation", ctx, mock.AnythingOfType("email.NotificationData")).Return(nil)
+			mockFactory.On("CreateAndValidateProvider", ctx, "aws", mock.Anything).Return(mockProvider, nil)
+			mockProvider.On("GetServiceClient", ctx, tc.serviceType, tc.region).Return(mockServiceClient, nil)
+			mockServiceClient.On(
+				"PurchaseCommitment",
+				ctx,
+				mock.AnythingOfType("common.Recommendation"),
+				mock.AnythingOfType("common.PurchaseOptions"),
+			).Run(func(args mock.Arguments) {
+				capturedRec = args.Get(1).(common.Recommendation)
+			}).Return(
+				common.PurchaseResult{Success: true, CommitmentID: "ri-" + tc.name},
+				nil,
+			)
+			mockSTS.On("GetCallerIdentity", ctx, mock.Anything).Return(nil, errors.New("sts error"))
+
+			manager := &Manager{
+				config:          mockStore,
+				email:           mockEmail,
+				stsClient:       mockSTS,
+				providerFactory: mockFactory,
+				dashboardURL:    "https://dashboard.example.com",
+			}
+
+			_, err = manager.executePurchase(ctx, exec)
+			require.NoError(t, err, "purchase should not return the regression error 'invalid service details for <Service>'")
+			assert.True(t, exec.Recommendations[0].Purchased, "rec should be marked purchased")
+			assert.Empty(t, exec.Recommendations[0].Error, "rec error should be empty")
+			require.NotNil(t, capturedRec.Details, "rec.Details handed to the cloud client must be non-nil")
+			tc.assertDetails(t, capturedRec.Details)
+		})
+	}
+}
+
+// TestManager_ExecuteSinglePurchase_LegacyEmptyDetails locks down the
+// graceful-degradation path for rows persisted before #453 — they carry
+// an empty Details payload but the cloud client's findOfferingID still
+// needs a typed *pointer* to type-assert against. DecodeServiceDetailsFor
+// returns a zero-valued typed pointer in that case; the engine column
+// (which legacy rows DID carry) is folded back onto the Details by
+// applyEngineFallback so a non-default-engine DB rec doesn't silently
+// mis-purchase as the default.
+func TestManager_ExecuteSinglePurchase_LegacyEmptyDetails(t *testing.T) {
+	cases := []struct {
+		name          string
+		service       string
+		serviceType   common.ServiceType
+		region        string
+		resource      string
+		engine        string
+		assertDetails func(t *testing.T, d common.ServiceDetails)
+	}{
+		{
+			name:        "legacy_ec2",
+			service:     "ec2",
+			serviceType: common.ServiceEC2,
+			region:      "us-east-1",
+			resource:    "t4g.nano",
+			assertDetails: func(t *testing.T, d common.ServiceDetails) {
+				cd, ok := d.(*common.ComputeDetails)
+				if assert.True(t, ok, "EC2 legacy details must be *common.ComputeDetails, got %T", d) {
+					// Zero-valued — service client's
+					// buildOfferingFilters substitutes defaults.
+					assert.Empty(t, cd.Platform)
+					assert.Empty(t, cd.Tenancy)
+				}
+			},
+		},
+		{
+			name:        "legacy_rds_postgres",
+			service:     "rds",
+			serviceType: common.ServiceRDS,
+			region:      "us-east-1",
+			resource:    "db.r5.large",
+			engine:      "postgres",
+			assertDetails: func(t *testing.T, d common.ServiceDetails) {
+				dd, ok := d.(*common.DatabaseDetails)
+				if assert.True(t, ok, "RDS legacy details must be *common.DatabaseDetails, got %T", d) {
+					// Engine must be backfilled from the Engine
+					// column — without applyEngineFallback, the
+					// Postgres rec would silently mis-purchase as
+					// MySQL (or whatever default).
+					assert.Equal(t, "postgres", dd.Engine)
+				}
+			},
+		},
+		{
+			name:        "legacy_elasticache_redis",
+			service:     "elasticache",
+			serviceType: common.ServiceElastiCache,
+			region:      "us-east-1",
+			resource:    "cache.r5.large",
+			engine:      "redis",
+			assertDetails: func(t *testing.T, d common.ServiceDetails) {
+				cd, ok := d.(*common.CacheDetails)
+				if assert.True(t, ok, "ElastiCache legacy details must be *common.CacheDetails, got %T", d) {
+					assert.Equal(t, "redis", cd.Engine)
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			mockStore := new(MockConfigStore)
+			mockEmail := new(MockEmailSender)
+			mockFactory := new(MockProviderFactory)
+			mockProvider := new(MockProvider)
+			mockServiceClient := new(MockServiceClient)
+			mockSTS := new(MockSTSClient)
+
+			plan := &config.PurchasePlan{ID: "plan-" + tc.name, Name: "Plan"}
+			exec := &config.PurchaseExecution{
+				ExecutionID: "exec-" + tc.name,
+				PlanID:      "plan-" + tc.name,
+				Recommendations: []config.RecommendationRecord{
+					{
+						Provider:     "aws",
+						Service:      tc.service,
+						ResourceType: tc.resource,
+						Engine:       tc.engine,
+						// Details deliberately empty — simulates a
+						// row persisted before #453.
+						Region:      tc.region,
+						Count:       1,
+						Term:        1,
+						Payment:     "All Upfront",
+						Savings:     10.0,
+						UpfrontCost: 100.0,
+						Selected:    true,
+					},
+				},
+			}
+
+			var capturedRec common.Recommendation
+			mockStore.On("GetPurchasePlan", ctx, plan.ID).Return(plan, nil)
+			mockStore.On("SavePurchaseHistory", ctx, mock.AnythingOfType("*config.PurchaseHistoryRecord")).Return(nil)
+			mockEmail.On("SendPurchaseConfirmation", ctx, mock.AnythingOfType("email.NotificationData")).Return(nil)
+			mockFactory.On("CreateAndValidateProvider", ctx, "aws", mock.Anything).Return(mockProvider, nil)
+			mockProvider.On("GetServiceClient", ctx, tc.serviceType, tc.region).Return(mockServiceClient, nil)
+			mockServiceClient.On(
+				"PurchaseCommitment",
+				ctx,
+				mock.AnythingOfType("common.Recommendation"),
+				mock.AnythingOfType("common.PurchaseOptions"),
+			).Run(func(args mock.Arguments) {
+				capturedRec = args.Get(1).(common.Recommendation)
+			}).Return(
+				common.PurchaseResult{Success: true, CommitmentID: "ri-" + tc.name},
+				nil,
+			)
+			mockSTS.On("GetCallerIdentity", ctx, mock.Anything).Return(nil, errors.New("sts error"))
+
+			manager := &Manager{
+				config:          mockStore,
+				email:           mockEmail,
+				stsClient:       mockSTS,
+				providerFactory: mockFactory,
+				dashboardURL:    "https://dashboard.example.com",
+			}
+
+			_, err := manager.executePurchase(ctx, exec)
+			require.NoError(t, err, "legacy empty-Details rec must still purchase cleanly")
+			require.NotNil(t, capturedRec.Details, "rec.Details handed to the cloud client must be non-nil even for legacy rows")
+			tc.assertDetails(t, capturedRec.Details)
+		})
+	}
+}
+
+// TestApplyEngineFallback covers the engine-backfill helper directly so a
+// future refactor that changes which *Details types carry an Engine field
+// surfaces here rather than via a silent mis-purchase regression.
+func TestApplyEngineFallback(t *testing.T) {
+	// RDS: empty Engine should be backfilled.
+	rds := &common.DatabaseDetails{}
+	applyEngineFallback(rds, "mysql")
+	assert.Equal(t, "mysql", rds.Engine, "empty DB Engine must be backfilled from the record column")
+
+	// RDS: pre-populated Engine must NOT be overwritten — Details is
+	// the source of truth when present.
+	rdsKeep := &common.DatabaseDetails{Engine: "postgres"}
+	applyEngineFallback(rdsKeep, "mysql")
+	assert.Equal(t, "postgres", rdsKeep.Engine, "non-empty DB Engine must be preserved")
+
+	// Cache: same rule.
+	ec := &common.CacheDetails{}
+	applyEngineFallback(ec, "redis")
+	assert.Equal(t, "redis", ec.Engine)
+
+	// Empty engine arg is a no-op.
+	rdsZero := &common.DatabaseDetails{}
+	applyEngineFallback(rdsZero, "")
+	assert.Empty(t, rdsZero.Engine, "empty engine arg must leave Details untouched")
+
+	// Non-DB/Cache types are no-ops (don't accidentally write into them).
+	cc := &common.ComputeDetails{}
+	applyEngineFallback(cc, "mysql")
+	assert.Empty(t, cc.Platform, "ComputeDetails must remain untouched by applyEngineFallback")
+}

--- a/internal/purchase/execution.go
+++ b/internal/purchase/execution.go
@@ -445,11 +445,29 @@ func (m *Manager) executeSinglePurchase(ctx context.Context, rec config.Recommen
 		CommitmentCost: rec.UpfrontCost,
 	}
 
-	// Add service-specific details
-	if rec.Engine != "" {
-		recommendation.Details = common.DatabaseDetails{
-			Engine: rec.Engine,
-		}
+	// Reconstruct the typed *Details pointer from the persisted JSON
+	// payload (issue #453). The scheduler stores the full
+	// common.ServiceDetails at collection time; this is the read-back
+	// step that yields a *ComputeDetails / *DatabaseDetails /
+	// *CacheDetails / *SavingsPlanDetails (etc.) keyed on rec.Service
+	// so the cloud service client's findOfferingID type-assertion
+	// succeeds with the full per-rec details (Platform, Tenancy,
+	// Scope, AZConfig, HourlyCommitment, …), not just an Engine string.
+	//
+	// Legacy rows persisted before #453 carry an empty rec.Details —
+	// DecodeServiceDetailsFor returns a zero-valued typed pointer for
+	// those, and the cloud client's buildOfferingFilters substitutes
+	// defaults (Platform=Linux/UNIX, Tenancy=default, etc.). Engine is
+	// preserved on the record column too, so we use it as a last-resort
+	// fallback for DB/Cache services to avoid silently mis-purchasing a
+	// legacy non-default-engine rec as the default engine.
+	details, detailsErr := common.DecodeServiceDetailsFor(rec.Service, rec.Details)
+	if detailsErr != nil {
+		return common.PurchaseResult{}, fmt.Errorf("decode service details for %s rec %s: %w", rec.Service, rec.ResourceType, detailsErr)
+	}
+	if details != nil {
+		applyEngineFallback(details, rec.Engine)
+		recommendation.Details = details
 	}
 
 	// Execute the purchase
@@ -587,4 +605,29 @@ func derefFloat64(p *float64) float64 {
 		return 0
 	}
 	return *p
+}
+
+// applyEngineFallback backfills the Engine field on DB / Cache Details
+// from the persisted RecommendationRecord.Engine column when the decoded
+// Details left Engine empty. Legacy rows (persisted before #453) carry
+// an empty Details payload but a populated Engine column — without this
+// backfill, a Postgres RDS rec would silently mis-purchase as whatever
+// engine buildOfferingFilters defaults to. For non-DB/Cache Details
+// types the call is a no-op. Pointer-typed Details get mutated in
+// place; callers pass the pointer that's about to be assigned into
+// recommendation.Details so the caller's variable sees the update.
+func applyEngineFallback(details common.ServiceDetails, engine string) {
+	if engine == "" {
+		return
+	}
+	switch d := details.(type) {
+	case *common.DatabaseDetails:
+		if d.Engine == "" {
+			d.Engine = engine
+		}
+	case *common.CacheDetails:
+		if d.Engine == "" {
+			d.Engine = engine
+		}
+	}
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -980,25 +980,57 @@ func nonZeroPtr(v float64) *float64 {
 	return nil
 }
 
+// extractEngine pulls the engine string out of a polymorphic
+// common.ServiceDetails value when one is present, supporting both value
+// and pointer receivers as the provider parsers historically used either
+// shape. Returns "" for any other Details type (or nil). Extracted from
+// convertRecommendations to keep that function under the gocyclo budget
+// (min-complexity: 10 in .pre-commit-config.yaml).
+func extractEngine(details common.ServiceDetails) string {
+	if details == nil {
+		return ""
+	}
+	switch d := details.(type) {
+	case common.DatabaseDetails:
+		return d.Engine
+	case *common.DatabaseDetails:
+		return d.Engine
+	case common.CacheDetails:
+		return d.Engine
+	case *common.CacheDetails:
+		return d.Engine
+	}
+	return ""
+}
+
+// marshalRecDetails encodes the full ServiceDetails payload into a raw
+// JSON blob so the purchase manager can reconstruct the correct typed
+// *Details pointer later (issue #453). Without this, every persisted
+// rec round-trips through the DB as "service + engine" only — losing
+// EC2 platform / tenancy / scope, RDS AZ-config, SP plan-type / hourly
+// commitment, etc. — and findOfferingID either picks the wrong offering
+// (Windows recs purchased as Linux/UNIX) or fails the type-assertion
+// outright. Marshal errors are non-fatal: the row still gets persisted
+// without Details and falls through to the graceful-degradation path in
+// common.DecodeServiceDetailsFor. Extracted from convertRecommendations
+// to keep that function under the gocyclo budget.
+func marshalRecDetails(rec common.Recommendation, providerName string) []byte {
+	blob, err := common.MarshalServiceDetails(rec.Details)
+	if err != nil {
+		logging.Warnf("Failed to marshal service details for %s/%s rec (%s): %v — persisting without Details",
+			providerName, rec.Service, rec.ResourceType, err)
+		return nil
+	}
+	return blob
+}
+
 // convertRecommendations converts common.Recommendation slice to config.RecommendationRecord slice
 func (s *Scheduler) convertRecommendations(recs []common.Recommendation, providerName string) []config.RecommendationRecord {
 	records := make([]config.RecommendationRecord, 0, len(recs))
 
 	for _, rec := range recs {
-		// Extract engine from service details if available
-		engine := ""
-		if rec.Details != nil {
-			switch d := rec.Details.(type) {
-			case common.DatabaseDetails:
-				engine = d.Engine
-			case *common.DatabaseDetails:
-				engine = d.Engine
-			case common.CacheDetails:
-				engine = d.Engine
-			case *common.CacheDetails:
-				engine = d.Engine
-			}
-		}
+		engine := extractEngine(rec.Details)
+		detailsBlob := marshalRecDetails(rec, providerName)
 
 		// Parse term to integer (e.g., "3yr" -> 3)
 		term := 3
@@ -1054,6 +1086,7 @@ func (s *Scheduler) convertRecommendations(recs []common.Recommendation, provide
 			Region:       rec.Region,
 			ResourceType: rec.ResourceType,
 			Engine:       engine,
+			Details:      detailsBlob, // full ServiceDetails payload (issue #453)
 			Count:        rec.Count,
 			Term:         term,
 			Payment:      rec.PaymentOption,

--- a/pkg/common/service_details_codec.go
+++ b/pkg/common/service_details_codec.go
@@ -1,0 +1,146 @@
+// Package common — JSON codec helpers for the polymorphic ServiceDetails
+// interface so per-rec details survive the round-trip through
+// purchase_executions.recommendations (JSONB) without dropping the
+// service-specific fields that drive offering lookup.
+//
+// Background: before issue #453 the only Details data preserved across the
+// dashboard → DB → executePurchase boundary was a single "engine" string on
+// RecommendationRecord. EC2 platform / tenancy / scope, RDS AZ-config, SP
+// plan-type / hourly-commitment all vanished, so the cloud service client's
+// findOfferingID either fell back to "Linux/UNIX"-style defaults (silently
+// mis-purchasing Windows recs as Linux) or returned "invalid service
+// details for <Service>" outright. We now persist the full ServiceDetails
+// payload as a raw JSON blob on the record, and reconstruct the matching
+// typed pointer here at execute time using the rec's Service string as the
+// discriminator.
+//
+// All helpers live in pkg/common so the typed dispatch sits next to the
+// type definitions (ComputeDetails / DatabaseDetails / …). internal/config
+// (where RecommendationRecord lives) is deliberately kept free of
+// pkg/common imports so the dependency graph stays a strict DAG.
+package common
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// MarshalServiceDetails encodes a ServiceDetails value into a raw JSON
+// payload suitable for the RecommendationRecord.Details JSONB column.
+// Returns (nil, nil) when details is nil so the column stays NULL / absent
+// rather than persisting a literal JSON "null".
+func MarshalServiceDetails(details ServiceDetails) (json.RawMessage, error) {
+	if details == nil {
+		return nil, nil
+	}
+	b, err := json.Marshal(details)
+	if err != nil {
+		return nil, fmt.Errorf("marshal service details: %w", err)
+	}
+	// json.Marshal(nilPointer) returns "null" — fold that to a nil
+	// RawMessage so downstream callers can treat absent and explicitly-
+	// null identically (DecodeServiceDetailsFor below ignores both).
+	if string(b) == "null" {
+		return nil, nil
+	}
+	return b, nil
+}
+
+// DecodeServiceDetailsFor reconstructs a typed *Details pointer from a raw
+// JSON payload, dispatched by the service string from RecommendationRecord.
+// Service accepts the same strings persisted by the scheduler's converter
+// (e.g. "ec2", "rds", "elasticache", "opensearch", "redshift", "memorydb",
+// "savingsplans", "savings-plans-compute" and the dash-free spellings —
+// see internal/purchase/execution.go: mapServiceType / mapSavingsPlansSlug).
+//
+// Behaviour:
+//   - raw is empty AND service maps to a known *Details type → returns a
+//     zero-valued typed pointer (the legacy / pre-#453 fallback). The
+//     downstream service client's buildOfferingFilters tolerates zero-
+//     valued Platform / Tenancy / Scope etc. by substituting defaults.
+//   - raw is empty AND service maps to no *Details type (services we
+//     don't know about, plus AWS services whose clients don't currently
+//     type-assert Details and accept nil) → returns (nil, nil).
+//   - raw is non-empty → unmarshals into the typed pointer for the
+//     service. Unmarshal errors surface as errors (don't fall back
+//     silently — that's how #453's mis-purchases hid for a release).
+//   - service is unknown → returns (nil, nil) so callers fall through to
+//     their existing nil-details paths rather than refusing a purchase
+//     on a service we never had a *Details type for in the first place.
+func DecodeServiceDetailsFor(service string, raw json.RawMessage) (ServiceDetails, error) {
+	target, ok := newDetailsForService(service)
+	if !ok {
+		// Service has no *Details type — nothing to decode. Empty raw
+		// payload is fine; a non-empty payload on a service we don't
+		// recognise is suspicious but tolerated (writers and readers
+		// might be on different versions during a rolling deploy).
+		return nil, nil
+	}
+	if len(raw) == 0 || string(raw) == "null" {
+		// Legacy row or genuinely absent payload — hand back a zero-
+		// valued typed pointer so the service client's type-assertion
+		// succeeds. buildOfferingFilters tolerates zero fields and
+		// substitutes Platform=Linux/UNIX, Tenancy=default, Scope=Region
+		// etc. This is documented as a known-degraded path; new rows
+		// always carry full details. See issue #453 § "graceful
+		// degradation for legacy rows".
+		return target, nil
+	}
+	if err := json.Unmarshal(raw, target); err != nil {
+		return nil, fmt.Errorf("unmarshal %s service details: %w", service, err)
+	}
+	return target, nil
+}
+
+// newDetailsForService returns a fresh zero-valued *Details pointer for a
+// given service slug, or (nil, false) when no *Details type applies. The
+// boolean lets callers distinguish "service we don't have a typed Details
+// shape for" (OpenSearch / Redshift / MemoryDB use case today) from
+// "unknown service" — both currently get nil but the semantic intent
+// differs and a future refactor that adds a Details type for one of them
+// will only need to flip the map here.
+func newDetailsForService(service string) (ServiceDetails, bool) {
+	switch service {
+	// AWS — EC2 / RDS / ElastiCache: the three services whose
+	// findOfferingID type-asserts a typed *Details pointer today. These
+	// are the must-have entries — without them, every purchase fails
+	// with "invalid service details" (issue #453).
+	case string(ServiceEC2), string(ServiceCompute):
+		return &ComputeDetails{}, true
+	case string(ServiceRDS), string(ServiceRelationalDB):
+		return &DatabaseDetails{}, true
+	case string(ServiceElastiCache), string(ServiceCache):
+		return &CacheDetails{}, true
+
+	// AWS Savings Plans — all umbrella + per-plan-type slugs use
+	// SavingsPlanDetails. The dash-free spellings are the canonical
+	// values of ServiceSavingsPlans / ServiceSavingsPlansCompute etc.;
+	// "savings-plans" (with a dash) is the legacy umbrella alias that
+	// internal/purchase/execution.go: mapSavingsPlansSlug still
+	// recognises so purchase_executions JSONB rows persisted before
+	// the rename in PR #94 still resolve. Recognising it here means a
+	// legacy direct-execute approval still decodes against the right
+	// type.
+	case string(ServiceSavingsPlans),
+		string(ServiceSavingsPlansCompute),
+		string(ServiceSavingsPlansEC2Instance),
+		string(ServiceSavingsPlansSageMaker),
+		string(ServiceSavingsPlansDatabase),
+		"savings-plans":
+		return &SavingsPlanDetails{}, true
+
+	// Services that don't currently type-assert Details in
+	// findOfferingID (OpenSearch / Redshift / MemoryDB read rec.ResourceType
+	// directly). We still recognise OpenSearch and Redshift here so a
+	// forthcoming refactor that starts asserting can flip the table
+	// value without changing call sites. MemoryDB has no dedicated
+	// *Details type yet, so it's intentionally absent — callers see
+	// (nil, false) and pass a nil Details, which the MemoryDB client
+	// tolerates.
+	case string(ServiceOpenSearch), string(ServiceSearch):
+		return &SearchDetails{}, true
+	case string(ServiceRedshift), string(ServiceDataWarehouse):
+		return &DataWarehouseDetails{}, true
+	}
+	return nil, false
+}

--- a/pkg/common/service_details_codec.go
+++ b/pkg/common/service_details_codec.go
@@ -21,9 +21,16 @@
 package common
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 )
+
+// jsonNullBytes is the JSON encoding of nil. Cached so the null-payload
+// check below doesn't allocate on every call (this is the read-back step
+// of every purchase, so it's worth avoiding the string conversion that
+// would otherwise happen on the same path).
+var jsonNullBytes = []byte("null")
 
 // MarshalServiceDetails encodes a ServiceDetails value into a raw JSON
 // payload suitable for the RecommendationRecord.Details JSONB column.
@@ -40,7 +47,7 @@ func MarshalServiceDetails(details ServiceDetails) (json.RawMessage, error) {
 	// json.Marshal(nilPointer) returns "null" — fold that to a nil
 	// RawMessage so downstream callers can treat absent and explicitly-
 	// null identically (DecodeServiceDetailsFor below ignores both).
-	if string(b) == "null" {
+	if bytes.Equal(b, jsonNullBytes) {
 		return nil, nil
 	}
 	return b, nil
@@ -76,7 +83,7 @@ func DecodeServiceDetailsFor(service string, raw json.RawMessage) (ServiceDetail
 		// might be on different versions during a rolling deploy).
 		return nil, nil
 	}
-	if len(raw) == 0 || string(raw) == "null" {
+	if len(raw) == 0 || bytes.Equal(raw, jsonNullBytes) {
 		// Legacy row or genuinely absent payload — hand back a zero-
 		// valued typed pointer so the service client's type-assertion
 		// succeeds. buildOfferingFilters tolerates zero fields and

--- a/pkg/common/service_details_codec_test.go
+++ b/pkg/common/service_details_codec_test.go
@@ -1,0 +1,200 @@
+package common
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMarshalServiceDetails_NilAndPointers confirms the contract that:
+//   - nil interface  → (nil, nil)
+//   - non-nil value  → JSON bytes containing the fields
+//   - typed nil ptr  → (nil, nil) (json.Marshal of a nil pointer emits
+//     "null"; the helper folds that to a nil RawMessage so callers can
+//     treat absent and null identically).
+func TestMarshalServiceDetails_NilAndPointers(t *testing.T) {
+	b, err := MarshalServiceDetails(nil)
+	require.NoError(t, err)
+	assert.Nil(t, b, "nil interface must produce nil RawMessage")
+
+	var nilCompute *ComputeDetails
+	b, err = MarshalServiceDetails(nilCompute)
+	require.NoError(t, err)
+	assert.Nil(t, b, "typed nil pointer must produce nil RawMessage")
+
+	b, err = MarshalServiceDetails(&ComputeDetails{InstanceType: "m5.large", Platform: "Windows"})
+	require.NoError(t, err)
+	assert.NotEmpty(t, b)
+	assert.Contains(t, string(b), `"platform":"Windows"`)
+}
+
+// TestDecodeServiceDetailsFor_RoundTrip is the core round-trip regression
+// guard for issue #453: a Windows EC2 rec must come back out as Windows,
+// not silently default to Linux/UNIX.
+func TestDecodeServiceDetailsFor_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name    string
+		service string
+		in      ServiceDetails
+		// assert inspects the typed pointer returned by decode and verifies
+		// the per-service fields round-tripped.
+		assert func(t *testing.T, d ServiceDetails)
+	}{
+		{
+			name:    "ec2_windows_dedicated",
+			service: string(ServiceEC2),
+			in:      &ComputeDetails{InstanceType: "m5.large", Platform: "Windows", Tenancy: "dedicated", Scope: "Region", VCPU: 2, MemoryGB: 8},
+			assert: func(t *testing.T, d ServiceDetails) {
+				cd, ok := d.(*ComputeDetails)
+				if assert.True(t, ok, "want *ComputeDetails, got %T", d) {
+					assert.Equal(t, "Windows", cd.Platform)
+					assert.Equal(t, "dedicated", cd.Tenancy)
+					assert.Equal(t, "Region", cd.Scope)
+					assert.Equal(t, 2, cd.VCPU)
+					assert.InDelta(t, 8.0, cd.MemoryGB, 0.001)
+				}
+			},
+		},
+		{
+			name:    "rds_postgres_multiaz",
+			service: string(ServiceRDS),
+			in:      &DatabaseDetails{Engine: "postgres", EngineVersion: "15", AZConfig: "multi-az", InstanceClass: "db.r5.large"},
+			assert: func(t *testing.T, d ServiceDetails) {
+				dd, ok := d.(*DatabaseDetails)
+				if assert.True(t, ok, "want *DatabaseDetails, got %T", d) {
+					assert.Equal(t, "postgres", dd.Engine)
+					assert.Equal(t, "15", dd.EngineVersion)
+					assert.Equal(t, "multi-az", dd.AZConfig)
+				}
+			},
+		},
+		{
+			name:    "elasticache_redis",
+			service: string(ServiceElastiCache),
+			in:      &CacheDetails{Engine: "redis", NodeType: "cache.r5.large", Shards: 3},
+			assert: func(t *testing.T, d ServiceDetails) {
+				cd, ok := d.(*CacheDetails)
+				if assert.True(t, ok, "want *CacheDetails, got %T", d) {
+					assert.Equal(t, "redis", cd.Engine)
+					assert.Equal(t, 3, cd.Shards)
+				}
+			},
+		},
+		{
+			name:    "savings_plans_compute",
+			service: string(ServiceSavingsPlansCompute),
+			in:      &SavingsPlanDetails{PlanType: "Compute", HourlyCommitment: 1.5, Coverage: "ec2"},
+			assert: func(t *testing.T, d ServiceDetails) {
+				sp, ok := d.(*SavingsPlanDetails)
+				if assert.True(t, ok, "want *SavingsPlanDetails, got %T", d) {
+					assert.Equal(t, "Compute", sp.PlanType)
+					assert.InDelta(t, 1.5, sp.HourlyCommitment, 0.001)
+				}
+			},
+		},
+		{
+			name:    "opensearch",
+			service: string(ServiceOpenSearch),
+			in:      &SearchDetails{InstanceType: "r5.large.search", MasterNodeCount: 3, MasterNodeType: "m6g.large.search"},
+			assert: func(t *testing.T, d ServiceDetails) {
+				sd, ok := d.(*SearchDetails)
+				if assert.True(t, ok, "want *SearchDetails, got %T", d) {
+					assert.Equal(t, "r5.large.search", sd.InstanceType)
+					assert.Equal(t, 3, sd.MasterNodeCount)
+				}
+			},
+		},
+		{
+			name:    "redshift",
+			service: string(ServiceRedshift),
+			in:      &DataWarehouseDetails{NodeType: "ra3.xlplus", NumberOfNodes: 4, ClusterType: "multi-node"},
+			assert: func(t *testing.T, d ServiceDetails) {
+				dw, ok := d.(*DataWarehouseDetails)
+				if assert.True(t, ok, "want *DataWarehouseDetails, got %T", d) {
+					assert.Equal(t, "ra3.xlplus", dw.NodeType)
+					assert.Equal(t, 4, dw.NumberOfNodes)
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			blob, err := MarshalServiceDetails(tc.in)
+			require.NoError(t, err)
+			require.NotEmpty(t, blob)
+
+			out, err := DecodeServiceDetailsFor(tc.service, blob)
+			require.NoError(t, err)
+			require.NotNil(t, out)
+			tc.assert(t, out)
+		})
+	}
+}
+
+// TestDecodeServiceDetailsFor_LegacyEmpty pins the documented fallback
+// behaviour: an empty payload on a service that needs typed Details
+// yields a zero-valued typed pointer (so the cloud client's type-
+// assertion succeeds and buildOfferingFilters can substitute defaults).
+func TestDecodeServiceDetailsFor_LegacyEmpty(t *testing.T) {
+	for _, svc := range []string{
+		string(ServiceEC2),
+		string(ServiceRDS),
+		string(ServiceElastiCache),
+		string(ServiceSavingsPlans),
+		string(ServiceSavingsPlansCompute),
+		string(ServiceOpenSearch),
+		string(ServiceRedshift),
+	} {
+		t.Run(svc+"_nil_raw", func(t *testing.T) {
+			out, err := DecodeServiceDetailsFor(svc, nil)
+			require.NoError(t, err)
+			assert.NotNil(t, out, "empty raw on a known service must yield a typed zero pointer")
+		})
+		t.Run(svc+"_explicit_null", func(t *testing.T) {
+			out, err := DecodeServiceDetailsFor(svc, json.RawMessage(`null`))
+			require.NoError(t, err)
+			assert.NotNil(t, out, "explicit JSON null must be treated like an empty payload")
+		})
+	}
+}
+
+// TestDecodeServiceDetailsFor_UnknownService confirms that an unknown
+// service slug returns (nil, nil) rather than erroring — callers can
+// then fall through to their existing nil-Details paths.
+func TestDecodeServiceDetailsFor_UnknownService(t *testing.T) {
+	out, err := DecodeServiceDetailsFor("not-a-real-service", nil)
+	require.NoError(t, err)
+	assert.Nil(t, out)
+
+	out, err = DecodeServiceDetailsFor("not-a-real-service", json.RawMessage(`{"foo":"bar"}`))
+	require.NoError(t, err)
+	assert.Nil(t, out, "non-empty payload on unknown service must NOT raise; rolling deploys can produce this shape")
+}
+
+// TestDecodeServiceDetailsFor_MalformedJSON ensures a malformed payload
+// surfaces as an error rather than silently producing a zero-valued
+// Details (which is how #453 hid for a release).
+func TestDecodeServiceDetailsFor_MalformedJSON(t *testing.T) {
+	_, err := DecodeServiceDetailsFor(string(ServiceEC2), json.RawMessage(`{not json}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unmarshal")
+}
+
+// TestDecodeServiceDetailsFor_LegacyDashFormSP keeps the legacy
+// "savings-plans" umbrella alias decoding to *SavingsPlanDetails so a
+// purchase_execution row persisted under the dash form before PR #94
+// still resolves correctly when re-executed.
+func TestDecodeServiceDetailsFor_LegacyDashFormSP(t *testing.T) {
+	in := &SavingsPlanDetails{PlanType: "Compute", HourlyCommitment: 1.0}
+	blob, err := MarshalServiceDetails(in)
+	require.NoError(t, err)
+
+	out, err := DecodeServiceDetailsFor("savings-plans", blob)
+	require.NoError(t, err)
+	sp, ok := out.(*SavingsPlanDetails)
+	require.True(t, ok, "got %T", out)
+	assert.Equal(t, "Compute", sp.PlanType)
+}


### PR DESCRIPTION
## Summary

- Closes #453. Every AWS dashboard purchase has failed with `invalid service details for <Service>` since #373 made approve synchronous (root cause analysed in the issue body).
- Persists the full `common.ServiceDetails` payload on `RecommendationRecord` at collection time so `executeSinglePurchase` can reconstruct the correct typed `*Details` pointer for every service — not just `*DatabaseDetails` with an `Engine` string.
- New codec helpers in `pkg/common/service_details_codec.go` (`MarshalServiceDetails` + `DecodeServiceDetailsFor`) dispatch on `rec.Service` to produce `*ComputeDetails` / `*DatabaseDetails` / `*CacheDetails` / `*SavingsPlanDetails` / `*SearchDetails` / `*DataWarehouseDetails`. `internal/config` stays free of `pkg/common` imports — the raw payload is `json.RawMessage`.
- Legacy rows persisted before this fix carry an empty Details — `DecodeServiceDetailsFor` returns a zero-valued typed pointer for those, and `applyEngineFallback` backfills `Engine` from the existing column for DB/Cache services so a Postgres rec doesn't silently mis-purchase as MySQL.

## Why not the shortcut?

The simpler "just hand each service an empty typed pointer" workaround was considered first. It would unblock EC2 today but silently mis-purchase Windows recs as Linux/UNIX (and same shape of bug for RDS engines, ElastiCache engines, SP plan-types) — exactly the fidelity loss the recommendations carry to begin with. The revised approach round-trips the original Details so the cloud client sees the actual platform / tenancy / AZ-config / plan-type the user reviewed and clicked Purchase on.

## Independent of #412

#412 fixes the empty plan_id crash that happens before `executeSinglePurchase` even runs. This PR fixes the next layer — the `invalid service details` failure that strikes once a valid plan_id is present. They compose cleanly.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` → 4454 pass across 37 packages
- [x] Pre-commit hooks (gofmt, go mod tidy, go vet, gocyclo, secret scan, gosec, trivy) pass
- [x] Round-trip codec tests in `pkg/common/service_details_codec_test.go` cover EC2 Windows/dedicated, RDS Postgres/multi-AZ, ElastiCache Redis with shards, SP Compute with HourlyCommitment, OpenSearch, Redshift, legacy empty payloads, malformed JSON, unknown service slug, legacy dash-form SP alias
- [x] End-to-end `TestManager_ExecuteSinglePurchase_DetailsByService` captures the `rec.Details` handed to the mock cloud client per service and asserts both pointer type AND that fields round-trip (Platform=Windows survives, not silently Linux/UNIX)
- [x] Legacy-fallback `TestManager_ExecuteSinglePurchase_LegacyEmptyDetails` covers EC2/RDS/ElastiCache empty-Details rows produced before this fix
- [ ] Manual smoke from staging dashboard after deploy (Purchase button on a Windows EC2 / Postgres RDS rec)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Service-specific details are now serialized with recommendations and reliably reconstructed during purchase execution so platform/configuration fields are preserved.

* **Bug Fixes**
  * Enhanced fallback logic restores missing engine/DB fields for legacy records; malformed or missing payloads are handled explicitly (errors surfaced when decoding fails).

* **Tests**
  * Extensive tests added to cover encoding/decoding, per-service round-trips, legacy fallbacks, and purchase execution behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/454)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->