### PR TITLE
fix(ux/opportunities): deterministic sort on Term/Payment/Cost/Effective % cells

### DIFF
--- a/frontend/src/__tests__/recommendations.test.ts
+++ b/frontend/src/__tests__/recommendations.test.ts
@@ -4749,3 +4749,473 @@ describe('Column visibility (issue #318)', () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// Issue #494: deterministic group sort on multi-variant cells.
+//
+// After PR #195's per-(term, payment) fan-out, every cell has BOTH 1yr and 3yr
+// variants. The previous `Math.max(...va.map(numericKey))` cell-score collapses
+// to the same value across every cell for Term / Payment / Monthly Cost /
+// Effective % / (and many cells for Upfront), producing apparently-random row
+// order. These regression tests assert deterministic ordering matching what
+// the user sees in the rendered summary row.
+//
+// PR #491 (closes #480) fixed the default-direction inversion; this PR fixes
+// the upstream "every cell ties" symptom.
+// ---------------------------------------------------------------------------
+describe('Issue #494: deterministic group sort on multi-variant cells', () => {
+  /** Build the minimum DOM loadRecommendations needs, using createElement so
+   * no innerHTML assignment is required (the rest of the file uses innerHTML;
+   * here we use the safer DOM API to match the test boilerplate pattern in
+   * `Bundle B: column header filter triggers`). */
+  function buildTestDOM(): void {
+    document.body.replaceChildren();
+    const recsTab = document.createElement('div');
+    recsTab.id = 'opportunities-tab';
+    recsTab.className = 'tab-content active';
+    const summary = document.createElement('div');
+    summary.id = 'recommendations-summary';
+    const list = document.createElement('div');
+    list.id = 'recommendations-list';
+    recsTab.appendChild(summary);
+    recsTab.appendChild(list);
+    document.body.appendChild(recsTab);
+
+    const purchaseModal = document.createElement('div');
+    purchaseModal.id = 'purchase-modal';
+    purchaseModal.className = 'hidden';
+    const purchaseDetails = document.createElement('div');
+    purchaseDetails.id = 'purchase-details';
+    purchaseModal.appendChild(purchaseDetails);
+    document.body.appendChild(purchaseModal);
+  }
+
+  /**
+   * Build a single multi-variant cell (2 variants: term=1 + term=3) with the
+   * provided per-variant payments / upfront / monthly_cost. Cell identity is
+   * controlled by `resource_type` so callers can build N distinct cells in one
+   * fixture.
+   */
+  function multiVariantCell(opts: {
+    resourceType: string;
+    payment1y: string;
+    payment3y: string;
+    upfront1y: number;
+    upfront3y: number;
+    monthly1y?: number | null;
+    monthly3y?: number | null;
+    onDemand?: number | null;
+    savings1y?: number;
+    savings3y?: number;
+  }): LocalRecommendation[] {
+    const slug = opts.resourceType.replace(/\W/g, '');
+    return [
+      {
+        id: `${slug}-1y`,
+        provider: 'aws',
+        cloud_account_id: 'a1',
+        service: 'ec2',
+        resource_type: opts.resourceType,
+        region: 'us-east-1',
+        count: 1,
+        term: 1,
+        payment: opts.payment1y,
+        savings: opts.savings1y ?? 100,
+        upfront_cost: opts.upfront1y,
+        monthly_cost: opts.monthly1y === undefined ? 50 : opts.monthly1y,
+        on_demand_cost: opts.onDemand === undefined ? 200 : opts.onDemand,
+      } as unknown as LocalRecommendation,
+      {
+        id: `${slug}-3y`,
+        provider: 'aws',
+        cloud_account_id: 'a1',
+        service: 'ec2',
+        resource_type: opts.resourceType,
+        region: 'us-east-1',
+        count: 1,
+        term: 3,
+        payment: opts.payment3y,
+        savings: opts.savings3y ?? 300,
+        upfront_cost: opts.upfront3y,
+        monthly_cost: opts.monthly3y === undefined ? 40 : opts.monthly3y,
+        on_demand_cost: opts.onDemand === undefined ? 200 : opts.onDemand,
+      } as unknown as LocalRecommendation,
+    ];
+  }
+
+  /**
+   * Read the rendered cell order from the DOM. Multi-variant cells render as
+   * `tr.rec-cell-summary-row[data-cell-key]`; the test fixtures here use only
+   * multi-variant cells (every cell has 2 variants) so this single selector
+   * captures the full ordering.
+   */
+  function renderedCellOrder(): string[] {
+    return Array.from(
+      document.querySelectorAll<HTMLTableRowElement>('tr.rec-cell-summary-row'),
+    ).map((tr) => tr.getAttribute('data-cell-key') ?? '');
+  }
+
+  /** Set up the DOM + standard mocks; caller provides the rec list + sort. */
+  function setupTestFixture(
+    recs: LocalRecommendation[],
+    sort: { column: string; direction: 'asc' | 'desc' },
+  ): void {
+    buildTestDOM();
+    jest.clearAllMocks();
+    (api.getRecommendations as jest.Mock).mockResolvedValue({
+      summary: {},
+      recommendations: recs,
+      regions: [],
+    });
+    (state.getRecommendations as jest.Mock).mockReturnValue(recs);
+    (state.getVisibleRecommendations as jest.Mock).mockReturnValue(recs);
+    (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(new Set());
+    (state.getRecommendationsSort as jest.Mock).mockReturnValue(sort);
+    (state.getRecommendationsColumnFilters as jest.Mock).mockReturnValue({});
+    (state.getCostPeriod as jest.Mock).mockReturnValue('monthly');
+  }
+
+  // -------------------------------------------------------------------------
+  // 4.9 - Term
+  // -------------------------------------------------------------------------
+  test('Term asc: orders cells by summary.termMin (1yr-grouped before 3yr-grouped)', async () => {
+    const cellMixed = multiVariantCell({
+      resourceType: 'aaa-mixed', payment1y: 'no-upfront', payment3y: 'no-upfront',
+      upfront1y: 0, upfront3y: 0,
+    });
+    // "1yr-only" cell: both variants term=1, different payments so they
+    // produce two distinct rec rows under the same cellKey.
+    const cell1yOnly: LocalRecommendation[] = [
+      { id: 'bbb-1y-nu', provider: 'aws', cloud_account_id: 'a1', service: 'ec2',
+        resource_type: 'bbb-1y-only', region: 'us-east-1', count: 1, term: 1,
+        payment: 'no-upfront', savings: 100, upfront_cost: 0, monthly_cost: 50 } as unknown as LocalRecommendation,
+      { id: 'bbb-1y-au', provider: 'aws', cloud_account_id: 'a1', service: 'ec2',
+        resource_type: 'bbb-1y-only', region: 'us-east-1', count: 1, term: 1,
+        payment: 'all-upfront', savings: 110, upfront_cost: 800, monthly_cost: 0 } as unknown as LocalRecommendation,
+    ];
+    const cell3yOnly: LocalRecommendation[] = [
+      { id: 'ccc-3y-nu', provider: 'aws', cloud_account_id: 'a1', service: 'ec2',
+        resource_type: 'ccc-3y-only', region: 'us-east-1', count: 1, term: 3,
+        payment: 'no-upfront', savings: 300, upfront_cost: 0, monthly_cost: 40 } as unknown as LocalRecommendation,
+      { id: 'ccc-3y-au', provider: 'aws', cloud_account_id: 'a1', service: 'ec2',
+        resource_type: 'ccc-3y-only', region: 'us-east-1', count: 1, term: 3,
+        payment: 'all-upfront', savings: 320, upfront_cost: 2400, monthly_cost: 0 } as unknown as LocalRecommendation,
+    ];
+    // Intentionally wrong insertion order so a no-op sort would fail.
+    const recs = [...cell3yOnly, ...cellMixed, ...cell1yOnly];
+
+    setupTestFixture(recs, { column: 'term', direction: 'asc' });
+    await loadRecommendations();
+
+    const order = renderedCellOrder();
+    // Expected: 1yr-only first (termMin=1, termMax=1), mixed second (termMin=1,
+    // termMax=3), 3yr-only last (termMin=3). The encoded score termMin*100 +
+    // termMax distinguishes the 1yr-only and mixed cells via termMax.
+    expect(order.findIndex((k) => k.includes('bbb-1y-only')))
+      .toBeLessThan(order.findIndex((k) => k.includes('aaa-mixed')));
+    expect(order.findIndex((k) => k.includes('aaa-mixed')))
+      .toBeLessThan(order.findIndex((k) => k.includes('ccc-3y-only')));
+  });
+
+  test('Term desc: order is the exact reverse of ascending', async () => {
+    const cellMixed = multiVariantCell({
+      resourceType: 'aaa-mixed', payment1y: 'no-upfront', payment3y: 'no-upfront',
+      upfront1y: 0, upfront3y: 0,
+    });
+    const cell1yOnly: LocalRecommendation[] = [
+      { id: 'bbb-1y-nu', provider: 'aws', cloud_account_id: 'a1', service: 'ec2',
+        resource_type: 'bbb-1y-only', region: 'us-east-1', count: 1, term: 1,
+        payment: 'no-upfront', savings: 100, upfront_cost: 0, monthly_cost: 50 } as unknown as LocalRecommendation,
+      { id: 'bbb-1y-au', provider: 'aws', cloud_account_id: 'a1', service: 'ec2',
+        resource_type: 'bbb-1y-only', region: 'us-east-1', count: 1, term: 1,
+        payment: 'all-upfront', savings: 110, upfront_cost: 800, monthly_cost: 0 } as unknown as LocalRecommendation,
+    ];
+    const cell3yOnly: LocalRecommendation[] = [
+      { id: 'ccc-3y-nu', provider: 'aws', cloud_account_id: 'a1', service: 'ec2',
+        resource_type: 'ccc-3y-only', region: 'us-east-1', count: 1, term: 3,
+        payment: 'no-upfront', savings: 300, upfront_cost: 0, monthly_cost: 40 } as unknown as LocalRecommendation,
+      { id: 'ccc-3y-au', provider: 'aws', cloud_account_id: 'a1', service: 'ec2',
+        resource_type: 'ccc-3y-only', region: 'us-east-1', count: 1, term: 3,
+        payment: 'all-upfront', savings: 320, upfront_cost: 2400, monthly_cost: 0 } as unknown as LocalRecommendation,
+    ];
+    const recs = [...cellMixed, ...cell1yOnly, ...cell3yOnly];
+
+    setupTestFixture(recs, { column: 'term', direction: 'desc' });
+    await loadRecommendations();
+
+    const order = renderedCellOrder();
+    expect(order.findIndex((k) => k.includes('ccc-3y-only')))
+      .toBeLessThan(order.findIndex((k) => k.includes('aaa-mixed')));
+    expect(order.findIndex((k) => k.includes('aaa-mixed')))
+      .toBeLessThan(order.findIndex((k) => k.includes('bbb-1y-only')));
+  });
+
+  // -------------------------------------------------------------------------
+  // 4.10 - Payment
+  // -------------------------------------------------------------------------
+  test('Payment asc: orders cells by canonical PAYMENT_ORDER (no-upfront < partial-upfront < all-upfront)', async () => {
+    // Each cell has term=1 + term=3 variants with the *same* payment so the
+    // canonical first-variant payment per cell is unambiguous.
+    const cellPartial = multiVariantCell({
+      resourceType: 'partial-cell', payment1y: 'partial-upfront', payment3y: 'partial-upfront',
+      upfront1y: 200, upfront3y: 600,
+    });
+    const cellAllUp = multiVariantCell({
+      resourceType: 'allup-cell', payment1y: 'all-upfront', payment3y: 'all-upfront',
+      upfront1y: 1000, upfront3y: 3000,
+    });
+    const cellNoUp = multiVariantCell({
+      resourceType: 'noup-cell', payment1y: 'no-upfront', payment3y: 'no-upfront',
+      upfront1y: 0, upfront3y: 0,
+    });
+    const recs = [...cellAllUp, ...cellPartial, ...cellNoUp];  // intentionally wrong insertion order
+
+    setupTestFixture(recs, { column: 'payment', direction: 'asc' });
+    await loadRecommendations();
+
+    const order = renderedCellOrder();
+    // Expected semantic order: no-upfront < partial-upfront < all-upfront.
+    // Previous alphabetic comparator would have produced all-upfront <
+    // no-upfront < partial-upfront, which this test would fail under.
+    expect(order.findIndex((k) => k.includes('noup-cell')))
+      .toBeLessThan(order.findIndex((k) => k.includes('partial-cell')));
+    expect(order.findIndex((k) => k.includes('partial-cell')))
+      .toBeLessThan(order.findIndex((k) => k.includes('allup-cell')));
+  });
+
+  // -------------------------------------------------------------------------
+  // 4.12 - Upfront Cost
+  // -------------------------------------------------------------------------
+  test('Upfront Cost asc: orders cells by summary.upfrontMin', async () => {
+    const cellLow = multiVariantCell({
+      resourceType: 'low-upfront', payment1y: 'no-upfront', payment3y: 'partial-upfront',
+      upfront1y: 0, upfront3y: 500,
+    });
+    const cellMid = multiVariantCell({
+      resourceType: 'mid-upfront', payment1y: 'partial-upfront', payment3y: 'all-upfront',
+      upfront1y: 300, upfront3y: 1500,
+    });
+    const cellHigh = multiVariantCell({
+      resourceType: 'high-upfront', payment1y: 'all-upfront', payment3y: 'all-upfront',
+      upfront1y: 800, upfront3y: 2400,
+    });
+    const recs = [...cellHigh, ...cellMid, ...cellLow];  // wrong insertion order
+
+    setupTestFixture(recs, { column: 'upfront_cost', direction: 'asc' });
+    await loadRecommendations();
+
+    const order = renderedCellOrder();
+    // Expected: upfrontMin asc -> 0 < 300 < 800.
+    expect(order.findIndex((k) => k.includes('low-upfront')))
+      .toBeLessThan(order.findIndex((k) => k.includes('mid-upfront')));
+    expect(order.findIndex((k) => k.includes('mid-upfront')))
+      .toBeLessThan(order.findIndex((k) => k.includes('high-upfront')));
+  });
+
+  // -------------------------------------------------------------------------
+  // 4.13 - Monthly Cost
+  // -------------------------------------------------------------------------
+  test('Monthly Cost asc: orders cells by Math.min over non-null variants', async () => {
+    const cellLow = multiVariantCell({  // min(30, 20) = 20
+      resourceType: 'low-monthly', payment1y: 'no-upfront', payment3y: 'no-upfront',
+      upfront1y: 0, upfront3y: 0, monthly1y: 30, monthly3y: 20,
+    });
+    const cellMid = multiVariantCell({  // min(60, null) = 60 (best-case-of-known)
+      resourceType: 'mid-monthly', payment1y: 'no-upfront', payment3y: 'all-upfront',
+      upfront1y: 0, upfront3y: 2400, monthly1y: 60, monthly3y: null,
+    });
+    const cellHigh = multiVariantCell({  // min(100, 90) = 90
+      resourceType: 'high-monthly', payment1y: 'no-upfront', payment3y: 'no-upfront',
+      upfront1y: 0, upfront3y: 0, monthly1y: 100, monthly3y: 90,
+    });
+    const recs = [...cellHigh, ...cellMid, ...cellLow];
+
+    setupTestFixture(recs, { column: 'monthly_cost', direction: 'asc' });
+    await loadRecommendations();
+
+    const order = renderedCellOrder();
+    // Expected: 20 < 60 < 90.
+    expect(order.findIndex((k) => k.includes('low-monthly')))
+      .toBeLessThan(order.findIndex((k) => k.includes('mid-monthly')));
+    expect(order.findIndex((k) => k.includes('mid-monthly')))
+      .toBeLessThan(order.findIndex((k) => k.includes('high-monthly')));
+  });
+
+  test('Monthly Cost: cells with all-null monthly_cost sort last in both asc and desc', async () => {
+    const cellFinite = multiVariantCell({
+      resourceType: 'finite-monthly', payment1y: 'no-upfront', payment3y: 'no-upfront',
+      upfront1y: 0, upfront3y: 0, monthly1y: 50, monthly3y: 40,
+    });
+    const cellAllNull = multiVariantCell({
+      resourceType: 'allnull-monthly', payment1y: 'all-upfront', payment3y: 'all-upfront',
+      upfront1y: 1000, upfront3y: 3000, monthly1y: null, monthly3y: null,
+    });
+    const recs = [...cellAllNull, ...cellFinite];
+
+    // Ascending: finite first, all-null last.
+    setupTestFixture(recs, { column: 'monthly_cost', direction: 'asc' });
+    await loadRecommendations();
+    let order = renderedCellOrder();
+    expect(order.findIndex((k) => k.includes('finite-monthly')))
+      .toBeLessThan(order.findIndex((k) => k.includes('allnull-monthly')));
+
+    // Descending: all-null cells STAY last regardless of direction - the
+    // POSITIVE_INFINITY null-sentinel logic flips them out of the normal
+    // descending order specifically because "no data" rows should be
+    // de-emphasised in both directions.
+    setupTestFixture(recs, { column: 'monthly_cost', direction: 'desc' });
+    await loadRecommendations();
+    order = renderedCellOrder();
+    expect(order.findIndex((k) => k.includes('finite-monthly')))
+      .toBeLessThan(order.findIndex((k) => k.includes('allnull-monthly')));
+  });
+
+  // -------------------------------------------------------------------------
+  // 4.15 - Effective %
+  // -------------------------------------------------------------------------
+  test('Effective % asc: orders cells by Math.max over non-null variants (lowest best-pct first)', async () => {
+    // effectiveSavingsPct uses on_demand_cost when set. Pick on-demand values
+    // so each cell's pct is predictable. Formula:
+    //   pct = (savings - upfront/(term*12)) / on_demand * 100
+    // low-pct  cell: both variants score ~5%, max = 5%
+    const cellLowPct = multiVariantCell({
+      resourceType: 'low-pct', payment1y: 'no-upfront', payment3y: 'no-upfront',
+      upfront1y: 0, upfront3y: 0, savings1y: 10, savings3y: 10, onDemand: 200,
+    });
+    // mid-pct cell: both variants score ~15%, max = 15%
+    const cellMidPct = multiVariantCell({
+      resourceType: 'mid-pct', payment1y: 'no-upfront', payment3y: 'no-upfront',
+      upfront1y: 0, upfront3y: 0, savings1y: 30, savings3y: 30, onDemand: 200,
+    });
+    // high-pct cell: both variants score ~25%, max = 25%
+    const cellHighPct = multiVariantCell({
+      resourceType: 'high-pct', payment1y: 'no-upfront', payment3y: 'no-upfront',
+      upfront1y: 0, upfront3y: 0, savings1y: 50, savings3y: 50, onDemand: 200,
+    });
+    const recs = [...cellHighPct, ...cellMidPct, ...cellLowPct];
+
+    setupTestFixture(recs, { column: 'effective_savings_pct', direction: 'asc' });
+    await loadRecommendations();
+
+    const order = renderedCellOrder();
+    // Expected asc: 5% < 15% < 25%.
+    expect(order.findIndex((k) => k.includes('low-pct')))
+      .toBeLessThan(order.findIndex((k) => k.includes('mid-pct')));
+    expect(order.findIndex((k) => k.includes('mid-pct')))
+      .toBeLessThan(order.findIndex((k) => k.includes('high-pct')));
+  });
+
+  test('Effective %: cells with all-null pct sort last regardless of direction', async () => {
+    // A cell whose every variant has term=0 returns null from
+    // effectiveSavingsPct - that's the null sentinel under test.
+    const cellFinite = multiVariantCell({
+      resourceType: 'finite-pct', payment1y: 'no-upfront', payment3y: 'no-upfront',
+      upfront1y: 0, upfront3y: 0, savings1y: 20, savings3y: 30, onDemand: 200,
+    });
+    const cellAllNull: LocalRecommendation[] = [
+      { id: 'nullpct-v1', provider: 'aws', cloud_account_id: 'a1', service: 'ec2',
+        resource_type: 'allnull-pct', region: 'us-east-1', count: 1, term: 0,
+        payment: 'no-upfront', savings: 0, upfront_cost: 0, monthly_cost: 50,
+        on_demand_cost: 200 } as unknown as LocalRecommendation,
+      { id: 'nullpct-v2', provider: 'aws', cloud_account_id: 'a1', service: 'ec2',
+        resource_type: 'allnull-pct', region: 'us-east-1', count: 1, term: 0,
+        payment: 'all-upfront', savings: 0, upfront_cost: 0, monthly_cost: 50,
+        on_demand_cost: 200 } as unknown as LocalRecommendation,
+    ];
+    const recs = [...cellAllNull, ...cellFinite];
+
+    setupTestFixture(recs, { column: 'effective_savings_pct', direction: 'asc' });
+    await loadRecommendations();
+    let order = renderedCellOrder();
+    expect(order.findIndex((k) => k.includes('finite-pct')))
+      .toBeLessThan(order.findIndex((k) => k.includes('allnull-pct')));
+
+    setupTestFixture(recs, { column: 'effective_savings_pct', direction: 'desc' });
+    await loadRecommendations();
+    order = renderedCellOrder();
+    expect(order.findIndex((k) => k.includes('finite-pct')))
+      .toBeLessThan(order.findIndex((k) => k.includes('allnull-pct')));
+  });
+
+  // -------------------------------------------------------------------------
+  // Determinism: repeating the same sort yields the same order.
+  //
+  // The pre-#494 bug also surfaced as "two clicks of the same header may
+  // produce a different broken order" because every cell tied -> fallback to
+  // browser sort stability, which is implementation-defined for old V8 builds
+  // and varies across JS engines. With the new comparator every cell has a
+  // distinct score (or, if genuinely tied, a stable cellKey tiebreaker), so
+  // repeated invocations MUST produce the same order.
+  // -------------------------------------------------------------------------
+  // -------------------------------------------------------------------------
+  // Selected-variant interaction: when a cell has a selected variant, the
+  // cell's sort score must use that variant's value but must remain on the
+  // same scale as non-selected cells (otherwise a selected term=1 ranks
+  // above a non-selected mixed cell when it should rank below the
+  // 1yr-only non-selected cell).
+  // -------------------------------------------------------------------------
+  test('Selected-variant cell sorts on the same scale as non-selected cells (Term)', async () => {
+    // Non-selected mixed (1, 3) cell.
+    const cellMixed = multiVariantCell({
+      resourceType: 'mixed-cell', payment1y: 'no-upfront', payment3y: 'no-upfront',
+      upfront1y: 0, upfront3y: 0,
+    });
+    // Selected cell: user picked the 3yr variant inside a (1, 3) cell.
+    const cellSel3y = multiVariantCell({
+      resourceType: 'sel3y-cell', payment1y: 'no-upfront', payment3y: 'no-upfront',
+      upfront1y: 0, upfront3y: 0,
+    });
+    // Selected cell: user picked the 1yr variant inside a (1, 3) cell.
+    const cellSel1y = multiVariantCell({
+      resourceType: 'sel1y-cell', payment1y: 'no-upfront', payment3y: 'no-upfront',
+      upfront1y: 0, upfront3y: 0,
+    });
+    const recs = [...cellMixed, ...cellSel3y, ...cellSel1y];
+
+    setupTestFixture(recs, { column: 'term', direction: 'asc' });
+    // Override selection mock AFTER setupTestFixture so it sticks.
+    (state.getSelectedRecommendationIDs as jest.Mock).mockReturnValue(
+      new Set(['sel3ycell-3y', 'sel1ycell-1y']),
+    );
+    await loadRecommendations();
+
+    const order = renderedCellOrder();
+    // Expected under term asc:
+    //   selected-1y cell  (score = 1*100+1 = 101)
+    //   mixed cell        (score = 1*100+3 = 103)
+    //   selected-3y cell  (score = 3*100+3 = 303)
+    expect(order.findIndex((k) => k.includes('sel1y-cell')))
+      .toBeLessThan(order.findIndex((k) => k.includes('mixed-cell')));
+    expect(order.findIndex((k) => k.includes('mixed-cell')))
+      .toBeLessThan(order.findIndex((k) => k.includes('sel3y-cell')));
+  });
+
+  test('Sort is deterministic across repeated renders for each affected column', async () => {
+    const cells = [
+      multiVariantCell({ resourceType: 'A-cell', payment1y: 'no-upfront',      payment3y: 'all-upfront',     upfront1y: 0,   upfront3y: 1500, monthly1y: 50,  monthly3y: 0,  savings1y: 20, savings3y: 30 }),
+      multiVariantCell({ resourceType: 'B-cell', payment1y: 'partial-upfront', payment3y: 'partial-upfront', upfront1y: 300, upfront3y: 900,  monthly1y: 40,  monthly3y: 30, savings1y: 25, savings3y: 35 }),
+      multiVariantCell({ resourceType: 'C-cell', payment1y: 'all-upfront',     payment3y: 'no-upfront',      upfront1y: 800, upfront3y: 0,    monthly1y: 60,  monthly3y: 45, savings1y: 30, savings3y: 40 }),
+    ].flat();
+
+    const columns: Array<{ column: string; direction: 'asc' | 'desc' }> = [
+      { column: 'term',                  direction: 'asc' },
+      { column: 'payment',               direction: 'asc' },
+      { column: 'upfront_cost',          direction: 'asc' },
+      { column: 'monthly_cost',          direction: 'asc' },
+      { column: 'effective_savings_pct', direction: 'asc' },
+    ];
+
+    for (const sort of columns) {
+      setupTestFixture(cells, sort);
+      await loadRecommendations();
+      const first = renderedCellOrder();
+      // Re-run with the SAME inputs.
+      setupTestFixture(cells, sort);
+      await loadRecommendations();
+      const second = renderedCellOrder();
+      expect(second).toEqual(first);
+      // Must not be the empty / single-element trivial case.
+      expect(first.length).toBe(3);
+    }
+  });
+});

--- a/frontend/src/__tests__/recommendations.test.ts
+++ b/frontend/src/__tests__/recommendations.test.ts
@@ -4855,6 +4855,18 @@ describe('Issue #494: deterministic group sort on multi-variant cells', () => {
     ).map((tr) => tr.getAttribute('data-cell-key') ?? '');
   }
 
+  /**
+   * Find a key fragment in the rendered order and assert it is actually
+   * present. Returns the index. Prevents false-positive `<` comparisons that
+   * would silently pass when `findIndex` returns `-1` for both sides (per CR
+   * review on the initial commit).
+   */
+  function indexOrFail(order: string[], keyFragment: string): number {
+    const idx = order.findIndex((k) => k.includes(keyFragment));
+    expect(idx).toBeGreaterThanOrEqual(0);
+    return idx;
+  }
+
   /** Set up the DOM + standard mocks; caller provides the rec list + sort. */
   function setupTestFixture(
     recs: LocalRecommendation[],
@@ -4911,10 +4923,10 @@ describe('Issue #494: deterministic group sort on multi-variant cells', () => {
     // Expected: 1yr-only first (termMin=1, termMax=1), mixed second (termMin=1,
     // termMax=3), 3yr-only last (termMin=3). The encoded score termMin*100 +
     // termMax distinguishes the 1yr-only and mixed cells via termMax.
-    expect(order.findIndex((k) => k.includes('bbb-1y-only')))
-      .toBeLessThan(order.findIndex((k) => k.includes('aaa-mixed')));
-    expect(order.findIndex((k) => k.includes('aaa-mixed')))
-      .toBeLessThan(order.findIndex((k) => k.includes('ccc-3y-only')));
+    expect(indexOrFail(order, 'bbb-1y-only'))
+      .toBeLessThan(indexOrFail(order, 'aaa-mixed'));
+    expect(indexOrFail(order, 'aaa-mixed'))
+      .toBeLessThan(indexOrFail(order, 'ccc-3y-only'));
   });
 
   test('Term desc: order is the exact reverse of ascending', async () => {
@@ -4944,10 +4956,10 @@ describe('Issue #494: deterministic group sort on multi-variant cells', () => {
     await loadRecommendations();
 
     const order = renderedCellOrder();
-    expect(order.findIndex((k) => k.includes('ccc-3y-only')))
-      .toBeLessThan(order.findIndex((k) => k.includes('aaa-mixed')));
-    expect(order.findIndex((k) => k.includes('aaa-mixed')))
-      .toBeLessThan(order.findIndex((k) => k.includes('bbb-1y-only')));
+    expect(indexOrFail(order, 'ccc-3y-only'))
+      .toBeLessThan(indexOrFail(order, 'aaa-mixed'));
+    expect(indexOrFail(order, 'aaa-mixed'))
+      .toBeLessThan(indexOrFail(order, 'bbb-1y-only'));
   });
 
   // -------------------------------------------------------------------------
@@ -4977,10 +4989,10 @@ describe('Issue #494: deterministic group sort on multi-variant cells', () => {
     // Expected semantic order: no-upfront < partial-upfront < all-upfront.
     // Previous alphabetic comparator would have produced all-upfront <
     // no-upfront < partial-upfront, which this test would fail under.
-    expect(order.findIndex((k) => k.includes('noup-cell')))
-      .toBeLessThan(order.findIndex((k) => k.includes('partial-cell')));
-    expect(order.findIndex((k) => k.includes('partial-cell')))
-      .toBeLessThan(order.findIndex((k) => k.includes('allup-cell')));
+    expect(indexOrFail(order, 'noup-cell'))
+      .toBeLessThan(indexOrFail(order, 'partial-cell'));
+    expect(indexOrFail(order, 'partial-cell'))
+      .toBeLessThan(indexOrFail(order, 'allup-cell'));
   });
 
   // -------------------------------------------------------------------------
@@ -5006,10 +5018,10 @@ describe('Issue #494: deterministic group sort on multi-variant cells', () => {
 
     const order = renderedCellOrder();
     // Expected: upfrontMin asc -> 0 < 300 < 800.
-    expect(order.findIndex((k) => k.includes('low-upfront')))
-      .toBeLessThan(order.findIndex((k) => k.includes('mid-upfront')));
-    expect(order.findIndex((k) => k.includes('mid-upfront')))
-      .toBeLessThan(order.findIndex((k) => k.includes('high-upfront')));
+    expect(indexOrFail(order, 'low-upfront'))
+      .toBeLessThan(indexOrFail(order, 'mid-upfront'));
+    expect(indexOrFail(order, 'mid-upfront'))
+      .toBeLessThan(indexOrFail(order, 'high-upfront'));
   });
 
   // -------------------------------------------------------------------------
@@ -5035,10 +5047,10 @@ describe('Issue #494: deterministic group sort on multi-variant cells', () => {
 
     const order = renderedCellOrder();
     // Expected: 20 < 60 < 90.
-    expect(order.findIndex((k) => k.includes('low-monthly')))
-      .toBeLessThan(order.findIndex((k) => k.includes('mid-monthly')));
-    expect(order.findIndex((k) => k.includes('mid-monthly')))
-      .toBeLessThan(order.findIndex((k) => k.includes('high-monthly')));
+    expect(indexOrFail(order, 'low-monthly'))
+      .toBeLessThan(indexOrFail(order, 'mid-monthly'));
+    expect(indexOrFail(order, 'mid-monthly'))
+      .toBeLessThan(indexOrFail(order, 'high-monthly'));
   });
 
   test('Monthly Cost: cells with all-null monthly_cost sort last in both asc and desc', async () => {
@@ -5056,8 +5068,8 @@ describe('Issue #494: deterministic group sort on multi-variant cells', () => {
     setupTestFixture(recs, { column: 'monthly_cost', direction: 'asc' });
     await loadRecommendations();
     let order = renderedCellOrder();
-    expect(order.findIndex((k) => k.includes('finite-monthly')))
-      .toBeLessThan(order.findIndex((k) => k.includes('allnull-monthly')));
+    expect(indexOrFail(order, 'finite-monthly'))
+      .toBeLessThan(indexOrFail(order, 'allnull-monthly'));
 
     // Descending: all-null cells STAY last regardless of direction - the
     // POSITIVE_INFINITY null-sentinel logic flips them out of the normal
@@ -5066,8 +5078,40 @@ describe('Issue #494: deterministic group sort on multi-variant cells', () => {
     setupTestFixture(recs, { column: 'monthly_cost', direction: 'desc' });
     await loadRecommendations();
     order = renderedCellOrder();
-    expect(order.findIndex((k) => k.includes('finite-monthly')))
-      .toBeLessThan(order.findIndex((k) => k.includes('allnull-monthly')));
+    expect(indexOrFail(order, 'finite-monthly'))
+      .toBeLessThan(indexOrFail(order, 'allnull-monthly'));
+  });
+
+  test('Monthly Cost: two all-null cells sort deterministically via cellKey tiebreaker', async () => {
+    // Both cells have ALL null monthly_cost - their scores are both
+    // POSITIVE_INFINITY. The naive numeric diff would be Infinity - Infinity
+    // = NaN; the comparator MUST short-circuit to the cellKey tiebreaker so
+    // the two cells render in a stable order across repeated invocations.
+    // Closes the gap surfaced by CodeRabbit on the initial #494 commit.
+    const cellA = multiVariantCell({
+      resourceType: 'aaa-null', payment1y: 'all-upfront', payment3y: 'all-upfront',
+      upfront1y: 1000, upfront3y: 3000, monthly1y: null, monthly3y: null,
+    });
+    const cellB = multiVariantCell({
+      resourceType: 'bbb-null', payment1y: 'all-upfront', payment3y: 'all-upfront',
+      upfront1y: 2000, upfront3y: 6000, monthly1y: null, monthly3y: null,
+    });
+    const recs = [...cellB, ...cellA];  // intentionally wrong insertion order
+
+    setupTestFixture(recs, { column: 'monthly_cost', direction: 'asc' });
+    await loadRecommendations();
+    const first = renderedCellOrder();
+    expect(first.length).toBe(2);
+    // cellKey contains the resource_type slug, so cellKey for 'aaa-null'
+    // sorts before 'bbb-null' under localeCompare.
+    expect(indexOrFail(first, 'aaa-null'))
+      .toBeLessThan(indexOrFail(first, 'bbb-null'));
+
+    // Re-run to confirm determinism (would fail under Infinity - Infinity = NaN).
+    setupTestFixture(recs, { column: 'monthly_cost', direction: 'asc' });
+    await loadRecommendations();
+    const second = renderedCellOrder();
+    expect(second).toEqual(first);
   });
 
   // -------------------------------------------------------------------------
@@ -5099,10 +5143,10 @@ describe('Issue #494: deterministic group sort on multi-variant cells', () => {
 
     const order = renderedCellOrder();
     // Expected asc: 5% < 15% < 25%.
-    expect(order.findIndex((k) => k.includes('low-pct')))
-      .toBeLessThan(order.findIndex((k) => k.includes('mid-pct')));
-    expect(order.findIndex((k) => k.includes('mid-pct')))
-      .toBeLessThan(order.findIndex((k) => k.includes('high-pct')));
+    expect(indexOrFail(order, 'low-pct'))
+      .toBeLessThan(indexOrFail(order, 'mid-pct'));
+    expect(indexOrFail(order, 'mid-pct'))
+      .toBeLessThan(indexOrFail(order, 'high-pct'));
   });
 
   test('Effective %: cells with all-null pct sort last regardless of direction', async () => {
@@ -5127,14 +5171,14 @@ describe('Issue #494: deterministic group sort on multi-variant cells', () => {
     setupTestFixture(recs, { column: 'effective_savings_pct', direction: 'asc' });
     await loadRecommendations();
     let order = renderedCellOrder();
-    expect(order.findIndex((k) => k.includes('finite-pct')))
-      .toBeLessThan(order.findIndex((k) => k.includes('allnull-pct')));
+    expect(indexOrFail(order, 'finite-pct'))
+      .toBeLessThan(indexOrFail(order, 'allnull-pct'));
 
     setupTestFixture(recs, { column: 'effective_savings_pct', direction: 'desc' });
     await loadRecommendations();
     order = renderedCellOrder();
-    expect(order.findIndex((k) => k.includes('finite-pct')))
-      .toBeLessThan(order.findIndex((k) => k.includes('allnull-pct')));
+    expect(indexOrFail(order, 'finite-pct'))
+      .toBeLessThan(indexOrFail(order, 'allnull-pct'));
   });
 
   // -------------------------------------------------------------------------
@@ -5184,10 +5228,10 @@ describe('Issue #494: deterministic group sort on multi-variant cells', () => {
     //   selected-1y cell  (score = 1*100+1 = 101)
     //   mixed cell        (score = 1*100+3 = 103)
     //   selected-3y cell  (score = 3*100+3 = 303)
-    expect(order.findIndex((k) => k.includes('sel1y-cell')))
-      .toBeLessThan(order.findIndex((k) => k.includes('mixed-cell')));
-    expect(order.findIndex((k) => k.includes('mixed-cell')))
-      .toBeLessThan(order.findIndex((k) => k.includes('sel3y-cell')));
+    expect(indexOrFail(order, 'sel1y-cell'))
+      .toBeLessThan(indexOrFail(order, 'mixed-cell'));
+    expect(indexOrFail(order, 'mixed-cell'))
+      .toBeLessThan(indexOrFail(order, 'sel3y-cell'));
   });
 
   test('Sort is deterministic across repeated renders for each affected column', async () => {

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -808,8 +808,15 @@ function groupsInSortOrder(
       const aNullish = scoreA === Number.POSITIVE_INFINITY;
       const bNullish = scoreB === Number.POSITIVE_INFINITY;
       if (aNullish !== bNullish) return aNullish ? 1 : -1;
-      const diff = (scoreA - scoreB) * direction;
-      if (diff !== 0) return diff;
+      // Both-nullish case: `Infinity - Infinity` would yield NaN and
+      // `NaN !== 0` would short-circuit the cellKey tiebreaker below,
+      // leaving two all-null cells in implementation-defined order.
+      // Skip the numeric diff when both sides are sentinel-null so the
+      // tiebreaker runs (matches the well-defined-order intent of #494).
+      if (!aNullish) {
+        const diff = (scoreA - scoreB) * direction;
+        if (diff !== 0) return diff;
+      }
     } else if (typeof scoreA === 'string' && typeof scoreB === 'string') {
       const diff = scoreA.localeCompare(scoreB) * direction;
       if (diff !== 0) return diff;

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -643,12 +643,148 @@ function sortVariantsInCell(variants: LocalRecommendation[]): LocalRecommendatio
 }
 
 /**
+ * Per-column cell-score helper: collapse a cell's variants to ONE deterministic
+ * sort key per (column, cell) pair. Closes #494 - the previous comparator used
+ * `Math.max(...va.map(numericKey))` for every numeric column, which collapses
+ * to the same value across all multi-variant cells after PR #195's per-(term,
+ * payment) fan-out (every cell has both 1yr and 3yr variants → `Math.max` always
+ * = 3 for `term`; every cell has at least one null monthly_cost or null pct →
+ * `Math.max` always = POSITIVE_INFINITY) and produces apparently-random row
+ * order.
+ *
+ * Strategy: for each affected column, pick the per-cell score that matches what
+ * the user sees in the rendered summary row:
+ *
+ *   - `term`            → summary.termMin (then termMax as inner tiebreaker
+ *                         via the returned tuple, encoded as `termMin * 100 +
+ *                         termMax` since both are small ints)
+ *   - `upfront_cost`    → summary.upfrontMin
+ *   - `monthly_cost`    → min over non-null variants (best-case framing);
+ *                         POSITIVE_INFINITY only when ALL variants are null
+ *   - `effective_savings_pct` → max over non-null variants (highest pct is the
+ *                               cell's best pitch); POSITIVE_INFINITY only
+ *                               when ALL variants are null
+ *   - `payment` (categorical) → PAYMENT_ORDER index of the variant
+ *                               `sortVariantsInCell` orders first (lowest term,
+ *                               then lowest PAYMENT_ORDER). Replaces the
+ *                               previous alphabetic comparator which sorted
+ *                               `all-upfront` before `no-upfront`, semantically
+ *                               wrong.
+ *
+ * For all other numeric columns (savings, count, on_demand_monthly) the
+ * established `Math.max` semantics are preserved: a savings table sorted by
+ * "best per cell" is the established convention and #494 does not flag these.
+ * For all other string columns (provider, account, service, resource_type,
+ * region) the value is invariant across a cell's variants (it's part of
+ * cellKey), so `va[0]` continues to work.
+ *
+ * Returned number/string is the score the caller should compare. The null
+ * sentinel `POSITIVE_INFINITY` is preserved for numeric scores so the existing
+ * "always sort all-null cells last" early-return continues to work.
+ */
+function cellScoreFor(
+  column: string,
+  variants: LocalRecommendation[],
+  selectedRecs: ReadonlySet<string>,
+): number | string {
+  // Selected-variant short-circuit: when one variant is selected in the cell,
+  // sort the cell by THAT variant's value. Matches the rendered summary row,
+  // which also surfaces the selected variant's individual values.
+  const selected = variants.find((r) => selectedRecs.has(r.id));
+
+  const numericKey = SORTABLE_NUMERIC_COLUMNS[column];
+  const stringKey = SORTABLE_STRING_COLUMNS[column];
+
+  if (selected) {
+    // Term uses the same termMin*100+termMax encoding for selected and
+    // non-selected cells so both paths produce comparable scores. (For a
+    // selected variant, min == max == selected.term, so the encoding
+    // simplifies to term*101, still ordered correctly against multi-variant
+    // cells encoded the same way.)
+    if (column === 'term') return selected.term * 100 + selected.term;
+    // Upfront uses raw selected.upfront_cost which matches the non-selected
+    // path's primary key (upfrontMin); the tiny tiebreaker term in the
+    // non-selected path is too small to flip a real comparison.
+    if (numericKey) return numericKey(selected);
+    if (stringKey && column === 'payment') {
+      // Selected-variant payment: use PAYMENT_ORDER index for semantic sort.
+      return String(PAYMENT_ORDER[selected.payment ?? ''] ?? 99);
+    }
+    if (stringKey) return stringKey(selected);
+  }
+
+  if (variants.length === 0) {
+    // Defensive: empty cells should not occur post-groupRecsByCell, but if one
+    // slips through return a sentinel that sorts last.
+    return numericKey ? Number.POSITIVE_INFINITY : '';
+  }
+
+  // No selected variant: pick a deterministic per-cell score.
+  if (column === 'term') {
+    const s = cellSummary(variants);
+    // Encode (termMin, termMax) into a single number for sort-key purposes:
+    // small positive ints multiplied by 100 keep ordering identical to lexical
+    // (termMin, termMax) tuple comparison without needing an array compare.
+    return s.termMin * 100 + s.termMax;
+  }
+  if (column === 'upfront_cost') {
+    const s = cellSummary(variants);
+    // upfrontMin as the primary key; upfrontMax only matters as a much smaller
+    // tiebreaker so divide by a large constant. Clamp the tiebreaker so it
+    // can never overwhelm the primary key for realistic upfront ranges.
+    return s.upfrontMin + s.upfrontMax / 1e12;
+  }
+  if (column === 'monthly_cost') {
+    const period = state.getCostPeriod();
+    const finite: number[] = [];
+    for (const v of variants) {
+      const scaled = scaleCost(v.monthly_cost, period);
+      if (scaled != null) finite.push(scaled);
+    }
+    // Best-case framing: lowest recurring cost wins. All-null cells sink to
+    // the bottom via the existing POSITIVE_INFINITY sentinel logic.
+    return finite.length === 0 ? Number.POSITIVE_INFINITY : Math.min(...finite);
+  }
+  if (column === 'effective_savings_pct') {
+    const finite: number[] = [];
+    for (const v of variants) {
+      const pct = effectiveSavingsPct(v);
+      if (pct != null) finite.push(pct);
+    }
+    // Best-case framing: highest savings pct is the cell's best pitch.
+    return finite.length === 0 ? Number.POSITIVE_INFINITY : Math.max(...finite);
+  }
+  if (column === 'payment' && stringKey) {
+    // Re-categorise: sort by the same PAYMENT_ORDER index sortVariantsInCell
+    // uses for within-cell ordering, applied to the first variant in that
+    // canonical order. Stringified so the existing string-column comparator
+    // path handles it.
+    const first = sortVariantsInCell(variants)[0];
+    return String(PAYMENT_ORDER[first?.payment ?? ''] ?? 99);
+  }
+
+  // All other numeric columns (savings, count, on_demand_monthly): preserve
+  // the established Math.max-over-variants semantics. These columns are NOT
+  // flagged by #494 and have a long history of working correctly under
+  // "best per cell" framing for a savings table.
+  if (numericKey) return Math.max(...variants.map(numericKey));
+
+  // All other string columns (provider, account, service, region,
+  // resource_type): the value is invariant across a cell's variants because
+  // it's part of cellKey. The first variant suffices.
+  if (stringKey) return stringKey(variants[0]!);
+
+  // Unsortable column.
+  return 0;
+}
+
+/**
  * Return cell keys in the active sort order.
- * For numeric sort columns: use selected-variant savings if one is selected;
- *   else use max savings across the cell's variants.
- * For string sort columns: all variants in a cell share the same value for
- *   provider/account/service/region/resource_type (they are part of cellKey),
- *   so use the first variant.
+ *
+ * Closes #494. Replaces the `Math.max(...va.map(numericKey))` collapse with a
+ * per-column score (see `cellScoreFor`) that produces a deterministic single
+ * value per cell. Adds a stable tiebreaker on `cellKey` so genuinely-tied cells
+ * render in a consistent order across renders / browsers.
  */
 function groupsInSortOrder(
   groups: Map<string, LocalRecommendation[]>,
@@ -656,33 +792,34 @@ function groupsInSortOrder(
   selectedRecs: ReadonlySet<string>,
 ): string[] {
   const direction = sort.direction === 'asc' ? 1 : -1;
-  const numericKey = SORTABLE_NUMERIC_COLUMNS[sort.column];
-  const stringKey = SORTABLE_STRING_COLUMNS[sort.column];
 
   const keys = Array.from(groups.keys());
   return keys.slice().sort((ka, kb) => {
     const va = groups.get(ka)!;
     const vb = groups.get(kb)!;
 
-    if (numericKey) {
-      // Use selected variant's value if one is selected in this cell.
-      const selectedA = va.find((r) => selectedRecs.has(r.id));
-      const selectedB = vb.find((r) => selectedRecs.has(r.id));
-      const scoreA = selectedA ? numericKey(selectedA) : Math.max(...va.map(numericKey));
-      const scoreB = selectedB ? numericKey(selectedB) : Math.max(...vb.map(numericKey));
-      // Nulls are encoded as POSITIVE_INFINITY. Always sort them last regardless
-      // of direction so "no data" rows are de-emphasised in both asc and desc.
+    const scoreA = cellScoreFor(sort.column, va, selectedRecs);
+    const scoreB = cellScoreFor(sort.column, vb, selectedRecs);
+
+    if (typeof scoreA === 'number' && typeof scoreB === 'number') {
+      // Nulls are encoded as POSITIVE_INFINITY. Always sort them last
+      // regardless of direction so "no data" rows are de-emphasised in both
+      // asc and desc.
       const aNullish = scoreA === Number.POSITIVE_INFINITY;
       const bNullish = scoreB === Number.POSITIVE_INFINITY;
       if (aNullish !== bNullish) return aNullish ? 1 : -1;
-      return (scoreA - scoreB) * direction;
+      const diff = (scoreA - scoreB) * direction;
+      if (diff !== 0) return diff;
+    } else if (typeof scoreA === 'string' && typeof scoreB === 'string') {
+      const diff = scoreA.localeCompare(scoreB) * direction;
+      if (diff !== 0) return diff;
     }
-    if (stringKey) {
-      const strA = va[0] ? stringKey(va[0]) : '';
-      const strB = vb[0] ? stringKey(vb[0]) : '';
-      return strA.localeCompare(strB) * direction;
-    }
-    return 0;
+
+    // Stable tiebreaker on cellKey, direction-invariant. Genuinely-tied cells
+    // render in a deterministic order on every render and across browsers
+    // (Array.prototype.sort stability varies historically; localeCompare on a
+    // stable key sidesteps it entirely).
+    return ka.localeCompare(kb);
   });
 }
 


### PR DESCRIPTION
## Summary

Fixes #494 — on the Opportunities table, clicking the sort headers for `Term` / `Payment` / `Upfront Cost` / `Monthly Cost` / `Effective %` produced apparently-random row order because `Math.max(...va.map(numericKey))` collapsed every multi-variant cell to the same score after PR #195's per-(term, payment) fan-out (every cell has both 1yr and 3yr variants → always max=3 for `term`; any null monthly_cost / pct → POSITIVE_INFINITY; cells with all-no-upfront variants → tie at 0).

PR #491 (closes #480) flipped the default direction for these columns from `desc` to `asc`; this PR fixes the upstream "every cell ties" symptom. The two PRs touch independent code paths (#491's diff against the same base doesn't modify `groupsInSortOrder`).

### What changed

- New `cellScoreFor(column, variants, selectedRecs)` helper in `frontend/src/recommendations.ts` that returns ONE deterministic per-cell score per column:
  - `term` → `summary.termMin * 100 + summary.termMax` (encodes both ends; 1yr-only < mixed < 3yr-only)
  - `upfront_cost` → `summary.upfrontMin` (matches rendered range)
  - `monthly_cost` → `Math.min` over non-null variants; `POSITIVE_INFINITY` only when ALL variants are null
  - `effective_savings_pct` → `Math.max` over non-null variants; same null rule
  - `payment` (categorical) → `PAYMENT_ORDER` index of the first variant in `sortVariantsInCell` order (replaces alphabetic comparator that placed `all-upfront` before `no-upfront`)
- Selected-variant cells use the selected variant's value on the SAME numeric scale as non-selected cells (specifically for `term`, otherwise a selected `term=1` cell would sort below a non-selected mixed `(1, 3)` cell when ascending).
- Stable `cellKey.localeCompare` tiebreaker (direction-invariant) for genuinely-tied cells so renders are deterministic across reloads and browsers.
- Other numeric columns (savings, count, on_demand_monthly) keep the established `Math.max` semantics — `#494` does not flag them.
- Other string columns (provider, account, service, region, resource_type) keep `va[0]` — the value is invariant across a cell's variants by definition of `cellKey`.

### Regression coverage

10 new tests in `frontend/src/__tests__/recommendations.test.ts` exercise multi-variant fixtures (the bug only manifests post per-(term, payment) fan-out):

- **4.9 Term asc** and **4.9 Term desc** — 1yr-only / mixed / 3yr-only cells ordered correctly
- **4.10 Payment asc** — no-upfront < partial-upfront < all-upfront
- **4.12 Upfront Cost asc** — sorted by `upfrontMin`
- **4.13 Monthly Cost asc** — sorted by `Math.min` over non-null variants
- **4.13 Monthly Cost null-handling** — all-null cells stay last in both asc and desc
- **4.15 Effective % asc** — sorted by `Math.max` over non-null variants
- **4.15 Effective % null-handling** — all-null cells stay last in both directions
- Selected-variant scale parity — selected `term=1` ranks above non-selected mixed `(1, 3)`
- Determinism — repeating the same sort twice produces identical row order for all 5 columns (regression for "two clicks of the same header produce different broken orders" per QA)

## Test plan

- [x] `npm test` — 1752 pass / 1 skip / 0 fail (54 suites; was 1742 pre-PR + 10 new regression tests)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — production bundle compiles cleanly (no new warnings)
- [x] Em-dash gate: zero net delta in `recommendations.ts` and `recommendations.test.ts` (per project convention)
- [ ] Post-merge: verify on a deployed preview that clicking each of the five sort headers on a multi-variant page reorders rows deterministically and in the expected semantic order

## Out of scope

- PR #491's domain (default direction, URL sort sync, tri-state checkboxes, popover scroll, numeric filter rounding) — independent branch, independent merge.
- `on_demand_monthly` column — same root cause technically applies but is not flagged in the issue body's QA rows (4.9-4.15); leaving unchanged here to keep blast radius tight. If the same pattern matters there too, filing a follow-up after merge per CLAUDE.md §1.

Closes #494


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Recommendation cell sorting made deterministic and stable: consistent ordering across rerenders, ties resolved predictably, null-like values sort last, and selected variants participate without changing the scoring scale.

* **Tests**
  * Added comprehensive tests covering multi-variant cells, column-specific ordering (term, payment, upfront, monthly, effective savings), null handling, and repeatability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/496?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->