### PR TITLE
fix(ux/settings): inline range validation on numeric settings inputs

### DIFF
--- a/frontend/src/__tests__/settings-purchasing-grace.test.ts
+++ b/frontend/src/__tests__/settings-purchasing-grace.test.ts
@@ -11,7 +11,7 @@
  *   - Reset-to-defaults restores every input to 7.
  */
 
-import { loadGlobalSettings, saveGlobalSettings, resetSettings } from '../settings';
+import { loadGlobalSettings, saveGlobalSettings, resetSettings, setupSettingsHandlers } from '../settings';
 
 jest.mock('../api', () => ({
   getConfig: jest.fn(),
@@ -207,5 +207,102 @@ describe('Settings → Purchasing grace-period inputs', () => {
     expect((document.getElementById('setting-grace-aws') as HTMLInputElement).value).toBe('7');
     expect((document.getElementById('setting-grace-azure') as HTMLInputElement).value).toBe('7');
     expect((document.getElementById('setting-grace-gcp') as HTMLInputElement).value).toBe('7');
+  });
+});
+
+/**
+ * Settings → Purchasing: per-provider grace inputs flow through
+ * wireInlineRangeValidation (follow-up to #471's "Out of scope" carve-out).
+ *
+ * Verifies the same inline contract the three top-level numeric inputs
+ * now use: aria-invalid + a sibling .field-error appears as the user
+ * types an out-of-range or fractional value, and clears when the value
+ * comes back in range or the field is emptied. Save remains blocked
+ * for invalid input but uses showToast (not alert/window.alert), so
+ * the inline indicator stays the primary feedback channel.
+ */
+describe('Settings → Purchasing grace inputs: inline range validation', () => {
+  let alertSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    seedDOM();
+    setupSettingsHandlers();
+    alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    alertSpy.mockRestore();
+  });
+
+  function fire(el: HTMLInputElement, type: 'input' | 'blur'): void {
+    el.dispatchEvent(new Event(type));
+  }
+
+  function errorEl(inputId: string): HTMLElement | null {
+    return document.getElementById(`${inputId}-range-error`);
+  }
+
+  it.each([
+    ['setting-grace-aws', '31'],
+    ['setting-grace-azure', '31'],
+    ['setting-grace-gcp', '-1'],
+  ])('typing out-of-range value into %s shows inline error', (inputId, value) => {
+    const input = document.getElementById(inputId) as HTMLInputElement;
+    input.value = value;
+    fire(input, 'input');
+
+    expect(input.getAttribute('aria-invalid')).toBe('true');
+    const err = errorEl(inputId);
+    expect(err).not.toBeNull();
+    expect(err!.classList.contains('hidden')).toBe(false);
+    expect(err!.textContent).toBe('Must be a whole number between 0 and 30');
+  });
+
+  it('typing a fractional value (7.5) is rejected inline (requireInteger)', () => {
+    const input = document.getElementById('setting-grace-azure') as HTMLInputElement;
+    input.value = '7.5';
+    fire(input, 'input');
+
+    expect(input.getAttribute('aria-invalid')).toBe('true');
+    expect(errorEl('setting-grace-azure')!.textContent).toBe('Must be a whole number between 0 and 30');
+  });
+
+  it('clearing the field removes aria-invalid and hides the inline error', () => {
+    const input = document.getElementById('setting-grace-aws') as HTMLInputElement;
+    input.value = '99';
+    fire(input, 'input');
+    expect(input.getAttribute('aria-invalid')).toBe('true');
+
+    input.value = '';
+    fire(input, 'input');
+    expect(input.getAttribute('aria-invalid')).toBeNull();
+    expect(errorEl('setting-grace-aws')!.classList.contains('hidden')).toBe(true);
+  });
+
+  it('typing a valid in-range value removes aria-invalid', () => {
+    const input = document.getElementById('setting-grace-gcp') as HTMLInputElement;
+    input.value = '99';
+    fire(input, 'input');
+    expect(input.getAttribute('aria-invalid')).toBe('true');
+
+    input.value = '15';
+    fire(input, 'input');
+    expect(input.getAttribute('aria-invalid')).toBeNull();
+    expect(errorEl('setting-grace-gcp')!.classList.contains('hidden')).toBe(true);
+  });
+
+  it('save with a grace input still invalid is blocked and never calls window.alert', async () => {
+    (document.getElementById('setting-grace-aws') as HTMLInputElement).value = '31';
+
+    await saveGlobalSettings(new Event('submit'));
+
+    expect(api.updateConfig).not.toHaveBeenCalled();
+    expect(alertSpy).not.toHaveBeenCalled();
+    // The save-time toast carries the same text the inline indicator renders.
+    expect(mockShowToast).toHaveBeenCalled();
+    const toastArg = mockShowToast.mock.calls[0]![0] as { message: string; kind: string };
+    expect(toastArg.message).toBe('AWS grace period: Must be a whole number between 0 and 30');
+    expect(toastArg.kind).toBe('error');
   });
 });

--- a/frontend/src/settings.ts
+++ b/frontend/src/settings.ts
@@ -180,6 +180,64 @@ function byId<T extends HTMLElement>(id: string): T | null {
 }
 
 /**
+ * Wire inline range validation on a numeric `<input>` driven by its
+ * existing `min` / `max` HTML5 attributes. Surfaces a single
+ * "Must be between X and Y" message under the field as the user types
+ * (and on blur) instead of waiting for Save Settings to reject the
+ * value — addresses #465 by collapsing the two-trip "must be ≥ X" /
+ * "must be ≤ Y" pattern into a single inline indication.
+ *
+ * The element's min/max attributes are the source of truth so the
+ * range stays in sync with the HTML. An empty value clears the error
+ * (the input may have its own "required" enforcement; we don't fight
+ * that here).
+ */
+function wireInlineRangeValidation(inputId: string, signal?: AbortSignal): void {
+  const input = document.getElementById(inputId) as HTMLInputElement | null;
+  if (!input) return;
+  const min = parseFloat(input.getAttribute('min') ?? '');
+  const max = parseFloat(input.getAttribute('max') ?? '');
+  if (!Number.isFinite(min) || !Number.isFinite(max)) return;
+
+  const errorId = `${inputId}-range-error`;
+  let errorEl = document.getElementById(errorId);
+  if (!errorEl) {
+    errorEl = document.createElement('small');
+    errorEl.id = errorId;
+    errorEl.className = 'field-error hidden';
+    errorEl.setAttribute('role', 'alert');
+    input.insertAdjacentElement('afterend', errorEl);
+    // Append (don't overwrite) any pre-existing aria-describedby so the
+    // input's existing help text (e.g. unit hints) stays announced.
+    const existingDescribedBy = input.getAttribute('aria-describedby');
+    input.setAttribute(
+      'aria-describedby',
+      existingDescribedBy ? `${existingDescribedBy} ${errorId}` : errorId,
+    );
+  }
+
+  const check = (): void => {
+    const raw = input.value.trim();
+    if (raw === '') {
+      input.removeAttribute('aria-invalid');
+      errorEl!.classList.add('hidden');
+      return;
+    }
+    const n = Number(raw);
+    if (!Number.isFinite(n) || n < min || n > max) {
+      input.setAttribute('aria-invalid', 'true');
+      errorEl!.textContent = `Must be between ${min} and ${max}`;
+      errorEl!.classList.remove('hidden');
+    } else {
+      input.removeAttribute('aria-invalid');
+      errorEl!.classList.add('hidden');
+    }
+  };
+  input.addEventListener('input', check, { signal });
+  input.addEventListener('blur', check, { signal });
+}
+
+/**
  * setInputValue writes a value to an <input>/<textarea> looked up by id, no-op
  * if the element is missing. Consolidates the repetitive
  * `byId<HTMLInputElement>('x'); if (el) el.value = v;` pattern used across
@@ -2080,6 +2138,13 @@ export function setupSettingsHandlers(signal?: AbortSignal): void {
     termEl?.addEventListener('change', () => syncPaymentConstraintsForService(field), { signal });
   });
 
+  // Inline range validation on numeric settings — surfaces a single
+  // "Must be between X and Y" message under the field as the user
+  // types, instead of waiting for Save Settings (#465).
+  wireInlineRangeValidation('setting-notification-days', signal);
+  wireInlineRangeValidation('setting-recs-stale-hours', signal);
+  wireInlineRangeValidation('setting-default-coverage', signal);
+
   // Set up dirty-field tracking
   setupDirtyTracking(signal);
 
@@ -2675,9 +2740,26 @@ export async function saveGlobalSettings(e: Event): Promise<void> {
     gracePeriodDays[provider] = v.value;
   }
 
-  // Validate recommendations_cache_stale_hours before building the save payload.
-  // Use Number() so fractional input like "1.5" fails Number.isInteger instead of silently
-  // truncating to 1 as parseInt would.
+  // Validate the three numeric inputs before building the save payload.
+  // Use Number() (not parseInt) so fractional input like "1.5" fails
+  // Number.isInteger() instead of silently truncating to 1. Each range
+  // is the same one declared on the <input>'s min/max attributes —
+  // wireInlineRangeValidation surfaces these inline as the user types
+  // (#465); this is the defensive guard for clients that bypass it.
+  const rawNotifyDays = Number(byId<HTMLInputElement>('setting-notification-days')?.value ?? '3');
+  if (!Number.isFinite(rawNotifyDays) || !Number.isInteger(rawNotifyDays) || rawNotifyDays < 1 || rawNotifyDays > 30) {
+    showToast({ message: 'Notification days before purchase must be a whole number between 1 and 30', kind: 'error' });
+    if (saveBtn) saveBtn.disabled = false;
+    saveInFlight = false;
+    return;
+  }
+  const rawCoverage = Number(byId<HTMLInputElement>('setting-default-coverage')?.value ?? '80');
+  if (!Number.isFinite(rawCoverage) || !Number.isInteger(rawCoverage) || rawCoverage < 0 || rawCoverage > 100) {
+    showToast({ message: 'Target coverage must be a whole number between 0 and 100', kind: 'error' });
+    if (saveBtn) saveBtn.disabled = false;
+    saveInFlight = false;
+    return;
+  }
   const rawStaleHours = Number(byId<HTMLInputElement>('setting-recs-stale-hours')?.value ?? '24');
   if (!Number.isFinite(rawStaleHours) || !Number.isInteger(rawStaleHours) || rawStaleHours < 0 || rawStaleHours > 8760) {
     showToast({ message: 'Cache stale threshold must be a whole number between 0 and 8760 hours (0 = disable)', kind: 'error' });
@@ -2693,8 +2775,8 @@ export async function saveGlobalSettings(e: Event): Promise<void> {
     collection_schedule: byId<HTMLSelectElement>('setting-collection-schedule')?.value || 'daily',
     default_term: parseInt(byId<HTMLSelectElement>('setting-default-term')?.value || '3', 10),
     default_payment: (byId<HTMLSelectElement>('setting-default-payment')?.value || 'all-upfront') as api.PaymentOption,
-    default_coverage: parseInt(byId<HTMLInputElement>('setting-default-coverage')?.value || '80', 10),
-    notification_days_before: parseInt(byId<HTMLInputElement>('setting-notification-days')?.value || '3', 10),
+    default_coverage: rawCoverage,
+    notification_days_before: rawNotifyDays,
     grace_period_days: gracePeriodDays,
     recommendations_cache_stale_hours: rawStaleHours,
     recommendations_lookback_days: parseInt(byId<HTMLSelectElement>('setting-recs-lookback-days')?.value || '7', 10),

--- a/frontend/src/settings.ts
+++ b/frontend/src/settings.ts
@@ -181,18 +181,28 @@ function byId<T extends HTMLElement>(id: string): T | null {
 
 /**
  * Wire inline range validation on a numeric `<input>` driven by its
- * existing `min` / `max` HTML5 attributes. Surfaces a single
- * "Must be between X and Y" message under the field as the user types
- * (and on blur) instead of waiting for Save Settings to reject the
- * value — addresses #465 by collapsing the two-trip "must be ≥ X" /
- * "must be ≤ Y" pattern into a single inline indication.
+ * existing `min` / `max` HTML5 attributes. Surfaces a single message
+ * under the field as the user types (and on blur) instead of waiting
+ * for Save Settings to reject the value — addresses #465 by collapsing
+ * the two-trip "must be ≥ X" / "must be ≤ Y" pattern into one inline
+ * indication.
+ *
+ * When `requireInteger` is true the validator additionally rejects
+ * fractional values like `1.5` (matching the save-time guards), and
+ * the message reads "Must be a whole number between X and Y" to
+ * explain why an in-range fraction is still rejected. Without it the
+ * inline path accepts 1.5 while save-time rejects it — exactly the
+ * two-trip behaviour this PR sets out to fix (CodeRabbit on #471).
  *
  * The element's min/max attributes are the source of truth so the
  * range stays in sync with the HTML. An empty value clears the error
  * (the input may have its own "required" enforcement; we don't fight
  * that here).
  */
-function wireInlineRangeValidation(inputId: string, signal?: AbortSignal): void {
+function wireInlineRangeValidation(
+  inputId: string,
+  { signal, requireInteger = false }: { signal?: AbortSignal; requireInteger?: boolean } = {},
+): void {
   const input = document.getElementById(inputId) as HTMLInputElement | null;
   if (!input) return;
   const min = parseFloat(input.getAttribute('min') ?? '');
@@ -205,7 +215,12 @@ function wireInlineRangeValidation(inputId: string, signal?: AbortSignal): void 
     errorEl = document.createElement('small');
     errorEl.id = errorId;
     errorEl.className = 'field-error hidden';
-    errorEl.setAttribute('role', 'alert');
+    // role=status + aria-live=polite (not role=alert/aria-live=assertive)
+    // so screen readers wait for a typing pause before announcing — an
+    // assertive live region would interrupt the user on every keystroke
+    // while the value is still in flux (WCAG SCR32). CodeRabbit on #471.
+    errorEl.setAttribute('role', 'status');
+    errorEl.setAttribute('aria-live', 'polite');
     input.insertAdjacentElement('afterend', errorEl);
     // Append (don't overwrite) any pre-existing aria-describedby so the
     // input's existing help text (e.g. unit hints) stays announced.
@@ -215,22 +230,32 @@ function wireInlineRangeValidation(inputId: string, signal?: AbortSignal): void 
       existingDescribedBy ? `${existingDescribedBy} ${errorId}` : errorId,
     );
   }
+  // Capture as const so the closure doesn't need a non-null assertion.
+  const error = errorEl;
+  const message = requireInteger
+    ? `Must be a whole number between ${min} and ${max}`
+    : `Must be between ${min} and ${max}`;
 
   const check = (): void => {
     const raw = input.value.trim();
     if (raw === '') {
       input.removeAttribute('aria-invalid');
-      errorEl!.classList.add('hidden');
+      error.classList.add('hidden');
       return;
     }
     const n = Number(raw);
-    if (!Number.isFinite(n) || n < min || n > max) {
+    const invalid =
+      !Number.isFinite(n) ||
+      (requireInteger && !Number.isInteger(n)) ||
+      n < min ||
+      n > max;
+    if (invalid) {
       input.setAttribute('aria-invalid', 'true');
-      errorEl!.textContent = `Must be between ${min} and ${max}`;
-      errorEl!.classList.remove('hidden');
+      error.textContent = message;
+      error.classList.remove('hidden');
     } else {
       input.removeAttribute('aria-invalid');
-      errorEl!.classList.add('hidden');
+      error.classList.add('hidden');
     }
   };
   input.addEventListener('input', check, { signal });
@@ -2139,11 +2164,14 @@ export function setupSettingsHandlers(signal?: AbortSignal): void {
   });
 
   // Inline range validation on numeric settings — surfaces a single
-  // "Must be between X and Y" message under the field as the user
-  // types, instead of waiting for Save Settings (#465).
-  wireInlineRangeValidation('setting-notification-days', signal);
-  wireInlineRangeValidation('setting-recs-stale-hours', signal);
-  wireInlineRangeValidation('setting-default-coverage', signal);
+  // "Must be a whole number between X and Y" message under the field
+  // as the user types, instead of waiting for Save Settings (#465).
+  // All three fields are integer-only at the backend, so pass
+  // requireInteger so the inline check rejects fractional input that
+  // the save-time guard would otherwise catch on a second trip.
+  wireInlineRangeValidation('setting-notification-days', { signal, requireInteger: true });
+  wireInlineRangeValidation('setting-recs-stale-hours', { signal, requireInteger: true });
+  wireInlineRangeValidation('setting-default-coverage', { signal, requireInteger: true });
 
   // Set up dirty-field tracking
   setupDirtyTracking(signal);

--- a/frontend/src/settings.ts
+++ b/frontend/src/settings.ts
@@ -160,17 +160,20 @@ function populateGraceInput(id: string, value: number | undefined): void {
 // readGraceInput parses the grace-period input, returning the numeric
 // value or an error message (out of range, not a number). Empty input
 // defaults to 7.
+//
+// The error wording mirrors what wireInlineRangeValidation renders
+// under the field on input/blur, so the inline indicator and the
+// save-time toast carry the same text — a user who ignores the inline
+// red mark and clicks Save shouldn't see a differently-phrased message
+// describing the same failure (CodeRabbit follow-up to #471).
 function readGraceInput(id: string): { value: number; err?: undefined } | { value: 0; err: string } {
   const el = document.getElementById(id) as HTMLInputElement | null;
   if (!el) return { value: 7 };
   const raw = el.value.trim();
   if (raw === '') return { value: 7 };
   const n = Number(raw);
-  if (!Number.isFinite(n) || !Number.isInteger(n)) {
-    return { value: 0, err: 'enter a whole number of days' };
-  }
-  if (n < 0 || n > 30) {
-    return { value: 0, err: 'must be between 0 and 30 days' };
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n < 0 || n > 30) {
+    return { value: 0, err: 'Must be a whole number between 0 and 30' };
   }
   return { value: n };
 }
@@ -2166,12 +2169,21 @@ export function setupSettingsHandlers(signal?: AbortSignal): void {
   // Inline range validation on numeric settings — surfaces a single
   // "Must be a whole number between X and Y" message under the field
   // as the user types, instead of waiting for Save Settings (#465).
-  // All three fields are integer-only at the backend, so pass
-  // requireInteger so the inline check rejects fractional input that
-  // the save-time guard would otherwise catch on a second trip.
+  // All fields are integer-only at the backend, so pass requireInteger
+  // so the inline check rejects fractional input that the save-time
+  // guard would otherwise catch on a second trip.
+  //
+  // Every numeric input on the Settings page is wired through this
+  // helper — the three top-level inputs covered by #471, plus the
+  // per-provider grace inputs (originally on a separate readGraceInput
+  // save-time-only toast contract) — so the inline-error UX is uniform
+  // across Settings.
   wireInlineRangeValidation('setting-notification-days', { signal, requireInteger: true });
   wireInlineRangeValidation('setting-recs-stale-hours', { signal, requireInteger: true });
   wireInlineRangeValidation('setting-default-coverage', { signal, requireInteger: true });
+  wireInlineRangeValidation('setting-grace-aws', { signal, requireInteger: true });
+  wireInlineRangeValidation('setting-grace-azure', { signal, requireInteger: true });
+  wireInlineRangeValidation('setting-grace-gcp', { signal, requireInteger: true });
 
   // Set up dirty-field tracking
   setupDirtyTracking(signal);

--- a/frontend/src/styles/base.css
+++ b/frontend/src/styles/base.css
@@ -294,6 +294,27 @@ body {
     display: none;
 }
 
+/* Inline field-level error — sits underneath a single <input> rather
+   than wrapping a whole form section like .error-message does. Used
+   for live range / format validation messages so a user typing an
+   out-of-range value sees the bound immediately instead of on Save
+   (issue #465). */
+.field-error {
+    display: block;
+    color: var(--cudly-error-fg);
+    font-size: 0.85em;
+    margin-top: 0.25rem;
+}
+
+.field-error.hidden {
+    display: none;
+}
+
+[aria-invalid="true"] {
+    border-color: var(--cudly-error);
+    outline-color: var(--cudly-error);
+}
+
 /* Success message */
 .success-message {
     padding: 1rem;


### PR DESCRIPTION
## Summary

Three numeric inputs on the Settings page currently accept out-of-range values without complaint while the user types, then surface a validation toast only when Save Settings is clicked — and the lower-bound and upper-bound cases get separate two-trip toasts.

Affected inputs:

- **Notification Days Before Purchase** — range [1, 30]. No client validation at all (relied on backend rejection).
- **Recommendations Cache Stale Threshold (hours)** — range [0, 8760].
- **Target Coverage (%)** — range [0, 100]. No client validation.

## Fix

`frontend/src/settings.ts` and `frontend/src/styles/base.css`:

- Add `wireInlineRangeValidation(inputId, signal?)` — reads min/max off the `<input>` attributes, listens to `input` + `blur`, and toggles `aria-invalid` plus a sibling `.field-error` showing "Must be between X and Y". Cleared automatically when the value comes back in range or the field is emptied.
- Wire it on the three inputs in `setupSettingsHandlers`.
- Backfill the two missing save-time guards (`notification_days_before`, `default_coverage`) in `saveGlobalSettings` using the same `Number()` + `Number.isInteger()` shape the cache-hours check already uses, so a client that bypasses the inline check still gets a structured toast.
- Add `.field-error` and `[aria-invalid="true"]` CSS so the inline error renders consistently with the existing `.error-message` palette.

Result: 2 files, +108 / −5.

Closes #465.

## Test plan

- [x] `go build ./...` (no Go change, sanity)
- [ ] Settings → General → Notification Days. Type `0`, `31`, `1.5`, `-5`. Each case shows "Must be between 1 and 30" inline immediately; clearing the value clears the error.
- [ ] Same for Recommendations Cache Stale Threshold (hours) [0, 8760].
- [ ] Same for Settings → Purchasing → Target Coverage (%) [0, 100].
- [ ] Save Settings with any field still red is still blocked (toast).
- [ ] Save Settings with all fields green succeeds.
- [ ] aria-invalid + .field-error are announced by VoiceOver/NVDA (manual a11y check).

## Out of scope

- ~~Other numeric inputs on the Settings page (`setting-grace-*`) already have their own `readGraceInput` helper and a distinct error contract — leaving them untouched until/unless QA flags them.~~ **Closed by the additional commit below.**

## Additional fixes (2026-05-19)

Folded the per-provider grace inputs (`setting-grace-aws`, `setting-grace-azure`, `setting-grace-gcp`) into the same `wireInlineRangeValidation` contract so the Settings page now ships with one consistent inline-error UX across every numeric input. Previously they used the older `readGraceInput` save-time-only toast path.

`frontend/src/settings.ts` + `frontend/src/__tests__/settings-purchasing-grace.test.ts`:

- Wire `wireInlineRangeValidation` on the three grace inputs in `setupSettingsHandlers` with `requireInteger: true` (matching the existing three calls).
- Keep the `readGraceInput` save-time guard as a defensive check for clients that bypass the inline path; unify its error wording with what the inline helper renders (`"Must be a whole number between 0 and 30"`) so the message is identical whether it appears under the field as the user types or in the save-time toast.
- Extend the existing `settings-purchasing-grace.test.ts` with inline-validation cases: out-of-range typing surfaces `aria-invalid="true"` + a visible `.field-error` with the right text on each of the three grace inputs; fractional input (`7.5`) is rejected inline via `requireInteger`; clearing or correcting the value removes `aria-invalid` and hides the inline error; an in-flight save with a still-invalid grace value is blocked **and** `window.alert` is never called (the inline indicator + save-time toast are the only feedback channels).

No functional change to the three inputs covered in the original PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ECnwGTg2UNzuKHEgN69X4X)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time numeric validation for settings with inline, accessible error messages and preserved aria descriptions
  * Integer-only option enforces whole-number messaging for applicable fields

* **Bug Fixes**
  * Prevents saving when numeric inputs are invalid and shows a targeted error toast
  * Visual error styling applied to invalid inputs

* **Tests**
  * Added tests covering inline range/integer validation and blocked saves when invalid

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/471?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
