### PR TITLE
fix(ux/settings): four small UX nits flagged in QA review

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -574,7 +574,7 @@
                                 <label>Term: <select id="gcp-memorystore-term"><option value="1">1 Year</option><option value="3" selected>3 Years</option></select></label>
                             </div>
                             <div class="service-default-card">
-                                <h5>Cloud Storage CUDs</h5>
+                                <h5>Cloud Storage</h5>
                                 <label>Term: <select id="gcp-storage-term"><option value="1">1 Year</option><option value="3" selected>3 Years</option></select></label>
                             </div>
                         </div>

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -315,12 +315,16 @@
                             </div>
                             <div class="setting-row">
                                 <div class="setting-info">
-                                    <label for="setting-auto-collect">Auto-collect Recommendations</label>
+                                    <!-- Plain span (not <label for=>) so clicking the descriptive text doesn't
+                                         flip the toggle. The toggle's own <label class="toggle-label"> wraps the
+                                         input and provides the click target. aria-labelledby on the input keeps
+                                         the descriptive text as the toggle's accessible name. Issue #464. -->
+                                    <span id="setting-auto-collect-label">Auto-collect Recommendations</span>
                                     <span class="info-icon">&#9432;<span class="tooltip-text">Automatically fetch recommendations from cloud providers on a schedule.</span></span>
                                 </div>
                                 <div class="setting-input">
                                     <label class="toggle-label">
-                                        <input type="checkbox" id="setting-auto-collect" checked>
+                                        <input type="checkbox" id="setting-auto-collect" aria-labelledby="setting-auto-collect-label" checked>
                                         <span class="slider"></span>
                                     </label>
                                 </div>
@@ -409,7 +413,7 @@
 
                     <fieldset class="settings-category" id="purchasing-recommendations-lookback">
                         <legend>Recommendations Lookback</legend>
-                        <p class="settings-help">Controls how far back AWS Cost Explorer looks when computing fresh recommendations. Must be 7, 30, or 60 days (AWS Cost Explorer API constraint). GCP CUD Recommender has no equivalent parameter and always uses its own internal window.</p>
+                        <p class="settings-help">Controls how far back AWS Cost Explorer looks when computing fresh recommendations. Must be 7, 30, or 60 days (AWS Cost Explorer API constraint). Azure Cost Management and GCP CUD Recommender have no equivalent parameter — each uses its own internal window — so this setting affects AWS only.</p>
                         <div class="setting-row">
                             <div class="setting-info">
                                 <label for="setting-recs-lookback-days"><span class="provider-badge aws">AWS</span> lookback period</label>

--- a/frontend/src/settings.ts
+++ b/frontend/src/settings.ts
@@ -2346,7 +2346,13 @@ const SERVICE_DISPLAY_NAMES: Record<string, Record<string, string>> = {
     'compute': 'Compute Engine CUDs',
     'sql': 'Cloud SQL CUDs',
     'memorystore': 'Memorystore CUDs',
-    'storage': 'Cloud Storage CUDs',
+    // GCP Cloud Storage doesn't have a Committed Use Discount product
+    // (CUDs only apply to Compute Engine / Bigtable / NetApp / etc.),
+    // so the label is intentionally plain "Cloud Storage" — kept in
+    // sync with the matching <h5> on the Service Default card so the
+    // Global-Defaults confirmation pop-up still mirrors the card title
+    // (CodeRabbit on #472).
+    'storage': 'Cloud Storage',
   },
 };
 

--- a/frontend/src/settings.ts
+++ b/frontend/src/settings.ts
@@ -2312,6 +2312,50 @@ function paymentLabel(value: string): string {
   }
 }
 
+// Human-readable display names for each (provider, service) tuple,
+// keyed to match the SERVICE_FIELDS constant. Source of truth: the
+// <h5> titles on each Service Default card in index.html. Used by
+// buildAffectedList so the "Propagate to N services" confirmation
+// pop-up reads "AWS EC2 Reserved Instances" instead of the backend
+// identifier "aws ec2" (#467).
+//
+// Missing entries fall back to a UPPER + raw service slug, which is
+// strictly an improvement-of-niceness — anything missing here renders
+// the way the old code rendered everything. Keep this table in sync
+// when SERVICE_FIELDS grows.
+const SERVICE_DISPLAY_NAMES: Record<string, Record<string, string>> = {
+  aws: {
+    'ec2': 'EC2 Reserved Instances',
+    'rds': 'RDS Reserved Instances',
+    'elasticache': 'ElastiCache Reserved Nodes',
+    'opensearch': 'OpenSearch Reserved Instances',
+    'redshift': 'Redshift Reserved Nodes',
+    'savings-plans-compute': 'Compute Savings Plans',
+    'savings-plans-ec2instance': 'EC2 Instance Savings Plans',
+    'savings-plans-sagemaker': 'SageMaker Savings Plans',
+    'savings-plans-database': 'Database Savings Plans',
+  },
+  azure: {
+    'vm': 'Virtual Machine Reservations',
+    'sql': 'SQL Database Reservations',
+    'cosmosdb': 'CosmosDB Reservations',
+    'redis': 'Redis Cache Reservations',
+    'search': 'Cognitive Search Reservations',
+  },
+  gcp: {
+    'compute': 'Compute Engine CUDs',
+    'sql': 'Cloud SQL CUDs',
+    'memorystore': 'Memorystore CUDs',
+    'storage': 'Cloud Storage CUDs',
+  },
+};
+
+function serviceDisplayName(provider: string, service: string): string {
+  const providerLabel = provider.toUpperCase();
+  const display = SERVICE_DISPLAY_NAMES[provider]?.[service];
+  return display ? `${providerLabel} ${display}` : `${providerLabel} ${service}`;
+}
+
 function buildAffectedList(affected: { provider: string; service: string }[]): HTMLDivElement {
   // Build the diff list via DOM APIs (not innerHTML) so we don't need an
   // escapeHtml import; provider + service values come from the SERVICE_FIELDS
@@ -2325,7 +2369,7 @@ function buildAffectedList(affected: { provider: string; service: string }[]): H
   const ul = document.createElement('ul');
   affected.forEach((f) => {
     const li = document.createElement('li');
-    li.textContent = `${f.provider.toUpperCase()} ${f.service}`;
+    li.textContent = serviceDisplayName(f.provider, f.service);
     ul.appendChild(li);
   });
   wrap.appendChild(ul);
@@ -2356,8 +2400,13 @@ async function confirmAndPropagateTerm(select: HTMLSelectElement): Promise<void>
     updateDirtyMarkers();
   } else {
     // User cancelled — restore the default select to its prior value so
-    // the visible state matches what's persisted/saved.
+    // the visible state matches what's persisted/saved. Re-run the
+    // dirty-marker diff (setting .value via JS doesn't fire 'input', so
+    // setupDirtyTracking's listener wouldn't catch the revert) so the
+    // field highlight and global "Unsaved changes" badge clear when the
+    // restored value matches the saved snapshot. Issue #468.
     select.value = previousValue;
+    updateDirtyMarkers();
   }
 }
 
@@ -2385,7 +2434,11 @@ async function confirmAndPropagatePayment(select: HTMLSelectElement): Promise<vo
     select.dataset['previous'] = newValue;
     updateDirtyMarkers();
   } else {
+    // Mirror the Term branch: re-run the dirty-marker diff after the
+    // JS-driven value restore so the visible state matches the saved
+    // snapshot. Issue #468.
     select.value = previousValue;
+    updateDirtyMarkers();
   }
 }
 


### PR DESCRIPTION
## Summary

Four small unrelated UX nits flagged in the QA review that share the same area (Settings page) and risk profile (cosmetic + accessibility), bundled so they review as one diff instead of four tiny PRs. Each is independently revert-safe.

## Fixes

### 1. Auto-collect Recommendations label is clickable (#464)

`frontend/src/index.html`. The descriptive text wrapped in `<label for="setting-auto-collect">` made clicking the words "Auto-collect Recommendations" flip the toggle in addition to clicking the pill itself — inconsistent with the rest of the toggle-row contract.

Replace the outer `<label for=>` with a plain `<span id="setting-auto-collect-label">` and add `aria-labelledby="setting-auto-collect-label"` to the checkbox so screen readers still announce the toggle's name from the descriptive text.

### 2. Global-Defaults confirmation pop-up shows backend service IDs (#467)

`frontend/src/settings.ts::buildAffectedList`. The "N services will change:" pop-up rendered raw SERVICE_FIELDS tuples — "AWS ec2", "AZURE cosmosdb", "GCP memorystore" — instead of the human-readable card titles "AWS EC2 Reserved Instances" / "AZURE CosmosDB Reservations" / "GCP Memorystore CUDs".

Add a `SERVICE_DISPLAY_NAMES` table keyed off the same `(provider, service)` tuples and a `serviceDisplayName()` helper. Missing entries fall back to the previous `provider.toUpperCase() + service` rendering, so adding a new SERVICE_FIELDS row is strictly forward-compatible.

### 3. Cancel leaves "Unsaved changes" badge + field highlight (#468)

`frontend/src/settings.ts::confirmAndPropagate{Term,Payment}`. The Cancel branch restores `select.value` via JS — which does NOT trigger an `input` event — so the listener registered by `setupDirtyTracking` never re-diffs and the dirty markers stay on even though the value matches the saved snapshot again.

Call `updateDirtyMarkers()` explicitly after the JS-driven restore. Both Term and Payment branches.

### 4. Recommendation Lookback help text omits Azure (#469)

`frontend/src/index.html`. Current copy only names AWS and GCP. Confirmed via the scheduler (`internal/scheduler/scheduler.go::collectAzureForAccount` and the recommender clients) that Azure Cost Management has no equivalent `lookback_days` parameter and uses its own internal window — so the setting affects **AWS only**, and the copy needs to say so explicitly. Otherwise users expect Azure recommendations to react to the slider.

Result: 2 files, +62 / −5.

Closes #464, #467, #468, #469.

## Test plan

- [x] `go build ./...` (no Go change, sanity)
- [ ] **Fix 1**: Settings → General. Click the words "Auto-collect Recommendations" — toggle does NOT flip. Click the toggle pill — it does. VoiceOver/NVDA announce the toggle as "Auto-collect Recommendations".
- [ ] **Fix 2**: Change Default Term in Settings → Purchasing → Global Defaults to a value that differs from at least one per-service row. Confirm the pop-up lists "AWS EC2 Reserved Instances", "AZURE CosmosDB Reservations", etc — not "AWS ec2" / "AZURE cosmosdb".
- [ ] **Fix 3**: Change Default Term, click Cancel in the confirm dialog. Field is no longer highlighted; "Unsaved changes" badge clears (assuming no other dirty fields). Repeat for Default Payment Option.
- [ ] **Fix 4**: Settings → Purchasing → Recommendations Lookback. Help text now mentions Azure (alongside GCP) as a provider that doesn't honour the slider.

## Out of scope

- Other toggle rows on the Plan-create modal (`plan-auto-purchase`, `plan-enabled`) use the same `<label for=>` pattern as the Auto-collect row. The QA report specifically called out the Settings page; if reviewer wants the modal cleaned up too, happy to follow up — but didn't want to expand this PR's scope.
- The Lookback help-text fix doesn't change the backend behaviour, only the copy. If we want Azure to honour the slider, that's a much bigger ticket (would need an explicit per-provider override in the Azure recommender client).


---
_Generated by [Claude Code](https://claude.ai/code/session_01ECnwGTg2UNzuKHEgN69X4X)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Improved checkbox labeling in Admin → General Settings so descriptive text no longer toggles the control and is read properly by assistive tech.

* **Bug Fixes**
  * Fixed dirty-state indicators to reflect when reverted setting changes restore the persisted state.

* **Documentation**
  * Clarified "Recommendations Lookback" help text to note it applies to AWS Cost Explorer; Azure/GCP use internal windows.

* **UI Improvements**
  * Confirmation dialogs now show friendly service names; GCP storage section heading renamed to "Cloud Storage".

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/472?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->