### PR TITLE
fix(ux/login): field-specific error copy for empty + malformed inputs

### DIFF
--- a/frontend/src/__tests__/auth.test.ts
+++ b/frontend/src/__tests__/auth.test.ts
@@ -118,6 +118,80 @@ describe('Auth Module', () => {
       expect(errorDiv?.textContent).toBe('Invalid credentials');
     });
 
+    // Pre-flight + server-error mapping tests (issues #455 and #456).
+    // Helper: submit the login form with the given values and return the
+    // resulting error-div text. Uses the same async settle pattern as the
+    // surrounding tests.
+    async function submitLogin(email: string, password: string): Promise<string | null | undefined> {
+      const emailInput = document.getElementById('login-email') as HTMLInputElement;
+      const passwordInput = document.getElementById('login-password') as HTMLInputElement;
+      const loginForm = document.getElementById('login-form');
+      emailInput.value = email;
+      passwordInput.value = password;
+      loginForm?.dispatchEvent(new Event('submit', { cancelable: true }));
+      await new Promise(resolve => setTimeout(resolve, 50));
+      const errorDiv = document.getElementById('login-error');
+      return errorDiv?.textContent;
+    }
+
+    test('empty email shows "Enter email address" without calling api.login', async () => {
+      await showLoginModal();
+      const text = await submitLogin('', 'somepassword');
+      expect(text).toBe('Enter email address');
+      expect(api.login).not.toHaveBeenCalled();
+    });
+
+    test('empty password shows "Enter password" without calling api.login', async () => {
+      await showLoginModal();
+      const text = await submitLogin('user@example.com', '');
+      expect(text).toBe('Enter password');
+      expect(api.login).not.toHaveBeenCalled();
+    });
+
+    test('both empty shows single "Enter email and password" message', async () => {
+      await showLoginModal();
+      const text = await submitLogin('', '');
+      expect(text).toBe('Enter email and password');
+      expect(api.login).not.toHaveBeenCalled();
+    });
+
+    test('malformed email shows "Incorrect email format" without calling api.login', async () => {
+      await showLoginModal();
+      const text = await submitLogin('not-an-email', 'somepassword');
+      expect(text).toBe('Incorrect email format');
+      expect(api.login).not.toHaveBeenCalled();
+    });
+
+    test('backend "authentication failed" maps to "Incorrect email or password"', async () => {
+      (api.login as jest.Mock).mockRejectedValue(new Error('authentication failed'));
+      await showLoginModal();
+      const text = await submitLogin('user@example.com', 'wrongpassword');
+      expect(text).toBe('Incorrect email or password');
+    });
+
+    test('backend "invalid email or password" maps to "Incorrect email or password"', async () => {
+      (api.login as jest.Mock).mockRejectedValue(new Error('invalid email or password'));
+      await showLoginModal();
+      const text = await submitLogin('user@example.com', 'wrongpassword');
+      expect(text).toBe('Incorrect email or password');
+    });
+
+    test('backend "invalid email format" maps to "Incorrect email format"', async () => {
+      (api.login as jest.Mock).mockRejectedValue(new Error('invalid email format'));
+      await showLoginModal();
+      // Bypass client-side check with an email that passes the regex but
+      // that the backend would reject (e.g. extra-strict server policy).
+      const text = await submitLogin('shape-ok@example.com', 'somepassword');
+      expect(text).toBe('Incorrect email format');
+    });
+
+    test('unknown backend error passes through unchanged (e.g. MFA prompt)', async () => {
+      (api.login as jest.Mock).mockRejectedValue(new Error('MFA code required'));
+      await showLoginModal();
+      const text = await submitLogin('user@example.com', 'somepassword');
+      expect(text).toBe('MFA code required');
+    });
+
     test('reloads page after successful login', async () => {
       (api.login as jest.Mock).mockResolvedValue({});
       await showLoginModal();

--- a/frontend/src/__tests__/auth.test.ts
+++ b/frontend/src/__tests__/auth.test.ts
@@ -192,6 +192,25 @@ describe('Auth Module', () => {
       expect(text).toBe('MFA code required');
     });
 
+    test('non-Error rejection (string) is handled defensively', async () => {
+      // Guards against a non-Error rejection causing undefined.toLowerCase()
+      // inside the server-error mapper.
+      (api.login as jest.Mock).mockImplementation(() => Promise.reject('boom'));
+      await showLoginModal();
+      const text = await submitLogin('user@example.com', 'somepassword');
+      expect(text).toBe('boom');
+    });
+
+    test('non-Error rejection (plain object) is handled defensively', async () => {
+      (api.login as jest.Mock).mockImplementation(() => Promise.reject({ code: 500 }));
+      await showLoginModal();
+      const text = await submitLogin('user@example.com', 'somepassword');
+      // String({...}) returns "[object Object]" — the exact stringification is
+      // less important than the fact that no exception is thrown and the
+      // login-error div is populated with something.
+      expect(text).toBe('[object Object]');
+    });
+
     test('reloads page after successful login', async () => {
       (api.login as jest.Mock).mockResolvedValue({});
       await showLoginModal();

--- a/frontend/src/auth.ts
+++ b/frontend/src/auth.ts
@@ -480,39 +480,101 @@ function setupLoginModalHandlers(modal: HTMLElement): void {
   setupPasswordToggle(modal);
 }
 
+// Basic email shape check used to short-circuit obviously-malformed input
+// client-side before sending it to the server. Intentionally permissive: it
+// only catches "obviously not an email" (missing @, missing TLD, whitespace).
+// The backend's regex remains the authoritative validator.
+const EMAIL_SHAPE_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/**
+ * Pre-flight validation for the login form. Returns a user-facing message
+ * naming the specific problem, or null if the inputs are submittable.
+ *
+ * Issue #455: empty fields previously produced "Invalid email format" or
+ * "Invalid email or password" which hid which field was actually blank.
+ * Issue #456 (case 3.3): malformed-email + valid-password previously came
+ * back from the server as "authentication failed", which made it look like
+ * a credential problem rather than a typo in the email.
+ */
+function validateLoginInputs(email: string, password: string): string | null {
+  if (email === '' && password === '') {
+    return 'Enter email and password';
+  }
+  if (email === '') {
+    return 'Enter email address';
+  }
+  if (password === '') {
+    return 'Enter password';
+  }
+  if (!EMAIL_SHAPE_RE.test(email)) {
+    return 'Incorrect email format';
+  }
+  return null;
+}
+
+/**
+ * Translate the known generic backend error strings into clearer
+ * user-facing copy. The mapping deliberately collapses both
+ * "authentication failed" (user not found) and "invalid email or
+ * password" (wrong password) into the same client-side message so we do
+ * not regress the account-enumeration mitigation called out in #456.
+ * Anything else (MFA prompts, rate-limit, server errors) passes through
+ * unchanged so operational signals are not suppressed.
+ */
+function mapServerLoginError(message: string): string {
+  const lower = message.toLowerCase();
+  if (lower.includes('invalid email format')) {
+    return 'Incorrect email format';
+  }
+  if (lower.includes('authentication failed') || lower.includes('invalid email or password')) {
+    return 'Incorrect email or password';
+  }
+  return message;
+}
+
+function showLoginError(message: string): void {
+  const errorDiv = document.getElementById('login-error');
+  if (errorDiv) {
+    errorDiv.textContent = message;
+    errorDiv.classList.remove('hidden');
+  }
+}
+
 async function handleLogin(e: Event): Promise<void> {
   e.preventDefault();
+
+  const emailInput = document.getElementById('login-email') as HTMLInputElement | null;
+  const passwordInput = document.getElementById('login-password') as HTMLInputElement | null;
+  const email = emailInput?.value.trim() || '';
+  const password = passwordInput?.value || '';
+
+  // Client-side pre-flight (issues #455 + #456). Runs before the rate-limit
+  // check so an accidental click on an empty form does not burn the
+  // cooldown window the user needs for their real attempt.
+  const preflightError = validateLoginInputs(email, password);
+  if (preflightError !== null) {
+    showLoginError(preflightError);
+    return;
+  }
 
   // Rate limiting check
   const now = Date.now();
   if (now - lastLoginAttempt < LOGIN_COOLDOWN_MS) {
-    const errorDiv = document.getElementById('login-error');
-    if (errorDiv) {
-      errorDiv.textContent = 'Please wait before trying again';
-      errorDiv.classList.remove('hidden');
-    }
+    showLoginError('Please wait before trying again');
     return;
   }
   lastLoginAttempt = now;
 
-  const errorDiv = document.getElementById('login-error');
-  errorDiv?.classList.add('hidden');
+  document.getElementById('login-error')?.classList.add('hidden');
 
   try {
-    const emailInput = document.getElementById('login-email') as HTMLInputElement | null;
-    const passwordInput = document.getElementById('login-password') as HTMLInputElement | null;
-    const email = emailInput?.value.trim() || '';
-    const password = passwordInput?.value || '';
     await api.login(email, password);
 
     document.getElementById('login-modal')?.remove();
     location.reload();
   } catch (error) {
     const err = error as Error;
-    if (errorDiv) {
-      errorDiv.textContent = err.message;
-      errorDiv.classList.remove('hidden');
-    }
+    showLoginError(mapServerLoginError(err.message));
   }
 }
 

--- a/frontend/src/auth.ts
+++ b/frontend/src/auth.ts
@@ -573,8 +573,12 @@ async function handleLogin(e: Event): Promise<void> {
     document.getElementById('login-modal')?.remove();
     location.reload();
   } catch (error) {
-    const err = error as Error;
-    showLoginError(mapServerLoginError(err.message));
+    // `error` is `unknown` per TS strict catch typing. Extract a string
+    // defensively so a non-Error rejection (e.g. a thrown string or a
+    // plain object) does not produce `undefined.toLowerCase()` inside
+    // `mapServerLoginError`.
+    const message = error instanceof Error ? error.message : String(error);
+    showLoginError(mapServerLoginError(message));
   }
 }
 


### PR DESCRIPTION
## Summary

Replace the generic / wrong-field error copy on the login modal with field-specific, user-actionable messages, while preserving the account-enumeration mitigation already in the backend.

- `validateLoginInputs` runs as a client-side pre-flight before the rate-limit check, so an accidental click on a blank form does not burn the cooldown the user needs for their real attempt. Empty / both-empty / malformed inputs are caught locally and produce "Enter email address", "Enter password", "Enter email and password", or "Incorrect email format".
- `mapServerLoginError` translates the known generic backend strings into clearer copy. The backend's `authentication failed` (user-not-found) and `invalid email or password` (wrong-password) BOTH collapse to a single client-side message ("Incorrect email or password"), so the enumeration mitigation called out in #456 is preserved. Unknown server messages pass through unchanged so MFA / rate-limit / server signals are not suppressed.
- No backend changes. The backend remains the authoritative validator for email format and credentials.

## Test plan

- [x] 8 new component tests in `frontend/src/__tests__/auth.test.ts` cover empty email, empty password, both-empty, malformed email, backend `authentication failed`, backend `invalid email or password`, backend `invalid email format`, and the unknown-error pass-through.
- [x] Full frontend test suite green (1750 passed, 1 skipped, 0 failed).
- [x] `tsc --noEmit` clean.
- [ ] Manual smoke against a deployed frontend: submit each branch (empty, empty/empty, malformed, wrong creds) and confirm the message text + the modal stays open.

## Security note

The QA suggestion in #456 for cases 3.2 / 3.5 (distinguish "user does not exist" from "wrong password") is intentionally NOT applied. Doing so would leak account-existence information and weaken the brute-force / enumeration mitigation that the backend already enforces by returning the generic `invalid email or password` from both paths. The user-visible improvement here comes from catching empty / malformed inputs locally before the request goes out and from rewording the generic credential message; the security-critical merge of "wrong-user" and "wrong-password" stays.

Closes #455, #456.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Client-side login validation for empty email/password and email format; clearer, normalized user-facing error messages.
  * Login flow now safely handles unexpected server error shapes so errors display without breaking the UI.

* **Tests**
  * Expanded login tests covering pre-flight validation, normalized server errors, and defensive handling of non-standard error responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/485?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->