### PR TITLE
sec(iac/gcp-target): require non-empty oidc_subject + aws_role_name to block trust wildcards (closes #417, #382)

### DIFF
--- a/iac/federation/gcp-target/terraform/main.tf
+++ b/iac/federation/gcp-target/terraform/main.tf
@@ -103,10 +103,12 @@ resource "google_iam_workload_identity_pool_provider" "cudly" {
     "attribute.account"  = "assertion.account"
   } : var.oidc_attribute_mapping
 
+  # Both branches are non-null: aws_role_name and oidc_subject are validated
+  # as non-empty by lifecycle preconditions below, so neither falls back to null.
   attribute_condition = var.provider_type == "aws" ? (
-    var.aws_role_name != "" ? "attribute.aws_role.contains('assumed-role/${var.aws_role_name}/')" : null
+    "attribute.aws_role.contains('assumed-role/${var.aws_role_name}/')"
     ) : (
-    var.oidc_subject != "" ? "google.subject == '${var.oidc_subject}'" : null
+    "google.subject == '${var.oidc_subject}'"
   )
 
   dynamic "aws" {
@@ -132,6 +134,16 @@ resource "google_iam_workload_identity_pool_provider" "cudly" {
       condition     = var.provider_type != "oidc" || var.oidc_issuer_uri != ""
       error_message = "oidc_issuer_uri is required when provider_type is 'oidc'."
     }
+    # Security: a null attribute_condition trusts every role/subject in the account
+    # or from the issuer. Both inputs must be non-empty so the condition is always set.
+    precondition {
+      condition     = var.provider_type != "aws" || var.aws_role_name != ""
+      error_message = "aws_role_name is required when provider_type is 'aws'. Without it the attribute_condition is null and any IAM role in the AWS account can federate as the GCP service account."
+    }
+    precondition {
+      condition     = var.provider_type != "oidc" || var.oidc_subject != ""
+      error_message = "oidc_subject is required when provider_type is 'oidc'. Without it the attribute_condition is null and any subject from the OIDC issuer can federate as the GCP service account."
+    }
   }
 }
 
@@ -139,11 +151,12 @@ resource "google_iam_workload_identity_pool_provider" "cudly" {
 resource "google_service_account_iam_member" "cudly_wif" {
   service_account_id = "projects/${local.project}/serviceAccounts/${local.service_account_email}"
   role               = "roles/iam.workloadIdentityUser"
-  # For AWS: always use wildcard principalSet — role restriction is enforced by
-  # attribute_condition on the provider (session ARNs include variable session
-  # names, so exact-match principalSet cannot work).
-  # For OIDC: scope to specific subject when provided.
-  member = var.provider_type == "oidc" && var.oidc_subject != "" ? (
+  # For OIDC: scope binding to the specific subject (oidc_subject is required; see
+  # lifecycle precondition above), so only that subject can impersonate this SA.
+  # For AWS: wildcard principalSet is intentional; session ARNs include variable
+  # session names so exact-match principalSet cannot work. Trust is scoped by the
+  # mandatory attribute_condition on the provider (aws_role_name is required).
+  member = var.provider_type == "oidc" ? (
     "principal://iam.googleapis.com/${google_iam_workload_identity_pool.cudly.name}/subject/${var.oidc_subject}"
     ) : (
     "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.cudly.name}/*"

--- a/iac/federation/gcp-target/terraform/variables.tf
+++ b/iac/federation/gcp-target/terraform/variables.tf
@@ -55,13 +55,13 @@ variable "oidc_attribute_mapping" {
 }
 
 variable "aws_role_name" {
-  description = "AWS IAM role name to restrict trust to (e.g. 'CUDly-Execution'). Only used when provider_type is 'aws'. If empty, all roles in the AWS account are trusted."
+  description = "AWS IAM role name to restrict trust to (e.g. 'CUDly-Execution'). Required when provider_type is 'aws'. Without this the attribute_condition is null and any IAM role in the account can federate."
   type        = string
   default     = ""
 }
 
 variable "oidc_subject" {
-  description = "OIDC subject claim to restrict trust to. Only used when provider_type is 'oidc'. If empty, all subjects from the issuer are trusted."
+  description = "OIDC subject claim to restrict trust to. Required when provider_type is 'oidc'. Without this the attribute_condition is null and any subject from the issuer can federate."
   type        = string
   default     = ""
 }


### PR DESCRIPTION
## Summary

- **#382**: `attribute_condition` was null when `aws_role_name` is empty (provider_type=aws), trusting every IAM role in the AWS account. Now a `lifecycle.precondition` requires `aws_role_name != ""` and the condition is always non-null.
- **#417**: OIDC `member` fell back to `principalSet://<pool>/*` wildcard when `oidc_subject` was empty, granting `workloadIdentityUser` to any pool identity. Now a `lifecycle.precondition` requires `oidc_subject != ""` and the member is always the subject-scoped `principal://` form.
- `attribute_condition` ternary simplified: both branches now produce a non-null string (preconditions enforce the inputs are set before apply).
- Variable descriptions updated to state the fields are required (not optional) for each provider type.

## Files changed

- `iac/federation/gcp-target/terraform/main.tf`
- `iac/federation/gcp-target/terraform/variables.tf`

## Test plan

- [ ] `terraform fmt -check` passes (verified locally: no output)
- [ ] `terraform plan` with `provider_type=aws` and empty `aws_role_name` fails with the new precondition error message
- [ ] `terraform plan` with `provider_type=oidc` and empty `oidc_subject` fails with the new precondition error message
- [ ] `terraform plan` with both fields populated succeeds and shows a non-null `attribute_condition`
- [ ] For OIDC, the plan shows `member = principal://.../subject/<oidc_subject>` (no wildcard)