### PR TITLE
sec(iac): require OIDC subject claim, reject empty value (closes #381)

### DIFF
--- a/iac/federation/aws-target/terraform/main.tf
+++ b/iac/federation/aws-target/terraform/main.tf
@@ -129,14 +129,10 @@ resource "aws_iam_role" "cudly" {
           }
           Action = "sts:AssumeRoleWithWebIdentity"
           Condition = {
-            StringEquals = merge(
-              {
-                "${local.oidc_condition_host}:aud" = local.audience
-              },
-              var.oidc_subject_claim != "" ? {
-                "${local.oidc_condition_host}:sub" = var.oidc_subject_claim
-              } : {}
-            )
+            StringEquals = {
+              "${local.oidc_condition_host}:aud" = local.audience
+              "${local.oidc_condition_host}:sub" = var.oidc_subject_claim
+            }
           }
         }
       ],

--- a/iac/federation/aws-target/terraform/variables.tf
+++ b/iac/federation/aws-target/terraform/variables.tf
@@ -26,9 +26,20 @@ variable "oidc_audience" {
 }
 
 variable "oidc_subject_claim" {
-  description = "Optional subject (sub) claim to restrict trust. Leave empty to allow any subject."
+  description = <<-EOT
+    Subject (sub) claim used to restrict OIDC trust to a specific identity.
+    Azure AD managed identity: the object ID of the managed identity.
+    GCP service account:       the service account email in the form
+                               system:serviceaccount:<project>:<sa-email>.
+    This variable is required and must not be empty. An empty value would
+    allow any principal in the same OIDC provider tenant to assume this role.
+  EOT
   type        = string
-  default     = ""
+
+  validation {
+    condition     = var.oidc_subject_claim != null && length(trimspace(var.oidc_subject_claim)) > 0
+    error_message = "oidc_subject_claim must be set to a non-empty subject claim. Leaving it empty would allow any principal in the OIDC provider tenant to assume this role."
+  }
 }
 
 variable "role_name" {


### PR DESCRIPTION
## Summary

- `oidc_subject_claim` is now a required variable with no default; an empty or whitespace-only value fails at `terraform plan` with a clear error message.
- The conditional `merge()` branch in the trust policy is replaced with a flat `StringEquals` map that always includes both `aud` and `sub`, so the role can never be deployed with audience-only trust.

## Security impact

Without a subject claim the IAM OIDC trust policy contained only an audience check. Any service principal in the same Azure AD tenant (or GCP project) that could obtain a token for the audience could assume the role -- not just the CUDly managed identity. This is full cross-tenant lateral movement for shared IdP deployments.

## Test plan

- [ ] `terraform plan` on the module with `oidc_subject_claim = ""` fails with the validation error message
- [ ] `terraform plan` with a non-empty subject succeeds and emits `StringEquals` with both `:aud` and `:sub` keys in the trust policy
- [ ] `terraform fmt -check` passes (verified by pre-commit hook)