### PR TITLE
fix(frontend/archera): show offer modal on purchase approval (closes #499)

### DIFF
--- a/frontend/src/__tests__/archera.test.ts
+++ b/frontend/src/__tests__/archera.test.ts
@@ -18,10 +18,14 @@ import {
   openArcheraOfferModal,
   closeArcheraOfferModal,
   handleArcheraDeeplink,
+  maybeOfferArcheraAfterExecution,
   ARCHERA_SIGNUP_URL,
   ARCHERA_PAGE_A_PATH,
   ARCHERA_PAGE_B_PATH,
+  ARCHERA_OFFERED_FOR_KEY,
+  ARCHERA_OFFER_WINDOW_DAYS,
 } from '../archera';
+import * as api from '../api';
 
 // ---------------------------------------------------------------------------
 // Mocks required by recommendations.ts and plans.ts
@@ -37,6 +41,7 @@ jest.mock('../api', () => ({
   getPlannedPurchases: jest.fn().mockResolvedValue({ purchases: [] }),
   listPlanAccounts: jest.fn().mockResolvedValue([]),
   setPlanAccounts: jest.fn().mockResolvedValue(undefined),
+  getHistory: jest.fn().mockResolvedValue({ purchases: [] }),
 }));
 
 jest.mock('../api/recommendations', () => ({
@@ -467,5 +472,141 @@ describe('handleArcheraDeeplink', () => {
     const container = document.getElementById('archera-page-container')!;
     expect(container.classList.contains('hidden')).toBe(false);
     expect(container.querySelector('h1')?.textContent).toBe('Archera Insurance');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// maybeOfferArcheraAfterExecution
+// ---------------------------------------------------------------------------
+
+describe('maybeOfferArcheraAfterExecution', () => {
+  const mockGetHistory = api.getHistory as jest.Mock;
+
+  // Build a completed purchase within the offer window.
+  function recentCompleted(id: string, daysAgo = 1): Record<string, unknown> {
+    const ts = new Date();
+    ts.setDate(ts.getDate() - daysAgo);
+    return { purchase_id: id, timestamp: ts.toISOString(), status: 'completed' };
+  }
+
+  // Helper: configure localStorage.getItem mock to return a specific JSON array.
+  function seedOfferedFor(ids: string[]): void {
+    (localStorage.getItem as jest.Mock).mockImplementation((key: string) => {
+      if (key === ARCHERA_OFFERED_FOR_KEY) return JSON.stringify(ids);
+      return null;
+    });
+  }
+
+  // Helper: extract what was written to the offered-for key from setItem calls.
+  function captureOfferedForWrite(): string[] {
+    const calls = (localStorage.setItem as jest.Mock).mock.calls as [string, string][];
+    const last = calls.filter(([k]) => k === ARCHERA_OFFERED_FOR_KEY).pop();
+    if (!last) return [];
+    return JSON.parse(last[1]) as string[];
+  }
+
+  beforeEach(() => {
+    buildArcheraOfferContainer();
+    buildArcheraContainer();
+    mockGetHistory.mockReset();
+    // Default: no offered-for set stored.
+    (localStorage.getItem as jest.Mock).mockReturnValue(null);
+  });
+
+  it('returns early without opening modal when no executions in the window', async () => {
+    mockGetHistory.mockResolvedValue({ purchases: [] });
+    await maybeOfferArcheraAfterExecution();
+    const container = document.getElementById('archera-offer-modal-container')!;
+    expect(container.classList.contains('hidden')).toBe(true);
+  });
+
+  it('opens modal for the most recent completed execution not yet offered', async () => {
+    mockGetHistory.mockResolvedValue({ purchases: [recentCompleted('exec-1')] });
+    await maybeOfferArcheraAfterExecution();
+    const container = document.getElementById('archera-offer-modal-container')!;
+    expect(container.classList.contains('hidden')).toBe(false);
+  });
+
+  it('does not re-open modal for an execution already in the localStorage offered-for set', async () => {
+    seedOfferedFor(['exec-1']);
+    mockGetHistory.mockResolvedValue({ purchases: [recentCompleted('exec-1')] });
+    await maybeOfferArcheraAfterExecution();
+    const container = document.getElementById('archera-offer-modal-container')!;
+    expect(container.classList.contains('hidden')).toBe(true);
+  });
+
+  it('does not open modal for non-completed executions (failed, pending, expired)', async () => {
+    const ts = new Date().toISOString();
+    mockGetHistory.mockResolvedValue({
+      purchases: [
+        { purchase_id: 'exec-fail', timestamp: ts, status: 'failed' },
+        { purchase_id: 'exec-pend', timestamp: ts, status: 'pending' },
+        { purchase_id: 'exec-exp', timestamp: ts, status: 'expired' },
+      ],
+    });
+    await maybeOfferArcheraAfterExecution();
+    const container = document.getElementById('archera-offer-modal-container')!;
+    expect(container.classList.contains('hidden')).toBe(true);
+  });
+
+  it('passes start date of ARCHERA_OFFER_WINDOW_DAYS ago to getHistory', async () => {
+    mockGetHistory.mockResolvedValue({ purchases: [] });
+    await maybeOfferArcheraAfterExecution();
+    const expected = new Date();
+    expected.setDate(expected.getDate() - ARCHERA_OFFER_WINDOW_DAYS);
+    const expectedStr = expected.toISOString().split('T')[0];
+    expect(mockGetHistory).toHaveBeenCalledWith(expect.objectContaining({ start: expectedStr }));
+  });
+
+  it('records the offered execution in localStorage so it is not shown again', async () => {
+    mockGetHistory.mockResolvedValue({ purchases: [recentCompleted('exec-2')] });
+    await maybeOfferArcheraAfterExecution();
+    const stored = captureOfferedForWrite();
+    expect(stored).toContain('exec-2');
+  });
+
+  it('enforces FIFO cap of 50 entries in the localStorage set', async () => {
+    // Pre-fill with 50 entries so next write must evict the oldest.
+    const existing = Array.from({ length: 50 }, (_, i) => `old-exec-${i}`);
+    seedOfferedFor(existing);
+    mockGetHistory.mockResolvedValue({ purchases: [recentCompleted('exec-new')] });
+    await maybeOfferArcheraAfterExecution();
+    const stored = captureOfferedForWrite();
+    // Total length must not exceed 50.
+    expect(stored.length).toBeLessThanOrEqual(50);
+    // The new entry must be present.
+    expect(stored).toContain('exec-new');
+    // The oldest entry must have been evicted.
+    expect(stored).not.toContain('old-exec-0');
+  });
+
+  it('swallows getHistory errors and does not open modal', async () => {
+    mockGetHistory.mockRejectedValue(new Error('network error'));
+    // Should not throw.
+    await expect(maybeOfferArcheraAfterExecution()).resolves.toBeUndefined();
+    const container = document.getElementById('archera-offer-modal-container')!;
+    expect(container.classList.contains('hidden')).toBe(true);
+  });
+
+  it('fires for the most recent completed purchase when multiple exist', async () => {
+    const older = recentCompleted('exec-older', 3);
+    const newer = recentCompleted('exec-newer', 1);
+    mockGetHistory.mockResolvedValue({ purchases: [older, newer] });
+    await maybeOfferArcheraAfterExecution();
+    // exec-newer should be recorded (most recent) — not exec-older.
+    const stored = captureOfferedForWrite();
+    expect(stored).toContain('exec-newer');
+    expect(stored).not.toContain('exec-older');
+  });
+
+  it('skips executions that lack a purchase_id', async () => {
+    // A row without purchase_id (legacy) must not be offered.
+    const ts = new Date().toISOString();
+    mockGetHistory.mockResolvedValue({
+      purchases: [{ timestamp: ts, status: 'completed' }], // no purchase_id
+    });
+    await maybeOfferArcheraAfterExecution();
+    const container = document.getElementById('archera-offer-modal-container')!;
+    expect(container.classList.contains('hidden')).toBe(true);
   });
 });

--- a/frontend/src/__tests__/archera.test.ts
+++ b/frontend/src/__tests__/archera.test.ts
@@ -18,14 +18,10 @@ import {
   openArcheraOfferModal,
   closeArcheraOfferModal,
   handleArcheraDeeplink,
-  maybeOfferArcheraAfterExecution,
   ARCHERA_SIGNUP_URL,
   ARCHERA_PAGE_A_PATH,
   ARCHERA_PAGE_B_PATH,
-  ARCHERA_OFFERED_FOR_KEY,
-  ARCHERA_OFFER_WINDOW_DAYS,
 } from '../archera';
-import * as api from '../api';
 
 // ---------------------------------------------------------------------------
 // Mocks required by recommendations.ts and plans.ts
@@ -41,7 +37,6 @@ jest.mock('../api', () => ({
   getPlannedPurchases: jest.fn().mockResolvedValue({ purchases: [] }),
   listPlanAccounts: jest.fn().mockResolvedValue([]),
   setPlanAccounts: jest.fn().mockResolvedValue(undefined),
-  getHistory: jest.fn().mockResolvedValue({ purchases: [] }),
 }));
 
 jest.mock('../api/recommendations', () => ({
@@ -472,141 +467,5 @@ describe('handleArcheraDeeplink', () => {
     const container = document.getElementById('archera-page-container')!;
     expect(container.classList.contains('hidden')).toBe(false);
     expect(container.querySelector('h1')?.textContent).toBe('Archera Insurance');
-  });
-});
-
-// ---------------------------------------------------------------------------
-// maybeOfferArcheraAfterExecution
-// ---------------------------------------------------------------------------
-
-describe('maybeOfferArcheraAfterExecution', () => {
-  const mockGetHistory = api.getHistory as jest.Mock;
-
-  // Build a completed purchase within the offer window.
-  function recentCompleted(id: string, daysAgo = 1): Record<string, unknown> {
-    const ts = new Date();
-    ts.setDate(ts.getDate() - daysAgo);
-    return { purchase_id: id, timestamp: ts.toISOString(), status: 'completed' };
-  }
-
-  // Helper: configure localStorage.getItem mock to return a specific JSON array.
-  function seedOfferedFor(ids: string[]): void {
-    (localStorage.getItem as jest.Mock).mockImplementation((key: string) => {
-      if (key === ARCHERA_OFFERED_FOR_KEY) return JSON.stringify(ids);
-      return null;
-    });
-  }
-
-  // Helper: extract what was written to the offered-for key from setItem calls.
-  function captureOfferedForWrite(): string[] {
-    const calls = (localStorage.setItem as jest.Mock).mock.calls as [string, string][];
-    const last = calls.filter(([k]) => k === ARCHERA_OFFERED_FOR_KEY).pop();
-    if (!last) return [];
-    return JSON.parse(last[1]) as string[];
-  }
-
-  beforeEach(() => {
-    buildArcheraOfferContainer();
-    buildArcheraContainer();
-    mockGetHistory.mockReset();
-    // Default: no offered-for set stored.
-    (localStorage.getItem as jest.Mock).mockReturnValue(null);
-  });
-
-  it('returns early without opening modal when no executions in the window', async () => {
-    mockGetHistory.mockResolvedValue({ purchases: [] });
-    await maybeOfferArcheraAfterExecution();
-    const container = document.getElementById('archera-offer-modal-container')!;
-    expect(container.classList.contains('hidden')).toBe(true);
-  });
-
-  it('opens modal for the most recent completed execution not yet offered', async () => {
-    mockGetHistory.mockResolvedValue({ purchases: [recentCompleted('exec-1')] });
-    await maybeOfferArcheraAfterExecution();
-    const container = document.getElementById('archera-offer-modal-container')!;
-    expect(container.classList.contains('hidden')).toBe(false);
-  });
-
-  it('does not re-open modal for an execution already in the localStorage offered-for set', async () => {
-    seedOfferedFor(['exec-1']);
-    mockGetHistory.mockResolvedValue({ purchases: [recentCompleted('exec-1')] });
-    await maybeOfferArcheraAfterExecution();
-    const container = document.getElementById('archera-offer-modal-container')!;
-    expect(container.classList.contains('hidden')).toBe(true);
-  });
-
-  it('does not open modal for non-completed executions (failed, pending, expired)', async () => {
-    const ts = new Date().toISOString();
-    mockGetHistory.mockResolvedValue({
-      purchases: [
-        { purchase_id: 'exec-fail', timestamp: ts, status: 'failed' },
-        { purchase_id: 'exec-pend', timestamp: ts, status: 'pending' },
-        { purchase_id: 'exec-exp', timestamp: ts, status: 'expired' },
-      ],
-    });
-    await maybeOfferArcheraAfterExecution();
-    const container = document.getElementById('archera-offer-modal-container')!;
-    expect(container.classList.contains('hidden')).toBe(true);
-  });
-
-  it('passes start date of ARCHERA_OFFER_WINDOW_DAYS ago to getHistory', async () => {
-    mockGetHistory.mockResolvedValue({ purchases: [] });
-    await maybeOfferArcheraAfterExecution();
-    const expected = new Date();
-    expected.setDate(expected.getDate() - ARCHERA_OFFER_WINDOW_DAYS);
-    const expectedStr = expected.toISOString().split('T')[0];
-    expect(mockGetHistory).toHaveBeenCalledWith(expect.objectContaining({ start: expectedStr }));
-  });
-
-  it('records the offered execution in localStorage so it is not shown again', async () => {
-    mockGetHistory.mockResolvedValue({ purchases: [recentCompleted('exec-2')] });
-    await maybeOfferArcheraAfterExecution();
-    const stored = captureOfferedForWrite();
-    expect(stored).toContain('exec-2');
-  });
-
-  it('enforces FIFO cap of 50 entries in the localStorage set', async () => {
-    // Pre-fill with 50 entries so next write must evict the oldest.
-    const existing = Array.from({ length: 50 }, (_, i) => `old-exec-${i}`);
-    seedOfferedFor(existing);
-    mockGetHistory.mockResolvedValue({ purchases: [recentCompleted('exec-new')] });
-    await maybeOfferArcheraAfterExecution();
-    const stored = captureOfferedForWrite();
-    // Total length must not exceed 50.
-    expect(stored.length).toBeLessThanOrEqual(50);
-    // The new entry must be present.
-    expect(stored).toContain('exec-new');
-    // The oldest entry must have been evicted.
-    expect(stored).not.toContain('old-exec-0');
-  });
-
-  it('swallows getHistory errors and does not open modal', async () => {
-    mockGetHistory.mockRejectedValue(new Error('network error'));
-    // Should not throw.
-    await expect(maybeOfferArcheraAfterExecution()).resolves.toBeUndefined();
-    const container = document.getElementById('archera-offer-modal-container')!;
-    expect(container.classList.contains('hidden')).toBe(true);
-  });
-
-  it('fires for the most recent completed purchase when multiple exist', async () => {
-    const older = recentCompleted('exec-older', 3);
-    const newer = recentCompleted('exec-newer', 1);
-    mockGetHistory.mockResolvedValue({ purchases: [older, newer] });
-    await maybeOfferArcheraAfterExecution();
-    // exec-newer should be recorded (most recent) — not exec-older.
-    const stored = captureOfferedForWrite();
-    expect(stored).toContain('exec-newer');
-    expect(stored).not.toContain('exec-older');
-  });
-
-  it('skips executions that lack a purchase_id', async () => {
-    // A row without purchase_id (legacy) must not be offered.
-    const ts = new Date().toISOString();
-    mockGetHistory.mockResolvedValue({
-      purchases: [{ timestamp: ts, status: 'completed' }], // no purchase_id
-    });
-    await maybeOfferArcheraAfterExecution();
-    const container = document.getElementById('archera-offer-modal-container')!;
-    expect(container.classList.contains('hidden')).toBe(true);
   });
 });

--- a/frontend/src/__tests__/plans.test.ts
+++ b/frontend/src/__tests__/plans.test.ts
@@ -64,6 +64,12 @@ jest.mock('../commitmentOptions', () => ({
   normalizePaymentValue: jest.fn((value) => value)
 }));
 
+// Mock archera: savePlan must NOT call openArcheraOfferModal after #499.
+const mockOpenArcheraOfferModal = jest.fn();
+jest.mock('../archera', () => ({
+  openArcheraOfferModal: (...args: unknown[]) => mockOpenArcheraOfferModal(...args),
+}));
+
 // Q7: plans.ts migrated alert() → showToast and destructive confirm() →
 // confirmDialog. Mock both so tests can assert calls and control confirm.
 const mockShowToast = jest.fn<{ dismiss: () => void }, [unknown]>(() => ({ dismiss: jest.fn() }));
@@ -93,6 +99,7 @@ import { populateTermSelect, populatePaymentSelect, isValidCombination } from '.
 
 describe('Plans Module', () => {
   beforeEach(() => {
+    mockOpenArcheraOfferModal.mockClear();
     // Reset DOM with full form structure
     document.body.innerHTML = `
       <div id="plans-list"></div>
@@ -1056,6 +1063,33 @@ describe('Plans Module', () => {
       expect(api.createPlan).toHaveBeenCalledWith(expect.objectContaining({
         ramp_schedule: 'monthly-10pct'
       }));
+    });
+
+    test('does NOT open Archera offer modal on plan create (fix #499)', async () => {
+      // After #499 the modal must be surfaced only after execution completes,
+      // never at plan-save time. Regression guard: ensure the removed call
+      // does not come back.
+      (api.createPlan as jest.Mock).mockResolvedValue({});
+      (api.getPlans as jest.Mock).mockResolvedValue({ plans: [] });
+      (api.getPlannedPurchases as jest.Mock).mockResolvedValue({ purchases: [] });
+      (document.getElementById('plan-id') as HTMLInputElement).value = '';
+
+      const event = { preventDefault: jest.fn() } as unknown as Event;
+      await savePlan(event);
+
+      expect(mockOpenArcheraOfferModal).not.toHaveBeenCalled();
+    });
+
+    test('does NOT open Archera offer modal on plan update (fix #499)', async () => {
+      (api.updatePlan as jest.Mock).mockResolvedValue({});
+      (api.getPlans as jest.Mock).mockResolvedValue({ plans: [] });
+      (api.getPlannedPurchases as jest.Mock).mockResolvedValue({ purchases: [] });
+      (document.getElementById('plan-id') as HTMLInputElement).value = 'plan-123';
+
+      const event = { preventDefault: jest.fn() } as unknown as Event;
+      await savePlan(event);
+
+      expect(mockOpenArcheraOfferModal).not.toHaveBeenCalled();
     });
   });
 

--- a/frontend/src/__tests__/plans.test.ts
+++ b/frontend/src/__tests__/plans.test.ts
@@ -1077,6 +1077,9 @@ describe('Plans Module', () => {
       const event = { preventDefault: jest.fn() } as unknown as Event;
       await savePlan(event);
 
+      // Guard against false positives: confirm the save actually ran (not a
+      // short-circuit) so the "modal not called" assertion is meaningful.
+      expect(api.createPlan).toHaveBeenCalledTimes(1);
       expect(mockOpenArcheraOfferModal).not.toHaveBeenCalled();
     });
 
@@ -1089,6 +1092,8 @@ describe('Plans Module', () => {
       const event = { preventDefault: jest.fn() } as unknown as Event;
       await savePlan(event);
 
+      // Guard against false positives: confirm the update actually ran.
+      expect(api.updatePlan).toHaveBeenCalledWith('plan-123', expect.any(Object));
       expect(mockOpenArcheraOfferModal).not.toHaveBeenCalled();
     });
   });

--- a/frontend/src/__tests__/purchase-execution-toast.test.ts
+++ b/frontend/src/__tests__/purchase-execution-toast.test.ts
@@ -96,12 +96,21 @@ jest.mock('../confirmDialog', () => ({
   confirmDialog: jest.fn().mockResolvedValue(true),
 }));
 
+// Archera offer modal: after issue #499 follow-up the offer must fire on the
+// success path of the approval-submission call (right after the user approves
+// the pre-purchase confirmation), not after the async execution completes.
+jest.mock('../archera', () => ({
+  handleArcheraDeeplink: jest.fn(),
+  openArcheraOfferModal: jest.fn(),
+}));
+
 // ── imports ───────────────────────────────────────────────────────────────────
 
 import { setupEventListeners } from '../app';
 import * as api from '../api';
 import * as recs from '../recommendations';
 import * as plans from '../plans';
+import * as archera from '../archera';
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
@@ -233,6 +242,35 @@ describe('handleExecutePurchase — single-record path', () => {
 
     expect(lastToastKind()).toBe('warning');
     expect(lastToastMessage()).toContain('no notification email configured');
+  });
+
+  // Issue #499 follow-up: offer timing moved from post-execution to the
+  // approval-submission success path (right after the user approves the
+  // pre-purchase confirmation).
+  test('opens Archera offer modal once the approval submission succeeds', async () => {
+    (api.executePurchase as jest.Mock).mockResolvedValue({
+      execution_id: 'exec-ok',
+      status: 'queued',
+      email_sent: true,
+      approval_recipient: 'approver@example.com',
+    });
+
+    const btn = setup();
+    btn.click();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(archera.openArcheraOfferModal).toHaveBeenCalledWith('purchase');
+  });
+
+  test('does NOT open Archera offer modal when the approval submission throws', async () => {
+    (api.executePurchase as jest.Mock).mockRejectedValue(new Error('boom'));
+
+    const btn = setup();
+    btn.click();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(lastToastKind()).toBe('error');
+    expect(archera.openArcheraOfferModal).not.toHaveBeenCalled();
   });
 });
 
@@ -408,5 +446,36 @@ describe('handleFanOutExecute — fan-out path', () => {
     const msg = lastToastMessage();
     expect(lastToastKind()).toBe('error');
     expect(msg).toContain('no SMTP config');
+    // Issue #499 follow-up: with zero successful submissions there is nothing
+    // to insure, so the offer must not fire.
+    expect(archera.openArcheraOfferModal).not.toHaveBeenCalled();
+  });
+
+  // Issue #499 follow-up: offer fires when at least one bucket's approval
+  // submission succeeds, immediately after the user approves the confirmation.
+  test('opens Archera offer modal when at least one bucket succeeds', async () => {
+    (recs.getFanOutBuckets as jest.Mock).mockReturnValue([
+      buildBucket('a'),
+      buildBucket('b'),
+    ]);
+
+    (api.executePurchase as jest.Mock)
+      .mockResolvedValueOnce({
+        execution_id: 'exec-a',
+        status: 'queued',
+        email_sent: true,
+        approval_recipient: 'alice@example.com',
+      })
+      .mockResolvedValueOnce({
+        execution_id: 'exec-b',
+        status: 'failed',
+        email_reason: 'backend error',
+      });
+
+    const btn = setup();
+    btn.click();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(archera.openArcheraOfferModal).toHaveBeenCalledWith('purchase');
   });
 });

--- a/frontend/src/__tests__/purchase-execution-toast.test.ts
+++ b/frontend/src/__tests__/purchase-execution-toast.test.ts
@@ -259,6 +259,7 @@ describe('handleExecutePurchase — single-record path', () => {
     btn.click();
     await new Promise((r) => setTimeout(r, 0));
 
+    expect(archera.openArcheraOfferModal).toHaveBeenCalledTimes(1);
     expect(archera.openArcheraOfferModal).toHaveBeenCalledWith('purchase');
   });
 
@@ -476,6 +477,7 @@ describe('handleFanOutExecute — fan-out path', () => {
     btn.click();
     await new Promise((r) => setTimeout(r, 0));
 
+    expect(archera.openArcheraOfferModal).toHaveBeenCalledTimes(1);
     expect(archera.openArcheraOfferModal).toHaveBeenCalledWith('purchase');
   });
 });

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -18,7 +18,7 @@ import { setupRIExchangeHandlers, saveAutomationSettings } from './riexchange';
 import { showToast } from './toast';
 import { confirmDialog } from './confirmDialog';
 import { handlePurchaseDeeplink } from './purchases-deeplink';
-import { handleArcheraDeeplink, openArcheraOfferModal } from './archera';
+import { handleArcheraDeeplink, maybeOfferArcheraAfterExecution } from './archera';
 import { closeModal } from './modal';
 
 /**
@@ -71,6 +71,12 @@ export async function init(): Promise<void> {
     // how-it-works) open the overlay panel on top of the dashboard. Normal
     // tab routing still runs underneath so the app is fully functional.
     handleArcheraDeeplink();
+    // Detect completed executions from the past 7 days and surface the
+    // Archera Insurance offer once per execution. Runs on every dashboard
+    // load so the offer fires after the approver clicks the email link
+    // (async approval flow) rather than when the approval request is sent.
+    // Errors are swallowed inside the function; app init is not blocked.
+    await maybeOfferArcheraAfterExecution();
     const target = applyTabFromPath();
     let url = '/' + target;
     if (target === 'admin') {
@@ -386,13 +392,6 @@ async function handleExecutePurchase(): Promise<void> {
       });
     }
     await loadDashboard();
-    // Offer Archera Insurance after a successful approval submission.
-    // The actual cloud commitment isn't charged until the approver clicks
-    // the email link, but the user has now committed their intent — this
-    // is the natural moment to surface optional insurance coverage.
-    // Only fires on the success path; on email_sent=false we still opened
-    // a pending execution so the offer is still relevant.
-    openArcheraOfferModal('purchase');
   } catch (error) {
     const err = error as Error;
     showToast({ message: `Failed to send purchase for approval: ${err.message}`, kind: 'error' });
@@ -516,13 +515,6 @@ async function handleFanOutExecute(buckets: FanOutBucket[]): Promise<void> {
     });
   }
   await loadDashboard();
-
-  // Offer Archera Insurance when at least one bucket succeeded. Skipping
-  // the offer on the all-fail path keeps the modal from layering on top
-  // of an error toast for a user who has nothing to insure yet.
-  if (succeeded > 0) {
-    openArcheraOfferModal('purchase');
-  }
 
   if (executeBtn) {
     executeBtn.disabled = false;

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -18,7 +18,7 @@ import { setupRIExchangeHandlers, saveAutomationSettings } from './riexchange';
 import { showToast } from './toast';
 import { confirmDialog } from './confirmDialog';
 import { handlePurchaseDeeplink } from './purchases-deeplink';
-import { handleArcheraDeeplink, maybeOfferArcheraAfterExecution } from './archera';
+import { handleArcheraDeeplink, openArcheraOfferModal } from './archera';
 import { closeModal } from './modal';
 
 /**
@@ -71,12 +71,6 @@ export async function init(): Promise<void> {
     // how-it-works) open the overlay panel on top of the dashboard. Normal
     // tab routing still runs underneath so the app is fully functional.
     handleArcheraDeeplink();
-    // Detect completed executions from the past 7 days and surface the
-    // Archera Insurance offer once per execution. Runs on every dashboard
-    // load so the offer fires after the approver clicks the email link
-    // (async approval flow) rather than when the approval request is sent.
-    // Errors are swallowed inside the function; app init is not blocked.
-    await maybeOfferArcheraAfterExecution();
     const target = applyTabFromPath();
     let url = '/' + target;
     if (target === 'admin') {
@@ -391,6 +385,13 @@ async function handleExecutePurchase(): Promise<void> {
         timeout: 10_000,
       });
     }
+    // Offer Archera Insurance immediately after the user approves the
+    // pre-purchase confirmation and the approval-submission call succeeds
+    // (issue #499 follow-up). Firing here, rather than after the async
+    // email-link execution completes, surfaces the optional coverage at
+    // the moment the user has committed their intent. Gated on the
+    // executePurchase success path so a failed submission shows no offer.
+    openArcheraOfferModal('purchase');
     await loadDashboard();
   } catch (error) {
     const err = error as Error;
@@ -514,6 +515,16 @@ async function handleFanOutExecute(buckets: FanOutBucket[]): Promise<void> {
       timeout: null,
     });
   }
+  // Offer Archera Insurance when at least one bucket's approval submission
+  // succeeded (issue #499 follow-up). Fires right after the user approves
+  // the pre-purchase confirmation and the calls resolve, not after the
+  // async email-link execution completes. Skipping the all-fail path keeps
+  // the modal from layering on top of an error toast for a user who has
+  // nothing to insure yet.
+  if (succeeded > 0) {
+    openArcheraOfferModal('purchase');
+  }
+
   await loadDashboard();
 
   if (executeBtn) {

--- a/frontend/src/archera.ts
+++ b/frontend/src/archera.ts
@@ -2,10 +2,13 @@
  * Archera Insurance integration: post-action offer modal + education page.
  *
  * This module provides:
- *   - openArcheraOfferModal(context): small modal shown AFTER a successful
- *     purchase-approval submission or plan creation. Offers "Sign up at
- *     Archera →" (opens archera.ai in a new tab) or "No thanks". Carries
- *     a "Learn more" link to the full education page below the buttons.
+ *   - openArcheraOfferModal(context): small modal shown AFTER a completed
+ *     purchase execution. Offers "Sign up at Archera =" (opens archera.ai
+ *     in a new tab) or "No thanks". Carries a "Learn more" link to the
+ *     full education page below the buttons.
+ *   - maybeOfferArcheraAfterExecution(): detector run on dashboard load.
+ *     Fetches recent purchase history, finds the most recent completed
+ *     execution not yet offered, and calls openArcheraOfferModal once.
  *   - openArcheraPage(): the full education page rendered as a
  *     full-viewport overlay (#archera-page-container). Opened from the
  *     offer modal's "Learn more" link and from deep-linked email URLs.
@@ -21,6 +24,9 @@
  *
  * No backend, routing, or IaC changes (frontend-only).
  */
+
+import * as api from './api';
+import type { HistoryResponse, HistoryPurchase } from './types';
 
 /** Canonical Archera signup URL with CUDly attribution. */
 export const ARCHERA_SIGNUP_URL = 'https://archera.ai/signup?mode=cudly';
@@ -519,4 +525,110 @@ function buildSignupBlock(): HTMLElement {
   div.appendChild(note);
 
   return div;
+}
+
+// ---------------------------------------------------------------------------
+// Post-execution offer detector
+// ---------------------------------------------------------------------------
+
+/**
+ * localStorage key for the set of purchase_id strings the Archera offer has
+ * already been shown for. Stored as a JSON string array; capped at
+ * ARCHERA_OFFERED_FOR_CAP entries (FIFO) to prevent unbounded growth.
+ */
+export const ARCHERA_OFFERED_FOR_KEY = 'cudly.archera.offeredForExecutions';
+
+/**
+ * Number of days to look back when searching for completed executions that
+ * warrant an Archera offer. Matches the "7 days from each purchase to sign
+ * up at Archera" enrollment window described on the education page.
+ */
+export const ARCHERA_OFFER_WINDOW_DAYS = 7;
+
+/** Maximum entries kept in the offered-for localStorage set (FIFO). */
+const ARCHERA_OFFERED_FOR_CAP = 50;
+
+/**
+ * Read the offered-for set from localStorage.
+ * Returns an empty array when localStorage is unavailable or the value is
+ * missing/malformed (private browsing, quota-exceeded, corrupted JSON).
+ */
+function readOfferedForSet(): string[] {
+  try {
+    const raw = localStorage.getItem(ARCHERA_OFFERED_FOR_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (Array.isArray(parsed)) {
+      return (parsed as unknown[]).filter((x): x is string => typeof x === 'string');
+    }
+    return [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Write the offered-for set back to localStorage.
+ * Silently ignores write failures (private browsing, quota-exceeded).
+ */
+function writeOfferedForSet(ids: string[]): void {
+  try {
+    // Enforce FIFO cap: keep only the most recent ARCHERA_OFFERED_FOR_CAP entries.
+    const capped = ids.slice(-ARCHERA_OFFERED_FOR_CAP);
+    localStorage.setItem(ARCHERA_OFFERED_FOR_KEY, JSON.stringify(capped));
+  } catch {
+    // Non-fatal; the modal may re-fire on the next load, which is acceptable.
+  }
+}
+
+/**
+ * Detector run on every dashboard load.
+ *
+ * Fetches executions from the past ARCHERA_OFFER_WINDOW_DAYS days via the
+ * existing purchase-history endpoint (no new backend endpoint). Finds the
+ * most recent completed execution the user has not been offered Archera for,
+ * and calls openArcheraOfferModal('purchase') exactly once. Tracks shown
+ * executions in localStorage under ARCHERA_OFFERED_FOR_KEY (FIFO, capped at
+ * ARCHERA_OFFERED_FOR_CAP entries) so the modal is not repeated.
+ *
+ * Errors are swallowed: a history-fetch failure must not block app init.
+ */
+export async function maybeOfferArcheraAfterExecution(): Promise<void> {
+  try {
+    const start = new Date();
+    start.setDate(start.getDate() - ARCHERA_OFFER_WINDOW_DAYS);
+    const startStr = start.toISOString().split('T')[0] ?? '';
+
+    const raw = await api.getHistory({ start: startStr });
+    // api.getHistory is typed as returning PurchaseHistory[], but the server
+    // actually returns a HistoryResponse envelope ({summary, purchases}).
+    // history.ts casts it the same way; we follow the same pattern.
+    const data = raw as unknown as HistoryResponse;
+    const purchases: HistoryPurchase[] = data.purchases ?? [];
+
+    // Keep only completed executions with a trackable purchase_id.
+    const completed = purchases.filter(
+      (p): p is HistoryPurchase & { purchase_id: string } =>
+        typeof p.purchase_id === 'string' &&
+        p.purchase_id.length > 0 &&
+        (p.status || 'completed') === 'completed',
+    );
+    if (completed.length === 0) return;
+
+    // Most recent first.
+    completed.sort((a, b) => Date.parse(b.timestamp) - Date.parse(a.timestamp));
+    const latest = completed[0];
+    if (!latest) return;
+
+    const offeredFor = readOfferedForSet();
+    if (offeredFor.includes(latest.purchase_id)) return;
+
+    // Record before opening so a re-entrant call can't double-fire.
+    offeredFor.push(latest.purchase_id);
+    writeOfferedForSet(offeredFor);
+
+    openArcheraOfferModal('purchase');
+  } catch {
+    // Non-fatal: history fetch failure must not block app init.
+  }
 }

--- a/frontend/src/archera.ts
+++ b/frontend/src/archera.ts
@@ -2,13 +2,11 @@
  * Archera Insurance integration: post-action offer modal + education page.
  *
  * This module provides:
- *   - openArcheraOfferModal(context): small modal shown AFTER a completed
- *     purchase execution. Offers "Sign up at Archera =" (opens archera.ai
- *     in a new tab) or "No thanks". Carries a "Learn more" link to the
- *     full education page below the buttons.
- *   - maybeOfferArcheraAfterExecution(): detector run on dashboard load.
- *     Fetches recent purchase history, finds the most recent completed
- *     execution not yet offered, and calls openArcheraOfferModal once.
+ *   - openArcheraOfferModal(context): small modal shown immediately after
+ *     the user approves a purchase in the pre-purchase confirmation and the
+ *     approval-submission call succeeds. Offers "Sign up at Archera →"
+ *     (opens archera.ai in a new tab) or "No thanks". Carries a "Learn more"
+ *     link to the full education page below the buttons.
  *   - openArcheraPage(): the full education page rendered as a
  *     full-viewport overlay (#archera-page-container). Opened from the
  *     offer modal's "Learn more" link and from deep-linked email URLs.
@@ -24,9 +22,6 @@
  *
  * No backend, routing, or IaC changes (frontend-only).
  */
-
-import * as api from './api';
-import type { HistoryResponse, HistoryPurchase } from './types';
 
 /** Canonical Archera signup URL with CUDly attribution. */
 export const ARCHERA_SIGNUP_URL = 'https://archera.ai/signup?mode=cudly';
@@ -525,110 +520,4 @@ function buildSignupBlock(): HTMLElement {
   div.appendChild(note);
 
   return div;
-}
-
-// ---------------------------------------------------------------------------
-// Post-execution offer detector
-// ---------------------------------------------------------------------------
-
-/**
- * localStorage key for the set of purchase_id strings the Archera offer has
- * already been shown for. Stored as a JSON string array; capped at
- * ARCHERA_OFFERED_FOR_CAP entries (FIFO) to prevent unbounded growth.
- */
-export const ARCHERA_OFFERED_FOR_KEY = 'cudly.archera.offeredForExecutions';
-
-/**
- * Number of days to look back when searching for completed executions that
- * warrant an Archera offer. Matches the "7 days from each purchase to sign
- * up at Archera" enrollment window described on the education page.
- */
-export const ARCHERA_OFFER_WINDOW_DAYS = 7;
-
-/** Maximum entries kept in the offered-for localStorage set (FIFO). */
-const ARCHERA_OFFERED_FOR_CAP = 50;
-
-/**
- * Read the offered-for set from localStorage.
- * Returns an empty array when localStorage is unavailable or the value is
- * missing/malformed (private browsing, quota-exceeded, corrupted JSON).
- */
-function readOfferedForSet(): string[] {
-  try {
-    const raw = localStorage.getItem(ARCHERA_OFFERED_FOR_KEY);
-    if (!raw) return [];
-    const parsed = JSON.parse(raw) as unknown;
-    if (Array.isArray(parsed)) {
-      return (parsed as unknown[]).filter((x): x is string => typeof x === 'string');
-    }
-    return [];
-  } catch {
-    return [];
-  }
-}
-
-/**
- * Write the offered-for set back to localStorage.
- * Silently ignores write failures (private browsing, quota-exceeded).
- */
-function writeOfferedForSet(ids: string[]): void {
-  try {
-    // Enforce FIFO cap: keep only the most recent ARCHERA_OFFERED_FOR_CAP entries.
-    const capped = ids.slice(-ARCHERA_OFFERED_FOR_CAP);
-    localStorage.setItem(ARCHERA_OFFERED_FOR_KEY, JSON.stringify(capped));
-  } catch {
-    // Non-fatal; the modal may re-fire on the next load, which is acceptable.
-  }
-}
-
-/**
- * Detector run on every dashboard load.
- *
- * Fetches executions from the past ARCHERA_OFFER_WINDOW_DAYS days via the
- * existing purchase-history endpoint (no new backend endpoint). Finds the
- * most recent completed execution the user has not been offered Archera for,
- * and calls openArcheraOfferModal('purchase') exactly once. Tracks shown
- * executions in localStorage under ARCHERA_OFFERED_FOR_KEY (FIFO, capped at
- * ARCHERA_OFFERED_FOR_CAP entries) so the modal is not repeated.
- *
- * Errors are swallowed: a history-fetch failure must not block app init.
- */
-export async function maybeOfferArcheraAfterExecution(): Promise<void> {
-  try {
-    const start = new Date();
-    start.setDate(start.getDate() - ARCHERA_OFFER_WINDOW_DAYS);
-    const startStr = start.toISOString().split('T')[0] ?? '';
-
-    const raw = await api.getHistory({ start: startStr });
-    // api.getHistory is typed as returning PurchaseHistory[], but the server
-    // actually returns a HistoryResponse envelope ({summary, purchases}).
-    // history.ts casts it the same way; we follow the same pattern.
-    const data = raw as unknown as HistoryResponse;
-    const purchases: HistoryPurchase[] = data.purchases ?? [];
-
-    // Keep only completed executions with a trackable purchase_id.
-    const completed = purchases.filter(
-      (p): p is HistoryPurchase & { purchase_id: string } =>
-        typeof p.purchase_id === 'string' &&
-        p.purchase_id.length > 0 &&
-        (p.status || 'completed') === 'completed',
-    );
-    if (completed.length === 0) return;
-
-    // Most recent first.
-    completed.sort((a, b) => Date.parse(b.timestamp) - Date.parse(a.timestamp));
-    const latest = completed[0];
-    if (!latest) return;
-
-    const offeredFor = readOfferedForSet();
-    if (offeredFor.includes(latest.purchase_id)) return;
-
-    // Record before opening so a re-entrant call can't double-fire.
-    offeredFor.push(latest.purchase_id);
-    writeOfferedForSet(offeredFor);
-
-    openArcheraOfferModal('purchase');
-  } catch {
-    // Non-fatal: history fetch failure must not block app init.
-  }
 }

--- a/frontend/src/plans.ts
+++ b/frontend/src/plans.ts
@@ -12,7 +12,6 @@ import { viewPlanHistory } from './history';
 import type { PlannedPurchase } from './api';
 import { populateTermSelect, populatePaymentSelect, isValidCombination, normalizePaymentValue } from './commitmentOptions';
 import { openModal, closeModal } from './modal';
-import { openArcheraOfferModal } from './archera';
 import { showSkeletonTiles, showSkeletonRows, teardownSkeleton } from './lib/skeleton';
 import { canAccess } from './permissions';
 
@@ -634,11 +633,6 @@ export async function savePlan(e: Event): Promise<void> {
     closePlanModal();
     await loadPlans();
     showToast({ message: planId ? 'Plan updated successfully' : 'Plan created successfully', kind: 'success', timeout: 5_000 });
-    // Offer Archera Insurance after a newly created plan only — updates
-    // never carry a fresh commitment intent, so the offer would be noise.
-    if (!planId) {
-      openArcheraOfferModal('plan');
-    }
   } catch (error) {
     console.error('Failed to save plan:', error);
     const err = error as Error;


### PR DESCRIPTION
## Summary

Per follow-up feedback on #499, the Archera offer modal now appears the
moment the user approves the pre-purchase confirmation (right after the
approval-submission call succeeds), not after the async email-link
execution later completes and not at approval-request click time.

## What changed (per file)

- `frontend/src/app.ts`: call `openArcheraOfferModal('purchase')` on the
  `executePurchase` success path in `handleExecutePurchase` and
  `handleFanOutExecute` (the fan-out path is gated on at least one
  successful submission). Removed the dashboard-load detector call from
  `init()` and switched the import back to `openArcheraOfferModal`.
- `frontend/src/archera.ts`: removed `maybeOfferArcheraAfterExecution`
  plus its `localStorage` offered-for set, FIFO cap, and the now-unused
  `api` / history-type imports. Updated the module header doc.
- `frontend/src/__tests__/purchase-execution-toast.test.ts`: mock
  `../archera`; assert the offer fires after a successful approval
  submission (single + fan-out) and never on the failure / all-fail path.
- `frontend/src/__tests__/archera.test.ts`: removed the post-execution
  detector test block and its unused imports/mocks.
- `frontend/src/__tests__/plans.test.ts`: unchanged regression guards
  confirm the modal is never opened on plan create/update.

## Trigger timing decision

The offer fires **after the approval-submission API call returns
success**, not optimistically on click. If the submission throws, no
offer is shown. On a business-level `email_sent === false` warning the
offer still fires, because a pending execution was created and the user
has committed their intent (matching the prior call-site semantics).

## Disclosure compliance

The non-gating sponsorship disclosure on the offer modal and the full
disclosure on the education page are untouched and remain guarded by the
`/sponsors/i` assertions in `archera.test.ts`.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `archera.test.ts`, `purchase-execution-toast.test.ts`, and
      `plans.test.ts` pass
- [x] Full suite: only the pre-existing unrelated
      `settings-purchasing-grace.test.ts` failure remains
- [ ] Modal appears immediately after clicking Approve on the
      pre-purchase confirmation (single + bulk fan-out)
- [ ] Modal does not appear if the approval submission fails
- [ ] Modal still does not appear on plan create/update

Closes #499


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Insurance offer modal now displays immediately after purchase approval succeeds, before the dashboard reloads.
  * Insurance offer modal no longer appears when creating or updating plans.

* **Tests**
  * Added tests covering insurance offer modal behavior for purchase executions, including single-record and fan-out scenarios (success vs. all-fail paths).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/507?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->