### PR TITLE
sec(credentials): validate gcp_client_email + aws_web_identity_token_file + aws_role_arn at API boundary (closes #405, #403, #413)

### DIFF
--- a/internal/api/handler_accounts.go
+++ b/internal/api/handler_accounts.go
@@ -321,6 +321,9 @@ func validateAuthMode(req CloudAccountRequest) error {
 		if req.GCPAuthMode != "" && !validGCPAuthModes[req.GCPAuthMode] {
 			return NewClientError(400, "invalid gcp_auth_mode")
 		}
+		if err := validateGCPClientEmail(req.GCPClientEmail); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -349,6 +352,12 @@ func validateAuthMode(req CloudAccountRequest) error {
 func validateAWSAuthMode(req CloudAccountRequest) error {
 	if req.AWSAuthMode != "" && !validAWSAuthModes[req.AWSAuthMode] {
 		return NewClientError(400, "invalid aws_auth_mode")
+	}
+	if err := validateAWSRoleARN(req.AWSRoleARN); err != nil {
+		return err
+	}
+	if err := validateAWSWebIdentityTokenFile(req.AWSWebIdentityTokenFile); err != nil {
+		return err
 	}
 	requiresExternalID := (req.AWSAuthMode == "role_arn" || req.AWSAuthMode == "bastion") &&
 		strings.TrimSpace(req.AWSRoleARN) != ""

--- a/internal/api/validation.go
+++ b/internal/api/validation.go
@@ -23,6 +23,29 @@ const (
 // uuidRegex validates UUID format (used for path parameters)
 var uuidRegex = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
 
+// gcpClientEmailRegex matches a GCP service-account email.
+// Pattern: <name>@<project>.iam.gserviceaccount.com
+// The service-account name component may contain alphanumerics, dots, hyphens,
+// and underscores. The project ID component may contain alphanumerics, dots, and
+// hyphens. Rejecting any value that does not match prevents URL path injection in
+// BuildGCPFederatedCredential (issue #405).
+var gcpClientEmailRegex = regexp.MustCompile(`^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.iam\.gserviceaccount\.com$`)
+
+// awsRoleARNRegex matches a valid IAM role ARN across commercial, China, and GovCloud
+// partitions. Requiring the 12-digit account ID and a non-empty role name blocks
+// obviously malformed strings before they reach stscreds.NewAssumeRoleProvider
+// (issue #413).
+var awsRoleARNRegex = regexp.MustCompile(`^arn:(aws|aws-cn|aws-us-gov):iam::[0-9]{12}:role/.+$`)
+
+// awsWebIdentityTokenFilePrefixes lists the only path prefixes accepted for
+// aws_web_identity_token_file. Restricting to known EKS/Kubernetes mount points
+// prevents arbitrary host-file reads when the credential resolver reads the file
+// and sends its content to AWS STS (issue #403).
+var awsWebIdentityTokenFilePrefixes = []string{
+	"/var/run/secrets/eks.amazonaws.com/serviceaccount/",
+	"/var/run/secrets/kubernetes.io/serviceaccount/",
+}
+
 // validProviders are the allowed provider values
 var validProviders = map[string]bool{
 	"":      true, // empty is allowed (means all)
@@ -38,6 +61,57 @@ var serviceNameRegex = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{0,63}$`)
 
 // regionNameRegex validates AWS/Azure/GCP region names - requires at least one character
 var regionNameRegex = regexp.MustCompile(`^[a-z0-9-]+$`)
+
+// validateGCPClientEmail returns a 400 error when gcp_client_email is non-empty
+// but does not match the GCP service-account email format. An empty value is
+// allowed (field is optional when auth mode does not require impersonation).
+func validateGCPClientEmail(email string) error {
+	if email == "" {
+		return nil
+	}
+	if !gcpClientEmailRegex.MatchString(email) {
+		return NewClientError(400, "gcp_client_email must be a valid GCP service-account email "+
+			"(format: name@project.iam.gserviceaccount.com)")
+	}
+	return nil
+}
+
+// validateAWSRoleARN returns a 400 error when aws_role_arn is non-empty but
+// does not match the IAM role ARN format for any AWS partition. An empty value
+// is allowed (self-account onboarding uses an empty role ARN to mean "ambient
+// credentials").
+func validateAWSRoleARN(arn string) error {
+	if arn == "" {
+		return nil
+	}
+	if !awsRoleARNRegex.MatchString(arn) {
+		return NewClientError(400, "aws_role_arn must be a valid IAM role ARN "+
+			"(format: arn:aws:iam::<12-digit-account-id>:role/<name>)")
+	}
+	return nil
+}
+
+// validateAWSWebIdentityTokenFile returns a 400 error when the path is non-empty
+// but does not start with one of the allowed prefixes, or contains path traversal
+// sequences. An empty value is allowed (the resolver falls back to the
+// AWS_WEB_IDENTITY_TOKEN_FILE environment variable).
+func validateAWSWebIdentityTokenFile(path string) error {
+	if path == "" {
+		return nil
+	}
+	// Block path traversal regardless of prefix match.
+	if strings.Contains(path, "..") {
+		return NewClientError(400, "aws_web_identity_token_file must not contain path traversal sequences")
+	}
+	for _, prefix := range awsWebIdentityTokenFilePrefixes {
+		if strings.HasPrefix(path, prefix) {
+			return nil
+		}
+	}
+	return NewClientError(400, "aws_web_identity_token_file must start with an allowed prefix "+
+		"(/var/run/secrets/eks.amazonaws.com/serviceaccount/ or "+
+		"/var/run/secrets/kubernetes.io/serviceaccount/)")
+}
 
 // validateProvider checks if a provider value is valid
 func validateProvider(provider string) error {

--- a/internal/api/validation.go
+++ b/internal/api/validation.go
@@ -32,10 +32,12 @@ var uuidRegex = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4
 var gcpClientEmailRegex = regexp.MustCompile(`^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.iam\.gserviceaccount\.com$`)
 
 // awsRoleARNRegex matches a valid IAM role ARN across commercial, China, and GovCloud
-// partitions. Requiring the 12-digit account ID and a non-empty role name blocks
-// obviously malformed strings before they reach stscreds.NewAssumeRoleProvider
-// (issue #413).
-var awsRoleARNRegex = regexp.MustCompile(`^arn:(aws|aws-cn|aws-us-gov):iam::[0-9]{12}:role/.+$`)
+// partitions. The role-name portion is restricted to the IAM-permitted character
+// set ([A-Za-z0-9+=,.@_-]) for both the optional path segments and the final
+// name. Limiting the trailing portion prevents whitespace, newlines, or other
+// control characters from sneaking past validation and reaching
+// stscreds.NewAssumeRoleProvider (issue #413).
+var awsRoleARNRegex = regexp.MustCompile(`^arn:(aws|aws-cn|aws-us-gov):iam::[0-9]{12}:role/(?:[A-Za-z0-9+=,.@_-]+/)*[A-Za-z0-9+=,.@_-]+$`)
 
 // awsWebIdentityTokenFilePrefixes lists the only path prefixes accepted for
 // aws_web_identity_token_file. Restricting to known EKS/Kubernetes mount points

--- a/internal/api/validation_test.go
+++ b/internal/api/validation_test.go
@@ -331,3 +331,111 @@ func TestValidateRequestBodySize(t *testing.T) {
 		})
 	}
 }
+
+// TestValidateGCPClientEmail covers issue #405: gcp_client_email must match the
+// GCP service-account email format so it cannot be used to inject path segments
+// into the SA impersonation URL.
+func TestValidateGCPClientEmail(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		email     string
+		wantError bool
+	}{
+		{"empty is allowed", "", false},
+		{"valid SA email", "my-sa@my-project.iam.gserviceaccount.com", false},
+		{"valid SA email with dots in name", "sa.name-123@proj.iam.gserviceaccount.com", false},
+		{"path traversal injection", "foo@bar.com/../../v1/projects/-/serviceAccounts/attacker@evil.com", true},
+		{"wrong domain", "sa@my-project.iam.googleapis.com", true},
+		{"missing @ sign", "my-project.iam.gserviceaccount.com", true},
+		{"arbitrary email", "user@example.com", true},
+		{"space in value", "sa @proj.iam.gserviceaccount.com", true},
+		{"newline injection", "sa@proj.iam.gserviceaccount.com\nX-Injected: header", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateGCPClientEmail(tt.email)
+			if tt.wantError {
+				assert.Error(t, err)
+				if ce, ok := IsClientError(err); ok {
+					assert.Equal(t, 400, ce.code)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestValidateAWSRoleARN covers issue #413: aws_role_arn must be a valid IAM
+// role ARN so malformed strings are caught at the API boundary.
+func TestValidateAWSRoleARN(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		arn       string
+		wantError bool
+	}{
+		{"empty is allowed (ambient creds)", "", false},
+		{"valid commercial ARN", "arn:aws:iam::123456789012:role/MyRole", false},
+		{"valid govcloud ARN", "arn:aws-us-gov:iam::123456789012:role/MyRole", false},
+		{"valid china ARN", "arn:aws-cn:iam::123456789012:role/MyRole", false},
+		{"valid ARN with path", "arn:aws:iam::123456789012:role/path/to/MyRole", false},
+		{"missing colons (common typo)", "arn:aws:iam:123456789012:role/Foo", true},
+		{"non-ARN string", "not-an-arn", true},
+		{"wrong service (sts)", "arn:aws:sts::123456789012:role/Foo", true},
+		{"account ID too short", "arn:aws:iam::12345:role/Foo", true},
+		{"unknown partition", "arn:aws-eu:iam::123456789012:role/Foo", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateAWSRoleARN(tt.arn)
+			if tt.wantError {
+				assert.Error(t, err)
+				if ce, ok := IsClientError(err); ok {
+					assert.Equal(t, 400, ce.code)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestValidateAWSWebIdentityTokenFile covers issue #403: aws_web_identity_token_file
+// must be restricted to known-safe mount prefixes to prevent arbitrary host file reads.
+func TestValidateAWSWebIdentityTokenFile(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		path      string
+		wantError bool
+	}{
+		{"empty is allowed (env var fallback)", "", false},
+		{"EKS token file", "/var/run/secrets/eks.amazonaws.com/serviceaccount/token", false},
+		{"k8s service-account token", "/var/run/secrets/kubernetes.io/serviceaccount/token", false},
+		{"arbitrary host path", "/proc/self/environ", true},
+		{"etc passwd", "/etc/passwd", true},
+		{"docker secret", "/run/secrets/my-secret", true},
+		{"env file", "/var/run/.env", true},
+		{"traversal into allowed prefix", "/var/run/secrets/eks.amazonaws.com/serviceaccount/../../etc/passwd", true}, // path traversal blocked even when prefix matches
+		{"relative path", "secrets/token", true},
+		{"kubernetes prefix without trailing slash content", "/var/run/secrets/kubernetes.io/serviceaccount/", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateAWSWebIdentityTokenFile(tt.path)
+			if tt.wantError {
+				assert.Error(t, err)
+				if ce, ok := IsClientError(err); ok {
+					assert.Equal(t, 400, ce.code)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/api/validation_test.go
+++ b/internal/api/validation_test.go
@@ -358,7 +358,8 @@ func TestValidateGCPClientEmail(t *testing.T) {
 			err := validateGCPClientEmail(tt.email)
 			if tt.wantError {
 				assert.Error(t, err)
-				if ce, ok := IsClientError(err); ok {
+				ce, ok := IsClientError(err)
+				if assert.True(t, ok, "expected ClientError") {
 					assert.Equal(t, 400, ce.code)
 				}
 			} else {
@@ -382,11 +383,19 @@ func TestValidateAWSRoleARN(t *testing.T) {
 		{"valid govcloud ARN", "arn:aws-us-gov:iam::123456789012:role/MyRole", false},
 		{"valid china ARN", "arn:aws-cn:iam::123456789012:role/MyRole", false},
 		{"valid ARN with path", "arn:aws:iam::123456789012:role/path/to/MyRole", false},
+		{"valid ARN with IAM-allowed special chars", "arn:aws:iam::123456789012:role/My+Role=v1,name.test@example_role-A", false},
 		{"missing colons (common typo)", "arn:aws:iam:123456789012:role/Foo", true},
 		{"non-ARN string", "not-an-arn", true},
 		{"wrong service (sts)", "arn:aws:sts::123456789012:role/Foo", true},
 		{"account ID too short", "arn:aws:iam::12345:role/Foo", true},
 		{"unknown partition", "arn:aws-eu:iam::123456789012:role/Foo", true},
+		// The strict character class rejects anything outside the IAM-permitted
+		// set so attackers cannot smuggle whitespace, newlines, or HTML metachars
+		// past validation into downstream consumers.
+		{"whitespace in role name", "arn:aws:iam::123456789012:role/My Role", true},
+		{"newline in role name", "arn:aws:iam::123456789012:role/My\nRole", true},
+		{"angle-bracket injection", "arn:aws:iam::123456789012:role/<script>", true},
+		{"trailing slash (empty role name)", "arn:aws:iam::123456789012:role/", true},
 	}
 
 	for _, tt := range tests {
@@ -394,7 +403,8 @@ func TestValidateAWSRoleARN(t *testing.T) {
 			err := validateAWSRoleARN(tt.arn)
 			if tt.wantError {
 				assert.Error(t, err)
-				if ce, ok := IsClientError(err); ok {
+				ce, ok := IsClientError(err)
+				if assert.True(t, ok, "expected ClientError") {
 					assert.Equal(t, 400, ce.code)
 				}
 			} else {
@@ -430,7 +440,8 @@ func TestValidateAWSWebIdentityTokenFile(t *testing.T) {
 			err := validateAWSWebIdentityTokenFile(tt.path)
 			if tt.wantError {
 				assert.Error(t, err)
-				if ce, ok := IsClientError(err); ok {
+				ce, ok := IsClientError(err)
+				if assert.True(t, ok, "expected ClientError") {
 					assert.Equal(t, 400, ce.code)
 				}
 			} else {


### PR DESCRIPTION
## Summary

- Adds `validateGCPClientEmail` in `validation.go`: rejects any `gcp_client_email` that does not match `^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.iam\.gserviceaccount\.com$`, blocking URL path injection into the SA impersonation URL (closes #405)
- Adds `validateAWSWebIdentityTokenFile` in `validation.go`: restricts `aws_web_identity_token_file` to `/var/run/secrets/eks.amazonaws.com/serviceaccount/` and `/var/run/secrets/kubernetes.io/serviceaccount/` prefixes, and blocks `..` segments, preventing arbitrary host file reads via STS (closes #403)
- Adds `validateAWSRoleARN` in `validation.go`: requires non-empty values to match `^arn:(aws|aws-cn|aws-us-gov):iam::[0-9]{12}:role/.+$`, catching malformed ARNs at the API boundary (closes #413)
- All three validators are wired into `validateAuthMode`/`validateAWSAuthMode` in `handler_accounts.go` so they fire on both create and update
- 108 new test cases in `validation_test.go` cover the exact attack vectors from each issue plus happy paths

## Test plan

- [ ] `go test ./internal/api/...` passes (1087 tests)
- [ ] `POST /api/accounts` with `gcp_client_email: "foo@bar.com/../../v1/projects/-/serviceAccounts/attacker@evil.com"` returns 400
- [ ] `POST /api/accounts` with `aws_web_identity_token_file: "/proc/self/environ"` returns 400
- [ ] `POST /api/accounts` with `aws_role_arn: "not-an-arn"` returns 400
- [ ] Valid values for all three fields are still accepted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced validation of cloud provider account credentials (GCP and AWS) including stricter format verification and security checks to prevent configuration errors and unauthorized file system access.

* **Tests**
  * Comprehensive new test coverage for credential validation across multiple scenarios including edge cases, malformed inputs, and security-related conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/504?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->