### PR TITLE
fix(ux/opportunities): re-query on filter change and persist to URL

### DIFF
--- a/frontend/src/__tests__/recommendations.test.ts
+++ b/frontend/src/__tests__/recommendations.test.ts
@@ -1725,6 +1725,31 @@ describe('Recommendations Module', () => {
 
       expect(api.getRecommendations).not.toHaveBeenCalled();
     });
+
+    // CR pass 1 (PR #488): the topbar provider-change handler updates BOTH
+    // account and provider state slots in sequence, firing both subscribers
+    // from a single user action. Coalesce via queueMicrotask so the user
+    // sees exactly one reload, not two — and avoid the stale-overwrite race
+    // where the first response lands after the second.
+    test('coalesces back-to-back account+provider changes into a single reload', async () => {
+      const tab = document.getElementById('opportunities-tab')!;
+      tab.classList.add('active');
+
+      setupRecommendationsHandlers();
+
+      const providerCb = (state.subscribeProvider as jest.Mock).mock.calls[0]?.[0];
+      const accountCb = (state.subscribeAccount as jest.Mock).mock.calls[0]?.[0];
+      (api.getRecommendations as jest.Mock).mockClear();
+
+      // Simulate the topbar's #185 ordering: clear account first, then set
+      // provider. Both callbacks fire synchronously; coalescing must collapse
+      // them into one microtask-deferred reload.
+      accountCb();
+      providerCb();
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(api.getRecommendations).toHaveBeenCalledTimes(1);
+    });
   });
 });
 

--- a/frontend/src/__tests__/recommendations.test.ts
+++ b/frontend/src/__tests__/recommendations.test.ts
@@ -89,6 +89,11 @@ jest.mock('../state', () => ({
   // unconditionally. Permission-gating coverage lives in
   // recommendations-permissions.test.ts.
   getCurrentUser: jest.fn().mockReturnValue({ id: 'u-admin', email: 'admin@example.com', role: 'admin' }),
+  // Issue #477: setupRecommendationsHandlers subscribes to provider/account
+  // changes; expose jest.fn() shims so tests can capture the callback and
+  // simulate a change without going through the real listener set.
+  subscribeProvider: jest.fn(),
+  subscribeAccount: jest.fn(),
 }));
 
 // Mock utils
@@ -1647,43 +1652,78 @@ describe('Recommendations Module', () => {
   });
 
   describe('setupRecommendationsHandlers', () => {
+    function makeDiv(id: string): HTMLDivElement {
+      const el = document.createElement('div');
+      el.id = id;
+      return el;
+    }
+
     beforeEach(() => {
-      document.body.innerHTML = `
-        <select id="recommendations-provider-filter">
-          <option value="">All Providers</option>
-          <option value="aws">AWS</option>
-          <option value="azure">Azure</option>
-        </select>
-        <select id="service-filter">
-          <optgroup label="AWS Services">
-            <option value="ec2">EC2</option>
-          </optgroup>
-          <optgroup label="Azure Services">
-            <option value="vm">Virtual Machines</option>
-          </optgroup>
-        </select>
-        <select id="region-filter">
-          <option value="">All Regions</option>
-        </select>
-        <input type="number" id="min-savings-filter" value="">
-        <div id="recommendations-list"></div>
-        <div id="recommendations-summary"></div>
-      `;
+      // Issue #477: Opportunities now subscribes to the global provider/account
+      // filter and reloads on change. The DOM only needs the opportunities-tab
+      // wrapper (active-class toggled per test) plus the elements the loader
+      // touches (recommendations-list, recommendations-summary).
+      while (document.body.firstChild) document.body.removeChild(document.body.firstChild);
+      document.body.appendChild(makeDiv('opportunities-tab'));
+      document.body.appendChild(makeDiv('recommendations-list'));
+      document.body.appendChild(makeDiv('recommendations-summary'));
       (api.getRecommendations as jest.Mock).mockResolvedValue({
         summary: {},
         recommendations: [],
         regions: []
       });
+      // Outer describe enables fake timers; we want real timers here so the
+      // subscriber callback's promise chain inside loadRecommendations can
+      // settle. afterEach() at the outer level resets via useRealTimers.
+      jest.useRealTimers();
     });
 
-    // The legacy top filter bar tests (provider-filter / service-filter /
-    // region-filter / min-savings-filter change handlers + service-filter
-    // visibility-toggle) are obsolete: Bundle B replaced those DOM elements
-    // with per-column header-mounted popovers. See the column-filter +
-    // bottom-action-box tests below for their successors.
-    test('setupRecommendationsHandlers is a no-op (Bundle B)', () => {
-      // Should not throw, even with the legacy filter-bar DOM absent.
-      expect(() => setupRecommendationsHandlers()).not.toThrow();
+    test('subscribes to provider changes and reloads when opportunities-tab is active', async () => {
+      const tab = document.getElementById('opportunities-tab')!;
+      tab.classList.add('active');
+
+      setupRecommendationsHandlers();
+
+      // Capture the callback registered with subscribeProvider and invoke it
+      // directly (state is jest.mock()'d for this file, so the real listener
+      // set never fires; the test verifies the wiring shape).
+      const providerCb = (state.subscribeProvider as jest.Mock).mock.calls[0]?.[0];
+      expect(typeof providerCb).toBe('function');
+      (api.getRecommendations as jest.Mock).mockClear();
+      providerCb();
+      // loadRecommendations awaits Promise.all internally; flush microtasks.
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(api.getRecommendations).toHaveBeenCalled();
+    });
+
+    test('subscribes to account changes and reloads when opportunities-tab is active', async () => {
+      const tab = document.getElementById('opportunities-tab')!;
+      tab.classList.add('active');
+
+      setupRecommendationsHandlers();
+
+      const accountCb = (state.subscribeAccount as jest.Mock).mock.calls[0]?.[0];
+      expect(typeof accountCb).toBe('function');
+      (api.getRecommendations as jest.Mock).mockClear();
+      accountCb();
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(api.getRecommendations).toHaveBeenCalled();
+    });
+
+    test('does NOT reload when opportunities-tab is inactive', async () => {
+      // No .active class — user is on Home / Plans / Purchases.
+      setupRecommendationsHandlers();
+
+      const providerCb = (state.subscribeProvider as jest.Mock).mock.calls[0]?.[0];
+      const accountCb = (state.subscribeAccount as jest.Mock).mock.calls[0]?.[0];
+      (api.getRecommendations as jest.Mock).mockClear();
+      providerCb();
+      accountCb();
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(api.getRecommendations).not.toHaveBeenCalled();
     });
   });
 });

--- a/frontend/src/__tests__/topbar-filters.test.ts
+++ b/frontend/src/__tests__/topbar-filters.test.ts
@@ -51,6 +51,109 @@ describe('Topbar filters', () => {
     expect(chips?.length).toBe(2);
   });
 
+  // Issue #477: URL hydration + writeback tests.
+  //
+  // jsdom honours history.replaceState() — setting it before initTopbarFilters
+  // simulates a hard refresh on a page that was previously filtered. We assert
+  // the chip-select's seed `value:` was hydrated from the URL by checking the
+  // post-init state via the state setters that the chip's onChange would fire.
+  describe('URL persistence', () => {
+    afterEach(() => {
+      // Reset URL so cross-test bleed doesn't pollute the next test.
+      window.history.replaceState({}, '', '/opportunities');
+    });
+
+    test('hydrates provider + account from URL query params before chips mount', () => {
+      window.history.replaceState({}, '', '/opportunities?provider=aws&account=acct-7');
+
+      initTopbarFilters();
+
+      expect(state.getCurrentProvider()).toBe('aws');
+      expect(state.getCurrentAccountIDs()).toEqual(['acct-7']);
+    });
+
+    test('ignores invalid provider values from URL (falls back to All)', () => {
+      window.history.replaceState({}, '', '/opportunities?provider=bogus&account=acct-1');
+
+      initTopbarFilters();
+
+      expect(state.getCurrentProvider()).toBe('');
+      // Account is opaque — passes through.
+      expect(state.getCurrentAccountIDs()).toEqual(['acct-1']);
+    });
+
+    test('account-chip change writes back to URL query params', async () => {
+      window.history.replaceState({}, '', '/opportunities');
+      (api.listAccounts as jest.Mock).mockResolvedValue([
+        { id: 'acct-99', name: 'prod', external_id: '999' },
+      ]);
+
+      initTopbarFilters();
+      // Drain the async populateAccountOptions so the account chip carries
+      // the real option list before we exercise its trigger.
+      await new Promise((r) => setTimeout(r, 0));
+
+      // Account chip is the second `.chip-select` trigger.
+      const triggers = document.querySelectorAll<HTMLButtonElement>('.chip-select');
+      const accountTrigger = triggers[1] as HTMLButtonElement;
+      accountTrigger.click();
+
+      const opt = Array.from(
+        document.querySelectorAll<HTMLLIElement>('.chip-select-option'),
+      ).find((el) => el.dataset['value'] === 'acct-99');
+      expect(opt).toBeDefined();
+      opt!.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+
+      const params = new URLSearchParams(window.location.search);
+      expect(params.get('account')).toBe('acct-99');
+    });
+
+    test('selecting "All Accounts" removes the account query param', async () => {
+      // Start with an account already selected via URL.
+      window.history.replaceState({}, '', '/opportunities?account=acct-7');
+      (api.listAccounts as jest.Mock).mockResolvedValue([
+        { id: 'acct-7', name: 'old', external_id: '7' },
+      ]);
+
+      initTopbarFilters();
+      await new Promise((r) => setTimeout(r, 0));
+
+      // Account chip is the second `.chip-select`.
+      const triggers = document.querySelectorAll<HTMLButtonElement>('.chip-select');
+      const accountTrigger = triggers[1] as HTMLButtonElement;
+      accountTrigger.click();
+      const allOpt = Array.from(
+        document.querySelectorAll<HTMLLIElement>('.chip-select-option'),
+      ).find((el) => el.dataset['value'] === '');
+      expect(allOpt).toBeDefined();
+      allOpt!.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+
+      const params = new URLSearchParams(window.location.search);
+      expect(params.has('account')).toBe(false);
+    });
+
+    test('provider change writes provider AND clears account in URL', async () => {
+      window.history.replaceState({}, '', '/opportunities?account=acct-7');
+
+      initTopbarFilters();
+      await new Promise((r) => setTimeout(r, 0));
+
+      const triggers = document.querySelectorAll<HTMLButtonElement>('.chip-select');
+      const providerTrigger = triggers[0] as HTMLButtonElement;
+      providerTrigger.click();
+      const gcpOpt = Array.from(
+        document.querySelectorAll<HTMLLIElement>('.chip-select-option'),
+      ).find((el) => el.dataset['value'] === 'gcp');
+      expect(gcpOpt).toBeDefined();
+      gcpOpt!.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+
+      const params = new URLSearchParams(window.location.search);
+      expect(params.get('provider')).toBe('gcp');
+      // Account was cleared by the #185 ordering rule; URL must reflect that.
+      expect(params.has('account')).toBe(false);
+    });
+  });
+
   // Issue #185 ordering invariant: a provider change clears
   // state.currentAccountIDs BEFORE awaiting the new account-list refetch.
   // The implementation lives in topbar-filters.ts::initTopbarFilters'

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -137,17 +137,43 @@ export function clearPurchaseModalRecommendations(): void {
 }
 
 /**
- * Setup recommendations event handlers
+ * True when the Opportunities tab is the currently-visible tab. The reload-
+ * on-filter-change subscriptions below skip the fetch when this is false so
+ * we don't burn an API call (and a skeleton flash) for a section the user
+ * isn't looking at — `switchTab('opportunities')` will run loadRecommend-
+ * ations() on next entry anyway.
+ */
+function isOpportunitiesTabActive(): boolean {
+  return document.getElementById('opportunities-tab')?.classList.contains('active') === true;
+}
+
+/**
+ * Setup recommendations event handlers (issue #477).
+ *
+ * The legacy per-section provider/account `<select>` elements were retired
+ * in issue #344 in favour of the global topbar chips. Each section reloads
+ * itself by subscribing to state.subscribeProvider / state.subscribeAccount;
+ * Bundle B had removed the legacy listeners without adding the new
+ * subscriptions, so Opportunities only re-queried on a full route-enter
+ * (issue #477 repro: change filter, list doesn't update).
+ *
+ * Mirrors the dashboard.ts pattern — except we guard on the active-tab
+ * check so the fetch only fires when the user is actually looking at
+ * Opportunities. The provider-change ordering invariant (#185 — clear
+ * accounts before refetching the account list) is enforced upstream in
+ * topbar-filters.ts.
+ *
+ * Per-column header-mounted popovers (Bundle B) continue to handle the
+ * in-page filter UX; their listeners are attached per-render inside
+ * renderRecommendationsList.
  */
 export function setupRecommendationsHandlers(): void {
-  // The legacy top filter bar (#recommendations-provider-filter,
-  // #recommendations-account-filter, #service-filter, #region-filter,
-  // #min-savings-filter) is gone — Bundle B replaced those with per-column
-  // header-mounted popovers driven by state.RecommendationsColumnFilters.
-  // No DOM listeners need wiring here anymore; the column-filter trigger
-  // listeners are attached per-render inside renderRecommendationsList,
-  // and Provider/Account-driven API re-fetch is handled by their popover
-  // commit hooks (see Bundle B follow-up).
+  state.subscribeProvider(() => {
+    if (isOpportunitiesTabActive()) void loadRecommendations();
+  });
+  state.subscribeAccount(() => {
+    if (isOpportunitiesTabActive()) void loadRecommendations();
+  });
 }
 
 /**

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -168,12 +168,30 @@ function isOpportunitiesTabActive(): boolean {
  * renderRecommendationsList.
  */
 export function setupRecommendationsHandlers(): void {
-  state.subscribeProvider(() => {
-    if (isOpportunitiesTabActive()) void loadRecommendations();
-  });
-  state.subscribeAccount(() => {
-    if (isOpportunitiesTabActive()) void loadRecommendations();
-  });
+  // Coalesce duplicate reloads. The topbar provider-change handler in
+  // topbar-filters.ts updates BOTH state slots in sequence (clear accounts
+  // then set provider, per the #185 ordering rule), which fires the
+  // account-subscriber AND the provider-subscriber from a single user
+  // action. Without coalescing we'd kick off two loadRecommendations()
+  // calls back-to-back — extra API load plus a stale-overwrite risk if
+  // the first response lands after the second.
+  //
+  // Microtask scheduling: both subscriber fires are synchronous within
+  // the same setCurrentProvider/setCurrentAccountIDs call chain, so a
+  // microtask runs once after the chain settles. setTimeout(_, 0) would
+  // also work but adds a macrotask delay the user could perceive on
+  // slow machines.
+  let reloadQueued = false;
+  const scheduleReload = (): void => {
+    if (!isOpportunitiesTabActive() || reloadQueued) return;
+    reloadQueued = true;
+    queueMicrotask(() => {
+      reloadQueued = false;
+      if (isOpportunitiesTabActive()) void loadRecommendations();
+    });
+  };
+  state.subscribeProvider(scheduleReload);
+  state.subscribeAccount(scheduleReload);
 }
 
 /**

--- a/frontend/src/topbar-filters.ts
+++ b/frontend/src/topbar-filters.ts
@@ -28,6 +28,52 @@ const PROVIDER_OPTIONS: ChipSelectOption[] = [
   { value: 'gcp', label: 'GCP' },
 ];
 
+// Issue #477: URL query params used to persist the global filter across
+// hard refresh. URL is preferred over localStorage so the filter state is
+// shareable via copy-paste link and avoids the cross-tab confusion that
+// shared localStorage would create. Empty values omit the param entirely
+// so `/opportunities` stays clean when nothing is filtered.
+const URL_PARAM_PROVIDER = 'provider';
+const URL_PARAM_ACCOUNT = 'account';
+
+// Closed set used to reject invalid `?provider=` values that would otherwise
+// flow into setCurrentProvider — which is typed `'' | 'aws' | 'azure' | 'gcp'`.
+const VALID_PROVIDERS: ReadonlySet<string> = new Set(['', 'aws', 'azure', 'gcp']);
+
+/**
+ * Read provider + account from the current URL. Invalid provider values
+ * (anything outside VALID_PROVIDERS) fall back to ''. The account id is
+ * returned verbatim — validation against the user's actual account list
+ * happens implicitly via the chip-select option matcher.
+ */
+function readFiltersFromURL(): { provider: '' | 'aws' | 'azure' | 'gcp'; account: string } {
+  const params = new URLSearchParams(window.location.search);
+  const rawProvider = params.get(URL_PARAM_PROVIDER) ?? '';
+  const provider = VALID_PROVIDERS.has(rawProvider)
+    ? (rawProvider as '' | 'aws' | 'azure' | 'gcp')
+    : '';
+  const account = params.get(URL_PARAM_ACCOUNT) ?? '';
+  return { provider, account };
+}
+
+/**
+ * Write provider + account back into `window.location.search` via
+ * replaceState (not pushState — filter changes are a setting, not a new
+ * navigation entry; the browser back button should not unwind individual
+ * chip clicks). Empty values are omitted so the URL stays clean.
+ */
+function writeFiltersToURL(provider: string, accountIDs: readonly string[]): void {
+  const params = new URLSearchParams(window.location.search);
+  if (provider) params.set(URL_PARAM_PROVIDER, provider);
+  else params.delete(URL_PARAM_PROVIDER);
+  const accountId = accountIDs[0] ?? '';
+  if (accountId) params.set(URL_PARAM_ACCOUNT, accountId);
+  else params.delete(URL_PARAM_ACCOUNT);
+  const qs = params.toString();
+  const url = window.location.pathname + (qs ? '?' + qs : '') + window.location.hash;
+  window.history.replaceState(window.history.state, '', url);
+}
+
 let providerChip: ChipSelectHandle | null = null;
 let accountChip: ChipSelectHandle | null = null;
 
@@ -81,6 +127,24 @@ export function initTopbarFilters(): void {
     return;
   }
 
+  // Issue #477: hydrate provider + account from URL query params BEFORE
+  // building the chips so each chip's `value:` seed picks up the persisted
+  // selection. Direct state setters here would fire the subscribers, but
+  // the subscribers are registered later in setupRecommendationsHandlers
+  // (after init() returns) so this is a no-op for listeners and just seeds
+  // the read path for the chip mount below.
+  const { provider: urlProvider, account: urlAccount } = readFiltersFromURL();
+  if (state.getCurrentProvider() !== urlProvider) {
+    state.setCurrentProvider(urlProvider);
+  }
+  const currentAccountIDs = state.getCurrentAccountIDs();
+  const accountChanged =
+    (urlAccount && currentAccountIDs[0] !== urlAccount) ||
+    (!urlAccount && currentAccountIDs.length > 0);
+  if (accountChanged) {
+    state.setCurrentAccountIDs(urlAccount ? [urlAccount] : []);
+  }
+
   // Tear down any prior chips before re-mount (idempotent).
   while (slot.firstChild) slot.removeChild(slot.firstChild);
   providerChip = null;
@@ -97,6 +161,9 @@ export function initTopbarFilters(): void {
       // the prior provider.
       state.setCurrentAccountIDs([]);
       state.setCurrentProvider(newProvider as '' | 'aws' | 'azure' | 'gcp');
+      // Issue #477: persist the new selection (and the now-cleared account)
+      // to the URL so a hard refresh restores the same view.
+      writeFiltersToURL(newProvider, []);
       // Refresh account options for the new provider; chip resets to
       // "All Accounts".
       void populateAccountOptions(newProvider).then(() => {
@@ -113,6 +180,8 @@ export function initTopbarFilters(): void {
     value: state.getCurrentAccountIDs()[0] ?? '',
     onChange: (newAccountId) => {
       state.setCurrentAccountIDs(newAccountId ? [newAccountId] : []);
+      // Issue #477: keep URL in sync with the new account selection.
+      writeFiltersToURL(state.getCurrentProvider(), newAccountId ? [newAccountId] : []);
     },
   });
 


### PR DESCRIPTION
## Summary

The Opportunities page captured global provider/account filter changes in state but never re-queried the list. The only way to see filtered results was to navigate away and back. A hard refresh also wiped the filter back to "All".

Root cause: `setupRecommendationsHandlers()` was a no-op left over from Bundle B's removal of the legacy per-section filter `<select>`s; the matching `state.subscribeProvider` / `state.subscribeAccount` wiring (used by `dashboard.ts`) never landed for Opportunities.

Fix in two parts:
- **Re-query on filter change**: `recommendations.ts` subscribes to provider/account state changes and re-fires `loadRecommendations()` when the Opportunities tab is active, mirroring the dashboard pattern. Active-tab guard avoids burning an API call for a section the user isn't looking at.
- **Persist filter state via URL query params**: `topbar-filters.ts` hydrates provider + account from `?provider=` / `?account=` on init (before chip mount, so chip seeds pick up the persisted state), and writes back via `history.replaceState` on each chip change. Invalid provider values fall back to "" so a hand-crafted URL can't poison state. Empty selections omit the param entirely.

URL preferred over localStorage per the issue body — filter state is shareable via copy-paste link and avoids the cross-tab confusion shared localStorage would create.

## Test plan

- [x] `recommendations.test.ts`: subscriber wiring fires `loadRecommendations` when `opportunities-tab` is active, skips when inactive, mirrors for account changes
- [x] `topbar-filters.test.ts`: URL hydration of provider + account, invalid-provider sanitisation, writeback on account change, "All Accounts" removes the query param, provider change clears account in the URL
- [x] `npm test` — 1749 passed, 1 skipped (pre-existing)
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [ ] Manual verification post-merge: change provider/account on Opportunities and confirm the list re-renders; reload with `?provider=aws&account=…` and confirm filters survive

Closes #477.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Topbar filter selections (Provider and Account) now persist in the browser URL, enabling easy sharing and bookmarking of filtered views
  * Filters are automatically restored when accessing the page via previously saved URLs
  * Recommendations update dynamically when filter selections change on the Opportunities tab

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/488?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->