### PR TITLE
fix(ux/reset-password): swap modal + surface specific reuse error

### DIFF
--- a/frontend/src/__tests__/auth.test.ts
+++ b/frontend/src/__tests__/auth.test.ts
@@ -161,7 +161,7 @@ describe('Auth Module', () => {
       expect(sendBtn).toBeTruthy();
     });
 
-    test('password reset sends request', async () => {
+    test('password reset swaps modal body to confirmation panel (issue #457)', async () => {
       (api.requestPasswordReset as jest.Mock).mockResolvedValue({});
       await showLoginModal();
 
@@ -179,10 +179,38 @@ describe('Auth Module', () => {
       await new Promise(resolve => setTimeout(resolve, 50));
 
       expect(api.requestPasswordReset).toHaveBeenCalledWith('test@example.com');
-      expect(window.alert).toHaveBeenCalledWith('If an account exists with that email, you will receive a password reset link.');
+      // No alert(): the lingering-modal bug came from stacking an
+      // alert on top of the modal; we now swap the modal body in place.
+      expect(window.alert).not.toHaveBeenCalled();
+      // Modal still in DOM with a confirmation panel, NOT the email form.
+      const modal = document.getElementById('login-modal');
+      expect(modal).toBeTruthy();
+      expect(document.getElementById('reset-email')).toBeNull();
+      expect(document.getElementById('send-reset-btn')).toBeNull();
+      const closeBtn = document.getElementById('reset-confirmation-close');
+      expect(closeBtn).toBeTruthy();
+      expect(modal?.textContent).toContain('Check your email');
     });
 
-    test('password reset handles empty email', async () => {
+    test('confirmation Close button reloads to return to login (issue #457)', async () => {
+      (api.requestPasswordReset as jest.Mock).mockResolvedValue({});
+      await showLoginModal();
+
+      const forgotLink = document.getElementById('forgot-password-link');
+      forgotLink?.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      const resetEmail = document.getElementById('reset-email') as HTMLInputElement;
+      resetEmail.value = 'test@example.com';
+      document.getElementById('send-reset-btn')?.click();
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      document.getElementById('reset-confirmation-close')?.click();
+
+      expect(window.location.reload).toHaveBeenCalled();
+    });
+
+    test('password reset handles empty email inline (no alert)', async () => {
       await showLoginModal();
 
       const forgotLink = document.getElementById('forgot-password-link');
@@ -195,11 +223,15 @@ describe('Auth Module', () => {
 
       await new Promise(resolve => setTimeout(resolve, 10));
 
-      expect(window.alert).toHaveBeenCalledWith('Please enter your email address');
+      // Issue #457: error is now inline in the modal, not via alert().
+      const errorDiv = document.getElementById('login-error');
+      expect(errorDiv?.textContent).toBe('Please enter your email address');
+      expect(errorDiv?.classList.contains('hidden')).toBe(false);
+      expect(window.alert).not.toHaveBeenCalled();
       expect(api.requestPasswordReset).not.toHaveBeenCalled();
     });
 
-    test('password reset handles API error', async () => {
+    test('password reset handles API error inline (no alert)', async () => {
       (api.requestPasswordReset as jest.Mock).mockRejectedValue(new Error('Network error'));
       console.error = jest.fn();
       await showLoginModal();
@@ -217,7 +249,10 @@ describe('Auth Module', () => {
 
       await new Promise(resolve => setTimeout(resolve, 50));
 
-      expect(window.alert).toHaveBeenCalledWith('Failed to send reset email. Please try again.');
+      const errorDiv = document.getElementById('login-error');
+      expect(errorDiv?.textContent).toBe('Failed to send reset email. Please try again.');
+      expect(errorDiv?.classList.contains('hidden')).toBe(false);
+      expect(window.alert).not.toHaveBeenCalled();
     });
 
     test('back to login link reloads page', async () => {

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -101,8 +101,15 @@ export async function resetPassword(token: string, newPassword: string): Promise
   });
 
   if (!response.ok) {
-    const error = await response.json().catch(() => ({ message: 'Failed to reset password' }));
-    throw new Error(error.message || 'Failed to reset password');
+    // Backend's NewClientError emits {error: "<msg>"} (see internal/api/
+    // handler.go writeError). We previously only read `message`, so the
+    // specific reason (e.g. "this is your current password, choose a
+    // different one") never reached the toast and users saw the opaque
+    // fallback. Read `error` first; keep `message` as a defensive
+    // fallback for any other shape. See issue #459.
+    const data = await response.json().catch(() => ({})) as { error?: string; message?: string };
+    const msg = data.error || data.message;
+    throw new Error(msg || 'Failed to reset password');
   }
 }
 

--- a/frontend/src/auth.ts
+++ b/frontend/src/auth.ts
@@ -540,19 +540,60 @@ function showForgotPasswordForm(modal: HTMLElement): void {
 
 async function handlePasswordReset(): Promise<void> {
   const emailInput = document.getElementById('reset-email') as HTMLInputElement | null;
+  const errorDiv = document.getElementById('login-error');
   const email = emailInput?.value.trim() || '';
+
+  // Reset any previous error before validating.
+  errorDiv?.classList.add('hidden');
+
   if (!email) {
-    alert('Please enter your email address');
+    if (errorDiv) {
+      errorDiv.textContent = 'Please enter your email address';
+      errorDiv.classList.remove('hidden');
+    }
     return;
   }
 
   try {
     await api.requestPasswordReset(email);
-    alert('If an account exists with that email, you will receive a password reset link.');
+    // Issue #457: previously this surfaced as an alert() that, when
+    // closed, left the underlying modal open with nothing for the user
+    // to do. Swap the modal body in place with a confirmation panel +
+    // single Close button so the user has one explicit exit that
+    // returns them to login (option 2 from the issue, agreed cleaner).
+    showResetEmailConfirmation();
   } catch (error) {
     console.error('Password reset error:', error);
-    alert('Failed to send reset email. Please try again.');
+    if (errorDiv) {
+      errorDiv.textContent = 'Failed to send reset email. Please try again.';
+      errorDiv.classList.remove('hidden');
+    }
   }
+}
+
+// showResetEmailConfirmation swaps the inner #login-form body with a
+// confirmation panel after a successful forgot-password submission.
+// The wrapping #login-modal stays in the DOM so the user has a single
+// explicit Close action; fixes issue #457 (lingering modal after the
+// confirmation pop-up closed).
+function showResetEmailConfirmation(): void {
+  const form = document.querySelector('#login-modal #login-form');
+  if (!form) return;
+
+  // Static template, no user-controlled interpolation; same pattern
+  // the surrounding modal code uses for every panel.
+  form.innerHTML = `
+    <h3>Check your email</h3>
+    <p>If an account exists with that email, you will receive a password reset link shortly.</p>
+    <p class="help-text">The link is valid for one hour. If you don't see it, check your spam folder.</p>
+    <button type="button" id="reset-confirmation-close" class="primary">Close</button>
+  `;
+
+  document.getElementById('reset-confirmation-close')?.addEventListener('click', () => {
+    // Reloading returns the user to the login modal in a clean state
+    // (same exit-path as the existing back-to-login-link).
+    location.reload();
+  });
 }
 
 /**

--- a/internal/api/handler_auth.go
+++ b/internal/api/handler_auth.go
@@ -159,6 +159,19 @@ func (h *Handler) forgotPassword(ctx context.Context, req *events.LambdaFunction
 	return map[string]string{"status": "if the email exists, a reset link has been sent"}, nil
 }
 
+// isResetPasswordClientError reports whether err originates from a user-correctable
+// condition during password reset. The substring list is intentionally narrow and
+// is matched against the error messages produced by internal/auth/service_password.go.
+// When adding a new client-correctable error in the service, add its substring here too.
+func isResetPasswordClientError(err error) bool {
+	s := err.Error()
+	return strings.Contains(s, "current password") ||
+		strings.Contains(s, "used recently") ||
+		strings.Contains(s, "invalid or expired reset token") ||
+		strings.Contains(s, "reset token has expired") ||
+		strings.Contains(s, "password must")
+}
+
 func (h *Handler) resetPassword(ctx context.Context, req *events.LambdaFunctionURLRequest) (any, error) {
 	if h.auth == nil {
 		return nil, fmt.Errorf("authentication service not configured")
@@ -186,13 +199,10 @@ func (h *Handler) resetPassword(ctx context.Context, req *events.LambdaFunctionU
 	pwdResetReq.NewPassword = decoded
 
 	if err := h.auth.ConfirmPasswordReset(ctx, pwdResetReq); err != nil {
-		// Surface the specific reason as a 4xx so the frontend can show
-		// it verbatim ("this is your current password, choose a different
-		// one", "password has been used recently", "invalid or expired
-		// reset token", etc.). Without this wrap, validation/history
-		// errors map to a generic 500 / opaque "Failed to reset
-		// password" toast on the client. See issue #459.
-		return nil, NewClientError(400, err.Error())
+		if isResetPasswordClientError(err) {
+			return nil, NewClientError(400, err.Error())
+		}
+		return nil, err
 	}
 
 	return map[string]string{"status": "password reset successful"}, nil

--- a/internal/api/handler_auth.go
+++ b/internal/api/handler_auth.go
@@ -186,7 +186,13 @@ func (h *Handler) resetPassword(ctx context.Context, req *events.LambdaFunctionU
 	pwdResetReq.NewPassword = decoded
 
 	if err := h.auth.ConfirmPasswordReset(ctx, pwdResetReq); err != nil {
-		return nil, err
+		// Surface the specific reason as a 4xx so the frontend can show
+		// it verbatim ("this is your current password, choose a different
+		// one", "password has been used recently", "invalid or expired
+		// reset token", etc.). Without this wrap, validation/history
+		// errors map to a generic 500 / opaque "Failed to reset
+		// password" toast on the client. See issue #459.
+		return nil, NewClientError(400, err.Error())
 	}
 
 	return map[string]string{"status": "password reset successful"}, nil

--- a/internal/api/handler_auth_test.go
+++ b/internal/api/handler_auth_test.go
@@ -857,3 +857,48 @@ func TestHandler_resetPassword_InvalidBase64(t *testing.T) {
 	// short-circuited before any service call fired.
 	mockAuth.AssertNotCalled(t, "ConfirmPasswordReset", mock.Anything, mock.Anything)
 }
+
+// TestHandler_resetPassword_ClientErrorSubstrings verifies that user-correctable
+// errors from ConfirmPasswordReset are mapped to 400 ClientError so the frontend
+// can surface the specific reason (e.g. "password must contain..." criteria).
+func TestHandler_resetPassword_ClientErrorSubstrings(t *testing.T) {
+	ctx := context.Background()
+	mockAuth := new(MockAuthService)
+
+	mockAuth.On("ConfirmPasswordReset", ctx, mock.Anything).
+		Return(errors.New("password must contain a number"))
+
+	handler := &Handler{auth: mockAuth}
+
+	encoded := base64.StdEncoding.EncodeToString([]byte("weakpass"))
+	req := &events.LambdaFunctionURLRequest{Body: `{"token": "tok-xyz", "new_password": "` + encoded + `"}`}
+	_, err := handler.resetPassword(ctx, req)
+	require.Error(t, err)
+
+	ce, ok := IsClientError(err)
+	require.True(t, ok, "user-correctable ConfirmPasswordReset error must be a ClientError, got %T: %v", err, err)
+	assert.Equal(t, 400, ce.code)
+	assert.Contains(t, ce.Error(), "password must contain a number")
+}
+
+// TestHandler_resetPassword_ServerSideErrorPassesThrough verifies that server-side
+// errors from ConfirmPasswordReset (DB outages, crypto failures, etc.) are NOT
+// wrapped as 400 ClientError so the framework's default 500-mapping can fire.
+func TestHandler_resetPassword_ServerSideErrorPassesThrough(t *testing.T) {
+	ctx := context.Background()
+	mockAuth := new(MockAuthService)
+
+	mockAuth.On("ConfirmPasswordReset", ctx, mock.Anything).
+		Return(errors.New("database connection lost"))
+
+	handler := &Handler{auth: mockAuth}
+
+	encoded := base64.StdEncoding.EncodeToString([]byte("ValidPass1!"))
+	req := &events.LambdaFunctionURLRequest{Body: `{"token": "tok-xyz", "new_password": "` + encoded + `"}`}
+	_, err := handler.resetPassword(ctx, req)
+	require.Error(t, err)
+
+	_, ok := IsClientError(err)
+	assert.False(t, ok, "server-side errors must NOT be wrapped as ClientError; got ok=true")
+	assert.Contains(t, err.Error(), "database connection lost")
+}

--- a/internal/api/handler_auth_test.go
+++ b/internal/api/handler_auth_test.go
@@ -594,6 +594,32 @@ func TestHandler_resetPassword_Error(t *testing.T) {
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "invalid or expired token")
 }
+
+// Issue #459: ConfirmPasswordReset errors must surface as a 4xx client
+// error with the original message preserved, so the frontend renders a
+// specific reason rather than the opaque "Failed to reset password" that
+// a generic 500 produces. Without the NewClientError wrap in the handler,
+// the error escaped as a plain error and got mapped to 500 / "Internal
+// server error" by the response writer.
+func TestHandler_resetPassword_ErrorIsClientError(t *testing.T) {
+	ctx := context.Background()
+	mockAuth := new(MockAuthService)
+
+	mockAuth.On("ConfirmPasswordReset", ctx, mock.Anything).
+		Return(errors.New("this is your current password, choose a different one"))
+
+	handler := &Handler{auth: mockAuth}
+
+	encoded := base64.StdEncoding.EncodeToString([]byte("ReUsedPassW0rd!"))
+	req := &events.LambdaFunctionURLRequest{Body: `{"token": "valid-token", "new_password": "` + encoded + `"}`}
+	_, err := handler.resetPassword(ctx, req)
+	require.Error(t, err)
+
+	ce, ok := IsClientError(err)
+	require.True(t, ok, "expected ConfirmPasswordReset failures to be wrapped in a clientError")
+	assert.Equal(t, 400, ce.code)
+	assert.Contains(t, ce.Error(), "current password")
+}
 func TestHandler_updateProfile_Success(t *testing.T) {
 	ctx := context.Background()
 	mockAuth := new(MockAuthService)

--- a/internal/auth/service_password.go
+++ b/internal/auth/service_password.go
@@ -83,12 +83,15 @@ func containsSequentialChars(password string, n int) bool {
 	return false
 }
 
-// checkPasswordHistory verifies that the new password hasn't been used recently
-// Checks both the current password hash and the password history
+// checkPasswordHistory verifies that the new password hasn't been used recently.
+// Checks the current password hash and the prior-password history separately so
+// the caller can render a more useful message for the dominant case (user
+// re-typing their existing password on the reset form): see issue #459.
 func (s *Service) checkPasswordHistory(newPassword string, currentHash string, passwordHistory []string) error {
-	// Check against current password first
+	// Check against current password first; distinct message so the user
+	// can tell "I typed my current one" from "this matches an old one".
 	if currentHash != "" && s.verifyPassword(newPassword, currentHash) {
-		return fmt.Errorf("password has been used recently, please choose a different password")
+		return fmt.Errorf("this is your current password, choose a different one")
 	}
 
 	// Check against all stored password hashes in history

--- a/internal/auth/service_password_test.go
+++ b/internal/auth/service_password_test.go
@@ -114,7 +114,9 @@ func TestService_ChangePassword(t *testing.T) {
 
 		err := service.ChangePassword(ctx, "user-123", req)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "used recently")
+		// Issue #459: current-password match now returns a distinct,
+		// more actionable message than the generic "used recently".
+		assert.Contains(t, err.Error(), "current password")
 
 		mockStore.AssertExpectations(t)
 	})
@@ -412,6 +414,45 @@ func TestService_ConfirmPasswordReset(t *testing.T) {
 
 		mockStore.AssertExpectations(t)
 	})
+
+	t.Run("current password reuse returns distinct message (issue #459)", func(t *testing.T) {
+		mockStore := new(MockStore)
+		mockEmail := new(MockEmailSender)
+		service := createTestService(mockStore, mockEmail)
+
+		// User's CURRENT password (not in history yet; only moves to
+		// history on a successful change/reset). The reset form is the
+		// common entry point where users accidentally re-type their
+		// existing password; the error message must tell them so.
+		currentPassword := "ActiveS3cur3Pass1!"
+		currentHash, _ := service.hashPassword(currentPassword)
+
+		expiry := time.Now().Add(time.Hour)
+		testUser := &User{
+			ID:                  "user-123",
+			Email:               "test@example.com",
+			PasswordHash:        currentHash,
+			PasswordResetToken:  "hashed-token",
+			PasswordResetExpiry: &expiry,
+			Active:              true,
+		}
+
+		mockStore.On("GetUserByResetToken", ctx, mock.AnythingOfType("string")).Return(testUser, nil).Once()
+		// Token is invalidated even on validation failure (one-time use).
+		mockStore.On("UpdateUser", ctx, mock.AnythingOfType("*auth.User")).Return(nil).Once()
+
+		req := PasswordResetConfirm{
+			Token:       "valid-reset-token",
+			NewPassword: currentPassword,
+		}
+
+		err := service.ConfirmPasswordReset(ctx, req)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "current password")
+		assert.NotContains(t, err.Error(), "used recently")
+
+		mockStore.AssertExpectations(t)
+	})
 }
 
 // Test password validation rules
@@ -675,13 +716,18 @@ func TestCheckPasswordHistory(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("password matches current hash", func(t *testing.T) {
+	t.Run("password matches current hash returns current-password message", func(t *testing.T) {
+		// Issue #459: current-password match returns a distinct copy
+		// from "used recently" so the frontend can render a useful
+		// toast ("This is your current password") rather than the
+		// opaque generic.
 		currentPassword := "CurrentS3cur3!"
 		currentHash, _ := service.hashPassword(currentPassword)
 
 		err := service.checkPasswordHistory(currentPassword, currentHash, []string{})
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "used recently")
+		assert.Contains(t, err.Error(), "current password")
+		assert.NotContains(t, err.Error(), "used recently")
 	})
 
 	t.Run("password found in history", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Two UX papercuts in the password-reset flow, both in the same modal/page area.

- **#457**: closing the "if an account exists" alert previously left the underlying Reset Password modal open with nothing for the user to do. Replace the `alert()` with a modal-body swap to a "Check your email" confirmation panel + single Close button; the wrapping login modal stays in the DOM and Close returns the user to login via the same reload path as the existing back-to-login link (option 2 from the issue, the agreed cleaner approach).
- **#459**: re-entering the current password during reset previously surfaced as the opaque "Failed to reset password" toast. Two underlying bugs:
  1. `internal/api/handler_auth.resetPassword` returned the raw service error, which got mapped to 500 + "Internal server error". Wrap with `NewClientError(400, err.Error())` so validation/history failures surface verbatim with a 4xx, matching the change-password / forgot-password patterns.
  2. `frontend/src/api/auth.ts::resetPassword` read `error.message` from the body, but the backend emits `{error: "<msg>"}`. Read `error` first, keep `message` as a defensive fallback.
- Additionally split `checkPasswordHistory` so a current-password match returns "this is your current password, choose a different one" (distinct from the unchanged history-match copy).

## Test plan

- [x] `go test ./internal/auth/... ./internal/api/...` green (1554 passed).
- [x] `cd frontend && npm test -- auth.test.ts` green (30 passed).
- [x] `cd frontend && npx tsc --noEmit` clean.
- [x] New test asserts the modal lifecycle on #457 (swap-in-place + close-reloads).
- [x] New test asserts the distinct current-password message on #459 (in `service_password_test.go` and the new `handler_auth_test.go` ClientError test).

Closes #457, #459.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Password reset now shows an inline confirmation panel inside the login modal with a Close button that returns you to the login view.

* **Bug Fixes**
  * Replaced blocking alert dialogs with inline modal messages during password reset.
  * Inline error text appears for empty-email and API error cases.
  * Error messaging for reusing the current password is clearer and more specific.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/489?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->