### PR TITLE
fix(ux/opportunities): table interaction bugs (#479-#484)

### DIFF
--- a/frontend/src/__tests__/recommendations.test.ts
+++ b/frontend/src/__tests__/recommendations.test.ts
@@ -101,7 +101,13 @@ jest.mock('../utils', () => ({
   formatCurrency: jest.fn((val) => `$${val || 0}`),
   formatTerm: jest.fn((years) => years == null ? '' : `${years} Year${years === 1 ? '' : 's'}`),
   escapeHtml: jest.fn((str) => str || ''),
-  populateAccountFilter: jest.fn(() => Promise.resolve())
+  populateAccountFilter: jest.fn(() => Promise.resolve()),
+  // CURRENCY_DEFAULT_DIGITS must be re-exported by the mock so that
+  // recommendations.ts (which imports it for its filter precision logic)
+  // sees the same default-digit count as the real utils.ts. Without this,
+  // displayPrecision's currency-column branches return undefined and the
+  // filter exact-match path breaks.
+  CURRENCY_DEFAULT_DIGITS: 0,
 }));
 
 import * as api from '../api';
@@ -2358,7 +2364,7 @@ describe('Bundle B: column header filter triggers', () => {
       ]);
     });
 
-    test('clicking group toggle (off) clears the SP filter', async () => {
+    test('clicking group toggle (off) persists an empty allow-list (0-row state)', async () => {
       // Pre-set the filter so the SP tri-state renders as checked.
       (state.getRecommendationsColumnFilters as jest.Mock).mockReturnValue({
         service: { kind: 'set', values: ['savings-plans-compute', 'savings-plans-ec2instance', 'savings-plans-sagemaker'] },
@@ -2372,9 +2378,12 @@ describe('Bundle B: column header filter triggers', () => {
       groupBox!.checked = false;
       groupBox!.dispatchEvent(new Event('change'));
 
-      // No SP boxes selected → commit() treats "no selections" as "no
-      // narrowing" and persists null (filter cleared).
-      expect(state.setRecommendationsColumnFilter).toHaveBeenLastCalledWith('service', null);
+      // CR pass #2: unchecking the SP group when no non-SP boxes are
+      // currently selected leaves zero checkboxes ticked. The individual
+      // commit() path now persists that as an explicit empty allow-list
+      // (matching (All)-off / Clear), not null — so the table renders 0
+      // rows rather than silently snapping back to "no narrowing applied".
+      expect(state.setRecommendationsColumnFilter).toHaveBeenLastCalledWith('service', { kind: 'set', values: [] });
     });
 
     test('group toggle resyncs to indeterminate when only some SPs are filter-active', async () => {
@@ -5730,6 +5739,49 @@ describe('Issue #482: column filter "All" tri-state semantics', () => {
     // All 3 now checked → commit collapses to null.
     expect(state.setRecommendationsColumnFilter).toHaveBeenLastCalledWith('provider', null);
   });
+
+  // CR pass #2 regression: unchecking the last individual value used to
+  // collapse to `null` (no filter), which silently snapped the popover
+  // back to all-checked. After the fix, the individual-checkbox commit
+  // mirrors the (All) / Clear path: an empty allow-list is persisted, so
+  // the table renders 0 rows just like Clear.
+  test('unchecking every individual value persists an explicit empty allow-list (not null)', async () => {
+    // Start narrowed to a single value so the popover opens with exactly
+    // one checkbox checked. Then untick it — commit() should produce
+    // {kind: 'set', values: []}, NOT null.
+    (state.getRecommendationsColumnFilters as jest.Mock).mockReturnValue({
+      provider: { kind: 'set', values: ['aws'] },
+    });
+    await loadRecommendations();
+    document.querySelector<HTMLButtonElement>('th .column-filter-btn[data-column="provider"]')!.click();
+    const awsCb = document.querySelector<HTMLInputElement>('.column-filter-popover input[data-value="aws"]')!;
+    expect(awsCb.checked).toBe(true);
+    awsCb.checked = false;
+    awsCb.dispatchEvent(new Event('change'));
+    // Zero of 3 checked — must NOT collapse to null.
+    expect(state.setRecommendationsColumnFilter).toHaveBeenLastCalledWith('provider', { kind: 'set', values: [] });
+    // Sanity: the call site MUST be the {set, values: []} branch, not the
+    // null branch. Guards against future refactors that re-introduce the
+    // `selected.length === 0 → null` shortcut.
+    const calls = (state.setRecommendationsColumnFilter as jest.Mock).mock.calls
+      .filter((c) => c[0] === 'provider');
+    const last = calls[calls.length - 1];
+    expect(last[1]).not.toBeNull();
+    expect(last[1]).toEqual({ kind: 'set', values: [] });
+  });
+
+  // CR pass #2 regression: with the empty allow-list persisted, applying
+  // the filter to the recommendations must render zero rows — i.e. the
+  // unchecking-last-value path reaches the same 0-row terminal state as
+  // the (All) / Clear path.
+  test('an empty allow-list filter renders 0 rows (applyColumnFilters returns [])', async () => {
+    const { applyColumnFilters } = await import('../recommendations');
+    const filtered = applyColumnFilters(
+      recs as unknown as Parameters<typeof applyColumnFilters>[0],
+      { provider: { kind: 'set', values: [] } },
+    );
+    expect(filtered).toEqual([]);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -5869,5 +5921,93 @@ describe('Issue #484: numeric filter matches the displayed rounded value', () =>
     });
     const { applyColumnFilters } = await import('../recommendations');
     expect(applyColumnFilters(sub as unknown as Parameters<typeof applyColumnFilters>[0], state.getRecommendationsColumnFilters()).map((r) => r.id)).toEqual(['r-5']);
+  });
+
+  // CR pass #2 regression: `displayPrecision` for currency columns MUST
+  // agree with the fraction-digit count `formatCurrency` actually renders,
+  // so that an exact-match filter on the displayed string ("$123") matches
+  // the row whose underlying value rounds to that string at the active
+  // period. Both sources must agree, so the test pins the symmetry at the
+  // canonical `CURRENCY_DEFAULT_DIGITS` constant — which formatCurrency
+  // uses as its default and displayPrecision now imports — rather than at
+  // a hard-coded literal that would silently drift if the default ever
+  // changes.
+  describe('displayPrecision agrees with formatCurrency for currency columns', () => {
+    function fractionDigitsOf(s: string): number {
+      // Strip leading currency symbol(s) and any locale group separators,
+      // then count digits after a decimal point. Returns 0 for "$123",
+      // 2 for "$123.45", etc.
+      const stripped = s.replace(/[^0-9.]/g, '');
+      const dot = stripped.indexOf('.');
+      return dot < 0 ? 0 : stripped.length - dot - 1;
+    }
+
+    test('upfront_cost: displayPrecision matches formatCurrency at every period', async () => {
+      const recsMod = await import('../recommendations');
+      // utils is jest.mock()'d at the top of this file (so the
+      // recommendations module sees a stubbed formatCurrency). For this
+      // test we want the REAL formatCurrency to assert the fraction-digit
+      // contract holds against actual production behaviour, so we pull it
+      // via jest.requireActual rather than the mocked import.
+      const utilsActual = jest.requireActual<typeof import('../utils')>('../utils');
+      const displayPrecision = recsMod.displayPrecision;
+      const formatCurrency = utilsActual.formatCurrency;
+      // upfront_cost is always rendered via plain formatCurrency (no
+      // period scaling). The fraction digit count must therefore be
+      // period-independent and equal to formatCurrency's own output.
+      const sample = 123.456789;
+      const renderedDigits = fractionDigitsOf(formatCurrency(sample));
+      const periods: CostPeriod[] = ['hourly', 'daily', 'monthly', 'yearly'];
+      for (const period of periods) {
+        expect(displayPrecision('upfront_cost', period)).toBe(renderedDigits);
+      }
+    });
+
+    test('monthly_cost: displayPrecision at monthly period matches formatCurrency', async () => {
+      const recsMod = await import('../recommendations');
+      // utils is jest.mock()'d at the top of this file (so the
+      // recommendations module sees a stubbed formatCurrency). For this
+      // test we want the REAL formatCurrency to assert the fraction-digit
+      // contract holds against actual production behaviour, so we pull it
+      // via jest.requireActual rather than the mocked import.
+      const utilsActual = jest.requireActual<typeof import('../utils')>('../utils');
+      const displayPrecision = recsMod.displayPrecision;
+      const formatCurrency = utilsActual.formatCurrency;
+      const sample = 123.456789;
+      const renderedDigits = fractionDigitsOf(formatCurrency(sample));
+      // At monthly period, formatCostForPeriod delegates to formatCurrency
+      // → displayPrecision must agree with formatCurrency's digit count.
+      expect(displayPrecision('monthly_cost', 'monthly')).toBe(renderedDigits);
+    });
+
+    test('on_demand_monthly: displayPrecision at monthly period matches formatCurrency', async () => {
+      const recsMod = await import('../recommendations');
+      // utils is jest.mock()'d at the top of this file (so the
+      // recommendations module sees a stubbed formatCurrency). For this
+      // test we want the REAL formatCurrency to assert the fraction-digit
+      // contract holds against actual production behaviour, so we pull it
+      // via jest.requireActual rather than the mocked import.
+      const utilsActual = jest.requireActual<typeof import('../utils')>('../utils');
+      const displayPrecision = recsMod.displayPrecision;
+      const formatCurrency = utilsActual.formatCurrency;
+      const sample = 123.456789;
+      const renderedDigits = fractionDigitsOf(formatCurrency(sample));
+      expect(displayPrecision('on_demand_monthly', 'monthly')).toBe(renderedDigits);
+    });
+
+    test('monthly_cost / on_demand_monthly non-monthly periods use PERIOD_DECIMALS-based precision', async () => {
+      // Non-monthly periods bypass formatCurrency (see formatCostForPeriod)
+      // and use `toFixed(PERIOD_DECIMALS[period])`. Verify the precision
+      // values are non-zero where expected so the exact-match filter
+      // matches the displayed string (e.g. "$0.1715" at hourly).
+      const { displayPrecision } = await import('../recommendations');
+      // hourly: 4 dp, daily: 2 dp, yearly: 0 dp (per PERIOD_DECIMALS).
+      expect(displayPrecision('monthly_cost', 'hourly')).toBe(4);
+      expect(displayPrecision('monthly_cost', 'daily')).toBe(2);
+      expect(displayPrecision('monthly_cost', 'yearly')).toBe(0);
+      expect(displayPrecision('on_demand_monthly', 'hourly')).toBe(4);
+      expect(displayPrecision('on_demand_monthly', 'daily')).toBe(2);
+      expect(displayPrecision('on_demand_monthly', 'yearly')).toBe(0);
+    });
   });
 });

--- a/frontend/src/__tests__/recommendations.test.ts
+++ b/frontend/src/__tests__/recommendations.test.ts
@@ -935,7 +935,9 @@ describe('Recommendations Module', () => {
       await loadRecommendations();
       const header = document.querySelector<HTMLTableCellElement>('th[data-sort="upfront_cost"]');
       header?.click();
-      expect(state.setRecommendationsSort).toHaveBeenCalledWith({ column: 'upfront_cost', direction: 'desc' });
+      // Issue #480: first click on a non-savings/non-on-demand numeric column
+      // uses the platform-default ascending direction (low → high).
+      expect(state.setRecommendationsSort).toHaveBeenCalledWith({ column: 'upfront_cost', direction: 'asc' });
     });
 
     test('Payment column header renders and is sortable (#282)', async () => {
@@ -945,8 +947,9 @@ describe('Recommendations Module', () => {
       expect(paymentTh).not.toBeNull();
       expect(paymentTh?.textContent).toContain('Payment');
       // Clicking the Payment header should call setRecommendationsSort with 'payment'.
+      // Issue #480: text columns default to 'asc' on first click (alpha order).
       (paymentTh as HTMLElement)?.click();
-      expect(state.setRecommendationsSort).toHaveBeenCalledWith({ column: 'payment', direction: 'desc' });
+      expect(state.setRecommendationsSort).toHaveBeenCalledWith({ column: 'payment', direction: 'asc' });
     });
 
     test('Payment column cell renders human-readable labels (#282)', async () => {
@@ -2145,7 +2148,11 @@ describe('Bundle B: column header filter triggers', () => {
     expect(values).toContain('sagemaker');
   });
 
-  test('Term popover labels show formatted terms; ticking commits string filter values', async () => {
+  test('Term popover labels show formatted terms; unticking one commits the remaining-values filter', async () => {
+    // Issue #482: opening a popover for a column with no active filter
+    // now renders all checkboxes as checked (reflecting the "no narrowing
+    // applied" semantic). The user's narrowing action is therefore an
+    // UNCHECK, not a check.
     await loadRecommendations();
     const termBtn = document.querySelector<HTMLButtonElement>('th .column-filter-btn[data-column="term"]');
     termBtn?.click();
@@ -2154,11 +2161,13 @@ describe('Bundle B: column header filter triggers', () => {
     );
     const labels = items.map((l) => l.querySelector('span')?.textContent);
     expect(labels.sort()).toEqual(['1 Year', '3 Years']);
-    // Tick the "3 Years" checkbox
-    const threeYearLabel = items.find((l) => l.textContent === '3 Years');
-    const cb = threeYearLabel?.querySelector<HTMLInputElement>('input[type="checkbox"]');
-    expect(cb?.dataset['value']).toBe('3');
-    cb!.checked = true;
+    // Both boxes start checked (no active filter → all included). Untick
+    // "1 Year"; remaining checked = ["3"] → filter narrows to that.
+    const oneYearLabel = items.find((l) => l.textContent === '1 Year');
+    const cb = oneYearLabel?.querySelector<HTMLInputElement>('input[type="checkbox"]');
+    expect(cb?.dataset['value']).toBe('1');
+    expect(cb?.checked).toBe(true);
+    cb!.checked = false;
     cb!.dispatchEvent(new Event('change'));
     expect(state.setRecommendationsColumnFilter).toHaveBeenCalledWith('term', { kind: 'set', values: ['3'] });
   });
@@ -2190,7 +2199,12 @@ describe('Bundle B: column header filter triggers', () => {
     expect(state.setRecommendationsColumnFilter).toHaveBeenCalledWith('savings', { kind: 'expr', expr: '>100' });
   });
 
-  test('Clear button drops the filter for that column', async () => {
+  test('Clear button on a categorical column commits an explicit empty allow-list', async () => {
+    // Issue #482: Clear is distinct from "All". It represents the user's
+    // explicit "no values selected" intent and now persists as
+    // {set, values: []} so the table shows 0 rows. Previously Clear
+    // and All collapsed to the same null state, making them visually
+    // indistinguishable per the bug report.
     (state.getRecommendationsColumnFilters as jest.Mock).mockReturnValue({
       provider: { kind: 'set', values: ['aws'] },
     });
@@ -2199,7 +2213,23 @@ describe('Bundle B: column header filter triggers', () => {
     providerBtn?.click();
     const clearBtn = document.querySelector<HTMLButtonElement>('.column-filter-popover .column-filter-clear');
     clearBtn?.click();
-    expect(state.setRecommendationsColumnFilter).toHaveBeenCalledWith('provider', null);
+    expect(state.setRecommendationsColumnFilter).toHaveBeenCalledWith('provider', { kind: 'set', values: [] });
+  });
+
+  test('Clear button on a numeric column clears the expression filter (null)', async () => {
+    // Numeric columns still use null on Clear: the empty-set semantic
+    // only applies to categorical filters because the set-membership
+    // model maps naturally to "no values allowed". Numeric "clear" just
+    // means "no expression applied".
+    (state.getRecommendationsColumnFilters as jest.Mock).mockReturnValue({
+      savings: { kind: 'expr', expr: '>100' },
+    });
+    await loadRecommendations();
+    const savingsBtn = document.querySelector<HTMLButtonElement>('th .column-filter-btn[data-column="savings"]');
+    savingsBtn?.click();
+    const clearBtn = document.querySelector<HTMLButtonElement>('.column-filter-popover .column-filter-clear');
+    clearBtn?.click();
+    expect(state.setRecommendationsColumnFilter).toHaveBeenCalledWith('savings', null);
   });
 
   test('Clear-filters badge appears when at least one filter is active', async () => {
@@ -2282,26 +2312,46 @@ describe('Bundle B: column header filter triggers', () => {
       expect(groupBox).toBeNull();
     });
 
-    test('clicking group toggle commits a filter with all SP slug values', async () => {
+    test('clicking group toggle from a non-SP filter expands it to include all SP slug values', async () => {
+      // Issue #482: with no active filter, every checkbox renders as
+      // checked (including the SP-group toggle). To exercise the "tick
+      // the SP group to add SPs" flow, start from a filter that already
+      // restricts service to a non-SP subset.
+      //
+      // Use a 5-distinct-value visible set (ec2, rds, + 3 SPs) so adding
+      // SPs lands at 4-of-5 selected, strictly partial, so the commit
+      // does NOT collapse to the "all selected" null state.
+      const widerRecs = [
+        { id: 'rec-ec2', provider: 'aws', cloud_account_id: 'a1', service: 'ec2',                        resource_type: 't3.medium', region: 'us-east-1', count: 1, term: 1, savings: 100, upfront_cost: 500 },
+        { id: 'rec-rds', provider: 'aws', cloud_account_id: 'a1', service: 'rds',                        resource_type: 'db.t3',     region: 'us-east-1', count: 1, term: 1, savings: 120, upfront_cost: 600 },
+        { id: 'rec-spc', provider: 'aws', cloud_account_id: 'a1', service: 'savings-plans-compute',      resource_type: 'sp',        region: 'us-east-1', count: 1, term: 1, savings: 200, upfront_cost: 800 },
+        { id: 'rec-spe', provider: 'aws', cloud_account_id: 'a1', service: 'savings-plans-ec2instance',  resource_type: 'sp',        region: 'us-east-1', count: 1, term: 1, savings: 150, upfront_cost: 700 },
+        { id: 'rec-sps', provider: 'aws', cloud_account_id: 'a1', service: 'savings-plans-sagemaker',    resource_type: 'sp',        region: 'us-east-1', count: 1, term: 1, savings: 250, upfront_cost: 900 },
+      ];
+      (api.getRecommendations as jest.Mock).mockResolvedValue({ summary: {}, recommendations: widerRecs, regions: [] });
+      (state.getRecommendations as jest.Mock).mockReturnValue(widerRecs);
+      (state.getVisibleRecommendations as jest.Mock).mockReturnValue(widerRecs);
+      (state.getRecommendationsColumnFilters as jest.Mock).mockReturnValue({
+        service: { kind: 'set', values: ['ec2'] },
+      });
       await loadRecommendations();
       const serviceBtn = document.querySelector<HTMLButtonElement>('th .column-filter-btn[data-column="service"]');
       serviceBtn?.click();
       const groupBox = document.querySelector<HTMLInputElement>('.column-filter-popover input[data-role="sp-group"]');
       expect(groupBox).not.toBeNull();
+      expect(groupBox?.checked).toBe(false);
       // Browser flips checked → true on first click; simulate that.
       groupBox!.checked = true;
       groupBox!.dispatchEvent(new Event('change'));
 
-      // Filter committed with the three SP values (in any order). Asserting
-      // on the mock rather than cb.checked because rerenderRecommendations
-      // → resyncOpenPopover resets cb state from the (mocked) filter
-      // accessor — the mock call args are the canonical signal of what
-      // the click handler did.
+      // Filter committed with ec2 + the three SP values (in any order).
+      // Total selected = 4 of 5 distinct, so the commit stays as a set.
       const calls = (state.setRecommendationsColumnFilter as jest.Mock).mock.calls;
       const lastCall = calls[calls.length - 1];
       expect(lastCall[0]).toBe('service');
       expect(lastCall[1]?.kind).toBe('set');
       expect((lastCall[1]?.values as string[]).sort()).toEqual([
+        'ec2',
         'savings-plans-compute',
         'savings-plans-ec2instance',
         'savings-plans-sagemaker',
@@ -2340,19 +2390,26 @@ describe('Bundle B: column header filter triggers', () => {
     });
 
     test('individual SP checkbox change commits the partial-SP filter', async () => {
+      // Issue #482: start from a single-SP filter so the popover opens
+      // with only `savings-plans-compute` checked; ticking another SP
+      // box exercises the partial-set commit path.
+      (state.getRecommendationsColumnFilters as jest.Mock).mockReturnValue({
+        service: { kind: 'set', values: ['savings-plans-compute'] },
+      });
       await loadRecommendations();
       const serviceBtn = document.querySelector<HTMLButtonElement>('th .column-filter-btn[data-column="service"]');
       serviceBtn?.click();
-      const cbCompute = document.querySelector<HTMLInputElement>('.column-filter-popover input[data-value="savings-plans-compute"]');
-      cbCompute!.checked = true;
-      cbCompute!.dispatchEvent(new Event('change'));
-      // 1 of 4 service distinct values selected → filter committed with
-      // just that slug.
+      const cbEc2sp = document.querySelector<HTMLInputElement>('.column-filter-popover input[data-value="savings-plans-ec2instance"]');
+      expect(cbEc2sp?.checked).toBe(false);
+      cbEc2sp!.checked = true;
+      cbEc2sp!.dispatchEvent(new Event('change'));
+      // 2 of 4 service distinct values selected → filter committed with
+      // both SP slugs.
       const calls = (state.setRecommendationsColumnFilter as jest.Mock).mock.calls;
       const lastCall = calls[calls.length - 1];
       expect(lastCall[0]).toBe('service');
       expect(lastCall[1]?.kind).toBe('set');
-      expect(lastCall[1]?.values).toEqual(['savings-plans-compute']);
+      expect((lastCall[1]?.values as string[]).sort()).toEqual(['savings-plans-compute', 'savings-plans-ec2instance']);
     });
   });
 });
@@ -5326,5 +5383,491 @@ describe('Issue #494: deterministic group sort on multi-variant cells', () => {
       // Must not be the empty / single-element trivial case.
       expect(first.length).toBe(3);
     }
+  });
+});
+
+// Helper used by the issue-#479/#480/#481/#482/#483/#484 describes below to
+// set up the same DOM the top-level "Recommendations Module" describe seeds
+// in its beforeEach. Each describe block runs at module scope and therefore
+// doesn't inherit that hook.
+function setupOpportunitiesTabDom(): void {
+  document.body.replaceChildren();
+  const recsTab = document.createElement('div');
+  recsTab.id = 'opportunities-tab';
+  recsTab.className = 'tab-content active';
+  const summary = document.createElement('div');
+  summary.id = 'recommendations-summary';
+  const list = document.createElement('div');
+  list.id = 'recommendations-list';
+  recsTab.appendChild(summary);
+  recsTab.appendChild(list);
+  document.body.appendChild(recsTab);
+  const purchaseModal = document.createElement('div');
+  purchaseModal.id = 'purchase-modal';
+  purchaseModal.className = 'hidden';
+  const purchaseDetails = document.createElement('div');
+  purchaseDetails.id = 'purchase-details';
+  purchaseModal.appendChild(purchaseDetails);
+  document.body.appendChild(purchaseModal);
+}
+
+// ---------------------------------------------------------------------------
+// Issue #479: Select-all checkbox tri-state.
+// The header checkbox renders with the right .checked / .indeterminate state
+// reflecting current selection vs. the set of best-variant-per-cell recs
+// (the set the select-all click actually populates).
+// ---------------------------------------------------------------------------
+describe('Issue #479: Select-all header checkbox tri-state', () => {
+  const recs = [
+    { id: 'r1', provider: 'aws', cloud_account_id: 'a1', service: 'ec2', resource_type: 't3.medium', region: 'us-east-1', count: 1, term: 1, savings: 100, upfront_cost: 500 },
+    { id: 'r2', provider: 'aws', cloud_account_id: 'a1', service: 'rds', resource_type: 'db.t3',     region: 'us-east-1', count: 1, term: 1, savings: 200, upfront_cost: 800 },
+  ];
+
+  beforeEach(() => {
+    setupOpportunitiesTabDom();
+    jest.clearAllMocks();
+    (api.getRecommendations as jest.Mock).mockResolvedValue({ summary: {}, recommendations: recs, regions: [] });
+    (state.getRecommendations as jest.Mock).mockReturnValue(recs);
+    (state.getVisibleRecommendations as jest.Mock).mockReturnValue(recs);
+    (state.getRecommendationsColumnFilters as jest.Mock).mockReturnValue({});
+    (state.getCostPeriod as jest.Mock).mockReturnValue('monthly');
+    (state.getRecommendationsSort as jest.Mock).mockReturnValue({ column: 'savings', direction: 'desc' });
+    (recsApi.getRecommendationsFreshness as jest.Mock).mockResolvedValue({
+      last_collected_at: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+      last_collection_error: null,
+    });
+  });
+
+  test('with no selection, header checkbox is unchecked and not indeterminate', async () => {
+    (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set());
+    await loadRecommendations();
+    const cb = document.getElementById('select-all-recs') as HTMLInputElement;
+    expect(cb.checked).toBe(false);
+    expect(cb.indeterminate).toBe(false);
+  });
+
+  test('with a partial selection, header checkbox is indeterminate', async () => {
+    (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set(['r1']));
+    await loadRecommendations();
+    const cb = document.getElementById('select-all-recs') as HTMLInputElement;
+    expect(cb.indeterminate).toBe(true);
+    expect(cb.checked).toBe(false);
+  });
+
+  test('with every best-variant selected, header checkbox is checked and not indeterminate', async () => {
+    (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set(['r1', 'r2']));
+    await loadRecommendations();
+    const cb = document.getElementById('select-all-recs') as HTMLInputElement;
+    expect(cb.checked).toBe(true);
+    expect(cb.indeterminate).toBe(false);
+  });
+
+  test('clicking when all selected clears selection (the previously-broken second-click path)', async () => {
+    // Repro from the issue: with all rows selected, the header checkbox
+    // used to render as unchecked, so the second click flipped it to
+    // checked and re-selected everything (no-op). Now it renders as
+    // checked, so the second click flips to unchecked and clears.
+    (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set(['r1', 'r2']));
+    await loadRecommendations();
+    const cb = document.getElementById('select-all-recs') as HTMLInputElement;
+    expect(cb.checked).toBe(true);
+    // Simulate the browser's pre-change flip from true → false.
+    cb.checked = false;
+    cb.dispatchEvent(new Event('change'));
+    expect(state.clearSelectedRecommendations).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #480: First-click sort direction per column.
+// Text columns and most numerics default to 'asc' (A→Z / low → high).
+// `savings` and `on_demand_monthly` keep 'desc' as the platform default.
+// ---------------------------------------------------------------------------
+describe('Issue #480: per-column default sort direction', () => {
+  const recs = [
+    { id: 'r1', provider: 'aws',   cloud_account_id: 'a1', service: 'ec2', resource_type: 't3.medium', region: 'us-east-1', count: 1, term: 1, payment: 'no-upfront', savings: 100, upfront_cost: 0,    monthly_cost: 50,  on_demand_cost: 80  },
+    { id: 'r2', provider: 'azure', cloud_account_id: 'a2', service: 'vm',  resource_type: 'D2s_v3',    region: 'eastus',    count: 1, term: 1, payment: 'no-upfront', savings: 150, upfront_cost: 1000, monthly_cost: 100, on_demand_cost: 130 },
+  ];
+
+  beforeEach(() => {
+    setupOpportunitiesTabDom();
+    jest.clearAllMocks();
+    (api.getRecommendations as jest.Mock).mockResolvedValue({ summary: {}, recommendations: recs, regions: [] });
+    (state.getRecommendations as jest.Mock).mockReturnValue(recs);
+    (state.getVisibleRecommendations as jest.Mock).mockReturnValue(recs);
+    (state.getRecommendationsColumnFilters as jest.Mock).mockReturnValue({});
+    (state.getRecommendationsSort as jest.Mock).mockReturnValue({ column: 'savings', direction: 'desc' });
+    (state.getCostPeriod as jest.Mock).mockReturnValue('monthly');
+    (recsApi.getRecommendationsFreshness as jest.Mock).mockResolvedValue({
+      last_collected_at: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+      last_collection_error: null,
+    });
+  });
+
+  test.each<[string, 'asc' | 'desc']>([
+    ['provider',              'asc'],
+    ['account',               'asc'],
+    ['service',               'asc'],
+    ['resource_type',         'asc'],
+    ['region',                'asc'],
+    ['count',                 'asc'],
+    ['term',                  'asc'],
+    ['payment',               'asc'],
+    ['upfront_cost',          'asc'],
+    ['monthly_cost',          'asc'],
+    ['effective_savings_pct', 'asc'],
+    ['savings',               'desc'],  // exception per QA notes
+    ['on_demand_monthly',     'desc'],  // exception per QA notes
+  ])('first click on %s header sorts %s', async (col, expectedDir) => {
+    // Pin the active sort to a column distinct from the one we click so
+    // the click is treated as a "first click on a previously-unsorted
+    // column" rather than a toggle on the active column. Pick `region`
+    // unless `region` itself is the column under test, in which case
+    // pick `provider`.
+    const initialColumn = col === 'region' ? 'provider' : 'region';
+    (state.getRecommendationsSort as jest.Mock).mockReturnValue({ column: initialColumn, direction: 'asc' });
+    await loadRecommendations();
+    const header = document.querySelector<HTMLTableCellElement>(`th[data-sort="${col}"]`);
+    expect(header).not.toBeNull();
+    header!.click();
+    expect(state.setRecommendationsSort).toHaveBeenCalledWith({ column: col, direction: expectedDir });
+  });
+
+  test('second click on the same column toggles the direction', async () => {
+    // Provider's first click goes to asc (covered above). After
+    // state reports the active sort, the next click flips to desc.
+    (state.getRecommendationsSort as jest.Mock).mockReturnValue({ column: 'provider', direction: 'asc' });
+    await loadRecommendations();
+    const header = document.querySelector<HTMLTableCellElement>('th[data-sort="provider"]');
+    header!.click();
+    expect(state.setRecommendationsSort).toHaveBeenLastCalledWith({ column: 'provider', direction: 'desc' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #481: Sort column + direction persisted across page refresh via
+// URL query params (?sort=<col>&dir=<asc|desc>).
+// ---------------------------------------------------------------------------
+describe('Issue #481: URL persistence of sort state', () => {
+  const recs = [
+    { id: 'r1', provider: 'aws', cloud_account_id: 'a1', service: 'ec2', resource_type: 't3.medium', region: 'us-east-1', count: 1, term: 1, savings: 100, upfront_cost: 500 },
+  ];
+
+  beforeEach(() => {
+    setupOpportunitiesTabDom();
+    jest.clearAllMocks();
+    (api.getRecommendations as jest.Mock).mockResolvedValue({ summary: {}, recommendations: recs, regions: [] });
+    (state.getRecommendations as jest.Mock).mockReturnValue(recs);
+    (state.getVisibleRecommendations as jest.Mock).mockReturnValue(recs);
+    (state.getRecommendationsColumnFilters as jest.Mock).mockReturnValue({});
+    (state.getRecommendationsSort as jest.Mock).mockReturnValue({ column: 'savings', direction: 'desc' });
+    (state.getCostPeriod as jest.Mock).mockReturnValue('monthly');
+    (recsApi.getRecommendationsFreshness as jest.Mock).mockResolvedValue({
+      last_collected_at: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+      last_collection_error: null,
+    });
+    // Reset URL between tests.
+    window.history.replaceState({}, '', '/');
+  });
+
+  test('valid ?sort=col&dir=asc seeds setRecommendationsSort on load', async () => {
+    window.history.replaceState({}, '', '/?sort=upfront_cost&dir=asc');
+    await loadRecommendations();
+    expect(state.setRecommendationsSort).toHaveBeenCalledWith({ column: 'upfront_cost', direction: 'asc' });
+  });
+
+  test('valid ?sort=col&dir=desc seeds setRecommendationsSort on load', async () => {
+    window.history.replaceState({}, '', '/?sort=provider&dir=desc');
+    await loadRecommendations();
+    expect(state.setRecommendationsSort).toHaveBeenCalledWith({ column: 'provider', direction: 'desc' });
+  });
+
+  test('invalid ?sort=<unknown> is silently ignored', async () => {
+    window.history.replaceState({}, '', '/?sort=not_a_column&dir=asc');
+    await loadRecommendations();
+    expect(state.setRecommendationsSort).not.toHaveBeenCalledWith(
+      expect.objectContaining({ column: 'not_a_column' }),
+    );
+  });
+
+  test('invalid ?dir=foo is silently ignored', async () => {
+    window.history.replaceState({}, '', '/?sort=provider&dir=foo');
+    await loadRecommendations();
+    expect(state.setRecommendationsSort).not.toHaveBeenCalledWith(
+      expect.objectContaining({ direction: 'foo' }),
+    );
+  });
+
+  test('clicking a header writes the active sort to the URL', async () => {
+    await loadRecommendations();
+    const header = document.querySelector<HTMLTableCellElement>('th[data-sort="upfront_cost"]');
+    header!.click();
+    const params = new URLSearchParams(window.location.search);
+    expect(params.get('sort')).toBe('upfront_cost');
+    expect(params.get('dir')).toBe('asc');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #482: "All" checkbox tri-state + null-filter renders as all-checked.
+// ---------------------------------------------------------------------------
+describe('Issue #482: column filter "All" tri-state semantics', () => {
+  const recs = [
+    { id: 'r1', provider: 'aws',   cloud_account_id: 'a1', service: 'ec2', resource_type: 't3.medium', region: 'us-east-1', count: 1, term: 1, savings: 100, upfront_cost: 500 },
+    { id: 'r2', provider: 'azure', cloud_account_id: 'a2', service: 'vm',  resource_type: 'D2s_v3',    region: 'eastus',    count: 1, term: 1, savings: 150, upfront_cost: 800 },
+    { id: 'r3', provider: 'gcp',   cloud_account_id: 'a3', service: 'gce', resource_type: 'n2-standard-2', region: 'us-central1', count: 1, term: 1, savings: 200, upfront_cost: 600 },
+  ];
+
+  beforeEach(() => {
+    setupOpportunitiesTabDom();
+    jest.clearAllMocks();
+    (api.getRecommendations as jest.Mock).mockResolvedValue({ summary: {}, recommendations: recs, regions: [] });
+    (state.getRecommendations as jest.Mock).mockReturnValue(recs);
+    (state.getVisibleRecommendations as jest.Mock).mockReturnValue(recs);
+    (state.getRecommendationsColumnFilters as jest.Mock).mockReturnValue({});
+    (state.getRecommendationsSort as jest.Mock).mockReturnValue({ column: 'savings', direction: 'desc' });
+    (state.getCostPeriod as jest.Mock).mockReturnValue('monthly');
+    (recsApi.getRecommendationsFreshness as jest.Mock).mockResolvedValue({
+      last_collected_at: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+      last_collection_error: null,
+    });
+  });
+
+  test('opening a popover on an unfiltered column renders every value as checked', async () => {
+    await loadRecommendations();
+    document.querySelector<HTMLButtonElement>('th .column-filter-btn[data-column="provider"]')!.click();
+    const cbs = Array.from(document.querySelectorAll<HTMLInputElement>('.column-filter-popover .column-filter-item input[type="checkbox"]'));
+    expect(cbs.length).toBe(3);
+    cbs.forEach((cb) => expect(cb.checked).toBe(true));
+    const allBox = document.querySelector<HTMLInputElement>('.column-filter-popover input[data-role="all"]');
+    expect(allBox?.checked).toBe(true);
+    expect(allBox?.indeterminate).toBe(false);
+  });
+
+  test('partial selection makes the (All) box indeterminate', async () => {
+    (state.getRecommendationsColumnFilters as jest.Mock).mockReturnValue({
+      provider: { kind: 'set', values: ['aws'] },
+    });
+    await loadRecommendations();
+    document.querySelector<HTMLButtonElement>('th .column-filter-btn[data-column="provider"]')!.click();
+    const allBox = document.querySelector<HTMLInputElement>('.column-filter-popover input[data-role="all"]');
+    expect(allBox?.checked).toBe(false);
+    expect(allBox?.indeterminate).toBe(true);
+  });
+
+  test('clicking (All) when it is checked unchecks every value AND persists an explicit empty allow-list', async () => {
+    await loadRecommendations();
+    document.querySelector<HTMLButtonElement>('th .column-filter-btn[data-column="provider"]')!.click();
+    const allBox = document.querySelector<HTMLInputElement>('.column-filter-popover input[data-role="all"]');
+    expect(allBox?.checked).toBe(true);
+    // Browser flips → unchecked on click of an already-checked tri-state.
+    allBox!.checked = false;
+    allBox!.dispatchEvent(new Event('change'));
+    expect(state.setRecommendationsColumnFilter).toHaveBeenCalledWith('provider', { kind: 'set', values: [] });
+  });
+
+  test('clicking (All) when it is unchecked checks every value AND clears the filter (null)', async () => {
+    // Start from a partial selection so the table still renders (any row
+    // passes — provider 'aws' is in the allow-list). We rely on the
+    // popover for THIS column showing only the aws box checked and the
+    // azure/gcp boxes unchecked → (All) tri-state is unchecked-not-
+    // indeterminate-not-checked, but since 1 of 3 is checked it's
+    // indeterminate. To exercise the explicit "(All) unchecked → click"
+    // path we set a second column's filter to narrow the visible set
+    // while leaving provider's checkboxes all-unchecked. Easier: use a
+    // {set, values: []} filter on a DIFFERENT column so the provider
+    // popover renders with no provider-narrowing applied (all checked).
+    // Then directly UNCHECK the (All) box to take it from checked → empty.
+    (state.getRecommendationsColumnFilters as jest.Mock).mockReturnValue({
+      // narrowing on service so the table is not empty when provider
+      // has no explicit filter
+      service: { kind: 'set', values: ['ec2', 'vm', 'gce'] },
+    });
+    await loadRecommendations();
+    document.querySelector<HTMLButtonElement>('th .column-filter-btn[data-column="provider"]')!.click();
+    const allBox = document.querySelector<HTMLInputElement>('.column-filter-popover input[data-role="all"]');
+    // No provider filter → resync shows everything ticked.
+    expect(allBox?.checked).toBe(true);
+    // Browser flips → unchecked on click of a checked tri-state.
+    allBox!.checked = false;
+    allBox!.dispatchEvent(new Event('change'));
+    expect(state.setRecommendationsColumnFilter).toHaveBeenCalledWith('provider', { kind: 'set', values: [] });
+    // Now flip it back — (All) unchecked → checked path. After the previous
+    // commitAll's rerender, the mock setRecommendationsColumnFilter has
+    // updated state, but jest mocks don't propagate writes; the popover
+    // would still render based on the still-mocked getRecommendationsColumnFilters
+    // return value. Simulate the intended state explicitly.
+    (state.getRecommendationsColumnFilters as jest.Mock).mockReturnValue({
+      provider: { kind: 'set', values: [] },
+      service: { kind: 'set', values: ['ec2', 'vm', 'gce'] },
+    });
+    // Re-open the popover by toggling the trigger twice; without this the
+    // popover keeps the previous resync's checkbox states.
+    document.querySelector<HTMLButtonElement>('th .column-filter-btn[data-column="provider"]')!.click(); // close
+    document.querySelector<HTMLButtonElement>('th .column-filter-btn[data-column="provider"]')!.click(); // reopen
+    const allBox2 = document.querySelector<HTMLInputElement>('.column-filter-popover input[data-role="all"]');
+    expect(allBox2?.checked).toBe(false);
+    expect(allBox2?.indeterminate).toBe(false);
+    allBox2!.checked = true;
+    allBox2!.dispatchEvent(new Event('change'));
+    expect(state.setRecommendationsColumnFilter).toHaveBeenLastCalledWith('provider', null);
+  });
+
+  test('checking every individual value collapses to null (the existing "all selected = no narrowing" rule)', async () => {
+    // Start narrowed to 2 of 3 (aws, azure); checking the 3rd (gcp) box
+    // takes us to all-3 → commit() collapses to null. One toggle keeps
+    // the mock state interaction trivial — see Bundle B's notes about
+    // resync re-reading the (mocked) filter after each commit.
+    (state.getRecommendationsColumnFilters as jest.Mock).mockReturnValue({
+      provider: { kind: 'set', values: ['aws', 'azure'] },
+    });
+    await loadRecommendations();
+    document.querySelector<HTMLButtonElement>('th .column-filter-btn[data-column="provider"]')!.click();
+    const gcpCb = document.querySelector<HTMLInputElement>('.column-filter-popover input[data-value="gcp"]')!;
+    expect(gcpCb.checked).toBe(false);
+    gcpCb.checked = true;
+    gcpCb.dispatchEvent(new Event('change'));
+    // All 3 now checked → commit collapses to null.
+    expect(state.setRecommendationsColumnFilter).toHaveBeenLastCalledWith('provider', null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #483: Scrolling inside the popover does NOT dismiss it.
+// ---------------------------------------------------------------------------
+describe('Issue #483: popover stays open while user scrolls its contents', () => {
+  const recs = [
+    { id: 'r1', provider: 'aws', cloud_account_id: 'a1', service: 'ec2', resource_type: 't3.medium', region: 'us-east-1', count: 1, term: 1, savings: 100, upfront_cost: 500 },
+  ];
+
+  beforeEach(() => {
+    setupOpportunitiesTabDom();
+    jest.clearAllMocks();
+    (api.getRecommendations as jest.Mock).mockResolvedValue({ summary: {}, recommendations: recs, regions: [] });
+    (state.getRecommendations as jest.Mock).mockReturnValue(recs);
+    (state.getVisibleRecommendations as jest.Mock).mockReturnValue(recs);
+    (state.getRecommendationsColumnFilters as jest.Mock).mockReturnValue({});
+    (state.getRecommendationsSort as jest.Mock).mockReturnValue({ column: 'savings', direction: 'desc' });
+    (state.getCostPeriod as jest.Mock).mockReturnValue('monthly');
+    (recsApi.getRecommendationsFreshness as jest.Mock).mockResolvedValue({
+      last_collected_at: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+      last_collection_error: null,
+    });
+  });
+
+  test('a scroll event whose target is inside the popover does not dismiss it', async () => {
+    await loadRecommendations();
+    document.querySelector<HTMLButtonElement>('th .column-filter-btn[data-column="resource_type"]')!.click();
+    const popover = document.querySelector('.column-filter-popover');
+    expect(popover).not.toBeNull();
+    const list = popover!.querySelector('.column-filter-list');
+    expect(list).not.toBeNull();
+    // Simulate the user scrolling inside the popover's list. The capture-
+    // phase scroll listener on window used to fire and close the popover;
+    // it now ignores scrolls whose target is inside openPopover.el.
+    const scrollEvt = new Event('scroll', { bubbles: true });
+    list!.dispatchEvent(scrollEvt);
+    expect(document.querySelector('.column-filter-popover')).not.toBeNull();
+  });
+
+  test('a scroll event outside the popover still dismisses it', async () => {
+    await loadRecommendations();
+    document.querySelector<HTMLButtonElement>('th .column-filter-btn[data-column="resource_type"]')!.click();
+    expect(document.querySelector('.column-filter-popover')).not.toBeNull();
+    // Scroll the document body (outside the popover) — should still close.
+    const scrollEvt = new Event('scroll', { bubbles: true });
+    document.body.dispatchEvent(scrollEvt);
+    expect(document.querySelector('.column-filter-popover')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #484: Numeric filter exact-match against the displayed rounded value.
+// ---------------------------------------------------------------------------
+describe('Issue #484: numeric filter matches the displayed rounded value', () => {
+  // Choose a savings value whose raw form rounds to a different display
+  // value depending on which precision we use. Under hourly period, the
+  // display rounds to PERIOD_DECIMALS.hourly (4) decimals.
+  //
+  // raw monthly = 123.456789 → daily = monthly/30 = 4.1152263; hourly =
+  // monthly/720 = 0.171467... Use a monthly that's clean enough to keep
+  // the assertions readable while still distinguishing exact rounding.
+  const recs = [
+    { id: 'r-exact',   provider: 'aws', cloud_account_id: 'a1', service: 'ec2', resource_type: 't3.medium', region: 'us-east-1', count: 1, term: 1, savings: 123.456789, upfront_cost: 500 },
+    { id: 'r-other',   provider: 'aws', cloud_account_id: 'a1', service: 'rds', resource_type: 'db.t3',     region: 'us-east-1', count: 1, term: 1, savings: 250,        upfront_cost: 800 },
+  ];
+
+  beforeEach(() => {
+    setupOpportunitiesTabDom();
+    jest.clearAllMocks();
+    (api.getRecommendations as jest.Mock).mockResolvedValue({ summary: {}, recommendations: recs, regions: [] });
+    (state.getRecommendations as jest.Mock).mockReturnValue(recs);
+    (state.getVisibleRecommendations as jest.Mock).mockReturnValue(recs);
+    (state.getRecommendationsColumnFilters as jest.Mock).mockReturnValue({});
+    (state.getRecommendationsSort as jest.Mock).mockReturnValue({ column: 'savings', direction: 'desc' });
+    (recsApi.getRecommendationsFreshness as jest.Mock).mockResolvedValue({
+      last_collected_at: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+      last_collection_error: null,
+    });
+  });
+
+  test('typing the rounded-display value of a row matches that row at daily period', async () => {
+    // Under daily period (PERIOD_DECIMALS.daily = 2), raw monthly
+    // 123.456789 / 30 = 4.1152263 → displays as "$4.12" (2 dp). Filter
+    // expression "4.12" must match the row even though the raw scaled
+    // value (4.1152263) doesn't equal 4.12.
+    (state.getCostPeriod as jest.Mock).mockReturnValue('daily');
+    (state.getRecommendationsColumnFilters as jest.Mock).mockReturnValue({
+      savings: { kind: 'expr', expr: '4.12' },
+    });
+    const { applyColumnFilters } = await import('../recommendations');
+    // Cast through unknown to match the LocalRecommendation shape used
+    // by the function; the test recs include all the fields the filter
+    // actually reads (savings).
+    const filtered = applyColumnFilters(recs as unknown as Parameters<typeof applyColumnFilters>[0], state.getRecommendationsColumnFilters());
+    expect(filtered.map((r) => r.id)).toEqual(['r-exact']);
+  });
+
+  test('typing a value that does NOT match the rounded display excludes the row', async () => {
+    (state.getCostPeriod as jest.Mock).mockReturnValue('daily');
+    (state.getRecommendationsColumnFilters as jest.Mock).mockReturnValue({
+      savings: { kind: 'expr', expr: '4.11' },
+    });
+    const { applyColumnFilters } = await import('../recommendations');
+    const filtered = applyColumnFilters(recs as unknown as Parameters<typeof applyColumnFilters>[0], state.getRecommendationsColumnFilters());
+    expect(filtered.map((r) => r.id)).toEqual([]);
+  });
+
+  test('comparison operators apply against the rounded value too (>5 with a raw 4.999 stays excluded)', async () => {
+    // Raw monthly 4.999 rounds to 5.00 at monthly period (0 dp → 5).
+    // Under "monthly" period the display precision for savings is 0
+    // decimals, so 4.999 displays as "$5" → ">4" includes it, ">5"
+    // does not (since rounded = 5 and 5 > 5 is false).
+    const sub = [
+      { id: 'r-near-5', provider: 'aws', cloud_account_id: 'a1', service: 'ec2', resource_type: 't3.medium', region: 'us-east-1', count: 1, term: 1, savings: 4.999, upfront_cost: 0 },
+    ];
+    (state.getCostPeriod as jest.Mock).mockReturnValue('monthly');
+    (state.getRecommendationsColumnFilters as jest.Mock).mockReturnValue({
+      savings: { kind: 'expr', expr: '>4' },
+    });
+    const { applyColumnFilters } = await import('../recommendations');
+    expect(applyColumnFilters(sub as unknown as Parameters<typeof applyColumnFilters>[0], state.getRecommendationsColumnFilters()).map((r) => r.id)).toEqual(['r-near-5']);
+
+    (state.getRecommendationsColumnFilters as jest.Mock).mockReturnValue({
+      savings: { kind: 'expr', expr: '>5' },
+    });
+    expect(applyColumnFilters(sub as unknown as Parameters<typeof applyColumnFilters>[0], state.getRecommendationsColumnFilters()).map((r) => r.id)).toEqual([]);
+  });
+
+  test('integer columns continue to match exact integer values', async () => {
+    const sub = [
+      { id: 'r-5',  provider: 'aws', cloud_account_id: 'a1', service: 'ec2', resource_type: 't3.medium', region: 'us-east-1', count: 5,  term: 1, savings: 100, upfront_cost: 0 },
+      { id: 'r-10', provider: 'aws', cloud_account_id: 'a1', service: 'ec2', resource_type: 't3.medium', region: 'us-east-1', count: 10, term: 1, savings: 100, upfront_cost: 0 },
+    ];
+    (state.getRecommendationsColumnFilters as jest.Mock).mockReturnValue({
+      count: { kind: 'expr', expr: '5' },
+    });
+    const { applyColumnFilters } = await import('../recommendations');
+    expect(applyColumnFilters(sub as unknown as Parameters<typeof applyColumnFilters>[0], state.getRecommendationsColumnFilters()).map((r) => r.id)).toEqual(['r-5']);
   });
 });

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -283,10 +283,72 @@ export async function triggerAutoRefreshIfStale(
     });
 }
 
+// Issue #481: URL <-> sort-state sync. State stays the source of truth;
+// the URL is a serialised reflection so refresh / bookmark / share keep
+// the user's chosen column + direction.
+//
+// VALID_SORT_COLUMNS gates URL params against the closed enumeration of
+// column ids; invalid params are silently ignored (no toast, no crash).
+const VALID_SORT_COLUMNS: ReadonlySet<state.RecommendationsColumnId> = new Set([
+  'provider', 'account', 'service', 'resource_type', 'region',
+  'count', 'term', 'payment', 'savings', 'upfront_cost',
+  'monthly_cost', 'on_demand_monthly', 'effective_savings_pct',
+]);
+
+/**
+ * If the URL carries `?sort=<col>&dir=<asc|desc>` with valid values, seed
+ * state.setRecommendationsSort with the parsed pair. Idempotent: safe to
+ * call on every loadRecommendations entry. Silently ignores anything
+ * malformed so a stale bookmark with an old column name doesn't crash the
+ * page or look broken.
+ */
+function readSortFromUrl(): void {
+  if (typeof window === 'undefined' || !window.location) return;
+  try {
+    const params = new URLSearchParams(window.location.search);
+    const col = params.get('sort');
+    const dir = params.get('dir');
+    if (!col || !dir) return;
+    if (!VALID_SORT_COLUMNS.has(col as state.RecommendationsColumnId)) return;
+    if (dir !== 'asc' && dir !== 'desc') return;
+    state.setRecommendationsSort({
+      column: col as state.RecommendationsSortColumn,
+      direction: dir,
+    });
+  } catch {
+    // URLSearchParams parsing should never throw on well-formed input, but
+    // be defensive: a malformed location.search shouldn't break the page.
+  }
+}
+
+/**
+ * Mirror the active sort to the URL via history.replaceState so the user
+ * can refresh / bookmark / share without losing it. Uses replaceState (not
+ * pushState) so the back button isn't polluted by every header click.
+ */
+function writeSortToUrl(sort: state.RecommendationsSort): void {
+  if (typeof window === 'undefined' || !window.location || !window.history) return;
+  try {
+    const url = new URL(window.location.href);
+    url.searchParams.set('sort', sort.column);
+    url.searchParams.set('dir', sort.direction);
+    window.history.replaceState(window.history.state, '', url.toString());
+  } catch {
+    // history.replaceState can throw on file:// URLs / iframes with a
+    // different origin; failing silently is the right call (sort still
+    // applies in-memory, just not persisted across this refresh).
+  }
+}
+
 /**
  * Load recommendations
  */
 export async function loadRecommendations(): Promise<void> {
+  // Issue #481: seed sort state from the URL before the first render so a
+  // refreshed / bookmarked page renders with the user's chosen sort, not
+  // the module default ("savings desc"). Idempotent on subsequent reloads.
+  readSortFromUrl();
+
   // Issue #344 T3: skeleton rows for the recommendations table so the
   // panel reads as "loading" instead of staying blank while the
   // (potentially multi-second) Promise.all resolves. 5 rows ≈ above-
@@ -1144,6 +1206,14 @@ export interface ColumnDef {
   key: state.RecommendationsColumnId;
   label: string;
   kind: 'numeric' | 'categorical';
+  // Issue #480: direction applied on the first click of a previously-
+  // unsorted column. Text columns and most numerics get 'asc' (A→Z, low →
+  // high) per platform convention. Two exceptions stay 'desc': `savings`
+  // (savings tables open "biggest wins first") and `on_demand_monthly`
+  // (per QA, current behaviour reads correctly there). Subsequent
+  // clicks on the active column still toggle desc <-> asc regardless of
+  // this default.
+  defaultSortDirection?: 'asc' | 'desc';
 }
 
 export const COLUMN_DEFS: readonly ColumnDef[] = [
@@ -1155,12 +1225,20 @@ export const COLUMN_DEFS: readonly ColumnDef[] = [
   { key: 'count',                 label: 'Count',             kind: 'numeric'     },
   { key: 'term',                  label: 'Term',              kind: 'categorical' },
   { key: 'payment',               label: 'Payment',           kind: 'categorical' },
-  { key: 'savings',               label: 'Monthly Savings',   kind: 'numeric'     },
+  { key: 'savings',               label: 'Monthly Savings',   kind: 'numeric',     defaultSortDirection: 'desc' },
   { key: 'upfront_cost',          label: 'Upfront Cost',      kind: 'numeric'     },
   { key: 'monthly_cost',          label: 'Monthly Cost',      kind: 'numeric'     },
-  { key: 'on_demand_monthly',     label: 'On-Demand Monthly', kind: 'numeric'     },
+  { key: 'on_demand_monthly',     label: 'On-Demand Monthly', kind: 'numeric',     defaultSortDirection: 'desc' },
   { key: 'effective_savings_pct', label: 'Effective %',       kind: 'numeric'     },
 ];
+
+// Issue #480: per-column default sort direction. Defaults to 'asc' unless
+// the COLUMN_DEFS entry overrides it. Looked up by sort-header onActivate
+// when transitioning from a different sort column.
+function defaultSortDirectionFor(col: state.RecommendationsColumnId): 'asc' | 'desc' {
+  const def = COLUMN_DEFS.find((c) => c.key === col);
+  return def?.defaultSortDirection ?? 'asc';
+}
 
 // Static labels for columns whose header is period-invariant. Derived from
 // COLUMN_DEFS so the source-of-truth still drives what's displayed; the
@@ -1308,7 +1386,12 @@ export function applyColumnFilters(
       } else {
         const parsed = parseNumericFilter(f.expr);
         if (!parsed.ok) continue; // ignore broken expressions; UI shows the error
-        const cellNum = numericCellValue(r, col);
+        // Issue #484: compare against the rounded display value so exact-match
+        // ("123.45") works for rows whose raw value rounds to the typed value,
+        // and ">N" / "<N" / "N..M" all behave consistently with what the user
+        // sees in the cell. NaN passes through roundForDisplay unchanged.
+        const period = state.getCostPeriod();
+        const cellNum = roundForDisplay(numericCellValue(r, col), displayPrecision(col, period));
         if (!parsed.predicate(cellNum)) return false;
       }
     }
@@ -1366,6 +1449,51 @@ function numericCellValue(r: LocalRecommendation, col: state.RecommendationsColu
   }
 }
 
+// Issue #484: number of decimal places the cell renders with for the active
+// period. Filter predicates compare against this rounded value so a user
+// typing the value they see (e.g. "123.45") matches the row that visibly
+// shows that value, regardless of how many decimals the raw backend value
+// has. Mirrors the precision used by formatCostForPeriod / formatCurrency /
+// pctText so display and filter logic stay in sync.
+function displayPrecision(col: state.RecommendationsColumnId, period: CostPeriod): number {
+  switch (col) {
+    case 'count':
+      return 0;
+    case 'effective_savings_pct':
+      // Header shows pct.toFixed(1): 1 decimal place.
+      return 1;
+    case 'savings':
+    case 'monthly_cost':
+    case 'on_demand_monthly':
+      // formatCostForPeriod uses formatCurrency (default 0 fraction digits)
+      // for monthly and toFixed(PERIOD_DECIMALS[period]) otherwise.
+      return period === 'monthly' ? 0 : PERIOD_DECIMALS[period];
+    case 'upfront_cost':
+      // formatCurrency default: 0 fraction digits.
+      return 0;
+    // Categorical columns never reach the numeric filter path; default
+    // is irrelevant but match formatCurrency's 0-decimal default for safety.
+    case 'provider':
+    case 'account':
+    case 'service':
+    case 'resource_type':
+    case 'region':
+    case 'term':
+    case 'payment':
+      return 0;
+  }
+}
+
+// Issue #484: round `n` to `precision` decimals using the same half-up
+// behaviour as Number.prototype.toFixed (the rendering path used by
+// formatCurrency / formatCostForPeriod / toFixed in pctText). Returns NaN
+// unchanged so missing data still fails every predicate (preserves the
+// "NaN-as-missing" contract from numericCellValue).
+function roundForDisplay(n: number, precision: number): number {
+  if (!Number.isFinite(n)) return n;
+  return Number(n.toFixed(precision));
+}
+
 // ---------------------------------------------------------------------------
 // Column-filter popover (portal pattern)
 //
@@ -1406,7 +1534,7 @@ let openPopover: PopoverState | null = null;
 // torn down on close.
 let outsideClickHandler: ((e: MouseEvent) => void) | null = null;
 let escKeyHandler: ((e: KeyboardEvent) => void) | null = null;
-let scrollCloseHandler: (() => void) | null = null;
+let scrollCloseHandler: ((e: Event) => void) | null = null;
 let resizeHandler: (() => void) | null = null;
 
 function getColumnTriggerButton(column: state.RecommendationsColumnId): HTMLButtonElement | null {
@@ -1620,10 +1748,18 @@ function buildPopoverContent(
       spBox.checked = checked === spSlugs.length && spSlugs.length > 0;
     };
 
+    // Individual-checkbox commit (issue #482; preserves existing collapse
+    // semantics for the SP-group toggle, where "uncheck every value"
+    // should fall back to "no narrowing" rather than to an empty allow-
+    // list. See commitAll / Clear below for the explicit empty-set path
+    // used by the (All) box and the Clear button.):
+    //   - N=size selected → null (no narrowing applied)
+    //   - N=0 selected → null (also no narrowing; the individual flow
+    //     never produces the "show zero rows" state by itself)
+    //   - 0<N<size → {set, selected}
     const commit = (): void => {
       const selected: string[] = [];
       checkboxes.forEach((cb, value) => { if (cb.checked) selected.push(value); });
-      // No selections OR all selections == "no narrowing", clear the filter.
       if (selected.length === 0 || selected.length === checkboxes.size) {
         state.setRecommendationsColumnFilter(column, null);
       } else {
@@ -1634,14 +1770,31 @@ function buildPopoverContent(
       rerenderRecommendations();
     };
 
+    // (All) and Clear use commitAll(target) directly:
+    //   - target=true → no narrowing (null); resync renders all individual
+    //     boxes checked. Matches issue #482's "All selects every value".
+    //   - target=false → explicit empty allow-list ({set, []}), table shows
+    //     0 rows. Matches issue #482's requirement that Clear/uncheck-All is
+    //     distinct from no-filter.
+    const commitAll = (target: boolean): void => {
+      checkboxes.forEach((cb) => { cb.checked = target; });
+      if (target) {
+        state.setRecommendationsColumnFilter(column, null);
+      } else {
+        state.setRecommendationsColumnFilter(column, { kind: 'set', values: [] });
+      }
+      updateAllTriState();
+      updateSPTriState();
+      rerenderRecommendations();
+    };
+
     checkboxes.forEach((cb) => {
       cb.addEventListener('change', commit);
     });
     allBox.addEventListener('change', () => {
-      const target = allBox.checked;
-      checkboxes.forEach((cb) => { cb.checked = target; });
-      // After (All) flips, update underlying filter once.
-      commit();
+      // Browser resolves indeterminate to checked on click, so allBox.checked
+      // after the click is the desired target.
+      commitAll(allBox.checked);
     });
     if (spBox) {
       spBox.addEventListener('change', () => {
@@ -1668,12 +1821,18 @@ function buildPopoverContent(
   clearBtn.className = 'column-filter-clear';
   clearBtn.textContent = 'Clear';
   clearBtn.addEventListener('click', () => {
-    state.setRecommendationsColumnFilter(column, null);
     if (input) {
+      // Numeric column: Clear drops the expression entirely (no filter).
+      state.setRecommendationsColumnFilter(column, null);
       input.value = '';
       if (errorEl) errorEl.textContent = '';
     } else {
+      // Issue #482: Clear on a categorical filter sets an explicit empty
+      // allow-list rather than null, so it's distinguishable from "no
+      // filter applied" (which renders as all-checked). The popover's
+      // checkboxes flip unchecked; the table renders 0 rows.
       checkboxes.forEach((cb) => { cb.checked = false; });
+      state.setRecommendationsColumnFilter(column, { kind: 'set', values: [] });
     }
     rerenderRecommendations();
   });
@@ -1697,12 +1856,19 @@ function resyncOpenPopover(): void {
     return;
   }
   // Categorical: tick checkboxes whose value is in the active filter.
-  const values: ReadonlySet<string> = f && f.kind === 'set' ? new Set(f.values) : new Set();
-  // Special case: if no filter is set, every checkbox should be unchecked
-  // (the (All) tri-state checkbox follows from this).
-  openPopover.checkboxes.forEach((cb, value) => {
-    cb.checked = f != null && values.has(value);
-  });
+  // Issue #482: when no filter is set (f == null), render every checkbox
+  // as checked and the (All) box as checked. This reflects the user
+  // mental model that "no narrowing applied" means "every value is
+  // included", distinct from an explicit empty allow-list ({set, []})
+  // which renders every box as unchecked.
+  if (f == null) {
+    openPopover.checkboxes.forEach((cb) => { cb.checked = true; });
+  } else {
+    const values: ReadonlySet<string> = f.kind === 'set' ? new Set(f.values) : new Set();
+    openPopover.checkboxes.forEach((cb, value) => {
+      cb.checked = values.has(value);
+    });
+  }
   // Update (All) tri-state.
   const allBox = openPopover.el.querySelector<HTMLInputElement>('input[data-role="all"]');
   if (allBox) {
@@ -1748,8 +1914,16 @@ function attachPopoverGlobalListeners(): void {
       closePopover(true);
     }
   };
-  scrollCloseHandler = (): void => {
-    if (openPopover) closePopover();
+  scrollCloseHandler = (e: Event): void => {
+    if (!openPopover) return;
+    // Issue #483: ignore scrolls that originate inside the popover itself
+    // (the outer popover scroll container or the inner column-filter-list).
+    // Capture-phase scroll events from inner scrollables bubble up to the
+    // window listener; without this guard, scrolling the popover's own
+    // contents dismisses it before the user can reach values below the fold.
+    const target = e.target as Node | null;
+    if (target && openPopover.el.contains(target)) return;
+    closePopover();
   };
   resizeHandler = (): void => {
     if (!openPopover) return;
@@ -2453,12 +2627,29 @@ function buildListMarkup(
     }
   }
 
+  // Issue #479: select-all header checkbox renders as a proper tri-state
+  // reflecting current selection vs. the set of best-variant-per-cell
+  // recommendations (the set that selectAll's onChange actually populates,
+  // see openColumnPopover wiring + #224). Indeterminate is set via JS in
+  // renderRecommendationsList's post-render hook because HTML attributes
+  // can't express the indeterminate state.
+  const bestVariants = pickBestVariantPerCell(recommendations);
+  const bestVariantIds = new Set(bestVariants.map((r) => r.id));
+  let selectedBestCount = 0;
+  selectedRecs.forEach((id) => { if (bestVariantIds.has(id)) selectedBestCount++; });
+  const allSelected = bestVariants.length > 0 && selectedBestCount === bestVariants.length;
+  const selectAllCheckedAttr = allSelected ? ' checked' : '';
+  // Threaded to the renderer via a data attribute so the post-render hook
+  // can flip the .indeterminate property without re-deriving the counts.
+  const selectAllIndeterminate = selectedBestCount > 0 && selectedBestCount < bestVariants.length;
+  const selectAllDataIndeterminate = ` data-indeterminate="${selectAllIndeterminate ? 'true' : 'false'}"`;
+
   return `
     <table>
       <thead>
         <tr>
           <th class="checkbox-col">
-            <input type="checkbox" id="select-all-recs" aria-label="Select all recommendations">
+            <input type="checkbox" id="select-all-recs" aria-label="Select all recommendations"${selectAllCheckedAttr}${selectAllDataIndeterminate}>
           </th>
           ${visibleCols.map((c) => sortHeader(c.key)).join('')}
         </tr>
@@ -3406,11 +3597,20 @@ function renderRecommendationsList(loadedRecs: LocalRecommendation[]): void {
       const col = th.dataset['sort'];
       if (!col) return;
       const prev = state.getRecommendationsSort();
+      // Issue #480: first click on a different column uses that column's
+      // per-config default direction (asc for text/most numerics; desc for
+      // `savings` and `on_demand_monthly`). Subsequent clicks on the active
+      // column toggle desc <-> asc.
       const direction: 'asc' | 'desc' =
         prev.column === col && prev.direction === 'desc' ? 'asc'
           : prev.column === col && prev.direction === 'asc' ? 'desc'
-          : 'desc';
+          : defaultSortDirectionFor(col as state.RecommendationsColumnId);
       state.setRecommendationsSort({ column: col as state.RecommendationsSortColumn, direction });
+      // Issue #481: persist sort to the URL so refreshes / bookmarks /
+      // shareable links restore the user's column + direction. Catches the
+      // common UX surprise of "I sorted by Account, refreshed, now I'm back
+      // at Savings desc".
+      writeSortToUrl({ column: col as state.RecommendationsSortColumn, direction });
       renderRecommendationsList(recommendations);
     };
     th.addEventListener('click', onActivate);
@@ -3425,6 +3625,12 @@ function renderRecommendationsList(loadedRecs: LocalRecommendation[]): void {
   // Add event listeners
   const selectAllCheckbox = document.getElementById('select-all-recs') as HTMLInputElement | null;
   if (selectAllCheckbox) {
+    // Issue #479: indeterminate is a DOM property only, so apply it from
+    // the data attribute the renderer threaded through. Without this, a
+    // partial selection shows no visual cue and clicking the header
+    // repeatedly becomes a no-op because the checkbox's .checked never
+    // flips.
+    selectAllCheckbox.indeterminate = selectAllCheckbox.dataset['indeterminate'] === 'true';
     selectAllCheckbox.addEventListener('change', () => {
       if (selectAllCheckbox.checked) {
         // Issue #224: select-all picks ONE variant per cell (highest-effective-

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -5,7 +5,7 @@
 import * as api from './api';
 import * as state from './state';
 import type { CostPeriod } from './state';
-import { formatCurrency, formatTerm, escapeHtml } from './utils';
+import { formatCurrency, formatTerm, escapeHtml, CURRENCY_DEFAULT_DIGITS } from './utils';
 import { getRecommendationsFreshness, refreshRecommendations as refreshRecommendationsAPI } from './api/recommendations';
 import { showToast } from './toast';
 import {
@@ -1100,9 +1100,12 @@ const PERIOD_DECIMALS: Record<CostPeriod, number> = {
 export function formatCostForPeriod(monthly: number | null | undefined, period: CostPeriod): string {
   const scaled = scaleCost(monthly, period);
   if (scaled === null) return '—';
-  // For the non-monthly periods use fixed-decimal formatting rather than
-  // formatCurrency (which always uses 2 decimals). Monthly keeps the
-  // existing formatCurrency behaviour for backward compatibility.
+  // For the non-monthly periods we want explicit per-period decimal
+  // precision (PERIOD_DECIMALS), so we side-step formatCurrency (which
+  // uses CURRENCY_DEFAULT_DIGITS for any caller that doesn't override).
+  // Monthly keeps the existing formatCurrency behaviour for backward
+  // compatibility (and to stay in lock-step with the rest of the
+  // dashboard's monthly $ formatting).
   if (period === 'monthly') return formatCurrency(scaled);
   return `$${scaled.toFixed(PERIOD_DECIMALS[period])}`;
 }
@@ -1455,7 +1458,14 @@ function numericCellValue(r: LocalRecommendation, col: state.RecommendationsColu
 // shows that value, regardless of how many decimals the raw backend value
 // has. Mirrors the precision used by formatCostForPeriod / formatCurrency /
 // pctText so display and filter logic stay in sync.
-function displayPrecision(col: state.RecommendationsColumnId, period: CostPeriod): number {
+//
+// For currency columns we deliberately reuse `CURRENCY_DEFAULT_DIGITS` from
+// utils.ts rather than hard-coding `0`: that constant is the single source
+// of truth for `formatCurrency`'s default fraction digits, so if the
+// dashboard ever switches to a 2-decimal default the filter precision will
+// follow automatically instead of silently diverging (the bug #484 was
+// meant to close).
+export function displayPrecision(col: state.RecommendationsColumnId, period: CostPeriod): number {
   switch (col) {
     case 'count':
       return 0;
@@ -1465,14 +1475,14 @@ function displayPrecision(col: state.RecommendationsColumnId, period: CostPeriod
     case 'savings':
     case 'monthly_cost':
     case 'on_demand_monthly':
-      // formatCostForPeriod uses formatCurrency (default 0 fraction digits)
+      // formatCostForPeriod uses formatCurrency (CURRENCY_DEFAULT_DIGITS)
       // for monthly and toFixed(PERIOD_DECIMALS[period]) otherwise.
-      return period === 'monthly' ? 0 : PERIOD_DECIMALS[period];
+      return period === 'monthly' ? CURRENCY_DEFAULT_DIGITS : PERIOD_DECIMALS[period];
     case 'upfront_cost':
-      // formatCurrency default: 0 fraction digits.
-      return 0;
+      // Always formatted via formatCurrency with default digits.
+      return CURRENCY_DEFAULT_DIGITS;
     // Categorical columns never reach the numeric filter path; default
-    // is irrelevant but match formatCurrency's 0-decimal default for safety.
+    // is irrelevant but match formatCurrency's default-digit count for safety.
     case 'provider':
     case 'account':
     case 'service':
@@ -1480,7 +1490,7 @@ function displayPrecision(col: state.RecommendationsColumnId, period: CostPeriod
     case 'region':
     case 'term':
     case 'payment':
-      return 0;
+      return CURRENCY_DEFAULT_DIGITS;
   }
 }
 
@@ -1748,19 +1758,16 @@ function buildPopoverContent(
       spBox.checked = checked === spSlugs.length && spSlugs.length > 0;
     };
 
-    // Individual-checkbox commit (issue #482; preserves existing collapse
-    // semantics for the SP-group toggle, where "uncheck every value"
-    // should fall back to "no narrowing" rather than to an empty allow-
-    // list. See commitAll / Clear below for the explicit empty-set path
-    // used by the (All) box and the Clear button.):
-    //   - N=size selected → null (no narrowing applied)
-    //   - N=0 selected → null (also no narrowing; the individual flow
-    //     never produces the "show zero rows" state by itself)
-    //   - 0<N<size → {set, selected}
+    // Individual-checkbox commit (issue #482):
+    //   - N=size selected → null (no narrowing applied; all values pass)
+    //   - 0<=N<size → {set, selected}; N=0 explicitly stores an empty
+    //     allow-list so unchecking the last value reaches the same
+    //     zero-row state as the (All) checkbox and the Clear button,
+    //     rather than snapping back to "all checked".
     const commit = (): void => {
       const selected: string[] = [];
       checkboxes.forEach((cb, value) => { if (cb.checked) selected.push(value); });
-      if (selected.length === 0 || selected.length === checkboxes.size) {
+      if (selected.length === checkboxes.size) {
         state.setRecommendationsColumnFilter(column, null);
       } else {
         state.setRecommendationsColumnFilter(column, { kind: 'set', values: selected });

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -5,17 +5,27 @@
 import type { CloudAccount, AccountListFilters } from './api';
 
 /**
+ * Default number of fraction digits used by formatCurrency when the caller
+ * doesn't pass an explicit `digits` value. Exported so downstream code (e.g.
+ * the Opportunities-table filter precision logic in recommendations.ts) can
+ * stay in lock-step with the formatter rather than hard-coding `0` and
+ * silently drifting if this default ever changes.
+ */
+export const CURRENCY_DEFAULT_DIGITS = 0;
+
+/**
  * Format a number as currency.
  *
- * `digits` controls fraction digits (defaults to 0 — the dashboard KPI
- * format). Callers that need cents, e.g. Purchase History summary cards
- * and RI Exchange cost chips, pass `digits: 2`. Having a single helper
- * keeps "$0" / "$0.00" / "$0.00/hr" from diverging across the app.
+ * `digits` controls fraction digits (defaults to `CURRENCY_DEFAULT_DIGITS`,
+ * currently 0 — the dashboard KPI format). Callers that need cents, e.g.
+ * Purchase History summary cards and RI Exchange cost chips, pass `digits:
+ * 2`. Having a single helper keeps "$0" / "$0.00" / "$0.00/hr" from
+ * diverging across the app.
  */
 export function formatCurrency(
   value: number | null | undefined,
   currency: string = '$',
-  digits: number = 0
+  digits: number = CURRENCY_DEFAULT_DIGITS
 ): string {
   if (value === null || value === undefined || isNaN(value)) {
     return `${currency}${(0).toFixed(digits)}`;


### PR DESCRIPTION
## Summary

Fixes six related UX bugs on the Opportunities table, all in `frontend/src/recommendations.ts`:

- **#479** Select-all header is a proper tri-state. Renders with `.checked` / `.indeterminate` reflecting current selection vs. `pickBestVariantPerCell(visible)`. Second click on an all-selected header now clears (previously a no-op).
- **#480** First-click sort direction is `asc` for text and most numeric columns. `savings` and `on_demand_monthly` keep `desc` per QA notes. Configured via a new `defaultSortDirection` field on `COLUMN_DEFS`.
- **#481** Sort column + direction persisted to the URL as `?sort=col&dir=asc|desc`. Read on every `loadRecommendations` entry, written on every header click via `history.replaceState` (no back-button pollution). Invalid params are silently ignored.
- **#482** Categorical filter `(All)` checkbox is a proper tri-state. Opening a popover on an unfiltered column shows every value checked. Unchecking `(All)` or clicking Clear persists `{kind: 'set', values: []}` (explicit empty allow-list, table shows 0 rows). Distinct from `null` (no narrowing applied).
- **#483** Popover no longer dismisses when the user scrolls inside it. `scrollCloseHandler` now ignores scroll events whose target is contained by `openPopover.el`.
- **#484** Numeric filter matches the displayed rounded value rather than the raw backend value. New `displayPrecision()` + `roundForDisplay()` helpers round the cell value to the renderer's precision before invoking the predicate, so `=`, `>`, `<`, and ranges all behave consistently with what the user sees.

## Test plan

- [x] Frontend Jest suite: 1777 pass / 1 skip / 0 fail across 54 suites (was 1743 pre-PR; added 34 new regression tests + adjusted 3 existing tests for the new semantics)
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` succeeds (production webpack bundle)
- [x] Per-issue regression tests cover: tri-state Select-all rendering + second-click clear (#479); default direction per sortable column with table-driven coverage (#480); URL read/write + invalid-param handling (#481); `(All)` tri-state in both directions + Clear-vs-All distinction (#482); scroll inside popover keeps it open + scroll outside dismisses it (#483); exact-match against rounded display + comparison operators against rounded value + integer-column path (#484)
- [ ] Post-merge: verify on a deployed preview that the six bug reproductions no longer trigger

Closes #479
Closes #480
Closes #481
Closes #482
Closes #483
Closes #484


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sort state persists in the URL for consistent behavior; columns use per-column default sort direction on first click.
  * Numeric filters compare against displayed rounded values for consistent results.

* **Bug Fixes**
  * Select-all header checkbox tri-state behavior corrected and expanded.
  * Categorical filters now distinguish “no filter” vs explicit empty selection; Clear commits an explicit empty allow-list.
  * Filter popovers no longer dismiss when scrolling inside the menu.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/491?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->