### PR TITLE
fix(ux/settings): three Settings-page UX fixes (#463 #466 #478)

### DIFF
--- a/frontend/src/__tests__/recommendations-enabled-providers.test.ts
+++ b/frontend/src/__tests__/recommendations-enabled-providers.test.ts
@@ -205,22 +205,16 @@ describe('loadRecommendations — Enabled Providers filter (#463)', () => {
     await loadRecommendations();
 
     // Only the gcp row's id should appear in the rendered list markup.
+    // buildListMarkup emits per-row checkboxes with data-rec-id="<id>"
+    // (see recommendations.ts ~L2142); assert against that attribute so
+    // the test exercises the actual rendered DOM instead of relying on
+    // a fallback.
     const list = document.getElementById('recommendations-list');
     expect(list).not.toBeNull();
-    const text = list?.textContent ?? '';
-    // The id attribute on a <tr data-id="…"> isn't visible in textContent;
-    // assert via the rendered DOM tree instead.
-    const rows = list?.querySelectorAll('[data-id]') ?? [];
-    const renderedIds = Array.from(rows).map(el => el.getAttribute('data-id'));
-    // Defensive: if buildListMarkup uses a different attribute name, fall
-    // back to scanning the resolved set on state.setRecommendations.
-    if (renderedIds.length > 0) {
-      expect(renderedIds).toContain('r3');
-      expect(renderedIds).not.toContain('r1');
-      expect(renderedIds).not.toContain('r2');
-    } else {
-      // Fall-through assertion: text-level check.
-      expect(text).not.toContain('m5.large from r1');
-    }
+    const checkboxes = list?.querySelectorAll('input[data-rec-id]') ?? [];
+    const renderedIds = Array.from(checkboxes).map(el => el.getAttribute('data-rec-id'));
+    expect(renderedIds).toContain('r3');
+    expect(renderedIds).not.toContain('r1');
+    expect(renderedIds).not.toContain('r2');
   });
 });

--- a/frontend/src/__tests__/recommendations-enabled-providers.test.ts
+++ b/frontend/src/__tests__/recommendations-enabled-providers.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Issue #463: the Settings → General → Enabled Providers toggles must
+ * filter the Opportunities list. The backend returns all collected
+ * recs irrespective of `enabled_providers`, so `loadRecommendations`
+ * applies a strict client-side filter against the GlobalConfig.
+ *
+ * Permissive default: empty/undefined `enabled_providers` falls
+ * through with no filter (matches the Settings load path).
+ */
+
+import { loadRecommendations } from '../recommendations';
+import type { LocalRecommendation } from '../types';
+
+jest.mock('../api', () => ({
+  getRecommendations: jest.fn(),
+  refreshRecommendations: jest.fn(),
+  listAccounts: jest.fn().mockResolvedValue([]),
+  getConfig: jest.fn(),
+  listAccountServiceOverrides: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('../api/recommendations', () => ({
+  getRecommendationDetail: jest.fn().mockResolvedValue({
+    id: 'rec-default',
+    usage_history: [],
+    confidence_bucket: 'low',
+    provenance_note: '',
+  }),
+  getRecommendationsFreshness: jest.fn().mockResolvedValue({
+    last_collected_at: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+    last_collection_error: null,
+  }),
+  refreshRecommendations: jest.fn().mockResolvedValue({}),
+}));
+
+const mockShowToast = jest.fn<{ dismiss: () => void }, [unknown]>(() => ({ dismiss: jest.fn() }));
+jest.mock('../toast', () => ({
+  showToast: (opts: unknown) => mockShowToast(opts),
+}));
+
+const setRecommendationsMock = jest.fn();
+jest.mock('../state', () => ({
+  getCurrentProvider: jest.fn().mockReturnValue('all'),
+  setCurrentProvider: jest.fn(),
+  getCurrentAccountIDs: jest.fn().mockReturnValue([]),
+  setCurrentAccountIDs: jest.fn(),
+  getRecommendations: jest.fn().mockReturnValue([]),
+  getRecommendationByID: jest.fn().mockReturnValue(undefined),
+  setRecommendations: (recs: unknown) => setRecommendationsMock(recs),
+  getSelectedRecommendationIDs: jest.fn().mockReturnValue(new Set()),
+  clearSelectedRecommendations: jest.fn(),
+  addSelectedRecommendation: jest.fn(),
+  removeSelectedRecommendation: jest.fn(),
+  getRecommendationsSort: jest.fn().mockReturnValue({ column: 'savings', direction: 'desc' }),
+  setRecommendationsSort: jest.fn(),
+  getRecommendationsColumnFilters: jest.fn().mockReturnValue({}),
+  setRecommendationsColumnFilter: jest.fn(),
+  clearAllRecommendationsColumnFilters: jest.fn(),
+  getVisibleRecommendations: jest.fn().mockReturnValue([]),
+  setVisibleRecommendations: jest.fn(),
+  getCostPeriod: jest.fn().mockReturnValue('monthly'),
+  setCostPeriod: jest.fn(),
+  getHiddenColumns: jest.fn().mockReturnValue(new Set()),
+  setHiddenColumns: jest.fn(),
+  getCurrentUser: jest.fn().mockReturnValue({ id: 'u-admin', email: 'admin@example.com', role: 'admin' }),
+}));
+
+jest.mock('../utils', () => ({
+  formatCurrency: jest.fn((val) => `$${val || 0}`),
+  formatTerm: jest.fn((years) => years == null ? '' : `${years} Year${years === 1 ? '' : 's'}`),
+  escapeHtml: jest.fn((str) => str || ''),
+  populateAccountFilter: jest.fn(() => Promise.resolve()),
+}));
+
+import * as api from '../api';
+
+function makeRec(provider: 'aws' | 'azure' | 'gcp', id: string): LocalRecommendation {
+  return {
+    id,
+    provider,
+    service: 'ec2',
+    resource_type: 'm5.large',
+    region: 'us-east-1',
+    count: 1,
+    term: 3,
+    savings: 100,
+    upfront_cost: 1000,
+  };
+}
+
+function seedDOM(): void {
+  while (document.body.firstChild) document.body.removeChild(document.body.firstChild);
+  const tab = document.createElement('div');
+  tab.id = 'opportunities-tab';
+  tab.className = 'tab-content active';
+  const summary = document.createElement('div');
+  summary.id = 'recommendations-summary';
+  const list = document.createElement('div');
+  list.id = 'recommendations-list';
+  tab.appendChild(summary);
+  tab.appendChild(list);
+  document.body.appendChild(tab);
+}
+
+describe('loadRecommendations — Enabled Providers filter (#463)', () => {
+  beforeEach(() => {
+    seedDOM();
+    jest.clearAllMocks();
+    setRecommendationsMock.mockClear();
+    mockShowToast.mockReturnValue({ dismiss: jest.fn() });
+  });
+
+  it('filters out providers absent from enabled_providers (aws-only)', async () => {
+    (api.getRecommendations as jest.Mock).mockResolvedValue({
+      summary: {},
+      recommendations: [
+        makeRec('aws', 'r1'),
+        makeRec('azure', 'r2'),
+        makeRec('gcp', 'r3'),
+      ],
+      regions: [],
+    });
+    (api.getConfig as jest.Mock).mockResolvedValue({
+      global: { enabled_providers: ['aws'] },
+    });
+
+    await loadRecommendations();
+
+    expect(setRecommendationsMock).toHaveBeenCalledTimes(1);
+    const passed = setRecommendationsMock.mock.calls[0]![0] as LocalRecommendation[];
+    expect(passed.map(r => r.id)).toEqual(['r1']);
+  });
+
+  it('keeps multiple enabled providers (aws + azure, drop gcp)', async () => {
+    (api.getRecommendations as jest.Mock).mockResolvedValue({
+      summary: {},
+      recommendations: [
+        makeRec('aws', 'r1'),
+        makeRec('azure', 'r2'),
+        makeRec('gcp', 'r3'),
+      ],
+      regions: [],
+    });
+    (api.getConfig as jest.Mock).mockResolvedValue({
+      global: { enabled_providers: ['aws', 'azure'] },
+    });
+
+    await loadRecommendations();
+
+    const passed = setRecommendationsMock.mock.calls[0]![0] as LocalRecommendation[];
+    expect(passed.map(r => r.id).sort()).toEqual(['r1', 'r2']);
+  });
+
+  it('empty enabled_providers falls back to no filter (permissive default)', async () => {
+    (api.getRecommendations as jest.Mock).mockResolvedValue({
+      summary: {},
+      recommendations: [
+        makeRec('aws', 'r1'),
+        makeRec('azure', 'r2'),
+        makeRec('gcp', 'r3'),
+      ],
+      regions: [],
+    });
+    (api.getConfig as jest.Mock).mockResolvedValue({
+      global: { enabled_providers: [] },
+    });
+
+    await loadRecommendations();
+
+    const passed = setRecommendationsMock.mock.calls[0]![0] as LocalRecommendation[];
+    expect(passed.map(r => r.id)).toEqual(['r1', 'r2', 'r3']);
+  });
+
+  it('undefined global config falls back to no filter', async () => {
+    (api.getRecommendations as jest.Mock).mockResolvedValue({
+      summary: {},
+      recommendations: [
+        makeRec('aws', 'r1'),
+        makeRec('azure', 'r2'),
+      ],
+      regions: [],
+    });
+    (api.getConfig as jest.Mock).mockResolvedValue(null);
+
+    await loadRecommendations();
+
+    const passed = setRecommendationsMock.mock.calls[0]![0] as LocalRecommendation[];
+    expect(passed.map(r => r.id)).toEqual(['r1', 'r2']);
+  });
+
+  it('renders only the filtered set in the Opportunities list DOM', async () => {
+    (api.getRecommendations as jest.Mock).mockResolvedValue({
+      summary: { total_count: 3 },
+      recommendations: [
+        makeRec('aws', 'r1'),
+        makeRec('azure', 'r2'),
+        makeRec('gcp', 'r3'),
+      ],
+      regions: [],
+    });
+    (api.getConfig as jest.Mock).mockResolvedValue({
+      global: { enabled_providers: ['gcp'] },
+    });
+
+    await loadRecommendations();
+
+    // Only the gcp row's id should appear in the rendered list markup.
+    const list = document.getElementById('recommendations-list');
+    expect(list).not.toBeNull();
+    const text = list?.textContent ?? '';
+    // The id attribute on a <tr data-id="…"> isn't visible in textContent;
+    // assert via the rendered DOM tree instead.
+    const rows = list?.querySelectorAll('[data-id]') ?? [];
+    const renderedIds = Array.from(rows).map(el => el.getAttribute('data-id'));
+    // Defensive: if buildListMarkup uses a different attribute name, fall
+    // back to scanning the resolved set on state.setRecommendations.
+    if (renderedIds.length > 0) {
+      expect(renderedIds).toContain('r3');
+      expect(renderedIds).not.toContain('r1');
+      expect(renderedIds).not.toContain('r2');
+    } else {
+      // Fall-through assertion: text-level check.
+      expect(text).not.toContain('m5.large from r1');
+    }
+  });
+});

--- a/frontend/src/__tests__/settings-purchasing-grace.test.ts
+++ b/frontend/src/__tests__/settings-purchasing-grace.test.ts
@@ -156,8 +156,11 @@ describe('Settings → Purchasing grace-period inputs', () => {
     expect(api.updateConfig).not.toHaveBeenCalled();
     expect(mockShowToast).toHaveBeenCalled();
     const toastArg = mockShowToast.mock.calls[0]![0] as { message: string; kind: string };
-    expect(toastArg.message).toMatch(/AWS grace period/i);
+    // Issue #478: validation message follows the aggregated format
+    // and names every affected provider. Single-provider failure still
+    // includes the provider name in parentheses.
     expect(toastArg.message).toMatch(/between 0 and 30/i);
+    expect(toastArg.message).toMatch(/\(AWS\)/);
     expect(toastArg.kind).toBe('error');
   });
 
@@ -169,8 +172,8 @@ describe('Settings → Purchasing grace-period inputs', () => {
     expect(api.updateConfig).not.toHaveBeenCalled();
     expect(mockShowToast).toHaveBeenCalled();
     const toastArg = mockShowToast.mock.calls[0]![0] as { message: string };
-    expect(toastArg.message).toMatch(/AZURE grace period/i);
     expect(toastArg.message).toMatch(/whole number/i);
+    expect(toastArg.message).toMatch(/\(AZURE\)/);
   });
 
   it('rejects negative input with a targeted toast', async () => {
@@ -181,7 +184,49 @@ describe('Settings → Purchasing grace-period inputs', () => {
     expect(api.updateConfig).not.toHaveBeenCalled();
     expect(mockShowToast).toHaveBeenCalled();
     const toastArg = mockShowToast.mock.calls[0]![0] as { message: string };
-    expect(toastArg.message).toMatch(/GCP grace period/i);
+    expect(toastArg.message).toMatch(/\(GCP\)/);
+  });
+
+  // Issue #478: when multiple providers have out-of-range values,
+  // surface a single toast that names every affected provider rather
+  // than bailing on the first failure.
+  it('aggregates every out-of-range provider in a single toast (#478)', async () => {
+    (document.getElementById('setting-grace-aws') as HTMLInputElement).value = '-1';
+    (document.getElementById('setting-grace-azure') as HTMLInputElement).value = '99';
+    (document.getElementById('setting-grace-gcp') as HTMLInputElement).value = '7.5';
+
+    await saveGlobalSettings(new Event("submit"));
+
+    expect(api.updateConfig).not.toHaveBeenCalled();
+    // Exactly one toast for the validation failure — not three.
+    const errorToasts = mockShowToast.mock.calls.filter(c => {
+      const arg = c[0] as { kind?: string };
+      return arg.kind === 'error';
+    });
+    expect(errorToasts).toHaveLength(1);
+    const toastArg = errorToasts[0]![0] as { message: string };
+    // All three providers named, in input order.
+    expect(toastArg.message).toMatch(/AWS, AZURE, GCP/);
+    expect(toastArg.message).toMatch(/whole number between 0 and 30/i);
+  });
+
+  it('aggregates two affected providers (AWS + GCP, Azure valid) (#478)', async () => {
+    (document.getElementById('setting-grace-aws') as HTMLInputElement).value = '-5';
+    (document.getElementById('setting-grace-azure') as HTMLInputElement).value = '7';
+    (document.getElementById('setting-grace-gcp') as HTMLInputElement).value = '50';
+
+    await saveGlobalSettings(new Event("submit"));
+
+    expect(api.updateConfig).not.toHaveBeenCalled();
+    const errorToasts = mockShowToast.mock.calls.filter(c => {
+      const arg = c[0] as { kind?: string };
+      return arg.kind === 'error';
+    });
+    expect(errorToasts).toHaveLength(1);
+    const toastArg = errorToasts[0]![0] as { message: string };
+    // AWS and GCP listed, Azure absent.
+    expect(toastArg.message).toMatch(/AWS, GCP/);
+    expect(toastArg.message).not.toMatch(/AZURE/);
   });
 
   it('empty input defaults to 7 in the save payload', async () => {

--- a/frontend/src/__tests__/settings.test.ts
+++ b/frontend/src/__tests__/settings.test.ts
@@ -111,7 +111,19 @@ describe('Settings Module', () => {
         <!-- GCP term selects -->
         <select id="gcp-compute-term"><option value="1">1</option><option value="3">3</option></select>
         <select id="gcp-sql-term"><option value="1">1</option><option value="3">3</option></select>
+        <!-- Per-provider grace-period inputs (issue #466 reset-to-defaults assertions
+             call populateGraceInput which needs these in the DOM). -->
+        <input type="number" id="setting-grace-aws" value="7" min="0" max="30">
+        <input type="number" id="setting-grace-azure" value="7" min="0" max="30">
+        <input type="number" id="setting-grace-gcp" value="7" min="0" max="30">
+        <!-- Issue #466: reflectDirtyState (in settings-subnav.ts) toggles
+             .has-unsaved on #admin-tab-btn and .dirty/.settings-savebar on
+             every .settings-buttons element. Seed both so the reset-to-
+             defaults expansion + unsaved-indicator assertions have DOM to
+             check. -->
+        <div class="settings-buttons"></div>
       </form>
+      <button id="admin-tab-btn"></button>
       <div id="settings-error" class="hidden"></div>
       <!-- Test element for copyToClipboard -->
       <code id="test-copy-element">test-value</code>
@@ -735,6 +747,42 @@ describe('Settings Module', () => {
 
       expect((document.getElementById('setting-recs-stale-hours') as HTMLInputElement).value).toBe('24');
       expect((document.getElementById('setting-recs-lookback-days') as HTMLSelectElement).value).toBe('7');
+    });
+
+    // Issue #466: Reset to Defaults must expand the Collection Schedule
+    // section (auto-collect re-flips ON, so the dependent controls need to
+    // be visible) AND mark the settings form as dirty so the user sees
+    // the "Unsaved changes" affordance and remembers to click Save.
+    test('expands the Collection Schedule row when re-enabling Auto-collect (#466)', async () => {
+      mockConfirmDialog.mockResolvedValueOnce(true);
+      // Pre-reset state: auto-collect off, schedule row hidden.
+      (document.getElementById('setting-auto-collect') as HTMLInputElement).checked = false;
+      const scheduleRow = document.getElementById('collection-schedule-row');
+      scheduleRow?.classList.add('hidden');
+
+      await resetSettings();
+
+      expect((document.getElementById('setting-auto-collect') as HTMLInputElement).checked).toBe(true);
+      expect(scheduleRow?.classList.contains('hidden')).toBe(false);
+    });
+
+    test('surfaces "Unsaved changes" indicator after reset (#466)', async () => {
+      mockConfirmDialog.mockResolvedValueOnce(true);
+      // Clear any prior dirty flag from a previous test.
+      const tabBtn = document.getElementById('admin-tab-btn');
+      tabBtn?.classList.remove('has-unsaved');
+      document.querySelectorAll('.settings-buttons').forEach(el => el.classList.remove('dirty'));
+
+      await resetSettings();
+
+      // reflectDirtyState toggles .has-unsaved on #admin-tab-btn and .dirty
+      // on .settings-buttons whenever any tracked field differs from the
+      // saved snapshot. After Reset, every field has been overwritten
+      // relative to the (still-empty) module-level snapshot, so the
+      // indicator must be active.
+      expect(tabBtn?.classList.contains('has-unsaved')).toBe(true);
+      const saveBar = document.querySelector('.settings-buttons') as HTMLElement | null;
+      expect(saveBar?.classList.contains('dirty')).toBe(true);
     });
   });
 

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -289,7 +289,26 @@ export async function loadRecommendations(): Promise<void> {
       // defaultBulkPurchaseState — the module-level cache is the source of truth).
     }
     accountNamesCache = new Map(accounts.map(a => [a.id, a.name]));
-    state.setRecommendations((data.recommendations || []) as unknown as api.Recommendation[]);
+
+    // Issue #463: gate the Opportunities list by the Settings →
+    // General → Enabled Providers preference. The backend currently
+    // returns all collected recs irrespective of `enabled_providers`,
+    // so a user who toggled Azure off in Settings still sees Azure
+    // rows on Opportunities. Apply a strict client-side filter on the
+    // provider field — Settings is the source of truth.
+    //
+    // Permissive default: if `enabled_providers` is empty/undefined
+    // (older configs or a tenant that never touched the toggles),
+    // fall through with no filter rather than surfacing a blank
+    // Opportunities page. The Settings load path renders the same
+    // permissive default on the checkboxes (line ~2510).
+    const enabledProviders = cfgResponse?.global?.enabled_providers;
+    const rawRecs = (data.recommendations || []) as unknown as api.Recommendation[];
+    const visibleByPreference: api.Recommendation[] = enabledProviders && enabledProviders.length > 0
+      ? rawRecs.filter(r => enabledProviders.includes(r.provider as api.Provider))
+      : rawRecs;
+
+    state.setRecommendations(visibleByPreference);
     state.clearSelectedRecommendations();
 
     // Cache the API-derived summary so renderRecommendationsList can
@@ -300,7 +319,7 @@ export async function loadRecommendations(): Promise<void> {
     // the card pinned to the unfiltered totals — the same divergence
     // #272 was supposed to close.
     lastRecommendationsSummary = data.summary || {};
-    renderRecommendationsList(data.recommendations || []);
+    renderRecommendationsList(visibleByPreference as unknown as LocalRecommendation[]);
 
     // Auto-refresh on page open (#284): check freshness and trigger an
     // async background refresh if the cache is cold or older than 24h.

--- a/frontend/src/settings.ts
+++ b/frontend/src/settings.ts
@@ -2863,13 +2863,16 @@ export async function resetSettings(): Promise<void> {
   const lookbackSelect = byId<HTMLSelectElement>('setting-recs-lookback-days');
   if (lookbackSelect) lookbackSelect.value = '7';
 
-  // Issue #466: setting el.value via JS does not fire 'change'/'input',
-  // so neither the auto-collect → schedule-row visibility toggle nor the
-  // dirty-tracking listeners run on their own here. Drive both manually
-  // so the user sees (a) the Collection Schedule controls now that
-  // Auto-collect is back ON, and (b) the same "Unsaved changes"
-  // affordance any interactive field-edit would produce — otherwise a
-  // user who clicks Reset and navigates away loses their reset silently.
+  // Issue #466: setting el.value / .checked via JS does not fire
+  // 'change'/'input', so none of the change-event-driven visibility
+  // togglers nor the dirty-tracking listeners run on their own here.
+  // Drive all of them manually so the user sees (a) the provider
+  // settings sections re-render to match the reset checkbox states,
+  // (b) the Collection Schedule controls now that Auto-collect is
+  // back ON, and (c) the same "Unsaved changes" affordance any
+  // interactive field-edit would produce. Otherwise a user who
+  // clicks Reset and navigates away loses their reset silently.
+  updateProviderSettingsVisibility();
   updateCollectionScheduleVisibility();
   updateDirtyMarkers();
 }

--- a/frontend/src/settings.ts
+++ b/frontend/src/settings.ts
@@ -2843,6 +2843,16 @@ export async function resetSettings(): Promise<void> {
   if (staleHoursInput) staleHoursInput.value = '24';
   const lookbackSelect = byId<HTMLSelectElement>('setting-recs-lookback-days');
   if (lookbackSelect) lookbackSelect.value = '7';
+
+  // Issue #466: setting el.value via JS does not fire 'change'/'input',
+  // so neither the auto-collect → schedule-row visibility toggle nor the
+  // dirty-tracking listeners run on their own here. Drive both manually
+  // so the user sees (a) the Collection Schedule controls now that
+  // Auto-collect is back ON, and (b) the same "Unsaved changes"
+  // affordance any interactive field-edit would produce — otherwise a
+  // user who clicks Reset and navigates away loses their reset silently.
+  updateCollectionScheduleVisibility();
+  updateDirtyMarkers();
 }
 
 /**

--- a/frontend/src/settings.ts
+++ b/frontend/src/settings.ts
@@ -2722,16 +2722,35 @@ export async function saveGlobalSettings(e: Event): Promise<void> {
   // settings object so we can reject out-of-range input early with a
   // targeted error instead of letting the API surface "invalid range"
   // without saying which input.
+  //
+  // Issue #478: aggregate every out-of-range provider into a single
+  // toast instead of bailing on the first failure. Previously, a user
+  // with bad values in AWS + Azure + GCP saw three separate Save
+  // attempts before all errors surfaced — one per click. Now: one
+  // toast naming every affected provider, in input order (AWS, Azure,
+  // GCP). Both error kinds readGraceInput can emit ("enter a whole
+  // number of days", "must be between 0 and 30 days") collapse to
+  // the same actionable instruction, so the aggregated message reads
+  // cleanly as a single rule even when providers fail for different
+  // reasons.
   const gracePeriodDays: Record<string, number> = {};
+  const graceErrors: string[] = [];
   for (const [provider, id] of [['aws', 'setting-grace-aws'], ['azure', 'setting-grace-azure'], ['gcp', 'setting-grace-gcp']] as const) {
     const v = readGraceInput(id);
     if (v.err) {
-      showToast({ message: `${provider.toUpperCase()} grace period: ${v.err}`, kind: 'error' });
-      if (saveBtn) saveBtn.disabled = false;
-      saveInFlight = false;
-      return;
+      graceErrors.push(provider.toUpperCase());
+      continue;
     }
     gracePeriodDays[provider] = v.value;
+  }
+  if (graceErrors.length > 0) {
+    showToast({
+      message: `Grace period must be a whole number between 0 and 30 days (${graceErrors.join(', ')}).`,
+      kind: 'error',
+    });
+    if (saveBtn) saveBtn.disabled = false;
+    saveInFlight = false;
+    return;
   }
 
   // Validate recommendations_cache_stale_hours before building the save payload.


### PR DESCRIPTION
## Summary

Bundles three small Settings UX fixes from QA review. All client-side, two files of production code (`recommendations.ts`, `settings.ts`) plus tests. Net diff: ~385 lines.

- **#463** — General Settings "Enabled Providers" toggles now actually filter the Opportunities list. Strict client-side filter in `loadRecommendations()` against `GlobalConfig.enabled_providers`. Permissive default (empty/missing config falls through with no filter).
- **#466** — `resetSettings()` now also calls `updateCollectionScheduleVisibility()` (expands the Collection Schedule row when Auto-collect re-enables) and `updateDirtyMarkers()` (surfaces "Unsaved changes" via `#admin-tab-btn.has-unsaved` + `.settings-buttons.dirty`). Setting `el.value` via JS does not fire `change`/`input`, so neither helper ran on its own.
- **#478** — Grace-period validation in `saveGlobalSettings()` aggregates every failing provider into one toast (in input order: AWS, Azure, GCP), instead of bailing on the first failure. Both error kinds collapse to the same actionable rule, so a uniform message reads cleanly across single- and multi-failure cases.

Closes #463
Closes #466
Closes #478

## Decisions

- **#463**: chose "strict filter" (option 1 from the issue body) over "cold pause" (option 2). Option 2 needs a per-row "no longer collected" badge, which is a feature, not a fix. Option 1 matches the literal QA expectation.
- **#463**: filter at `loadRecommendations()` (single funnel) rather than inside `applyColumnFilters` (per-render). Settings preference is a tenant-scope gate that must precede the column-filter pipeline; folding it into `applyColumnFilters` would make "Clear filters" un-hide disabled providers, exactly the bug we're fixing.
- **#478**: chose option 1 from the issue body (list affected providers) over option 2 (drop names). Field highlights already point at the bad inputs, but the aggregated toast still serves users who scrolled past the form; provider names give them a quicker scan target.

## Test plan

- [x] `npx jest src/__tests__/recommendations-enabled-providers.test.ts` (5 new tests: single provider, multi-provider, empty fallback, null config, DOM render).
- [x] `npx jest src/__tests__/settings.test.ts` (55 passing including 2 new `resetSettings` tests for #466).
- [x] `npx jest src/__tests__/settings-purchasing-grace.test.ts` (10 passing including 2 new aggregation tests for #478; existing single-provider tests updated to assert the new uniform toast format).
- [x] Full settings test directory (`src/__tests__/settings*`): 149 passing, 0 failing.
- [x] Full recommendations test (`src/__tests__/recommendations.test.ts`): 244 passing, 0 failing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recommendations now respect the enabled-providers setting and only show allowed providers in Opportunities.

* **Bug Fixes**
  * Grace-period validation aggregates errors for all affected providers into a single clear message.
  * Resetting settings correctly restores Collection Schedule visibility and updates unsaved-change indicators.

* **Tests**
  * Expanded test coverage for recommendations filtering, grace-period validation, and settings reset behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/486?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->