### PR TITLE
sec(iac): tighten CI/CD OIDC trust + scope PassRole by service (closes #423, closes #426)

### DIFF
--- a/terraform/environments/aws/ci-cd-permissions/policy_data.tf
+++ b/terraform/environments/aws/ci-cd-permissions/policy_data.tf
@@ -31,7 +31,6 @@ resource "aws_iam_policy" "data" {
           "iam:ListPolicyVersions",
           "iam:ListRolePolicies",
           "iam:ListRoleTags",
-          "iam:PassRole",
           "iam:PutRolePolicy",
           "iam:RemoveRoleFromInstanceProfile",
           "iam:TagInstanceProfile",
@@ -46,6 +45,29 @@ resource "aws_iam_policy" "data" {
           "arn:aws:iam::*:policy/cudly-*",
           "arn:aws:iam::*:instance-profile/cudly-*",
         ]
+      },
+      {
+        # iam:PassRole is split into its own statement so we can attach the
+        # iam:PassedToService condition without affecting the other IAM actions
+        # in IAMRolesAndPolicies. Without this condition an attacker who
+        # compromises the deploy role could pass any cudly-* role to any AWS
+        # service (Lambda, EC2, Glue, etc.) to escalate privileges beyond
+        # what Terraform deploy needs.
+        Sid    = "IAMPassRoleScopedByService"
+        Effect = "Allow"
+        Action = ["iam:PassRole"]
+        Resource = [
+          "arn:aws:iam::*:role/cudly-*",
+        ]
+        Condition = {
+          StringEquals = {
+            "iam:PassedToService" = [
+              "lambda.amazonaws.com",
+              "ecs-tasks.amazonaws.com",
+              "rds.amazonaws.com",
+            ]
+          }
+        }
       },
       {
         Sid    = "IAMReadForPassRole"

--- a/terraform/environments/aws/ci-cd-permissions/role.tf
+++ b/terraform/environments/aws/ci-cd-permissions/role.tf
@@ -20,11 +20,17 @@ resource "aws_iam_role" "cudly_deploy" {
         }
         Action = "sts:AssumeRoleWithWebIdentity"
         Condition = {
-          StringLike = {
-            "token.actions.githubusercontent.com:sub" = "repo:${var.github_repo}:*"
-          }
           StringEquals = {
             "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+            # Restrict to protected branches and named deployment environments.
+            # Any-branch wildcard (repo:org/repo:*) would let a developer push to
+            # an unprotected feature branch and mint valid deploy credentials.
+            "token.actions.githubusercontent.com:sub" = [
+              "repo:${var.github_repo}:ref:refs/heads/main",
+              "repo:${var.github_repo}:environment:dev",
+              "repo:${var.github_repo}:environment:staging",
+              "repo:${var.github_repo}:environment:prod",
+            ]
           }
         }
       }] : []


### PR DESCRIPTION
## Summary

- **#423**: Replace `StringLike` any-branch wildcard on the GitHub Actions OIDC `sub` claim with `StringEquals` restricted to `main` and the three named deployment environments (`dev`, `staging`, `prod`). A feature-branch push can no longer mint deploy credentials.
- **#426**: Split `iam:PassRole` out of the `IAMRolesAndPolicies` statement into a dedicated `IAMPassRoleScopedByService` statement with an `iam:PassedToService` condition limiting the target services to `lambda.amazonaws.com`, `ecs-tasks.amazonaws.com`, and `rds.amazonaws.com`. Without this gate an attacker holding the deploy role could pass any `cudly-*` role to any AWS service.

## Security impact

**#423**: Any developer who pushed to an unprotected branch and triggered a workflow could obtain a token satisfying `repo:LeanerCloud/CUDly:*` and assume the `cudly-terraform-deploy` role, which holds `iam:CreateRole`, `iam:PassRole`, KMS destructive actions, and Terraform state R/W.

**#426**: `iam:PassRole` without a service condition enables escalation from the CI/CD role to arbitrary compute (Lambda, EC2, Glue). An attacker could create a new Lambda, pass it the deploy role, and establish a persistent backdoor with full deploy permissions.

## Test plan

- [ ] A workflow triggered on a feature branch cannot assume `cudly-terraform-deploy`
- [ ] A workflow triggered on `main` or via a named environment can assume the role
- [ ] Attempting to `iam:PassRole` a `cudly-*` role to `glue.amazonaws.com` is denied
- [ ] `terraform fmt -check` passes (pre-commit verified)