### PR TITLE
fix(purchases): close P0 regressions from #373 (closes #395, #453, #372)

### DIFF
--- a/internal/purchase/coverage_extra_test.go
+++ b/internal/purchase/coverage_extra_test.go
@@ -954,6 +954,31 @@ func TestManager_ExecuteSinglePurchase_DetailsByService(t *testing.T) {
 				}
 			},
 		},
+		{
+			// Legacy umbrella slug ("savings-plans") that mapSavingsPlansSlug
+			// still accepts for purchase_execution rows persisted before the
+			// rename in PR #94. DecodeServiceDetailsFor must also recognise
+			// this alias so a stored "savings-plans" rec round-trips through
+			// the codec the same way as the canonical "savingsplans" form.
+			// Regression guard: without the "savings-plans" case in
+			// newDetailsForService, DecodeServiceDetailsFor returns (nil,
+			// false) and recommendation.Details is nil — the SP client's
+			// findOfferingID type-assertion then fails with "invalid service
+			// details" on legacy rows, re-introducing #453 for SP umbrella.
+			name:        "sp_legacy_umbrella",
+			service:     "savings-plans",
+			serviceType: common.ServiceSavingsPlans,
+			region:      "us-east-1",
+			resource:    "LegacySP",
+			details:     &common.SavingsPlanDetails{PlanType: "Compute", HourlyCommitment: 0.75},
+			assertDetails: func(t *testing.T, d common.ServiceDetails) {
+				sp, ok := d.(*common.SavingsPlanDetails)
+				if assert.True(t, ok, "legacy SP umbrella must decode to *common.SavingsPlanDetails, got %T", d) {
+					assert.Equal(t, "Compute", sp.PlanType)
+					assert.InDelta(t, 0.75, sp.HourlyCommitment, 0.001)
+				}
+			},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary

This PR explicitly references and closes all three P0 regressions introduced by #373.

The substantive fixes were already merged to feat/multicloud-web-frontend via:
- PR #412: empty plan_id crash (closes #395)
- PR #454: invalid service details / typed pointer mismatch (closes #453)
- PR #373 itself: synchronous execute (closes #372)

This PR adds one additional regression guard that was missing from the test suite:
`sp_legacy_umbrella` in `TestManager_ExecuteSinglePurchase_DetailsByService` — pins
that the legacy `"savings-plans"` (dash-form umbrella) slug, still accepted by
`mapSavingsPlansSlug` for rows persisted before the PR #94 rename, round-trips
through `DecodeServiceDetailsFor` and arrives at the SP service client with a
non-nil `*SavingsPlanDetails`. Without this test, dropping the `"savings-plans"`
alias from `newDetailsForService` would silently re-introduce #453 for legacy SP
umbrella rows.

## Test plan

- [x] `go test ./internal/purchase/...` — 1214 pass (one new: `sp_legacy_umbrella` subcase).
- [x] `go test ./internal/api/...` — pass.

Closes #395
Closes #453
Closes #372

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for legacy Savings Plans service handling to ensure proper validation and preservation of plan details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/501?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->