### PR TITLE
fix(ux/reset-password): detect expired/used tokens before the form

### DIFF
--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -14,6 +14,7 @@ import {
   logout,
   getCurrentUser,
   requestPasswordReset,
+  getResetTokenStatus,
   checkAdminExists,
   setupAdmin,
   getDashboardSummary,
@@ -544,6 +545,59 @@ describe('API Requests', () => {
           body: JSON.stringify({ email: 'test@example.com' })
         })
       );
+    });
+  });
+
+  // CR pass-1: the token-status response is consumed by branching UI
+  // (modal-routing, copy selection) that only handles the closed unions
+  // 'valid'|'expired'|'used' and 'reset'|'invite'. A malicious or
+  // misconfigured server returning e.g. {state:'pwned'} would otherwise
+  // be silently accepted via the unchecked `as` cast and cause downstream
+  // logic to fall through to the form (or worse). Validate at the boundary.
+  describe('getResetTokenStatus (runtime validation)', () => {
+    test('parses a valid response', async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ state: 'valid', flow: 'reset' })
+      });
+
+      await expect(getResetTokenStatus('tok')).resolves.toEqual({ state: 'valid', flow: 'reset' });
+    });
+
+    test('throws when state is not in the closed union', async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ state: 'pwned', flow: 'reset' })
+      });
+
+      await expect(getResetTokenStatus('tok')).rejects.toThrow(/invalid state.*pwned/);
+    });
+
+    test('throws when flow is not in the closed union', async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ state: 'valid', flow: 'phish' })
+      });
+
+      await expect(getResetTokenStatus('tok')).rejects.toThrow(/invalid flow.*phish/);
+    });
+
+    test('throws when state is not a string (e.g. a number)', async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ state: 42, flow: 'reset' })
+      });
+
+      await expect(getResetTokenStatus('tok')).rejects.toThrow(/invalid state/);
+    });
+
+    test('throws when the body is not an object', async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve('not-an-object')
+      });
+
+      await expect(getResetTokenStatus('tok')).rejects.toThrow(/was not an object/);
     });
   });
 

--- a/frontend/src/__tests__/auth.test.ts
+++ b/frontend/src/__tests__/auth.test.ts
@@ -1,13 +1,15 @@
 /**
  * Auth module tests
  */
-import { showLoginModal, updateUserUI, logout } from '../auth';
+import { showLoginModal, showResetPasswordModal, updateUserUI, logout } from '../auth';
 
 // Mock the api module
 jest.mock('../api', () => ({
   login: jest.fn(),
   logout: jest.fn(),
   requestPasswordReset: jest.fn(),
+  resetPassword: jest.fn(),
+  getResetTokenStatus: jest.fn(),
   apiRequest: jest.fn(),
   base64Encode: (s: string) => btoa(s)
 }));
@@ -785,6 +787,108 @@ describe('Auth Module', () => {
       const callArgs = (api.apiRequest as jest.Mock).mock.calls[0];
       const bodyData = JSON.parse(callArgs[1].body);
       expect(bodyData.new_password).toBeDefined();
+    });
+  });
+
+  // Issues #460 and #461: branch the reset modal on token status BEFORE
+  // rendering the form, so expired / already-used tokens land on a
+  // dedicated UX rather than a form that can never submit.
+  describe('showResetPasswordModal', () => {
+    test('valid + reset flow renders the form with "Reset Your Password" heading', async () => {
+      (api.getResetTokenStatus as jest.Mock).mockResolvedValue({ state: 'valid', flow: 'reset' });
+
+      await showResetPasswordModal('valid-token');
+
+      const modal = document.getElementById('reset-password-modal');
+      expect(modal).toBeTruthy();
+      expect(modal?.textContent).toContain('Reset Your Password');
+      expect(document.getElementById('reset-password-form')).toBeTruthy();
+      expect(document.getElementById('new-password')).toBeTruthy();
+    });
+
+    test('valid + invite flow uses "Set Your Password" wording (issue #461)', async () => {
+      (api.getResetTokenStatus as jest.Mock).mockResolvedValue({ state: 'valid', flow: 'invite' });
+
+      await showResetPasswordModal('valid-invite-token');
+
+      const modal = document.getElementById('reset-password-modal');
+      expect(modal).toBeTruthy();
+      expect(modal?.textContent).toContain('Set Your Password');
+      expect(modal?.textContent).not.toContain('Reset Your Password');
+      // Form still renders so the user can complete the invite.
+      expect(document.getElementById('reset-password-form')).toBeTruthy();
+    });
+
+    test('expired token renders the expired view, not the form (issue #460)', async () => {
+      (api.getResetTokenStatus as jest.Mock).mockResolvedValue({ state: 'expired', flow: 'reset' });
+
+      await showResetPasswordModal('expired-token');
+
+      const modal = document.getElementById('reset-password-modal');
+      expect(modal).toBeTruthy();
+      expect(modal?.textContent).toContain('expired');
+      // The password-entry form must NOT render.
+      expect(document.getElementById('reset-password-form')).toBeNull();
+      expect(document.getElementById('new-password')).toBeNull();
+      // The CTA to request a new email is present.
+      expect(document.getElementById('reset-expired-request-new')).toBeTruthy();
+    });
+
+    test('used token renders the used view, not the form (issue #461)', async () => {
+      (api.getResetTokenStatus as jest.Mock).mockResolvedValue({ state: 'used', flow: 'reset' });
+
+      await showResetPasswordModal('stale-token');
+
+      const modal = document.getElementById('reset-password-modal');
+      expect(modal).toBeTruthy();
+      expect(modal?.textContent).toContain('already been used');
+      expect(document.getElementById('reset-password-form')).toBeNull();
+      expect(document.getElementById('reset-used-go-to-login')).toBeTruthy();
+    });
+
+    test('used + invite flow uses invitation wording (issue #461)', async () => {
+      (api.getResetTokenStatus as jest.Mock).mockResolvedValue({ state: 'used', flow: 'invite' });
+
+      await showResetPasswordModal('used-invite-token');
+
+      const modal = document.getElementById('reset-password-modal');
+      expect(modal?.textContent).toContain('Invitation link already used');
+    });
+
+    test('status-check failure falls back to rendering the form', async () => {
+      (api.getResetTokenStatus as jest.Mock).mockRejectedValue(new Error('Network error'));
+
+      await showResetPasswordModal('uncertain-token');
+
+      const modal = document.getElementById('reset-password-modal');
+      expect(modal).toBeTruthy();
+      // Form renders so the user is not stranded on a transient outage.
+      expect(document.getElementById('reset-password-form')).toBeTruthy();
+      expect(document.getElementById('new-password')).toBeTruthy();
+    });
+
+    test('expired view "Send a new reset email" clears the token and routes to login', async () => {
+      (api.getResetTokenStatus as jest.Mock).mockResolvedValue({ state: 'expired', flow: 'reset' });
+
+      // Stub window.history.replaceState since jsdom's implementation
+      // does not noop on absent listeners.
+      const replaceState = jest.fn();
+      Object.defineProperty(window, 'history', {
+        writable: true,
+        value: { replaceState }
+      });
+
+      await showResetPasswordModal('expired-token');
+      document.getElementById('reset-expired-request-new')?.click();
+
+      await new Promise(resolve => setTimeout(resolve, 20));
+
+      // The reset modal is gone; the login modal is up.
+      expect(document.getElementById('reset-password-modal')).toBeNull();
+      expect(document.getElementById('login-modal')).toBeTruthy();
+      // URL query string is cleaned so a reload does not re-enter the
+      // reset flow with the stale token.
+      expect(replaceState).toHaveBeenCalled();
     });
   });
 });

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -128,11 +128,25 @@ export interface ResetTokenStatus {
   flow: 'reset' | 'invite';
 }
 
+// Whitelists for runtime validation of the token-status response. Kept
+// in sync with the ResetTokenStatus union above — if the union grows,
+// these arrays must grow with it (the satisfies clause makes that a
+// type-error rather than a silent drift).
+const VALID_RESET_TOKEN_STATES = ['valid', 'expired', 'used'] as const satisfies readonly ResetTokenStatus['state'][];
+const VALID_RESET_TOKEN_FLOWS  = ['reset', 'invite']           as const satisfies readonly ResetTokenStatus['flow'][];
+const VALID_RESET_TOKEN_STATE_SET: ReadonlySet<ResetTokenStatus['state']> = new Set(VALID_RESET_TOKEN_STATES);
+const VALID_RESET_TOKEN_FLOW_SET:  ReadonlySet<ResetTokenStatus['flow']>  = new Set(VALID_RESET_TOKEN_FLOWS);
+
 /**
  * Probe a reset token's state before rendering the form. On any
  * network or non-OK response, throws so the caller can fall back to
  * rendering the form (a safer default than hiding the form on a
  * transient failure).
+ *
+ * The server response is validated at runtime: a malicious or
+ * misconfigured server cannot inject arbitrary state/flow values
+ * that downstream code (modal-routing, copy selection) is not
+ * prepared to handle. Any deviation throws a descriptive error.
  */
 export async function getResetTokenStatus(token: string): Promise<ResetTokenStatus> {
   const API_BASE = getApiBase();
@@ -141,11 +155,18 @@ export async function getResetTokenStatus(token: string): Promise<ResetTokenStat
   if (!response.ok) {
     throw new Error(`reset-password status check failed: ${response.status}`);
   }
-  const data = await response.json() as { state?: string; flow?: string };
-  if (!data.state || !data.flow) {
-    throw new Error('reset-password status response missing state/flow');
+  const data = await response.json() as unknown;
+  if (data === null || typeof data !== 'object') {
+    throw new Error(`reset-password status response was not an object: ${JSON.stringify(data)}`);
   }
-  return { state: data.state as ResetTokenStatus['state'], flow: data.flow as ResetTokenStatus['flow'] };
+  const { state, flow } = data as { state?: unknown; flow?: unknown };
+  if (typeof state !== 'string' || !VALID_RESET_TOKEN_STATE_SET.has(state as ResetTokenStatus['state'])) {
+    throw new Error(`reset-password status response has invalid state: ${JSON.stringify(state)}`);
+  }
+  if (typeof flow !== 'string' || !VALID_RESET_TOKEN_FLOW_SET.has(flow as ResetTokenStatus['flow'])) {
+    throw new Error(`reset-password status response has invalid flow: ${JSON.stringify(flow)}`);
+  }
+  return { state: state as ResetTokenStatus['state'], flow: flow as ResetTokenStatus['flow'] };
 }
 
 /**

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -114,6 +114,41 @@ export async function resetPassword(token: string, newPassword: string): Promise
 }
 
 /**
+ * ResetTokenStatus describes the runtime state of a reset token. The
+ * frontend calls getResetTokenStatus() before rendering the reset-
+ * password form so it can show an "expired" or "already used" view
+ * instead of a form that can never submit (issues #460, #461).
+ *
+ * state: "valid" | "expired" | "used"  (the server collapses "never
+ *        existed" into "used" since the row is wiped on consumption)
+ * flow:  "reset" | "invite"             (drives "Reset" vs "Set" copy)
+ */
+export interface ResetTokenStatus {
+  state: 'valid' | 'expired' | 'used';
+  flow: 'reset' | 'invite';
+}
+
+/**
+ * Probe a reset token's state before rendering the form. On any
+ * network or non-OK response, throws so the caller can fall back to
+ * rendering the form (a safer default than hiding the form on a
+ * transient failure).
+ */
+export async function getResetTokenStatus(token: string): Promise<ResetTokenStatus> {
+  const API_BASE = getApiBase();
+  const url = `${API_BASE}/auth/reset-password/status?token=${encodeURIComponent(token)}`;
+  const response = await fetch(url, { method: 'GET' });
+  if (!response.ok) {
+    throw new Error(`reset-password status check failed: ${response.status}`);
+  }
+  const data = await response.json() as { state?: string; flow?: string };
+  if (!data.state || !data.flow) {
+    throw new Error('reset-password status response missing state/flow');
+  }
+  return { state: data.state as ResetTokenStatus['state'], flow: data.flow as ResetTokenStatus['flow'] };
+}
+
+/**
  * Check if admin exists
  */
 export async function checkAdminExists(key: string): Promise<boolean> {

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -76,6 +76,7 @@ export {
   getCurrentUser,
   requestPasswordReset,
   resetPassword,
+  getResetTokenStatus,
   checkAdminExists,
   setupAdmin,
   changePassword,

--- a/frontend/src/auth.ts
+++ b/frontend/src/auth.ts
@@ -22,7 +22,14 @@ export function isAdmin(): boolean {
 }
 
 /**
- * Show reset password modal (for password reset links)
+ * Show reset password modal (for password reset links).
+ *
+ * Probes the token state first (issues #460, #461) so the user lands
+ * on the right view: a form for valid tokens, an "expired link" view
+ * for expired tokens, an "already used" view for stale/consumed
+ * tokens. On a status-check failure the form is rendered as a
+ * fallback so the user still has a path forward; submit-time
+ * validation still catches bad tokens server-side.
  */
 export async function showResetPasswordModal(token: string): Promise<void> {
   // Remove any existing modal to prevent duplicates
@@ -30,10 +37,40 @@ export async function showResetPasswordModal(token: string): Promise<void> {
 
   const modal = document.createElement('div');
   modal.id = 'reset-password-modal';
+  document.body.appendChild(modal);
+
+  let status: { state: string; flow: string };
+  try {
+    status = await api.getResetTokenStatus(token);
+  } catch {
+    // Fallback: render the form unconditionally so an offline
+    // status endpoint does not strand users who have a valid token.
+    renderResetForm(modal, token, 'reset');
+    return;
+  }
+
+  if (status.state === 'expired') {
+    renderExpiredView(modal, status.flow);
+    return;
+  }
+  if (status.state === 'used') {
+    renderUsedView(modal, status.flow);
+    return;
+  }
+  // 'valid' (or any unexpected state defaults to the form path).
+  renderResetForm(modal, token, status.flow);
+}
+
+// renderResetForm builds the password-entry form. Heading/submit copy
+// flips between "Reset" and "Set" based on flow (issue #461 invite
+// path). Static template, no user-controlled interpolation.
+function renderResetForm(modal: HTMLElement, token: string, flow: string): void {
+  const heading = flow === 'invite' ? 'Set Your Password' : 'Reset Your Password';
+  const submitLabel = flow === 'invite' ? 'Set Password' : 'Reset Password';
   modal.innerHTML = `
     <div class="modal-overlay">
       <div class="modal-content">
-        <h2>Reset Your Password</h2>
+        <h2>${heading}</h2>
 
         <form id="reset-password-form">
           <label>New Password:
@@ -85,12 +122,11 @@ export async function showResetPasswordModal(token: string): Promise<void> {
 
           <div id="reset-error" class="error-message hidden"></div>
           <div id="reset-success" class="success-message hidden"></div>
-          <button type="submit" class="primary">Reset Password</button>
+          <button type="submit" class="primary">${submitLabel}</button>
         </form>
       </div>
     </div>
   `;
-  document.body.appendChild(modal);
 
   const form = document.getElementById('reset-password-form');
   const passwordInput = document.getElementById('new-password') as HTMLInputElement;
@@ -99,15 +135,96 @@ export async function showResetPasswordModal(token: string): Promise<void> {
     form.addEventListener('submit', (e) => void handleResetPasswordSubmit(e, token));
   }
 
-  // Add real-time password validation
   if (passwordInput) {
     passwordInput.addEventListener('input', () => {
       updatePasswordRequirements(passwordInput.value);
     });
   }
 
-  // Add password visibility toggle
   setupPasswordToggle(modal);
+}
+
+// renderExpiredView replaces the reset modal with a "link expired"
+// view + CTA to request a new reset email (issue #460). The email
+// tied to the expired token is not embedded in the URL, so the CTA
+// hands the user back to the forgot-password form where they re-type
+// their email.
+function renderExpiredView(modal: HTMLElement, flow: string): void {
+  const heading = flow === 'invite'
+    ? 'Invitation link expired'
+    : 'Password reset link expired';
+  const windowCopy = flow === 'invite'
+    ? 'Invitation links are valid for 7 days.'
+    : 'Password reset links are valid for one hour.';
+  modal.innerHTML = `
+    <div class="modal-overlay">
+      <div class="modal-content">
+        <h2>${heading}</h2>
+        <p>${windowCopy}</p>
+        <p>Request a new link to continue.</p>
+        <button type="button" id="reset-expired-request-new" class="primary">Send a new reset email</button>
+        <p><a href="#" id="reset-expired-back-to-login">Back to login</a></p>
+      </div>
+    </div>
+  `;
+
+  document.getElementById('reset-expired-request-new')?.addEventListener('click', () => {
+    void openForgotPasswordFromExpired();
+  });
+  document.getElementById('reset-expired-back-to-login')?.addEventListener('click', (e) => {
+    e.preventDefault();
+    void closeResetModalAndShowLogin();
+  });
+}
+
+// renderUsedView covers both consumed and never-existed tokens (the
+// server collapses them into one state because the row is wiped on
+// consumption; issue #461). Offers two exit paths: log in with the
+// password they already set, or restart the forgot-password flow.
+function renderUsedView(modal: HTMLElement, flow: string): void {
+  const heading = flow === 'invite'
+    ? 'Invitation link already used'
+    : 'Password reset link already used';
+  const body = flow === 'invite'
+    ? "This invitation link has already been used. Sign in with the password you set, or use Forgot Password if you do not remember it."
+    : "This password reset link has already been used. Sign in with the password you set, or use Forgot Password if you do not remember it.";
+  modal.innerHTML = `
+    <div class="modal-overlay">
+      <div class="modal-content">
+        <h2>${heading}</h2>
+        <p>${body}</p>
+        <button type="button" id="reset-used-go-to-login" class="primary">Go to login</button>
+        <p><a href="#" id="reset-used-forgot-password">Forgot password?</a></p>
+      </div>
+    </div>
+  `;
+
+  document.getElementById('reset-used-go-to-login')?.addEventListener('click', () => {
+    void closeResetModalAndShowLogin();
+  });
+  document.getElementById('reset-used-forgot-password')?.addEventListener('click', (e) => {
+    e.preventDefault();
+    void openForgotPasswordFromExpired();
+  });
+}
+
+async function closeResetModalAndShowLogin(): Promise<void> {
+  document.getElementById('reset-password-modal')?.remove();
+  // Clear ?token= so a reload does not bounce back into the reset flow.
+  window.history.replaceState({}, document.title, window.location.pathname);
+  await showLoginModal();
+}
+
+async function openForgotPasswordFromExpired(): Promise<void> {
+  document.getElementById('reset-password-modal')?.remove();
+  window.history.replaceState({}, document.title, window.location.pathname);
+  await showLoginModal();
+  // Trigger the forgot-password swap inside the freshly-shown login
+  // modal, matching the path a user would take by clicking the
+  // "Forgot password?" link manually.
+  document.getElementById('forgot-password-link')?.dispatchEvent(
+    new MouseEvent('click', { bubbles: true, cancelable: true })
+  );
 }
 
 function setupPasswordToggle(container: HTMLElement | Document = document): void {

--- a/internal/api/handler_auth.go
+++ b/internal/api/handler_auth.go
@@ -172,6 +172,45 @@ func isResetPasswordClientError(err error) bool {
 		strings.Contains(s, "password must")
 }
 
+// resetPasswordStatus returns the runtime state of a reset token without
+// consuming it. The frontend hits this before rendering the reset-
+// password form so it can show an "expired" or "already used" view
+// instead of a form that can never submit (issues #460, #461).
+//
+// Response shape is uniform: 200 with {state, flow} for every state,
+// including "used" (covers both consumed and never-issued tokens; the
+// row is wiped on consumption, so the store can't distinguish them).
+// A non-200 means an infrastructure failure, not a token-state signal.
+func (h *Handler) resetPasswordStatus(ctx context.Context, req *events.LambdaFunctionURLRequest) (any, error) {
+	if h.auth == nil {
+		return nil, fmt.Errorf("authentication service not configured")
+	}
+
+	// Same rate-limit bucket as the submit endpoint: a token-probing
+	// attacker would otherwise get a free oracle to test tokens.
+	if err := h.checkRateLimit(ctx, req, "reset_password"); err != nil {
+		return nil, err
+	}
+
+	token := ""
+	if req != nil {
+		token = req.QueryStringParameters["token"]
+	}
+	if token == "" {
+		return nil, NewClientError(400, "token is required")
+	}
+
+	state, flow, err := h.auth.ResetTokenStatus(ctx, token)
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string]string{
+		"state": state,
+		"flow":  flow,
+	}, nil
+}
+
 func (h *Handler) resetPassword(ctx context.Context, req *events.LambdaFunctionURLRequest) (any, error) {
 	if h.auth == nil {
 		return nil, fmt.Errorf("authentication service not configured")

--- a/internal/api/handler_auth_test.go
+++ b/internal/api/handler_auth_test.go
@@ -576,6 +576,99 @@ func TestHandler_resetPassword_InvalidBody(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid request body")
 }
 
+// Issues #460 + #461: token-status endpoint surfaces expired / used
+// state before the user types into a form that can never submit.
+func TestHandler_resetPasswordStatus_Valid(t *testing.T) {
+	ctx := context.Background()
+	mockAuth := new(MockAuthService)
+
+	mockAuth.On("ResetTokenStatus", ctx, "good-token").Return("valid", "reset", nil).Once()
+
+	handler := &Handler{auth: mockAuth}
+	req := &events.LambdaFunctionURLRequest{QueryStringParameters: map[string]string{"token": "good-token"}}
+	result, err := handler.resetPasswordStatus(ctx, req)
+	require.NoError(t, err)
+
+	resp := result.(map[string]string)
+	assert.Equal(t, "valid", resp["state"])
+	assert.Equal(t, "reset", resp["flow"])
+	mockAuth.AssertExpectations(t)
+}
+
+func TestHandler_resetPasswordStatus_Invite(t *testing.T) {
+	ctx := context.Background()
+	mockAuth := new(MockAuthService)
+
+	mockAuth.On("ResetTokenStatus", ctx, "invite-token").Return("valid", "invite", nil).Once()
+
+	handler := &Handler{auth: mockAuth}
+	req := &events.LambdaFunctionURLRequest{QueryStringParameters: map[string]string{"token": "invite-token"}}
+	result, err := handler.resetPasswordStatus(ctx, req)
+	require.NoError(t, err)
+
+	resp := result.(map[string]string)
+	assert.Equal(t, "valid", resp["state"])
+	assert.Equal(t, "invite", resp["flow"])
+	mockAuth.AssertExpectations(t)
+}
+
+func TestHandler_resetPasswordStatus_Expired(t *testing.T) {
+	ctx := context.Background()
+	mockAuth := new(MockAuthService)
+
+	mockAuth.On("ResetTokenStatus", ctx, "old-token").Return("expired", "reset", nil).Once()
+
+	handler := &Handler{auth: mockAuth}
+	req := &events.LambdaFunctionURLRequest{QueryStringParameters: map[string]string{"token": "old-token"}}
+	result, err := handler.resetPasswordStatus(ctx, req)
+	require.NoError(t, err)
+
+	resp := result.(map[string]string)
+	assert.Equal(t, "expired", resp["state"])
+	mockAuth.AssertExpectations(t)
+}
+
+func TestHandler_resetPasswordStatus_Used(t *testing.T) {
+	ctx := context.Background()
+	mockAuth := new(MockAuthService)
+
+	mockAuth.On("ResetTokenStatus", ctx, "stale-token").Return("used", "reset", nil).Once()
+
+	handler := &Handler{auth: mockAuth}
+	req := &events.LambdaFunctionURLRequest{QueryStringParameters: map[string]string{"token": "stale-token"}}
+	result, err := handler.resetPasswordStatus(ctx, req)
+	require.NoError(t, err)
+
+	resp := result.(map[string]string)
+	assert.Equal(t, "used", resp["state"])
+	mockAuth.AssertExpectations(t)
+}
+
+func TestHandler_resetPasswordStatus_MissingToken(t *testing.T) {
+	ctx := context.Background()
+	mockAuth := new(MockAuthService)
+	handler := &Handler{auth: mockAuth}
+
+	req := &events.LambdaFunctionURLRequest{QueryStringParameters: map[string]string{}}
+	_, err := handler.resetPasswordStatus(ctx, req)
+	require.Error(t, err)
+
+	ce, ok := IsClientError(err)
+	require.True(t, ok)
+	assert.Equal(t, 400, ce.code)
+	assert.Contains(t, ce.Error(), "token is required")
+}
+
+func TestHandler_resetPasswordStatus_NoAuthService(t *testing.T) {
+	ctx := context.Background()
+	handler := &Handler{auth: nil}
+
+	req := &events.LambdaFunctionURLRequest{QueryStringParameters: map[string]string{"token": "anything"}}
+	_, err := handler.resetPasswordStatus(ctx, req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "authentication service not configured")
+}
+
 func TestHandler_resetPassword_Error(t *testing.T) {
 	ctx := context.Background()
 	mockAuth := new(MockAuthService)

--- a/internal/api/handler_ri_exchange_test.go
+++ b/internal/api/handler_ri_exchange_test.go
@@ -482,6 +482,9 @@ func (m *mockAuthForExchange) RequestPasswordReset(_ context.Context, _ string) 
 func (m *mockAuthForExchange) ConfirmPasswordReset(_ context.Context, _ PasswordResetConfirm) error {
 	return nil
 }
+func (m *mockAuthForExchange) ResetTokenStatus(_ context.Context, _ string) (string, string, error) {
+	return "valid", "reset", nil
+}
 func (m *mockAuthForExchange) GetUser(_ context.Context, _ string) (*User, error) { return nil, nil }
 func (m *mockAuthForExchange) UpdateUserProfile(_ context.Context, _, _, _, _ string) error {
 	return nil

--- a/internal/api/mocks_test.go
+++ b/internal/api/mocks_test.go
@@ -662,6 +662,11 @@ func (m *MockAuthService) ConfirmPasswordReset(ctx context.Context, req Password
 	return args.Error(0)
 }
 
+func (m *MockAuthService) ResetTokenStatus(ctx context.Context, token string) (string, string, error) {
+	args := m.Called(ctx, token)
+	return args.String(0), args.String(1), args.Error(2)
+}
+
 func (m *MockAuthService) GetUser(ctx context.Context, userID string) (*User, error) {
 	args := m.Called(ctx, userID)
 	if args.Get(0) == nil {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -198,6 +198,7 @@ func (r *Router) registerRoutes() {
 		{ExactPath: "/api/auth/setup-admin", Method: "POST", Handler: r.setupAdminHandler, Auth: AuthPublic},
 		{ExactPath: "/api/auth/forgot-password", Method: "POST", Handler: r.forgotPasswordHandler, Auth: AuthPublic},
 		{ExactPath: "/api/auth/reset-password", Method: "POST", Handler: r.resetPasswordHandler, Auth: AuthPublic},
+		{ExactPath: "/api/auth/reset-password/status", Method: "GET", Handler: r.resetPasswordStatusHandler, Auth: AuthPublic},
 		{ExactPath: "/api/auth/profile", Method: "PUT", Handler: r.updateProfileHandler, Auth: AuthUser},
 		{ExactPath: "/api/auth/change-password", Method: "POST", Handler: r.changePasswordHandler, Auth: AuthUser},
 
@@ -531,6 +532,10 @@ func (r *Router) forgotPasswordHandler(ctx context.Context, req *events.LambdaFu
 
 func (r *Router) resetPasswordHandler(ctx context.Context, req *events.LambdaFunctionURLRequest, params map[string]string) (any, error) {
 	return r.h.resetPassword(ctx, req)
+}
+
+func (r *Router) resetPasswordStatusHandler(ctx context.Context, req *events.LambdaFunctionURLRequest, params map[string]string) (any, error) {
+	return r.h.resetPasswordStatus(ctx, req)
 }
 
 func (r *Router) updateProfileHandler(ctx context.Context, req *events.LambdaFunctionURLRequest, params map[string]string) (any, error) {

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -155,6 +155,13 @@ type AuthServiceInterface interface {
 	CheckAdminExists(ctx context.Context) (bool, error)
 	RequestPasswordReset(ctx context.Context, email string) error
 	ConfirmPasswordReset(ctx context.Context, req PasswordResetConfirm) error
+	// ResetTokenStatus returns the runtime state of a reset token
+	// without consuming it. Used by the GET /api/auth/reset-password/
+	// status endpoint so the frontend can branch on expired / used
+	// tokens before rendering the reset-password form (issues #460,
+	// #461). state is one of "valid" | "expired" | "used"; flow is
+	// "reset" | "invite".
+	ResetTokenStatus(ctx context.Context, token string) (state string, flow string, err error)
 	GetUser(ctx context.Context, userID string) (*User, error)
 	UpdateUserProfile(ctx context.Context, userID string, email string, currentPassword string, newPassword string) error
 	// User management - uses auth.API* types

--- a/internal/auth/service_password.go
+++ b/internal/auth/service_password.go
@@ -331,6 +331,74 @@ func (s *Service) ConfirmPasswordReset(ctx context.Context, req PasswordResetCon
 	return nil
 }
 
+// ResetTokenState describes the runtime state of a password-reset token.
+// One of "valid", "expired", "used". "used" doubles as the fallback for
+// tokens that never existed: the row is wiped on consumption (one-time
+// use), so the store cannot reliably distinguish "consumed" from
+// "never issued". Surfacing both as "used" matches the dominant
+// real-world case (stale link from an old email) and lets the frontend
+// branch on a single state.
+type ResetTokenState string
+
+const (
+	// ResetTokenStateValid means the token matches an issued, unexpired row.
+	ResetTokenStateValid ResetTokenState = "valid"
+	// ResetTokenStateExpired means the token matches but its expiry has passed.
+	ResetTokenStateExpired ResetTokenState = "expired"
+	// ResetTokenStateUsed covers both consumed and never-issued tokens.
+	ResetTokenStateUsed ResetTokenState = "used"
+)
+
+// ResetTokenFlow describes whether the matched token belongs to an
+// invite flow (user had Active = false at issue time, still false now)
+// or a normal password-reset flow. The frontend uses this to swap
+// "Set your password" vs "Reset your password" wording (issue #461).
+type ResetTokenFlow string
+
+const (
+	// ResetTokenFlowReset is the default flow for active users.
+	ResetTokenFlowReset ResetTokenFlow = "reset"
+	// ResetTokenFlowInvite is the bootstrap flow for not-yet-active users.
+	ResetTokenFlowInvite ResetTokenFlow = "invite"
+)
+
+// ResetTokenStatus returns the state of a reset token without consuming
+// it. The frontend calls this before rendering the reset-password form
+// so it can show an "expired" or "already used" view instead of a form
+// the user can never submit (issues #460, #461). For "used" / never-
+// issued, flow defaults to "reset" since there is no user to inspect.
+func (s *Service) ResetTokenStatus(ctx context.Context, token string) (ResetTokenState, ResetTokenFlow, error) {
+	if token == "" {
+		return ResetTokenStateUsed, ResetTokenFlowReset, nil
+	}
+
+	tokenHash := hashSessionToken(token)
+	user, err := s.store.GetUserByResetToken(ctx, tokenHash)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ResetTokenStateUsed, ResetTokenFlowReset, nil
+		}
+		return "", "", err
+	}
+	if user == nil {
+		return ResetTokenStateUsed, ResetTokenFlowReset, nil
+	}
+
+	if user.PasswordResetExpiry == nil || time.Now().After(*user.PasswordResetExpiry) {
+		flow := ResetTokenFlowReset
+		if !user.Active {
+			flow = ResetTokenFlowInvite
+		}
+		return ResetTokenStateExpired, flow, nil
+	}
+
+	flow := ResetTokenFlowReset
+	if !user.Active {
+		flow = ResetTokenFlowInvite
+	}
+	return ResetTokenStateValid, flow, nil
+}
+
 func (s *Service) validateResetToken(ctx context.Context, token string) (*User, error) {
 	tokenHash := hashSessionToken(token)
 

--- a/internal/auth/service_password_test.go
+++ b/internal/auth/service_password_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -450,6 +451,112 @@ func TestService_ConfirmPasswordReset(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "current password")
 		assert.NotContains(t, err.Error(), "used recently")
+
+		mockStore.AssertExpectations(t)
+	})
+}
+
+// TestService_ResetTokenStatus covers the read-only token-status probe
+// the frontend uses to branch on expired / used tokens before rendering
+// the reset-password form (issues #460, #461).
+func TestService_ResetTokenStatus(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("valid token on active user is valid + reset flow", func(t *testing.T) {
+		mockStore := new(MockStore)
+		mockEmail := new(MockEmailSender)
+		service := createTestService(mockStore, mockEmail)
+
+		expiry := time.Now().Add(time.Hour)
+		mockStore.On("GetUserByResetToken", ctx, mock.AnythingOfType("string")).
+			Return(&User{ID: "u1", Active: true, PasswordResetExpiry: &expiry}, nil).Once()
+
+		state, flow, err := service.ResetTokenStatus(ctx, "valid-token")
+		require.NoError(t, err)
+		assert.Equal(t, ResetTokenStateValid, state)
+		assert.Equal(t, ResetTokenFlowReset, flow)
+
+		mockStore.AssertExpectations(t)
+	})
+
+	t.Run("valid token on inactive user is valid + invite flow", func(t *testing.T) {
+		mockStore := new(MockStore)
+		mockEmail := new(MockEmailSender)
+		service := createTestService(mockStore, mockEmail)
+
+		expiry := time.Now().Add(time.Hour)
+		mockStore.On("GetUserByResetToken", ctx, mock.AnythingOfType("string")).
+			Return(&User{ID: "u2", Active: false, PasswordResetExpiry: &expiry}, nil).Once()
+
+		state, flow, err := service.ResetTokenStatus(ctx, "valid-invite-token")
+		require.NoError(t, err)
+		assert.Equal(t, ResetTokenStateValid, state)
+		assert.Equal(t, ResetTokenFlowInvite, flow)
+
+		mockStore.AssertExpectations(t)
+	})
+
+	t.Run("expired token reports expired", func(t *testing.T) {
+		mockStore := new(MockStore)
+		mockEmail := new(MockEmailSender)
+		service := createTestService(mockStore, mockEmail)
+
+		expiry := time.Now().Add(-time.Hour)
+		mockStore.On("GetUserByResetToken", ctx, mock.AnythingOfType("string")).
+			Return(&User{ID: "u3", Active: true, PasswordResetExpiry: &expiry}, nil).Once()
+
+		state, flow, err := service.ResetTokenStatus(ctx, "expired-token")
+		require.NoError(t, err)
+		assert.Equal(t, ResetTokenStateExpired, state)
+		assert.Equal(t, ResetTokenFlowReset, flow)
+
+		mockStore.AssertExpectations(t)
+	})
+
+	t.Run("unknown or consumed token reports used", func(t *testing.T) {
+		mockStore := new(MockStore)
+		mockEmail := new(MockEmailSender)
+		service := createTestService(mockStore, mockEmail)
+
+		mockStore.On("GetUserByResetToken", ctx, mock.AnythingOfType("string")).
+			Return(nil, nil).Once()
+
+		state, flow, err := service.ResetTokenStatus(ctx, "stale-token")
+		require.NoError(t, err)
+		assert.Equal(t, ResetTokenStateUsed, state)
+		// Default flow when there is no user row to inspect.
+		assert.Equal(t, ResetTokenFlowReset, flow)
+
+		mockStore.AssertExpectations(t)
+	})
+
+	t.Run("pgx.ErrNoRows from store maps to used", func(t *testing.T) {
+		mockStore := new(MockStore)
+		mockEmail := new(MockEmailSender)
+		service := createTestService(mockStore, mockEmail)
+
+		mockStore.On("GetUserByResetToken", ctx, mock.AnythingOfType("string")).
+			Return(nil, pgx.ErrNoRows).Once()
+
+		state, flow, err := service.ResetTokenStatus(ctx, "bogus-token")
+		require.NoError(t, err)
+		assert.Equal(t, ResetTokenStateUsed, state)
+		assert.Equal(t, ResetTokenFlowReset, flow)
+
+		mockStore.AssertExpectations(t)
+	})
+
+	t.Run("empty token short-circuits to used", func(t *testing.T) {
+		mockStore := new(MockStore)
+		mockEmail := new(MockEmailSender)
+		service := createTestService(mockStore, mockEmail)
+
+		// No store call expected; the empty-token branch returns
+		// before consulting the store.
+		state, flow, err := service.ResetTokenStatus(ctx, "")
+		require.NoError(t, err)
+		assert.Equal(t, ResetTokenStateUsed, state)
+		assert.Equal(t, ResetTokenFlowReset, flow)
 
 		mockStore.AssertExpectations(t)
 	})

--- a/internal/server/app.go
+++ b/internal/server/app.go
@@ -907,6 +907,11 @@ func (a *authServiceAdapter) ConfirmPasswordReset(ctx context.Context, req api.P
 	return a.service.ConfirmPasswordReset(ctx, authReq)
 }
 
+func (a *authServiceAdapter) ResetTokenStatus(ctx context.Context, token string) (string, string, error) {
+	state, flow, err := a.service.ResetTokenStatus(ctx, token)
+	return string(state), string(flow), err
+}
+
 func (a *authServiceAdapter) GetUser(ctx context.Context, userID string) (*api.User, error) {
 	user, err := a.service.GetUser(ctx, userID)
 	if err != nil {


### PR DESCRIPTION
## Summary

Following a password-reset link whose token is **expired** or **already consumed** previously landed the user on the normal reset-password modal: they would type a new password, hit submit, and only then see "Failed to reset password". Cover both cases (issues #460 and #461) by branching on token state **before** the form ever renders.

### Backend

- New `Service.ResetTokenStatus(ctx, token)` returns `(state, flow)`:
  - `state` in `"valid" | "expired" | "used"` ("used" collapses consumed and never-issued tokens because the row is wiped on consumption; the dominant real-world case is a stale link from an old email, and "already used" is the more useful framing).
  - `flow` in `"reset" | "invite"` (driven by `user.Active` at status-check time; defaults to `"reset"` when there is no user row to inspect).
- Register `GET /api/auth/reset-password/status?token=...` as `AuthPublic`, sharing the `reset_password` rate-limit bucket so the endpoint can't be used as a token-probing oracle.

### Frontend

- `showResetPasswordModal` probes status first and branches:
  - **valid + reset**: the form, heading "Reset Your Password"
  - **valid + invite**: the form, heading "Set Your Password" (issue #461 invite-vs-reset wording fix)
  - **expired**: "Password reset link expired" / "Invitation link expired" view with a "Send a new reset email" CTA that routes to the forgot-password form
  - **used**: "Password reset link already used" / "Invitation link already used" view with "Go to login" + "Forgot password?" CTAs
- Status-check failure falls back to rendering the form so a transient outage doesn't strand users holding valid tokens.

## Test plan

- [x] `go build ./...` clean; `go test ./...` green (4459 passed across 38 packages).
- [x] `cd frontend && npm test -- auth.test.ts` green (36 passed).
- [x] `cd frontend && npx tsc --noEmit` clean.
- [x] Frontend tests cover valid/reset, valid/invite, expired, used, used/invite, fallback-on-fetch-failure, and expired CTA routes back to the login modal.
- [x] Backend tests cover valid+reset, valid+invite, expired, used (not-found and pgx.ErrNoRows), empty token, plus the new handler's missing-token / no-auth-service paths.

Closes #460, #461.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced password reset flow with real-time token validation. Users now receive immediate feedback when opening reset links, with distinct messaging for valid, expired, and already-used tokens.
  * Added support for both password reset and invite flows with appropriate UI and copy variations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/490?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->