### PR TITLE
fix(ux/auth): name only the missing password criteria, not all four

### DIFF
--- a/frontend/src/__tests__/auth.test.ts
+++ b/frontend/src/__tests__/auth.test.ts
@@ -560,6 +560,10 @@ describe('Auth Module', () => {
       userEmail.click();
       await new Promise(resolve => setTimeout(resolve, 10));
 
+      // Re-query after reopen so we assert on the live DOM node, not a
+      // potentially stale pre-close reference.
+      const reopenedErrorDiv = document.getElementById('profile-password-error') as HTMLElement;
+
       // Length applies to empty string ("" < 12) so on reset it should
       // be `unmet`, and the inline error must be cleared + hidden.
       // Re-query the error div because the close-and-reopen cycle
@@ -568,7 +572,6 @@ describe('Auth Module', () => {
       // if the new modal regressed (CodeRabbit on #470).
       expect(document.getElementById('profile-req-length')?.classList.contains('unmet')).toBe(true);
       expect(document.getElementById('profile-req-uppercase')?.classList.contains('unmet')).toBe(true);
-      const reopenedErrorDiv = document.getElementById('profile-password-error') as HTMLElement;
       expect(reopenedErrorDiv.textContent).toBe('');
       expect(reopenedErrorDiv.classList.contains('hidden')).toBe(true);
     });

--- a/frontend/src/__tests__/auth.test.ts
+++ b/frontend/src/__tests__/auth.test.ts
@@ -562,10 +562,15 @@ describe('Auth Module', () => {
 
       // Length applies to empty string ("" < 12) so on reset it should
       // be `unmet`, and the inline error must be cleared + hidden.
+      // Re-query the error div because the close-and-reopen cycle
+      // re-renders the modal; the pre-reopen reference points at the
+      // detached element and would silently pass the assertions even
+      // if the new modal regressed (CodeRabbit on #470).
       expect(document.getElementById('profile-req-length')?.classList.contains('unmet')).toBe(true);
       expect(document.getElementById('profile-req-uppercase')?.classList.contains('unmet')).toBe(true);
-      expect(errorDiv.textContent).toBe('');
-      expect(errorDiv.classList.contains('hidden')).toBe(true);
+      const reopenedErrorDiv = document.getElementById('profile-password-error') as HTMLElement;
+      expect(reopenedErrorDiv.textContent).toBe('');
+      expect(reopenedErrorDiv.classList.contains('hidden')).toBe(true);
     });
 
     test('save profile updates user info on success', async () => {

--- a/frontend/src/__tests__/auth.test.ts
+++ b/frontend/src/__tests__/auth.test.ts
@@ -452,8 +452,120 @@ describe('Auth Module', () => {
 
       await new Promise(resolve => setTimeout(resolve, 10));
 
-      expect(window.alert).toHaveBeenCalledWith('New passwords do not match');
+      // Password mismatch is surfaced inline (parity with reset / setup
+      // flows). `alert` must not fire for this path.
+      const errorDiv = document.getElementById('profile-password-error') as HTMLElement;
+      expect(errorDiv.textContent).toBe('New passwords do not match');
+      expect(errorDiv.classList.contains('hidden')).toBe(false);
+      expect(window.alert).not.toHaveBeenCalled();
       expect(api.apiRequest).not.toHaveBeenCalled();
+    });
+
+    test('save profile shows inline error when new password fails complexity rules', async () => {
+      updateUserUI();
+
+      const userEmail = document.getElementById('user-email-display') as HTMLElement;
+      userEmail.click();
+
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      const currentPasswordInput = document.getElementById('profile-current-password') as HTMLInputElement;
+      const newPasswordInput = document.getElementById('profile-new-password') as HTMLInputElement;
+      const confirmPasswordInput = document.getElementById('profile-confirm-password') as HTMLInputElement;
+
+      currentPasswordInput.value = 'oldpassword';
+      // Too short — fails the length rule first.
+      newPasswordInput.value = 'short';
+      confirmPasswordInput.value = 'short';
+
+      const form = document.getElementById('profile-form');
+      form?.dispatchEvent(new Event('submit', { cancelable: true }));
+
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      const errorDiv = document.getElementById('profile-password-error') as HTMLElement;
+      expect(errorDiv.textContent).toBe('Password must be at least 12 characters long');
+      expect(errorDiv.classList.contains('hidden')).toBe(false);
+      expect(window.alert).not.toHaveBeenCalled();
+      expect(api.apiRequest).not.toHaveBeenCalled();
+    });
+
+    test('profile modal renders live password-requirement indicators', async () => {
+      updateUserUI();
+
+      const userEmail = document.getElementById('user-email-display') as HTMLElement;
+      userEmail.click();
+
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      // All five indicators must be present and prefixed `profile-req-`
+      // so they cannot collide with the reset / setup flows.
+      expect(document.getElementById('profile-req-length')).toBeTruthy();
+      expect(document.getElementById('profile-req-uppercase')).toBeTruthy();
+      expect(document.getElementById('profile-req-lowercase')).toBeTruthy();
+      expect(document.getElementById('profile-req-number')).toBeTruthy();
+      expect(document.getElementById('profile-req-special')).toBeTruthy();
+    });
+
+    test('typing into new password toggles requirement classes live', async () => {
+      updateUserUI();
+
+      const userEmail = document.getElementById('user-email-display') as HTMLElement;
+      userEmail.click();
+
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      const newPasswordInput = document.getElementById('profile-new-password') as HTMLInputElement;
+
+      // A fully-valid password should mark every rule as met.
+      newPasswordInput.value = 'Abcdefghijk1!';
+      newPasswordInput.dispatchEvent(new Event('input'));
+
+      expect(document.getElementById('profile-req-length')?.classList.contains('met')).toBe(true);
+      expect(document.getElementById('profile-req-uppercase')?.classList.contains('met')).toBe(true);
+      expect(document.getElementById('profile-req-lowercase')?.classList.contains('met')).toBe(true);
+      expect(document.getElementById('profile-req-number')?.classList.contains('met')).toBe(true);
+      expect(document.getElementById('profile-req-special')?.classList.contains('met')).toBe(true);
+
+      // Drop every rule simultaneously — short, no upper, no number, no
+      // special. Lowercase is the only remaining match.
+      newPasswordInput.value = 'abc';
+      newPasswordInput.dispatchEvent(new Event('input'));
+
+      expect(document.getElementById('profile-req-length')?.classList.contains('unmet')).toBe(true);
+      expect(document.getElementById('profile-req-uppercase')?.classList.contains('unmet')).toBe(true);
+      expect(document.getElementById('profile-req-lowercase')?.classList.contains('met')).toBe(true);
+      expect(document.getElementById('profile-req-number')?.classList.contains('unmet')).toBe(true);
+      expect(document.getElementById('profile-req-special')?.classList.contains('unmet')).toBe(true);
+    });
+
+    test('reopening profile modal resets stale indicators and error', async () => {
+      updateUserUI();
+
+      const userEmail = document.getElementById('user-email-display') as HTMLElement;
+      userEmail.click();
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      // Dirty the indicators and the inline error.
+      const newPasswordInput = document.getElementById('profile-new-password') as HTMLInputElement;
+      newPasswordInput.value = 'Abcdefghijk1!';
+      newPasswordInput.dispatchEvent(new Event('input'));
+      const errorDiv = document.getElementById('profile-password-error') as HTMLElement;
+      errorDiv.textContent = 'old error';
+      errorDiv.classList.remove('hidden');
+
+      // Close and re-open.
+      const cancelBtn = document.getElementById('profile-cancel');
+      cancelBtn?.click();
+      userEmail.click();
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      // Length applies to empty string ("" < 12) so on reset it should
+      // be `unmet`, and the inline error must be cleared + hidden.
+      expect(document.getElementById('profile-req-length')?.classList.contains('unmet')).toBe(true);
+      expect(document.getElementById('profile-req-uppercase')?.classList.contains('unmet')).toBe(true);
+      expect(errorDiv.textContent).toBe('');
+      expect(errorDiv.classList.contains('hidden')).toBe(true);
     });
 
     test('save profile updates user info on success', async () => {

--- a/frontend/src/auth.ts
+++ b/frontend/src/auth.ts
@@ -655,7 +655,7 @@ async function openProfileModal(): Promise<void> {
           <label>
             New Password (leave blank to keep current)
             <div class="password-input-wrapper">
-              <input type="password" id="profile-new-password" placeholder="Enter new password">
+              <input type="password" id="profile-new-password" placeholder="Enter new password" autocomplete="new-password">
               <button type="button" class="toggle-password" data-target="profile-new-password" aria-label="Show password">
                 <svg class="eye-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                   <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
@@ -664,10 +664,34 @@ async function openProfileModal(): Promise<void> {
               </button>
             </div>
           </label>
+
+          <div id="profile-password-requirements" class="password-requirements">
+            <div class="requirement" id="profile-req-length">
+              <span class="req-icon">&#9675;</span>
+              <span class="req-text">At least 12 characters</span>
+            </div>
+            <div class="requirement" id="profile-req-uppercase">
+              <span class="req-icon">&#9675;</span>
+              <span class="req-text">One uppercase letter (A-Z)</span>
+            </div>
+            <div class="requirement" id="profile-req-lowercase">
+              <span class="req-icon">&#9675;</span>
+              <span class="req-text">One lowercase letter (a-z)</span>
+            </div>
+            <div class="requirement" id="profile-req-number">
+              <span class="req-icon">&#9675;</span>
+              <span class="req-text">One number (0-9)</span>
+            </div>
+            <div class="requirement" id="profile-req-special">
+              <span class="req-icon">&#9675;</span>
+              <span class="req-text">One special character (!@#$%^&*)</span>
+            </div>
+          </div>
+
           <label>
             Confirm New Password
             <div class="password-input-wrapper">
-              <input type="password" id="profile-confirm-password" placeholder="Confirm new password">
+              <input type="password" id="profile-confirm-password" placeholder="Confirm new password" autocomplete="new-password">
               <button type="button" class="toggle-password" data-target="profile-confirm-password" aria-label="Show password">
                 <svg class="eye-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                   <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
@@ -676,6 +700,7 @@ async function openProfileModal(): Promise<void> {
               </button>
             </div>
           </label>
+          <div id="profile-password-error" class="error-message hidden"></div>
           <div class="modal-buttons">
             <button type="button" id="profile-cancel">Cancel</button>
             <button type="submit" class="primary">Save Changes</button>
@@ -689,6 +714,17 @@ async function openProfileModal(): Promise<void> {
     document.getElementById('profile-cancel')?.addEventListener('click', closeProfileModal);
     document.getElementById('profile-form')?.addEventListener('submit', (e) => void saveProfile(e));
 
+    // Live password-strength indicator. Mirrors the reset / admin-setup
+    // flows so the user sees criterion check-marks as they type instead
+    // of only on submit. Uses a flow-specific prefix so the IDs never
+    // collide with other modals that might be mounted on the same page.
+    const newPasswordInput = document.getElementById('profile-new-password') as HTMLInputElement | null;
+    if (newPasswordInput) {
+      newPasswordInput.addEventListener('input', () => {
+        updatePasswordRequirements(newPasswordInput.value, 'profile-req-');
+      });
+    }
+
     // Setup password toggle
     setupPasswordToggle(modal);
   }
@@ -698,6 +734,15 @@ async function openProfileModal(): Promise<void> {
   (document.getElementById('profile-current-password') as HTMLInputElement).value = '';
   (document.getElementById('profile-new-password') as HTMLInputElement).value = '';
   (document.getElementById('profile-confirm-password') as HTMLInputElement).value = '';
+
+  // Reset live indicators and any stale error so the previous open
+  // doesn't bleed into this one (modal is created once and reused).
+  updatePasswordRequirements('', 'profile-req-');
+  const errorDiv = document.getElementById('profile-password-error');
+  if (errorDiv) {
+    errorDiv.textContent = '';
+    errorDiv.classList.add('hidden');
+  }
 
   // Show modal
   openModal(modal);
@@ -722,19 +767,36 @@ async function saveProfile(e: Event): Promise<void> {
   const newPassword = (document.getElementById('profile-new-password') as HTMLInputElement).value;
   const confirmPassword = (document.getElementById('profile-confirm-password') as HTMLInputElement).value;
 
+  // Clear any stale password-validation error from a prior submit so we
+  // start with a clean slate on every attempt.
+  const passwordErrorDiv = document.getElementById('profile-password-error');
+  if (passwordErrorDiv) {
+    passwordErrorDiv.textContent = '';
+    passwordErrorDiv.classList.add('hidden');
+  }
+
   if (!currentPassword) {
     alert('Please enter your current password to save changes');
     return;
   }
 
   if (newPassword) {
+    // Password-validation failures render inline (matches reset and
+    // admin-setup flows) so the criterion text appears next to the
+    // requirements indicator the user is already looking at.
     const requirementError = describePasswordValidationError(newPassword);
     if (requirementError) {
-      alert(requirementError);
+      if (passwordErrorDiv) {
+        passwordErrorDiv.textContent = requirementError;
+        passwordErrorDiv.classList.remove('hidden');
+      }
       return;
     }
     if (newPassword !== confirmPassword) {
-      alert('New passwords do not match');
+      if (passwordErrorDiv) {
+        passwordErrorDiv.textContent = 'New passwords do not match';
+        passwordErrorDiv.classList.remove('hidden');
+      }
       return;
     }
   }

--- a/frontend/src/auth.ts
+++ b/frontend/src/auth.ts
@@ -148,13 +148,19 @@ function setupPasswordToggle(container: HTMLElement | Document = document): void
   });
 }
 
+// Special-character set used by every password-strength check in this
+// module (live indicator + submit-time validator). Module-level constant
+// so the regex isn't recompiled on every keystroke AND so the live
+// indicator and validator can't silently drift apart (#470 review).
+const SPECIAL_CHAR_RE = /[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]/;
+
 function updatePasswordRequirements(password: string, prefix = 'req-'): void {
   const requirements = {
     length: password.length >= 12,
     uppercase: /[A-Z]/.test(password),
     lowercase: /[a-z]/.test(password),
     number: /[0-9]/.test(password),
-    special: /[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]/.test(password)
+    special: SPECIAL_CHAR_RE.test(password)
   };
 
   // Update each requirement indicator
@@ -164,8 +170,6 @@ function updatePasswordRequirements(password: string, prefix = 'req-'): void {
   updateRequirement(`${prefix}number`, requirements.number);
   updateRequirement(`${prefix}special`, requirements.special);
 }
-
-const SPECIAL_CHAR_RE = /[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]/;
 
 /**
  * Return a user-facing description of which password complexity rules
@@ -186,7 +190,7 @@ export function describePasswordValidationError(password: string): string {
   if (!SPECIAL_CHAR_RE.test(password)) missing.push('one special character');
   if (missing.length === 0) return '';
   if (missing.length === 1) return `Password must contain ${missing[0]}`;
-  const last = missing.pop() as string;
+  const last = missing.pop()!;
   return `Password must contain ${missing.join(', ')} and ${last}`;
 }
 

--- a/frontend/src/auth.ts
+++ b/frontend/src/auth.ts
@@ -165,6 +165,31 @@ function updatePasswordRequirements(password: string, prefix = 'req-'): void {
   updateRequirement(`${prefix}special`, requirements.special);
 }
 
+const SPECIAL_CHAR_RE = /[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]/;
+
+/**
+ * Return a user-facing description of which password complexity rules
+ * the supplied password fails, or "" when the password satisfies every
+ * rule. Length is treated as its own message (an empty password isn't
+ * missing "one of N character classes", it's just too short); the
+ * complexity rules are joined into a single sentence that names ONLY
+ * the rules that actually failed, in priority order. Closes issue #458.
+ */
+export function describePasswordValidationError(password: string): string {
+  if (password.length < 12) {
+    return 'Password must be at least 12 characters long';
+  }
+  const missing: string[] = [];
+  if (!/[A-Z]/.test(password)) missing.push('one uppercase letter');
+  if (!/[a-z]/.test(password)) missing.push('one lowercase letter');
+  if (!/[0-9]/.test(password)) missing.push('one number');
+  if (!SPECIAL_CHAR_RE.test(password)) missing.push('one special character');
+  if (missing.length === 0) return '';
+  if (missing.length === 1) return `Password must contain ${missing[0]}`;
+  const last = missing.pop() as string;
+  return `Password must contain ${missing.join(', ')} and ${last}`;
+}
+
 function updateRequirement(id: string, isMet: boolean): void {
   const element = document.getElementById(id);
   if (!element) return;
@@ -196,23 +221,10 @@ async function handleResetPasswordSubmit(e: Event, token: string): Promise<void>
   const newPassword = newPasswordInput?.value || '';
   const confirmPassword = confirmPasswordInput?.value || '';
 
-  if (newPassword.length < 12) {
+  const requirementError = describePasswordValidationError(newPassword);
+  if (requirementError) {
     if (errorDiv) {
-      errorDiv.textContent = 'Password must be at least 12 characters long';
-      errorDiv.classList.remove('hidden');
-    }
-    return;
-  }
-
-  // Validate password complexity
-  const hasUppercase = /[A-Z]/.test(newPassword);
-  const hasLowercase = /[a-z]/.test(newPassword);
-  const hasNumber = /[0-9]/.test(newPassword);
-  const hasSpecial = /[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]/.test(newPassword);
-
-  if (!hasUppercase || !hasLowercase || !hasNumber || !hasSpecial) {
-    if (errorDiv) {
-      errorDiv.textContent = 'Password must contain at least one uppercase letter, one lowercase letter, one number, and one special character';
+      errorDiv.textContent = requirementError;
       errorDiv.classList.remove('hidden');
     }
     return;
@@ -365,22 +377,10 @@ async function handleAdminSetupSubmit(e: Event): Promise<void> {
   const password = (document.getElementById('setup-password') as HTMLInputElement)?.value || '';
   const confirmPassword = (document.getElementById('setup-confirm-password') as HTMLInputElement)?.value || '';
 
-  if (password.length < 12) {
+  const requirementError = describePasswordValidationError(password);
+  if (requirementError) {
     if (errorDiv) {
-      errorDiv.textContent = 'Password must be at least 12 characters long';
-      errorDiv.classList.remove('hidden');
-    }
-    return;
-  }
-
-  const hasUppercase = /[A-Z]/.test(password);
-  const hasLowercase = /[a-z]/.test(password);
-  const hasNumber = /[0-9]/.test(password);
-  const hasSpecial = /[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]/.test(password);
-
-  if (!hasUppercase || !hasLowercase || !hasNumber || !hasSpecial) {
-    if (errorDiv) {
-      errorDiv.textContent = 'Password must contain at least one uppercase letter, one lowercase letter, one number, and one special character';
+      errorDiv.textContent = requirementError;
       errorDiv.classList.remove('hidden');
     }
     return;
@@ -724,16 +724,9 @@ async function saveProfile(e: Event): Promise<void> {
   }
 
   if (newPassword) {
-    if (newPassword.length < 12) {
-      alert('New password must be at least 12 characters long');
-      return;
-    }
-    const hasUppercase = /[A-Z]/.test(newPassword);
-    const hasLowercase = /[a-z]/.test(newPassword);
-    const hasNumber = /[0-9]/.test(newPassword);
-    const hasSpecial = /[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]/.test(newPassword);
-    if (!hasUppercase || !hasLowercase || !hasNumber || !hasSpecial) {
-      alert('Password must contain uppercase, lowercase, number, and special character');
+    const requirementError = describePasswordValidationError(newPassword);
+    if (requirementError) {
+      alert(requirementError);
       return;
     }
     if (newPassword !== confirmPassword) {

--- a/frontend/src/users/userModals.ts
+++ b/frontend/src/users/userModals.ts
@@ -3,6 +3,7 @@
  */
 
 import * as api from '../api';
+import { describePasswordValidationError } from '../auth';
 import {
   currentEditingUser,
   setCurrentEditingUser,
@@ -116,16 +117,9 @@ export async function saveUser(e: Event): Promise<void> {
       // first login. Only run client-side strength checks when a
       // password was actually entered.
       if (password) {
-        if (password.length < 12) {
-          showError('Password must be at least 12 characters');
-          return;
-        }
-        const hasUppercase = /[A-Z]/.test(password);
-        const hasLowercase = /[a-z]/.test(password);
-        const hasNumber = /[0-9]/.test(password);
-        const hasSpecial = /[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]/.test(password);
-        if (!hasUppercase || !hasLowercase || !hasNumber || !hasSpecial) {
-          showError('Password must contain uppercase, lowercase, number, and special character');
+        const requirementError = describePasswordValidationError(password);
+        if (requirementError) {
+          showError(requirementError);
           return;
         }
       }


### PR DESCRIPTION
## Summary

QA review on the reset-password / admin-setup / profile-change / user-create flows found that when a new password fails multiple complexity rules at once, the form surfaces a single bundled message listing every rule ("uppercase, lowercase, number, and special") even when only one is missing. The length rule already returns its own targeted message; complexity was the only diverger.

## Fix

`frontend/src/auth.ts`:

- Add `describePasswordValidationError(password)` that returns a single specific message ("Password must contain one uppercase letter") when one rule fails, or names only the rules that actually failed when several fail ("Password must contain one uppercase letter and one special character"). Length keeps its own message.
- Replace the four duplicated bundled-message blocks at:
  - `handleResetPasswordSubmit` (reset-password modal)
  - `handleAdminSetupSubmit` (admin bootstrap modal)
  - profile change-password flow
  - `frontend/src/users/userModals.ts::saveUser` (admin-creating-a-user)

Result: 2 files, +38 / −51.

Closes #458.

## Test plan

- [x] `go build ./...` (no Go change, sanity)
- [ ] Open Settings → Profile → Change Password and submit a password missing only "one number" → message names just "one number".
- [ ] Same with a password missing 2 rules → message names exactly those two.
- [ ] Same in the user-create modal as an admin.
- [ ] Reset-password link with a too-short password still says "Password must be at least 12 characters long".

## Out of scope

- The backend's `validateCharacterRequirements` (`internal/auth/service_password.go`) still emits a bundled message; the live indicator on the modal usually short-circuits before the request goes out, so the backend message is rarely user-visible. If we want full parity, that's a follow-up — the live indicators already mirror the new copy.

## Additional fixes (2026-05-20)

Review of PR #470 surfaced two pre-existing UX gaps in the Profile change-password modal that the original PR did not touch (it only changed text). Added in commit `adc33db`:

- **Finding A — Profile modal lacks live password indicators.** Reset-password and admin-setup both render the `password-requirements` block with `req-*` rows that turn green as each rule is satisfied; the Profile modal had none. Replicated the same block under `#profile-new-password` with a `profile-req-` ID prefix (so it cannot collide with the reset / setup indicators if both modals are mounted concurrently), and wired the `input` event to `updatePasswordRequirements(value, 'profile-req-')`. The existing helper already accepts a prefix parameter — no helper change needed.
- **Finding B — `saveProfile` uses `alert()` for password-validation failures while reset / setup use inline `<div class="error-message">`.** Now that PR #470 unified the failure TEXT, the surface was the only inconsistency left. Added `<div id="profile-password-error" class="error-message hidden">` next to the password fields and routed both new-password validation paths (length/complexity + confirm-mismatch) through it. Other `saveProfile` paths (missing current password, success toast, API error) keep their existing `alert(...)` surface — out of scope here.

Tests: four new cases in `frontend/src/__tests__/auth.test.ts` covering live indicator rendering, criterion class toggling on input, indicator + error reset on reopen, and inline-error rendering for the length/complexity failure path. Existing `save profile validates new password confirmation` case updated to assert the inline div and that `alert` is NOT called.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECnwGTg2UNzuKHEgN69X4X)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized password validation with an exported helper and a live requirement indicator used during entry and submission across the app.

* **Bug Fixes**
  * Unified, prioritized inline password error messages for resets, account creation, admin setup, and profile updates (min-length first, then missing classes); avoids alert popups.

* **Tests**
  * Expanded tests for inline errors, live requirement indicators, and clearing stale indicators when reopening the profile modal.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/470?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
