### PR TITLE
sec(purchases): approval-token hardening (closes #408, #397, #398)

### DIFF
--- a/frontend/src/purchases-deeplink.ts
+++ b/frontend/src/purchases-deeplink.ts
@@ -99,10 +99,16 @@ export async function handlePurchaseDeeplink(): Promise<boolean> {
     return true;
   }
 
-  const endpoint = `/purchases/${dl.action}/${encodeURIComponent(dl.id)}?token=${encodeURIComponent(dl.token)}`;
+  // Issue #398: pass the token in the POST body rather than the query string
+  // so it does not appear in Lambda Function URL access logs (which record
+  // rawQueryString but not the request body).
+  const endpoint = `/purchases/${dl.action}/${encodeURIComponent(dl.id)}`;
   const actionPast = dl.action === 'approve' ? 'approved' : 'cancelled';
   try {
-    await apiRequest<{ status: string }>(endpoint, { method: 'POST' });
+    await apiRequest<{ status: string }>(endpoint, {
+      method: 'POST',
+      body: JSON.stringify({ token: dl.token }),
+    });
     showToast({ message: `Purchase ${actionPast}.`, kind: 'success', timeout: 5_000 });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);

--- a/internal/api/handler_purchases.go
+++ b/internal/api/handler_purchases.go
@@ -795,25 +795,36 @@ func (h *Handler) persistRetryExecution(ctx context.Context, failedExec *config.
 	// "successor" is a footgun we want to remove at the source.
 	copiedRecs := append([]config.RecommendationRecord(nil), failedExec.Recommendations...)
 
+	// Generate a crypto/rand-backed approval token for the retry execution
+	// (issue #408). uuid.New().String() was used here previously, which only
+	// provides 122 bits of entropy in a known format; common.GenerateApprovalToken
+	// provides 256 bits of uniform randomness, matching every other creation site.
+	approvalToken, err := common.GenerateApprovalToken()
+	if err != nil {
+		return nil, fmt.Errorf("generate approval token for retry: %w", err)
+	}
+	tokenExpiresAt := time.Now().Add(config.ApprovalTokenTTL)
+
 	newExecutionID := uuid.New().String()
 	// PlanID + StepNumber propagate from the predecessor so a retried
 	// planned execution stays attributed to its plan + ramp step (CR
 	// #168 review). For ad-hoc executions PlanID is "" and StepNumber
 	// is 0, so propagation is a no-op for the non-plan case.
 	newExecution := &config.PurchaseExecution{
-		ExecutionID:      newExecutionID,
-		PlanID:           failedExec.PlanID,
-		StepNumber:       failedExec.StepNumber,
-		Status:           "pending",
-		ScheduledDate:    time.Now(),
-		Recommendations:  copiedRecs,
-		TotalUpfrontCost: totalUpfront,
-		EstimatedSavings: totalSavings,
-		ApprovalToken:    uuid.New().String(),
-		Source:           common.PurchaseSourceWeb,
-		CapacityPercent:  failedExec.CapacityPercent,
-		CreatedByUserID:  resolveCreatorUserID(session),
-		RetryAttemptN:    failedExec.RetryAttemptN + 1,
+		ExecutionID:            newExecutionID,
+		PlanID:                 failedExec.PlanID,
+		StepNumber:             failedExec.StepNumber,
+		Status:                 "pending",
+		ScheduledDate:          time.Now(),
+		Recommendations:        copiedRecs,
+		TotalUpfrontCost:       totalUpfront,
+		EstimatedSavings:       totalSavings,
+		ApprovalToken:          approvalToken,
+		ApprovalTokenExpiresAt: &tokenExpiresAt,
+		Source:                 common.PurchaseSourceWeb,
+		CapacityPercent:        failedExec.CapacityPercent,
+		CreatedByUserID:        resolveCreatorUserID(session),
+		RetryAttemptN:          failedExec.RetryAttemptN + 1,
 	}
 
 	// Stamp the original failed row with the linkage. This is a
@@ -1146,16 +1157,18 @@ func newPendingExecution(req *ExecutePurchaseRequest, totalUpfront, totalSavings
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate approval token: %w", err)
 	}
+	tokenExpiresAt := time.Now().Add(config.ApprovalTokenTTL)
 	return &config.PurchaseExecution{
-		ExecutionID:      uuid.New().String(),
-		Status:           "pending",
-		ScheduledDate:    time.Now(),
-		Recommendations:  req.Recommendations,
-		TotalUpfrontCost: totalUpfront,
-		EstimatedSavings: totalSavings,
-		ApprovalToken:    approvalToken,
-		Source:           common.PurchaseSourceWeb,
-		CapacityPercent:  req.CapacityPercent,
+		ExecutionID:            uuid.New().String(),
+		Status:                 "pending",
+		ScheduledDate:          time.Now(),
+		Recommendations:        req.Recommendations,
+		TotalUpfrontCost:       totalUpfront,
+		EstimatedSavings:       totalSavings,
+		ApprovalToken:          approvalToken,
+		ApprovalTokenExpiresAt: &tokenExpiresAt,
+		Source:                 common.PurchaseSourceWeb,
+		CapacityPercent:        req.CapacityPercent,
 	}, nil
 }
 

--- a/internal/api/handler_purchases_test.go
+++ b/internal/api/handler_purchases_test.go
@@ -2126,6 +2126,129 @@ func TestHandler_retryPurchase_AlreadyRetried_RBACBeforeLeak(t *testing.T) {
 	}
 }
 
+// --- Regression tests for issue #408 (crypto/rand token in retry path) ---
+
+// TestPersistRetryExecution_ApprovalTokenNotUUID is the regression guard for
+// issue #408. Before the fix, persistRetryExecution set ApprovalToken via
+// uuid.New().String(), producing a 36-char UUID (122 bits, known format).
+// After the fix it uses common.GenerateApprovalToken(), producing a 64-char
+// hex string (256 bits). We assert the length and character set rather than
+// a specific value so the test never needs updating when entropy sources differ.
+func TestPersistRetryExecution_ApprovalTokenNotUUID(t *testing.T) {
+	creator := retryCallerID
+	failed := &config.PurchaseExecution{
+		ExecutionID:     retryExecID,
+		Status:          "failed",
+		Error:           "ses throttle",
+		CreatedByUserID: &creator,
+		Recommendations: []config.RecommendationRecord{{Provider: "aws", Service: "ec2", Term: 1}},
+	}
+	session := &Session{UserID: retryCallerID, Role: "admin", Email: "admin@example.com"}
+	newExec, _ := runSessionRetryAllowed(t, failed, session, false, false, sessionRetryReq())
+
+	// 64 hex characters = 32 bytes = 256 bits. UUID format is 36 chars
+	// (xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx). This length check is the
+	// simplest distinguisher without importing crypto/rand in test code.
+	assert.Len(t, newExec.ApprovalToken, 64,
+		"retry approval token must be 64-char hex (256-bit crypto/rand), not a 36-char UUID")
+
+	// Also verify it is all hex (no hyphens — UUID has 4 hyphens).
+	for _, ch := range newExec.ApprovalToken {
+		assert.True(t, (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f'),
+			"approval token must be lowercase hex, got char %q", ch)
+	}
+}
+
+// TestPersistRetryExecution_ApprovalTokenExpiresAtSet is the regression guard
+// for issue #397 on the retry path: the new execution must carry a non-nil
+// ApprovalTokenExpiresAt within the expected TTL window.
+func TestPersistRetryExecution_ApprovalTokenExpiresAtSet(t *testing.T) {
+	creator := retryCallerID
+	failed := &config.PurchaseExecution{
+		ExecutionID:     retryExecID,
+		Status:          "failed",
+		Error:           "ses throttle",
+		CreatedByUserID: &creator,
+		Recommendations: []config.RecommendationRecord{{Provider: "aws", Service: "ec2", Term: 1}},
+	}
+	session := &Session{UserID: retryCallerID, Role: "admin", Email: "admin@example.com"}
+
+	before := time.Now()
+	newExec, _ := runSessionRetryAllowed(t, failed, session, false, false, sessionRetryReq())
+	after := time.Now()
+
+	require.NotNil(t, newExec.ApprovalTokenExpiresAt,
+		"retry execution must have ApprovalTokenExpiresAt set (issue #397)")
+
+	// Deadline must be strictly in the future from the test's perspective.
+	assert.True(t, newExec.ApprovalTokenExpiresAt.After(after),
+		"ApprovalTokenExpiresAt must be beyond now")
+	// And must not exceed the TTL from before by more than a minute's slop.
+	upperBound := before.Add(config.ApprovalTokenTTL).Add(time.Minute)
+	assert.True(t, newExec.ApprovalTokenExpiresAt.Before(upperBound),
+		"ApprovalTokenExpiresAt must not exceed ApprovalTokenTTL")
+}
+
+// --- Regression tests for issue #398 (token from POST body) ---
+
+// TestResolveApprovalToken_PostBodyTakesPriority is the regression guard for
+// issue #398. A POST with a token in the JSON body must use the body token,
+// preventing the token from appearing in Lambda URL access logs (which record
+// rawQueryString but not the body).
+func TestResolveApprovalToken_PostBodyTakesPriority(t *testing.T) {
+	req := &events.LambdaFunctionURLRequest{
+		RequestContext: events.LambdaFunctionURLRequestContext{
+			HTTP: events.LambdaFunctionURLRequestContextHTTPDescription{Method: "POST"},
+		},
+		Body:                  `{"token":"body-token"}`,
+		QueryStringParameters: map[string]string{"token": "qs-token"},
+	}
+	assert.Equal(t, "body-token", resolveApprovalToken(req),
+		"POST body token must take priority over query-string token (issue #398)")
+}
+
+// TestResolveApprovalToken_GetFallsBackToQueryString verifies the backward-
+// compat path: a GET request (e.g. a legacy email link that bypasses the
+// frontend SPA) reads the token from the query string.
+func TestResolveApprovalToken_GetFallsBackToQueryString(t *testing.T) {
+	req := &events.LambdaFunctionURLRequest{
+		RequestContext: events.LambdaFunctionURLRequestContext{
+			HTTP: events.LambdaFunctionURLRequestContextHTTPDescription{Method: "GET"},
+		},
+		QueryStringParameters: map[string]string{"token": "qs-token"},
+	}
+	assert.Equal(t, "qs-token", resolveApprovalToken(req),
+		"GET request must read token from query string")
+}
+
+// TestResolveApprovalToken_PostNoBody falls back to query string when the POST
+// body is empty (e.g. session-authed approve that sends no body).
+func TestResolveApprovalToken_PostNoBody(t *testing.T) {
+	req := &events.LambdaFunctionURLRequest{
+		RequestContext: events.LambdaFunctionURLRequestContext{
+			HTTP: events.LambdaFunctionURLRequestContextHTTPDescription{Method: "POST"},
+		},
+		Body:                  "",
+		QueryStringParameters: map[string]string{"token": "qs-token"},
+	}
+	assert.Equal(t, "qs-token", resolveApprovalToken(req),
+		"POST with empty body must fall back to query-string token")
+}
+
+// TestResolveApprovalToken_PostBodyNoToken falls back to query string when the
+// POST body exists but does not contain a "token" field.
+func TestResolveApprovalToken_PostBodyNoToken(t *testing.T) {
+	req := &events.LambdaFunctionURLRequest{
+		RequestContext: events.LambdaFunctionURLRequestContext{
+			HTTP: events.LambdaFunctionURLRequestContextHTTPDescription{Method: "POST"},
+		},
+		Body:                  `{"other_field":"value"}`,
+		QueryStringParameters: map[string]string{"token": "qs-token"},
+	}
+	assert.Equal(t, "qs-token", resolveApprovalToken(req),
+		"POST body without token field must fall back to query-string token")
+}
+
 func TestResolveOpsHint(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -456,13 +457,34 @@ func (r *Router) getPurchaseDetailsHandler(ctx context.Context, req *events.Lamb
 	return r.h.getPurchaseDetails(ctx, req, params["id"])
 }
 
+// resolveApprovalToken extracts the approval token for approve/cancel actions
+// (issue #398). For POST requests the token is read from the JSON request body
+// so it does not appear in the Lambda Function URL access logs (which log the
+// rawQueryString but not the body). The query string is still accepted as a
+// fallback so legacy GET clicks from email links (which carry the token in the
+// URL and land on the same handler via AuthPublic GET routes) continue to work
+// during the transition period.
+//
+// Priority: POST body > query string.
+func resolveApprovalToken(req *events.LambdaFunctionURLRequest) string {
+	if req.RequestContext.HTTP.Method == "POST" && req.Body != "" {
+		var body struct {
+			Token string `json:"token"`
+		}
+		if err := json.Unmarshal([]byte(req.Body), &body); err == nil && body.Token != "" {
+			return body.Token
+		}
+	}
+	return req.QueryStringParameters["token"]
+}
+
 func (r *Router) approvePurchaseHandler(ctx context.Context, req *events.LambdaFunctionURLRequest, params map[string]string) (any, error) {
-	token := req.QueryStringParameters["token"]
+	token := resolveApprovalToken(req)
 	return r.h.approvePurchase(ctx, req, params["id"], token)
 }
 
 func (r *Router) cancelPurchaseHandler(ctx context.Context, req *events.LambdaFunctionURLRequest, params map[string]string) (any, error) {
-	token := req.QueryStringParameters["token"]
+	token := resolveApprovalToken(req)
 	return r.h.cancelPurchase(ctx, req, params["id"], token)
 }
 

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -89,3 +89,11 @@ const (
 	// MFADigits is the number of digits in MFA codes
 	MFADigits = 6
 )
+
+// ApprovalTokenTTL is the lifetime of a purchase approval token (issue #397).
+// Tokens older than this are rejected by ApproveExecution and
+// loadCancelableExecution. 7 days gives approvers a full business week to act
+// without the window being infinite. Mirror the RI exchange model which uses a
+// 6-hour TTL; purchase approvals are higher-stakes so a longer window is
+// appropriate but must still be bounded.
+const ApprovalTokenTTL = 7 * 24 * time.Hour

--- a/internal/config/store_postgres.go
+++ b/internal/config/store_postgres.go
@@ -695,8 +695,9 @@ func (s *PostgresStore) SavePurchaseExecutionTx(ctx context.Context, tx pgx.Tx, 
 			notification_sent, approval_token, recommendations,
 			total_upfront_cost, estimated_savings, completed_at, error, expires_at,
 			cloud_account_id, source, approved_by, cancelled_by, capacity_percent,
-			created_by_user_id, retry_execution_id, retry_attempt_n
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)
+			created_by_user_id, retry_execution_id, retry_attempt_n,
+			approval_token_expires_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22)
 		ON CONFLICT (execution_id) DO UPDATE SET
 			status = $3,
 			notification_sent = $6,
@@ -713,6 +714,7 @@ func (s *PostgresStore) SavePurchaseExecutionTx(ctx context.Context, tx pgx.Tx, 
 			cancelled_by = $17,
 			capacity_percent = $18,
 			retry_execution_id = $20,
+			approval_token_expires_at = $22,
 			updated_at = NOW()
 	`
 
@@ -758,6 +760,7 @@ func (s *PostgresStore) SavePurchaseExecutionTx(ctx context.Context, tx pgx.Tx, 
 		execution.CreatedByUserID,
 		execution.RetryExecutionID,
 		execution.RetryAttemptN,
+		execution.ApprovalTokenExpiresAt,
 	)
 
 	if err != nil {
@@ -779,7 +782,8 @@ func (s *PostgresStore) TransitionExecutionStatus(ctx context.Context, execution
 		          notification_sent, approval_token, recommendations,
 		          total_upfront_cost, estimated_savings, completed_at, error, expires_at,
 		          cloud_account_id, source, approved_by, cancelled_by, capacity_percent,
-		          created_by_user_id, retry_execution_id, retry_attempt_n
+		          created_by_user_id, retry_execution_id, retry_attempt_n,
+		          approval_token_expires_at
 	`
 
 	records, err := s.queryExecutions(ctx, query, executionID, toStatus, fromStatuses)
@@ -818,7 +822,8 @@ func (s *PostgresStore) GetExecutionsByStatuses(ctx context.Context, statuses []
 		       notification_sent, approval_token, recommendations,
 		       total_upfront_cost, estimated_savings, completed_at, error, expires_at,
 		       cloud_account_id, source, approved_by, cancelled_by, capacity_percent,
-		       created_by_user_id, retry_execution_id, retry_attempt_n
+		       created_by_user_id, retry_execution_id, retry_attempt_n,
+		       approval_token_expires_at
 		FROM purchase_executions
 		WHERE status = ANY($1)
 		ORDER BY scheduled_date DESC
@@ -834,7 +839,8 @@ func (s *PostgresStore) GetPendingExecutions(ctx context.Context) ([]PurchaseExe
 		       notification_sent, approval_token, recommendations,
 		       total_upfront_cost, estimated_savings, completed_at, error, expires_at,
 		       cloud_account_id, source, approved_by, cancelled_by, capacity_percent,
-		       created_by_user_id, retry_execution_id, retry_attempt_n
+		       created_by_user_id, retry_execution_id, retry_attempt_n,
+		       approval_token_expires_at
 		FROM purchase_executions
 		WHERE status IN ('pending', 'notified')
 		  AND (expires_at IS NULL OR expires_at > NOW())
@@ -852,7 +858,8 @@ func (s *PostgresStore) GetExecutionByID(ctx context.Context, executionID string
 		       notification_sent, approval_token, recommendations,
 		       total_upfront_cost, estimated_savings, completed_at, error, expires_at,
 		       cloud_account_id, source, approved_by, cancelled_by, capacity_percent,
-		       created_by_user_id, retry_execution_id, retry_attempt_n
+		       created_by_user_id, retry_execution_id, retry_attempt_n,
+		       approval_token_expires_at
 		FROM purchase_executions
 		WHERE execution_id = $1
 	`
@@ -876,7 +883,8 @@ func (s *PostgresStore) GetExecutionByPlanAndDate(ctx context.Context, planID st
 		       notification_sent, approval_token, recommendations,
 		       total_upfront_cost, estimated_savings, completed_at, error, expires_at,
 		       cloud_account_id, source, approved_by, cancelled_by, capacity_percent,
-		       created_by_user_id, retry_execution_id, retry_attempt_n
+		       created_by_user_id, retry_execution_id, retry_attempt_n,
+		       approval_token_expires_at
 		FROM purchase_executions
 		WHERE plan_id = $1 AND scheduled_date = $2
 	`
@@ -905,7 +913,7 @@ func (s *PostgresStore) queryExecutions(ctx context.Context, query string, args 
 	for rows.Next() {
 		var exec PurchaseExecution
 		var recommendationsJSON []byte
-		var notifSent, completedAt, expiresAt sql.NullTime
+		var notifSent, completedAt, expiresAt, tokenExpiresAt sql.NullTime
 		// plan_id is nullable since migration 000033 (direct-execute
 		// rows from the Recommendations page have no originating plan).
 		var planID sql.NullString
@@ -932,6 +940,7 @@ func (s *PostgresStore) queryExecutions(ctx context.Context, query string, args 
 			&exec.CreatedByUserID,
 			&exec.RetryExecutionID,
 			&exec.RetryAttemptN,
+			&tokenExpiresAt,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan execution: %w", err)
@@ -955,6 +964,9 @@ func (s *PostgresStore) queryExecutions(ctx context.Context, query string, args 
 		}
 		if expiresAt.Valid {
 			exec.TTL = ttlFromTime(expiresAt.Time)
+		}
+		if tokenExpiresAt.Valid {
+			exec.ApprovalTokenExpiresAt = &tokenExpiresAt.Time
 		}
 
 		executions = append(executions, exec)

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -255,6 +255,15 @@ type PurchaseExecution struct {
 	// carries the scaled counts, so backend math is unaffected by this
 	// field. Defaults to 100 for legacy and scheduler-driven executions.
 	CapacityPercent int `json:"capacity_percent,omitempty" dynamodbav:"capacity_percent,omitempty"`
+	// ApprovalTokenExpiresAt is the UTC deadline after which the
+	// ApprovalToken must be rejected by ApproveExecution and
+	// loadCancelableExecution (issue #397). Set at execution creation to
+	// ScheduledDate + ApprovalTokenTTL. NULL on rows created before
+	// migration 000051 — legacy rows are treated as not-yet-expired
+	// (backward-compatible: the TTL-checking gate only fires when the
+	// field is non-nil). Migration 000051 adds the column; new rows
+	// always carry a non-nil value.
+	ApprovalTokenExpiresAt *time.Time `json:"approval_token_expires_at,omitempty" dynamodbav:"approval_token_expires_at,omitempty"`
 }
 
 // RecommendationRecord stores a recommendation with purchase status

--- a/internal/database/postgres/migrations/000051_purchase_executions_token_expires_at.down.sql
+++ b/internal/database/postgres/migrations/000051_purchase_executions_token_expires_at.down.sql
@@ -1,0 +1,6 @@
+-- 000051 rollback: remove approval_token_expires_at from purchase_executions
+
+DROP INDEX IF EXISTS idx_executions_token_expires_at;
+
+ALTER TABLE purchase_executions
+    DROP COLUMN IF EXISTS approval_token_expires_at;

--- a/internal/database/postgres/migrations/000051_purchase_executions_token_expires_at.up.sql
+++ b/internal/database/postgres/migrations/000051_purchase_executions_token_expires_at.up.sql
@@ -1,0 +1,25 @@
+-- 000051: add approval_token_expires_at to purchase_executions (issue #397)
+--
+-- Approval tokens previously had no expiry, allowing a token leaked via email
+-- forwarding, a phished mailbox, or an access-log export to remain valid
+-- indefinitely. This migration adds a nullable TIMESTAMPTZ column that
+-- creation paths now populate; the application layer rejects tokens whose
+-- deadline has passed (ApproveExecution / loadCancelableExecution in
+-- internal/purchase/approvals.go).
+--
+-- Column is nullable so existing rows (created before this migration) are
+-- unaffected: a NULL ApprovalTokenExpiresAt is treated as "no deadline" in
+-- the application layer for backward compatibility. All new executions
+-- created after this migration carry a non-null value (7-day TTL from
+-- creation time, per config.ApprovalTokenTTL).
+
+ALTER TABLE purchase_executions
+    ADD COLUMN approval_token_expires_at TIMESTAMPTZ;
+
+-- Partial index: only rows that actually have a deadline benefit from
+-- range scans. On healthy deployments with routine approval windows, nearly
+-- all active rows will be non-null post-migration, so the partial index
+-- keeps the index compact during legacy rows' gradual retirement.
+CREATE INDEX idx_executions_token_expires_at
+    ON purchase_executions(approval_token_expires_at)
+    WHERE approval_token_expires_at IS NOT NULL;

--- a/internal/purchase/approvals.go
+++ b/internal/purchase/approvals.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/subtle"
 	"fmt"
+	"time"
 
 	"github.com/LeanerCloud/CUDly/internal/config"
 	"github.com/LeanerCloud/CUDly/pkg/logging"
@@ -37,6 +38,13 @@ func (m *Manager) ApproveExecution(ctx context.Context, executionID, token, acto
 	}
 	if subtle.ConstantTimeCompare([]byte(execution.ApprovalToken), []byte(token)) != 1 {
 		return fmt.Errorf("invalid approval token")
+	}
+
+	// Enforce token TTL (issue #397). Legacy rows that pre-date migration
+	// 000051 have ApprovalTokenExpiresAt == nil and are passed through
+	// for backward compatibility; all new rows carry a non-nil deadline.
+	if execution.ApprovalTokenExpiresAt != nil && time.Now().After(*execution.ApprovalTokenExpiresAt) {
+		return fmt.Errorf("approval token has expired")
 	}
 
 	return m.ApproveAndExecute(ctx, executionID, actor)
@@ -131,6 +139,13 @@ func (m *Manager) loadCancelableExecution(ctx context.Context, executionID, toke
 	if subtle.ConstantTimeCompare([]byte(execution.ApprovalToken), []byte(token)) != 1 {
 		return nil, fmt.Errorf("invalid approval token")
 	}
+
+	// Enforce token TTL (issue #397). Same backward-compat nil-guard as
+	// ApproveExecution: legacy rows without ApprovalTokenExpiresAt pass through.
+	if execution.ApprovalTokenExpiresAt != nil && time.Now().After(*execution.ApprovalTokenExpiresAt) {
+		return nil, fmt.Errorf("approval token has expired")
+	}
+
 	if execution.Status == "completed" || execution.Status == "cancelled" {
 		return nil, fmt.Errorf("execution cannot be cancelled, current status: %s", execution.Status)
 	}

--- a/internal/purchase/approvals_test.go
+++ b/internal/purchase/approvals_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/LeanerCloud/CUDly/internal/config"
 	"github.com/stretchr/testify/assert"
@@ -411,4 +412,113 @@ func TestManager_CancelExecution_GetError(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to get execution")
 
 	mockStore.AssertExpectations(t)
+}
+
+// --- Regression tests for issue #397 (token TTL enforcement) ---
+
+// TestManager_ApproveExecution_ExpiredToken is the regression guard for
+// issue #397: an approval token whose ApprovalTokenExpiresAt deadline has
+// passed must be rejected with "expired", not silently accepted. This
+// prevents a phished or log-leaked token from authorising a purchase weeks
+// after the approval window closed.
+func TestManager_ApproveExecution_ExpiredToken(t *testing.T) {
+	ctx := context.Background()
+	manager, store, _ := newApproveManager(t)
+
+	past := time.Now().Add(-1 * time.Hour) // expired 1 hour ago
+	execution := &config.PurchaseExecution{
+		ExecutionID:            "exec-expired",
+		Status:                 "pending",
+		ApprovalToken:          "valid-token",
+		ApprovalTokenExpiresAt: &past,
+	}
+	store.On("GetExecutionByID", ctx, "exec-expired").Return(execution, nil)
+
+	err := manager.ApproveExecution(ctx, "exec-expired", "valid-token", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expired")
+	// Token validation passes but the expiry check fires — TransitionExecutionStatus
+	// must never be called on an expired token.
+	store.AssertNotCalled(t, "TransitionExecutionStatus", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	store.AssertExpectations(t)
+}
+
+// TestManager_ApproveExecution_ValidTokenWithinTTL confirms that a
+// non-expired token still works (regression guard for the inverse case).
+func TestManager_ApproveExecution_ValidTokenWithinTTL(t *testing.T) {
+	ctx := context.Background()
+	manager, store, sender := newApproveManager(t)
+
+	future := time.Now().Add(7 * 24 * time.Hour)
+	execution := &config.PurchaseExecution{
+		ExecutionID:            "exec-live",
+		PlanID:                 "plan-live",
+		Status:                 "pending",
+		ApprovalToken:          "valid-token",
+		ApprovalTokenExpiresAt: &future,
+	}
+	updated := &config.PurchaseExecution{
+		ExecutionID:   "exec-live",
+		PlanID:        "plan-live",
+		Status:        "approved",
+		ApprovalToken: "valid-token",
+	}
+	store.On("GetExecutionByID", ctx, "exec-live").Return(execution, nil)
+	store.On("TransitionExecutionStatus", ctx, "exec-live", approveFromStatuses, "approved").Return(updated, nil)
+	stubExecuteChain(t, store, sender, "plan-live")
+
+	err := manager.ApproveExecution(ctx, "exec-live", "valid-token", "")
+	require.NoError(t, err)
+	store.AssertExpectations(t)
+}
+
+// TestManager_ApproveExecution_NilExpiresAt_LegacyRow verifies backward
+// compatibility: rows created before migration 000051 have a nil
+// ApprovalTokenExpiresAt and must not be rejected (issue #397 explicitly
+// carves out legacy rows for compatibility).
+func TestManager_ApproveExecution_NilExpiresAt_LegacyRow(t *testing.T) {
+	ctx := context.Background()
+	manager, store, sender := newApproveManager(t)
+
+	execution := &config.PurchaseExecution{
+		ExecutionID:            "exec-legacy",
+		PlanID:                 "plan-legacy",
+		Status:                 "pending",
+		ApprovalToken:          "valid-token",
+		ApprovalTokenExpiresAt: nil, // pre-migration row
+	}
+	updated := &config.PurchaseExecution{
+		ExecutionID: "exec-legacy",
+		PlanID:      "plan-legacy",
+		Status:      "approved",
+	}
+	store.On("GetExecutionByID", ctx, "exec-legacy").Return(execution, nil)
+	store.On("TransitionExecutionStatus", ctx, "exec-legacy", approveFromStatuses, "approved").Return(updated, nil)
+	stubExecuteChain(t, store, sender, "plan-legacy")
+
+	err := manager.ApproveExecution(ctx, "exec-legacy", "valid-token", "")
+	require.NoError(t, err)
+	store.AssertExpectations(t)
+}
+
+// TestManager_CancelExecution_ExpiredToken is the cancel-path regression
+// guard for issue #397.
+func TestManager_CancelExecution_ExpiredToken(t *testing.T) {
+	ctx := context.Background()
+	manager, store, _ := newApproveManager(t)
+
+	past := time.Now().Add(-2 * 24 * time.Hour)
+	execution := &config.PurchaseExecution{
+		ExecutionID:            "exec-cancel-expired",
+		Status:                 "pending",
+		ApprovalToken:          "valid-token",
+		ApprovalTokenExpiresAt: &past,
+	}
+	store.On("GetExecutionByID", ctx, "exec-cancel-expired").Return(execution, nil)
+
+	err := manager.CancelExecution(ctx, "exec-cancel-expired", "valid-token", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expired")
+	store.AssertNotCalled(t, "SavePurchaseExecution", mock.Anything, mock.Anything)
+	store.AssertExpectations(t)
 }

--- a/internal/purchase/notifications.go
+++ b/internal/purchase/notifications.go
@@ -109,13 +109,15 @@ func (m *Manager) getOrCreateExecution(ctx context.Context, plan *config.Purchas
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate approval token: %w", err)
 	}
+	tokenExpiresAt := time.Now().Add(config.ApprovalTokenTTL)
 	execution := &config.PurchaseExecution{
-		PlanID:        plan.ID,
-		ExecutionID:   uuid.New().String(),
-		Status:        "pending",
-		StepNumber:    plan.RampSchedule.CurrentStep,
-		ScheduledDate: *plan.NextExecutionDate,
-		ApprovalToken: approvalToken,
+		PlanID:                 plan.ID,
+		ExecutionID:            uuid.New().String(),
+		Status:                 "pending",
+		StepNumber:             plan.RampSchedule.CurrentStep,
+		ScheduledDate:          *plan.NextExecutionDate,
+		ApprovalToken:          approvalToken,
+		ApprovalTokenExpiresAt: &tokenExpiresAt,
 	}
 
 	if err := m.config.SavePurchaseExecution(ctx, execution); err != nil {


### PR DESCRIPTION
## Summary

Three layered security fixes for the purchase approval-token flow:

- **#408/#402**: `persistRetryExecution` was generating the approval token via `uuid.New().String()` (122-bit entropy, known format). Replaced with `common.GenerateApprovalToken()` (256-bit `crypto/rand`), matching every other creation site.
- **#397**: Approval tokens had no expiry. Added `ApprovalTokenExpiresAt *time.Time` to `PurchaseExecution`, set to `now + 7 days` (config.ApprovalTokenTTL) at all three creation sites. `ApproveExecution` and `loadCancelableExecution` reject tokens past their deadline. Migration 000051 adds the nullable column; legacy rows (NULL) pass through for backward compatibility.
- **#398**: The approval token appeared in Lambda Function URL access logs via `rawQueryString`. Added `resolveApprovalToken()` that reads the token from the POST body first and falls back to the query string for legacy GET email links. Frontend deep-link handler updated to POST the token in the request body.

## Changes

- `internal/config/types.go` - `ApprovalTokenExpiresAt *time.Time` field on `PurchaseExecution`
- `internal/config/constants.go` - `ApprovalTokenTTL = 7 * 24 * time.Hour`
- `internal/config/store_postgres.go` - INSERT/UPDATE/SELECT queries updated for new column; Scan updated
- `internal/database/postgres/migrations/000051_purchase_executions_token_expires_at.{up,down}.sql` - new migration
- `internal/api/handler_purchases.go` - `persistRetryExecution` and `newPendingExecution` use `GenerateApprovalToken` + set `ApprovalTokenExpiresAt`
- `internal/api/router.go` - `resolveApprovalToken` helper; `approvePurchaseHandler`/`cancelPurchaseHandler` updated
- `internal/purchase/approvals.go` - TTL check in `ApproveExecution` and `loadCancelableExecution`
- `internal/purchase/notifications.go` - `getOrCreateExecution` sets `ApprovalTokenExpiresAt`
- `frontend/src/purchases-deeplink.ts` - POST token in request body

## Test plan

- [ ] `go test ./internal/purchase/... ./internal/api/...` - all pass (122 + 1101 tests)
- [ ] `tsc --noEmit` in frontend - passes
- [ ] New regression tests added for all three issues:
  - `TestPersistRetryExecution_ApprovalTokenNotUUID` - verifies 64-char hex (not 36-char UUID)
  - `TestPersistRetryExecution_ApprovalTokenExpiresAtSet` - verifies TTL set on retry path
  - `TestManager_ApproveExecution_ExpiredToken` - verifies expired token rejected
  - `TestManager_ApproveExecution_ValidTokenWithinTTL` - verifies valid token accepted
  - `TestManager_ApproveExecution_NilExpiresAt_LegacyRow` - verifies legacy rows pass through
  - `TestManager_CancelExecution_ExpiredToken` - cancel path expiry enforcement
  - `TestResolveApprovalToken_PostBodyTakesPriority` - body token takes priority over query string
  - `TestResolveApprovalToken_GetFallsBackToQueryString` - GET uses query string
  - `TestResolveApprovalToken_PostNoBody` - empty body falls back to query string
  - `TestResolveApprovalToken_PostBodyNoToken` - missing token field falls back to query string