### PR TITLE
sec(frontend): close stored XSS in provider class + plans.ts purchase.status (closes #443, #445)

### DIFF
--- a/frontend/src/__tests__/xss-provider-class.test.ts
+++ b/frontend/src/__tests__/xss-provider-class.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Regression tests for stored XSS via provider field injected into class
+ * attribute (issue #443).
+ *
+ * providerCell() in history.ts used to interpolate p.provider directly into
+ * the class attribute of a <span>. An attacker-controlled provider value such
+ * as  `"><script>alert(1)</script><span class="` would break out of the
+ * attribute and inject arbitrary HTML.  The fix whitelists provider against
+ * VALID_PROVIDERS and falls back to the sentinel class `provider-unknown`.
+ */
+
+import { loadHistory } from '../history';
+
+// Use the real escapeHtml so DOM-based escaping is exercised, not a pass-through stub.
+jest.mock('../utils', () => {
+  const actual = jest.requireActual<typeof import('../utils')>('../utils');
+  return {
+    ...actual,
+    formatCurrency: jest.fn((val: number) => `$${val || 0}`),
+    formatDate: jest.fn((val: string) => val ? new Date(val).toLocaleDateString() : ''),
+    formatTerm: jest.fn((years: number | null | undefined) =>
+      years == null ? '' : `${years} Year${years === 1 ? '' : 's'}`),
+    populateAccountFilter: jest.fn(() => Promise.resolve()),
+  };
+});
+
+jest.mock('../api', () => ({
+  getHistory: jest.fn(),
+}));
+
+jest.mock('../navigation', () => ({
+  switchTab: jest.fn(),
+}));
+
+const mockGetCurrentProvider = jest.fn<string, []>().mockReturnValue('all');
+const mockGetCurrentAccountIDs = jest.fn<string[], []>().mockReturnValue([]);
+
+jest.mock('../state', () => ({
+  getCurrentUser: jest.fn(),
+  getCurrentProvider: () => mockGetCurrentProvider(),
+  setCurrentProvider: jest.fn(),
+  getCurrentAccountIDs: () => mockGetCurrentAccountIDs(),
+  setCurrentAccountIDs: jest.fn(),
+  subscribeProvider: jest.fn().mockReturnValue(() => {}),
+  subscribeAccount: jest.fn().mockReturnValue(() => {}),
+}));
+
+import * as api from '../api';
+
+const XSS_PAYLOAD = '"><script>alert(1)</script><span class="';
+const IMG_PAYLOAD = '" onmouseover="alert(1)" x="';
+
+describe('XSS regression: provider class attribute injection (#443)', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <input type="date" id="history-start">
+      <input type="date" id="history-end">
+      <div id="history-summary"></div>
+      <div id="history-list"></div>
+      <div id="purchases-approval-queue"></div>
+    `;
+    jest.clearAllMocks();
+    mockGetCurrentProvider.mockReturnValue('all');
+    mockGetCurrentAccountIDs.mockReturnValue([]);
+  });
+
+  test('script-tag payload in provider field does not create a <script> element', async () => {
+    (api.getHistory as jest.Mock).mockResolvedValue({
+      summary: {},
+      purchases: [
+        {
+          purchase_date: '2024-01-15',
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          provider: XSS_PAYLOAD as any,
+          service: 'ec2',
+          resource_type: 't3.medium',
+          region: 'us-east-1',
+          count: 1,
+          term: 1,
+          upfront_cost: 0,
+          monthly_savings: 10,
+        },
+      ],
+    });
+
+    await loadHistory();
+
+    const list = document.getElementById('history-list');
+    expect(list).not.toBeNull();
+    // No <script> element should have been created anywhere in the document.
+    expect(document.querySelectorAll('script').length).toBe(0);
+    // The rendered class attribute must not contain the raw payload.
+    expect(list!.innerHTML).not.toContain('<script>');
+    // The sentinel class "unknown" is applied instead (no raw payload in the class).
+    expect(list!.innerHTML).toContain('provider-badge unknown');
+  });
+
+  test('img-onerror payload in provider field does not inject event handler attribute', async () => {
+    (api.getHistory as jest.Mock).mockResolvedValue({
+      summary: {},
+      purchases: [
+        {
+          purchase_date: '2024-01-15',
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          provider: IMG_PAYLOAD as any,
+          service: 'ec2',
+          resource_type: 't3.medium',
+          region: 'us-east-1',
+          count: 1,
+          term: 1,
+          upfront_cost: 0,
+          monthly_savings: 10,
+        },
+      ],
+    });
+
+    await loadHistory();
+
+    const list = document.getElementById('history-list');
+    expect(list).not.toBeNull();
+    expect(list!.innerHTML).not.toContain('onmouseover');
+    expect(list!.innerHTML).toContain('provider-badge unknown');
+  });
+
+  test('valid provider "aws" renders the provider-aws class and is not treated as unknown', async () => {
+    (api.getHistory as jest.Mock).mockResolvedValue({
+      summary: {},
+      purchases: [
+        {
+          purchase_date: '2024-01-15',
+          provider: 'aws',
+          service: 'ec2',
+          resource_type: 't3.medium',
+          region: 'us-east-1',
+          count: 1,
+          term: 1,
+          upfront_cost: 0,
+          monthly_savings: 10,
+        },
+      ],
+    });
+
+    await loadHistory();
+
+    const list = document.getElementById('history-list');
+    expect(list).not.toBeNull();
+    expect(list!.innerHTML).toContain('provider-badge aws');
+    expect(list!.innerHTML).not.toContain('provider-badge unknown');
+  });
+
+  test('valid provider "azure" renders the provider-azure class', async () => {
+    (api.getHistory as jest.Mock).mockResolvedValue({
+      summary: {},
+      purchases: [
+        {
+          purchase_date: '2024-01-15',
+          provider: 'azure',
+          service: 'compute',
+          resource_type: 'Standard_D2s_v3',
+          region: 'eastus',
+          count: 1,
+          term: 1,
+          upfront_cost: 0,
+          monthly_savings: 10,
+        },
+      ],
+    });
+
+    await loadHistory();
+
+    const list = document.getElementById('history-list');
+    expect(list).not.toBeNull();
+    expect(list!.innerHTML).toContain('provider-badge azure');
+  });
+
+  test('valid provider "gcp" renders the provider-gcp class', async () => {
+    (api.getHistory as jest.Mock).mockResolvedValue({
+      summary: {},
+      purchases: [
+        {
+          purchase_date: '2024-01-15',
+          provider: 'gcp',
+          service: 'compute',
+          resource_type: 'n2-standard-2',
+          region: 'us-central1',
+          count: 1,
+          term: 1,
+          upfront_cost: 0,
+          monthly_savings: 10,
+        },
+      ],
+    });
+
+    await loadHistory();
+
+    const list = document.getElementById('history-list');
+    expect(list).not.toBeNull();
+    expect(list!.innerHTML).toContain('provider-badge gcp');
+  });
+});

--- a/frontend/src/__tests__/xss-purchase-status.test.ts
+++ b/frontend/src/__tests__/xss-purchase-status.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Regression tests for stored XSS via purchase.status rendered as an
+ * unescaped text node inside a <span> (issue #445).
+ *
+ * plans.ts:renderPlannedPurchaseRow used to emit:
+ *   <span class="status-badge …">${purchase.status}</span>
+ *
+ * An attacker-controlled status value such as `<script>alert(1)</script>`
+ * would be parsed as HTML and could execute arbitrary JavaScript.  The fix
+ * wraps the interpolation with the existing escapeHtml() from utils.ts.
+ */
+
+import { loadPlans } from '../plans';
+
+// Use the real escapeHtml so the DOM-based escaping is exercised, not a stub.
+jest.mock('../utils', () => {
+  const actual = jest.requireActual<typeof import('../utils')>('../utils');
+  return {
+    ...actual,
+    formatDate: jest.fn((val: string) => val ? new Date(val).toLocaleDateString() : ''),
+    formatTerm: jest.fn((years: number | null | undefined) =>
+      years == null ? '' : `${years} Year${years === 1 ? '' : 's'}`),
+    formatRampSchedule: jest.fn((val: string) => val || 'Unknown'),
+    formatCurrency: jest.fn((val: number) => `$${val || 0}`),
+    populateAccountFilter: jest.fn(() => Promise.resolve()),
+  };
+});
+
+jest.mock('../api', () => ({
+  getPlans: jest.fn(),
+  getPlannedPurchases: jest.fn(),
+  getPlan: jest.fn(),
+  createPlan: jest.fn(),
+  updatePlan: jest.fn(),
+  patchPlan: jest.fn(),
+  deletePlan: jest.fn(),
+  runPlannedPurchase: jest.fn(),
+  pausePlannedPurchase: jest.fn(),
+  resumePlannedPurchase: jest.fn(),
+  deletePlannedPurchase: jest.fn(),
+  createPlannedPurchases: jest.fn(),
+  listPlanAccounts: jest.fn().mockResolvedValue([]),
+  setPlanAccounts: jest.fn().mockResolvedValue(undefined),
+  listAccounts: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('../state', () => ({
+  getRecommendations: jest.fn().mockReturnValue([]),
+  getSelectedRecommendationIDs: jest.fn().mockReturnValue(new Set()),
+  getVisibleRecommendations: jest.fn().mockReturnValue([]),
+  setVisibleRecommendations: jest.fn(),
+  getCurrentProvider: jest.fn().mockReturnValue(''),
+  setCurrentProvider: jest.fn(),
+  getCurrentAccountIDs: jest.fn().mockReturnValue([]),
+  setCurrentAccountIDs: jest.fn(),
+  subscribeProvider: jest.fn().mockReturnValue(() => {}),
+  subscribeAccount: jest.fn().mockReturnValue(() => {}),
+  getCurrentUser: jest.fn().mockReturnValue({ id: 'u-admin', email: 'admin@example.com', role: 'admin' }),
+}));
+
+jest.mock('../history', () => ({
+  viewPlanHistory: jest.fn(),
+}));
+
+jest.mock('../commitmentOptions', () => ({
+  populateTermSelect: jest.fn(),
+  populatePaymentSelect: jest.fn(),
+  isValidCombination: jest.fn().mockReturnValue(true),
+  normalizePaymentValue: jest.fn((value: unknown) => value),
+}));
+
+jest.mock('../toast', () => ({
+  showToast: jest.fn(() => ({ dismiss: jest.fn() })),
+}));
+
+jest.mock('../confirmDialog', () => ({
+  confirmDialog: jest.fn(() => Promise.resolve(true)),
+}));
+
+jest.mock('../modal', () => ({
+  openModal: jest.fn(),
+  closeModal: jest.fn(),
+}));
+
+jest.mock('../archera', () => ({
+  openArcheraOfferModal: jest.fn(),
+}));
+
+jest.mock('../lib/skeleton', () => ({
+  showSkeletonTiles: jest.fn(),
+  showSkeletonRows: jest.fn(),
+  teardownSkeleton: jest.fn(),
+}));
+
+jest.mock('../permissions', () => ({
+  canAccess: jest.fn().mockReturnValue(true),
+}));
+
+import * as api from '../api';
+
+const SCRIPT_PAYLOAD = '<script>alert(1)</script>';
+const IMG_PAYLOAD = '"><img src=x onerror="alert(1)">';
+
+function makePurchase(status: string) {
+  return {
+    id: 'pp-1',
+    plan_id: 'plan-1',
+    plan_name: 'Test Plan',
+    scheduled_date: '2024-06-01',
+    provider: 'aws',
+    service: 'ec2',
+    resource_type: 't3.medium',
+    region: 'us-east-1',
+    count: 1,
+    term: 1,
+    payment: 'no-upfront',
+    estimated_savings: 50,
+    upfront_cost: 0,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    status: status as any,
+    step_number: 1,
+    total_steps: 1,
+  };
+}
+
+describe('XSS regression: purchase.status rendered as text node (#445)', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="plans-list"></div>
+      <div id="planned-purchases-list"></div>
+      <button id="new-plan-btn"></button>
+    `;
+    jest.clearAllMocks();
+    (api.getPlans as jest.Mock).mockResolvedValue({ plans: [] });
+  });
+
+  test('script-tag payload in purchase.status does not create a <script> element', async () => {
+    (api.getPlannedPurchases as jest.Mock).mockResolvedValue({
+      purchases: [makePurchase(SCRIPT_PAYLOAD)],
+    });
+
+    await loadPlans();
+
+    // No <script> element should have been injected.
+    expect(document.querySelectorAll('script').length).toBe(0);
+
+    const list = document.getElementById('planned-purchases-list');
+    expect(list).not.toBeNull();
+    // Raw tags must not appear in the rendered markup.
+    expect(list!.innerHTML).not.toContain('<script>');
+    // The payload must appear only as escaped text content, not as markup.
+    expect(list!.textContent).toContain(SCRIPT_PAYLOAD);
+  });
+
+  test('img-onerror payload in purchase.status does not inject an img element', async () => {
+    (api.getPlannedPurchases as jest.Mock).mockResolvedValue({
+      purchases: [makePurchase(IMG_PAYLOAD)],
+    });
+
+    await loadPlans();
+
+    const list = document.getElementById('planned-purchases-list');
+    expect(list).not.toBeNull();
+    // No <img> element should have been injected as a real DOM node.
+    expect(list!.querySelectorAll('img').length).toBe(0);
+    // The payload literal appears only as escaped text, not as a live attribute.
+    const badge = list!.querySelector('.status-badge');
+    expect(badge).not.toBeNull();
+    expect(badge!.textContent).toContain('onerror');
+  });
+
+  test('valid status "pending" renders as plain text inside the status badge', async () => {
+    (api.getPlannedPurchases as jest.Mock).mockResolvedValue({
+      purchases: [makePurchase('pending')],
+    });
+
+    await loadPlans();
+
+    const list = document.getElementById('planned-purchases-list');
+    expect(list).not.toBeNull();
+    const badge = list!.querySelector('.status-badge');
+    expect(badge).not.toBeNull();
+    expect(badge!.textContent).toBe('pending');
+  });
+
+  test('valid status "paused" renders as plain text inside the status badge', async () => {
+    (api.getPlannedPurchases as jest.Mock).mockResolvedValue({
+      purchases: [makePurchase('paused')],
+    });
+
+    await loadPlans();
+
+    const list = document.getElementById('planned-purchases-list');
+    expect(list).not.toBeNull();
+    const badge = list!.querySelector('.status-badge');
+    expect(badge).not.toBeNull();
+    expect(badge!.textContent).toBe('paused');
+  });
+});

--- a/frontend/src/history.ts
+++ b/frontend/src/history.ts
@@ -316,7 +316,9 @@ function buildStatusChipRowHTML(purchases: HistoryPurchase[], active: StatusFilt
 
 function providerCell(p: HistoryPurchase): string {
   if (!p.provider || p.provider === 'multiple') return '<span class="provider-badge">Multiple</span>';
-  return `<span class="provider-badge ${p.provider}">${p.provider.toUpperCase()}</span>`;
+  // Whitelist provider to prevent stored XSS via class attribute injection (#443).
+  const safeProvider = (VALID_PROVIDERS as string[]).includes(p.provider) ? p.provider : 'unknown';
+  return `<span class="provider-badge ${safeProvider}">${safeProvider.toUpperCase()}</span>`;
 }
 
 // canCancelPendingRow returns true when the current session is permitted

--- a/frontend/src/plans.ts
+++ b/frontend/src/plans.ts
@@ -185,7 +185,7 @@ function renderPlannedPurchaseRow(purchase: PlannedPurchase): string {
       <td>${termCell}</td>
       <td>${upfrontCell}</td>
       <td class="savings">${formatCurrency(purchase.estimated_savings)}/mo</td>
-      <td><span class="status-badge ${statusClass}">${purchase.status}</span></td>
+      <td><span class="status-badge ${statusClass}">${escapeHtml(purchase.status)}</span></td>
       <td class="actions">
         ${canManagePlan && canRun ? `<button data-action="run" data-id="${purchase.id}" class="btn-small primary" title="Run now">▶</button>` : ''}
         ${canManagePlan && isPending ? `<button data-action="pause" data-id="${purchase.id}" class="btn-small" title="Pause">⏸</button>` : ''}


### PR DESCRIPTION
## Summary

- **#443**: `providerCell()` in `history.ts` interpolated `p.provider` directly into a `class=` attribute; an attacker-controlled value could break out and inject arbitrary HTML. Fixed by whitelisting against `VALID_PROVIDERS`; unknown values render as the sentinel class `unknown`.
- **#445**: `renderPlannedPurchaseRow()` in `plans.ts` rendered `purchase.status` as an unescaped text node. Fixed by wrapping with the existing `escapeHtml()` already imported from `utils.ts`.

Regression tests added in `xss-provider-class.test.ts` and `xss-purchase-status.test.ts` using `jest.requireActual` for `escapeHtml` so real DOM-based escaping is exercised.

## Test plan

- [x] `cd frontend && npx jest src/__tests__/xss-provider-class.test.ts src/__tests__/xss-purchase-status.test.ts` — all 9 new regression tests pass
- [x] `cd frontend && npx jest` — 1866 pass; one pre-existing failure in `settings-purchasing-grace.test.ts` unrelated to this PR
- [x] `cd frontend && npx tsc --noEmit` — clean
