### PR TITLE
sec(purchases,ri-exchange): rate-limit public action endpoints + close empty-token bypass

### DIFF
--- a/internal/api/handler_purchases_test.go
+++ b/internal/api/handler_purchases_test.go
@@ -409,6 +409,65 @@ func TestHandler_approvePurchase_RejectsGlobalNotifyWhenContactSet(t *testing.T)
 	mockPurchase.AssertNotCalled(t, "ApproveExecution")
 }
 
+// TestRouter_approvePurchaseHandler_RateLimited is a regression test for issue #400.
+// The approve endpoint is AuthPublic (token-only); without rate limiting any
+// attacker can flood approve attempts to brute-force a valid token.
+// Once the "approve_cancel_public" bucket is exhausted the router wrapper must
+// return a 429 before dispatching to the business-logic handler.
+func TestRouter_approvePurchaseHandler_RateLimited(t *testing.T) {
+	ctx := context.Background()
+
+	mockRL := new(MockRateLimiter)
+	// Simulate the rate limit already exceeded.
+	mockRL.On("AllowWithIP", ctx, "1.2.3.4", "approve_cancel_public").Return(false, nil)
+
+	h := &Handler{rateLimiter: mockRL}
+	r := newTestRouter(h)
+
+	req := &events.LambdaFunctionURLRequest{
+		RequestContext: events.LambdaFunctionURLRequestContext{
+			HTTP: events.LambdaFunctionURLRequestContextHTTPDescription{
+				SourceIP: "1.2.3.4",
+			},
+		},
+		QueryStringParameters: map[string]string{"token": "any-token"},
+	}
+	_, err := r.approvePurchaseHandler(ctx, req, map[string]string{"id": "12345678-1234-1234-1234-123456789abc"})
+	require.Error(t, err)
+	ce, ok := IsClientError(err)
+	require.True(t, ok)
+	assert.Equal(t, 429, ce.code)
+
+	mockRL.AssertExpectations(t)
+}
+
+// TestRouter_cancelPurchaseHandler_RateLimited is a regression test for issue #400.
+func TestRouter_cancelPurchaseHandler_RateLimited(t *testing.T) {
+	ctx := context.Background()
+
+	mockRL := new(MockRateLimiter)
+	mockRL.On("AllowWithIP", ctx, "5.6.7.8", "approve_cancel_public").Return(false, nil)
+
+	h := &Handler{rateLimiter: mockRL}
+	r := newTestRouter(h)
+
+	req := &events.LambdaFunctionURLRequest{
+		RequestContext: events.LambdaFunctionURLRequestContext{
+			HTTP: events.LambdaFunctionURLRequestContextHTTPDescription{
+				SourceIP: "5.6.7.8",
+			},
+		},
+		QueryStringParameters: map[string]string{"token": "any-token"},
+	}
+	_, err := r.cancelPurchaseHandler(ctx, req, map[string]string{"id": "45645645-6456-4564-5645-645645645645"})
+	require.Error(t, err)
+	ce, ok := IsClientError(err)
+	require.True(t, ok)
+	assert.Equal(t, 429, ce.code)
+
+	mockRL.AssertExpectations(t)
+}
+
 func TestHandler_resolveApprovalRecipients_ContactBecomesTo(t *testing.T) {
 	ctx := context.Background()
 	contactA := "contact-a@example.com"

--- a/internal/api/handler_ri_exchange.go
+++ b/internal/api/handler_ri_exchange.go
@@ -720,6 +720,10 @@ func (h *Handler) rejectRIExchange(ctx context.Context, id, token string) (any, 
 		return nil, NewClientError(404, "exchange record not found")
 	}
 
+	if record.ApprovalToken == "" {
+		return nil, NewClientError(403, "this exchange record does not support rejection")
+	}
+
 	if subtle.ConstantTimeCompare([]byte(token), []byte(record.ApprovalToken)) != 1 {
 		return nil, NewClientError(403, "invalid rejection token")
 	}

--- a/internal/api/handler_ri_exchange_test.go
+++ b/internal/api/handler_ri_exchange_test.go
@@ -320,6 +320,34 @@ func TestRejectRIExchange_MissingToken(t *testing.T) {
 	assert.Contains(t, err.Error(), "rejection token is required")
 }
 
+// TestRejectRIExchange_EmptyStoredToken is a regression test for issue #399.
+// A record with an empty ApprovalToken must be rejected with 403 rather than
+// being cancelled by any caller passing an empty token string, because
+// crypto/subtle.ConstantTimeCompare([]byte(""), []byte("")) == 1.
+func TestRejectRIExchange_EmptyStoredToken(t *testing.T) {
+	mockStore := new(MockConfigStore)
+	h := &Handler{config: mockStore}
+	ctx := context.Background()
+	id := "550e8400-e29b-41d4-a716-446655440005"
+
+	// Record exists but was persisted without an ApprovalToken.
+	mockStore.On("GetRIExchangeRecord", ctx, id).Return(&config.RIExchangeRecord{
+		ID:            id,
+		ApprovalToken: "", // empty stored token
+		Status:        "pending",
+	}, nil)
+
+	// Passing an empty token must NOT match the empty stored token.
+	_, err := h.rejectRIExchange(ctx, id, "sometoken")
+	assert.Error(t, err)
+	ce, ok := IsClientError(err)
+	assert.True(t, ok)
+	assert.Equal(t, 403, ce.code)
+	assert.Contains(t, err.Error(), "does not support rejection")
+
+	mockStore.AssertExpectations(t)
+}
+
 // fakeReshapeEC2Stub is a unit-test stub for reshapeEC2Client.
 // Returns a single convertible RI so the downstream
 // AnalyzeReshapingWithRecs actually invokes purchaseRecLookupFromStore's

--- a/internal/api/rate_limiter.go
+++ b/internal/api/rate_limiter.go
@@ -24,12 +24,13 @@ func NewRateLimitConfig(maxAttempts int, windowSecs int) RateLimitConfig {
 // getDefaultRateLimits returns default rate limit configurations
 func getDefaultRateLimits() map[string]RateLimitConfig {
 	return map[string]RateLimitConfig{
-		"login":           NewRateLimitConfig(5, 15*60),  // 5 attempts / 15 minutes / IP
-		"forgot_password": NewRateLimitConfig(10, 5*60),  // 10 attempts / 5 minutes / email
-		"reset_password":  NewRateLimitConfig(10, 15*60), // 10 attempts / 15 minutes / IP
-		"change_password": NewRateLimitConfig(10, 15*60), // 10 attempts / 15 minutes / IP
-		"api_general":     NewRateLimitConfig(300, 60),   // 300 requests / minute / IP
-		"admin":           NewRateLimitConfig(30, 60),    // 30 / minute / user
+		"login":                 NewRateLimitConfig(5, 15*60),  // 5 attempts / 15 minutes / IP
+		"forgot_password":       NewRateLimitConfig(10, 5*60),  // 10 attempts / 5 minutes / email
+		"reset_password":        NewRateLimitConfig(10, 15*60), // 10 attempts / 15 minutes / IP
+		"change_password":       NewRateLimitConfig(10, 15*60), // 10 attempts / 15 minutes / IP
+		"api_general":           NewRateLimitConfig(300, 60),   // 300 requests / minute / IP
+		"admin":                 NewRateLimitConfig(30, 60),    // 30 / minute / user
+		"approve_cancel_public": NewRateLimitConfig(30, 60),    // 30 / minute / IP for public approve/cancel/reject
 	}
 }
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -479,11 +479,17 @@ func resolveApprovalToken(req *events.LambdaFunctionURLRequest) string {
 }
 
 func (r *Router) approvePurchaseHandler(ctx context.Context, req *events.LambdaFunctionURLRequest, params map[string]string) (any, error) {
+	if err := r.h.checkRateLimit(ctx, req, "approve_cancel_public"); err != nil {
+		return nil, err
+	}
 	token := resolveApprovalToken(req)
 	return r.h.approvePurchase(ctx, req, params["id"], token)
 }
 
 func (r *Router) cancelPurchaseHandler(ctx context.Context, req *events.LambdaFunctionURLRequest, params map[string]string) (any, error) {
+	if err := r.h.checkRateLimit(ctx, req, "approve_cancel_public"); err != nil {
+		return nil, err
+	}
 	token := resolveApprovalToken(req)
 	return r.h.cancelPurchase(ctx, req, params["id"], token)
 }
@@ -673,10 +679,16 @@ func (r *Router) getRIExchangeHistoryHandler(ctx context.Context, req *events.La
 }
 
 func (r *Router) approveRIExchangeHandler(ctx context.Context, req *events.LambdaFunctionURLRequest, params map[string]string) (any, error) {
+	if err := r.h.checkRateLimit(ctx, req, "approve_cancel_public"); err != nil {
+		return nil, err
+	}
 	return r.h.approveRIExchange(ctx, params["id"], req.QueryStringParameters["token"])
 }
 
 func (r *Router) rejectRIExchangeHandler(ctx context.Context, req *events.LambdaFunctionURLRequest, params map[string]string) (any, error) {
+	if err := r.h.checkRateLimit(ctx, req, "approve_cancel_public"); err != nil {
+		return nil, err
+	}
 	return r.h.rejectRIExchange(ctx, params["id"], req.QueryStringParameters["token"])
 }
 

--- a/internal/api/router_handlers_test.go
+++ b/internal/api/router_handlers_test.go
@@ -906,3 +906,65 @@ func TestHandler_getRIExchangeHistory_SinceTime(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }
+
+// ---------------------------------------------------------------------------
+// Rate-limit regression tests for AuthPublic action endpoints (issue #400)
+// ---------------------------------------------------------------------------
+
+// TestRouter_approveRIExchangeHandler_RateLimited verifies that the
+// approveRIExchangeHandler router wrapper enforces the approve_cancel_public
+// rate-limit bucket before dispatching to the business-logic handler.
+func TestRouter_approveRIExchangeHandler_RateLimited(t *testing.T) {
+	ctx := context.Background()
+
+	mockRL := new(MockRateLimiter)
+	mockRL.On("AllowWithIP", ctx, "9.8.7.6", "approve_cancel_public").Return(false, nil)
+
+	h := &Handler{rateLimiter: mockRL}
+	r := newTestRouter(h)
+
+	req := &events.LambdaFunctionURLRequest{
+		RequestContext: events.LambdaFunctionURLRequestContext{
+			HTTP: events.LambdaFunctionURLRequestContextHTTPDescription{
+				SourceIP: "9.8.7.6",
+			},
+		},
+		QueryStringParameters: map[string]string{"token": "tok"},
+	}
+	_, err := r.approveRIExchangeHandler(ctx, req, map[string]string{"id": "550e8400-e29b-41d4-a716-446655440000"})
+	require.Error(t, err)
+	ce, ok := IsClientError(err)
+	require.True(t, ok)
+	assert.Equal(t, 429, ce.code)
+
+	mockRL.AssertExpectations(t)
+}
+
+// TestRouter_rejectRIExchangeHandler_RateLimited verifies that the
+// rejectRIExchangeHandler router wrapper enforces the approve_cancel_public
+// rate-limit bucket before dispatching to the business-logic handler.
+func TestRouter_rejectRIExchangeHandler_RateLimited(t *testing.T) {
+	ctx := context.Background()
+
+	mockRL := new(MockRateLimiter)
+	mockRL.On("AllowWithIP", ctx, "1.1.1.1", "approve_cancel_public").Return(false, nil)
+
+	h := &Handler{rateLimiter: mockRL}
+	r := newTestRouter(h)
+
+	req := &events.LambdaFunctionURLRequest{
+		RequestContext: events.LambdaFunctionURLRequestContext{
+			HTTP: events.LambdaFunctionURLRequestContextHTTPDescription{
+				SourceIP: "1.1.1.1",
+			},
+		},
+		QueryStringParameters: map[string]string{"token": "tok"},
+	}
+	_, err := r.rejectRIExchangeHandler(ctx, req, map[string]string{"id": "550e8400-e29b-41d4-a716-446655440000"})
+	require.Error(t, err)
+	ce, ok := IsClientError(err)
+	require.True(t, ok)
+	assert.Equal(t, 429, ce.code)
+
+	mockRL.AssertExpectations(t)
+}


### PR DESCRIPTION
## Summary

- **#400**: Add per-IP rate limiting (30 req/min, `approve_cancel_public` bucket) to all four `AuthPublic` action endpoints: `POST /api/purchases/approve/*`, `POST /api/purchases/cancel/*`, `POST /api/ri-exchange/approve/*`, `POST /api/ri-exchange/reject/*`. Rate limit is enforced in the router handler wrappers, keeping the business-logic functions at their existing cyclomatic complexity.
- **#399**: Add `record.ApprovalToken == ""` guard to `rejectRIExchange`, matching the identical guard already present in `validateExchangeApproval` for the approve path. A record persisted without an `ApprovalToken` must return 403 rather than being cancellable because `crypto/subtle.ConstantTimeCompare("","") == 1`.

## Test plan

- [ ] `go test ./internal/api/... ./internal/auth/...` passes (1574 tests)
- [ ] `TestRouter_approvePurchaseHandler_RateLimited` - 429 when approve_cancel_public bucket exhausted
- [ ] `TestRouter_cancelPurchaseHandler_RateLimited` - 429 when approve_cancel_public bucket exhausted
- [ ] `TestRouter_approveRIExchangeHandler_RateLimited` - 429 when approve_cancel_public bucket exhausted
- [ ] `TestRouter_rejectRIExchangeHandler_RateLimited` - 429 when approve_cancel_public bucket exhausted
- [ ] `TestRejectRIExchange_EmptyStoredToken` - 403 when stored ApprovalToken is empty

Closes #400, closes #399

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Rate limiting now enforced on public purchase approval/cancellation endpoints and RI exchange approval/rejection endpoints (30 attempts per 60 seconds)

* **Bug Fixes**
  * Fixed RI exchange rejection validation to properly verify approval token support before processing

* **Tests**
  * Added regression tests for rate limiting enforcement on public endpoints
  * Added regression test for RI exchange rejection handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/505?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->