### PR TITLE
test(frontend/auth): cover cross-tab logout sync (closes #493)

### DIFF
--- a/frontend/src/__tests__/crosstab-session.test.ts
+++ b/frontend/src/__tests__/crosstab-session.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Cross-tab logout sync regression (issue #493).
+ * Guards installStorageListener() in api/client.ts: if its key filter,
+ * newValue check, install-order, or idempotency ever regresses the
+ * SECURITY mitigation noted in client.ts goes silently false.
+ */
+
+function loadAuth(): { api: typeof import('../api'); handler: (e: StorageEvent) => void; reload: jest.Mock; addSpy: jest.SpyInstance } {
+  let out: ReturnType<typeof loadAuth> | undefined;
+  jest.isolateModules(() => {
+    const addSpy = jest.spyOn(window, 'addEventListener');
+    const reload = jest.fn();
+    Object.defineProperty(window, 'location', { configurable: true, value: { ...window.location, reload } });
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const api = require('../api') as typeof import('../api');
+    api.initAuth();
+    const call = addSpy.mock.calls.find(c => c[0] === 'storage');
+    if (!call) throw new Error('initAuth() did not install a storage listener');
+    out = { api, handler: call[1] as (e: StorageEvent) => void, reload, addSpy };
+  });
+  return out!;
+}
+
+// jsdom rejects the jest.fn() storage mock as storageArea, so omit it
+// (the listener never reads it).
+const evt = (key: string | null, newValue: string | null): StorageEvent =>
+  new StorageEvent('storage', { key, newValue });
+
+describe('cross-tab logout sync (issue #493)', () => {
+  test.each(['authToken', 'apiKey', 'csrfToken'])('cleared %s in another tab clears in-memory auth and reloads', key => {
+    const { api, handler, reload } = loadAuth();
+    api.setAuthToken('t'); api.setApiKey('k');
+    handler(evt(key, null));
+    expect(api.isAuthenticated()).toBe(false);
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  test('ignores non-auth keys', () => {
+    const { api, handler, reload } = loadAuth();
+    api.setAuthToken('t');
+    handler(evt('someOtherKey', null));
+    expect(api.isAuthenticated()).toBe(true);
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  test('ignores partial updates such as token refresh (newValue !== null)', () => {
+    const { api, handler, reload } = loadAuth();
+    api.setAuthToken('t');
+    handler(evt('authToken', 'rotated'));
+    expect(api.isAuthenticated()).toBe(true);
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  test('initAuth() is idempotent: storage listener installs exactly once', () => {
+    const { api, addSpy } = loadAuth();
+    api.initAuth(); api.initAuth();
+    expect(addSpy.mock.calls.filter(c => c[0] === 'storage')).toHaveLength(1);
+  });
+});

--- a/frontend/src/__tests__/crosstab-session.test.ts
+++ b/frontend/src/__tests__/crosstab-session.test.ts
@@ -5,6 +5,11 @@
  * SECURITY mitigation noted in client.ts goes silently false.
  */
 
+const originalLocation = window.location;
+afterEach(() => {
+  Object.defineProperty(window, 'location', { configurable: true, value: originalLocation });
+});
+
 function loadAuth(): { api: typeof import('../api'); handler: (e: StorageEvent) => void; reload: jest.Mock; addSpy: jest.SpyInstance } {
   let out: ReturnType<typeof loadAuth> | undefined;
   jest.isolateModules(() => {


### PR DESCRIPTION
## Summary

Adds the missing regression test coverage flagged in #493 for the
cross-tab logout sync listener (`installStorageListener` in
`frontend/src/api/client.ts`, introduced by #487 to close #462).

The listener is the compensating control for the wider XSS exposure
window that came with moving tokens off `sessionStorage`. The
behaviour is implemented but had no automated regression test - if
the key filter, `newValue !== null` early-return, or idempotency
guard ever regress, the `SECURITY:` claim at the top of `client.ts`
becomes silently false.

## What this PR adds

`frontend/src/__tests__/crosstab-session.test.ts`, 6 test cases:

- cleared `authToken` / `apiKey` / `csrfToken` (parameterized over
  `STORAGE_KEYS`) clears in-memory auth and calls
  `window.location.reload` exactly once
- storage events for non-auth keys are ignored
- partial updates (`newValue !== null`, e.g. token refresh) are
  ignored (no reload)
- `initAuth()` is idempotent: the storage listener installs exactly
  once across multiple `initAuth()` calls

Each test loads the `api/client` module inside `jest.isolateModules()`
so the internal `storageListenerInstalled` flag is fresh per test.

## Notes

- Test-only PR, no production code touched.
- Stacked on top of #487 (base = `fix/issue-462-cross-tab-session`)
  because the listener under test only exists on that branch.
  Should land after #487 merges; rebasing onto
  `feat/multicloud-web-frontend` at that point is a no-op.
- 59-line single test file. `tsc --noEmit` clean.

## Test plan

- [x] `npx jest --testPathPattern=crosstab-session` - 6 passing
- [x] `npx jest --testPathPattern='api\.test'` - 65 passing (no
      regression in the neighbour suite)
- [x] `npx tsc --noEmit` - clean

Closes #493.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage for cross-tab logout synchronization to prevent regressions.
  * Verifies that clearing auth-related storage keys marks the session unauthenticated and triggers a single page reload.
  * Confirms unrelated storage changes are ignored, partial/non-null updates don’t log out, and initialization is idempotent.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/495?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->