### PR TITLE
sec(iac): reject wildcard CORS origin, set explicit origins per env (closes #390)

### DIFF
--- a/terraform/environments/aws/github-dev.tfvars
+++ b/terraform/environments/aws/github-dev.tfvars
@@ -24,7 +24,10 @@ lambda_reserved_concurrency   = -1
 lambda_log_retention_days     = 7
 lambda_enable_function_url    = true
 lambda_function_url_auth_type = "NONE"
-lambda_allowed_origins        = ["*"]
+# Set to the dev Lambda Function URL after first apply. Wildcard is rejected by the
+# module (allow_credentials=true + * = any-origin CSRF).
+# Example: ["https://<fn-url-id>.lambda-url.us-east-1.on.aws"]
+lambda_allowed_origins = ["https://localhost:3000"]
 
 # Fargate Configuration (when compute_platform = "fargate")
 fargate_cpu           = 256

--- a/terraform/environments/aws/github-dev.tfvars
+++ b/terraform/environments/aws/github-dev.tfvars
@@ -24,10 +24,13 @@ lambda_reserved_concurrency   = -1
 lambda_log_retention_days     = 7
 lambda_enable_function_url    = true
 lambda_function_url_auth_type = "NONE"
-# Set to the dev Lambda Function URL after first apply. Wildcard is rejected by the
-# module (allow_credentials=true + * = any-origin CSRF).
-# Example: ["https://<fn-url-id>.lambda-url.us-east-1.on.aws"]
-lambda_allowed_origins = ["https://localhost:3000"]
+# Current deployed dev origin (Lambda Function URL) + local Webpack dev server.
+# Wildcard is rejected by the module (allow_credentials=true + * = any-origin CSRF).
+# Update the Lambda Function URL entry when the dev environment is redeployed.
+lambda_allowed_origins = [
+  "https://33pz7pombdqwu3bdlxp4lqxyra0bsriy.lambda-url.us-east-1.on.aws",
+  "http://localhost:3000",
+]
 
 # Fargate Configuration (when compute_platform = "fargate")
 fargate_cpu           = 256

--- a/terraform/environments/aws/github-prod.tfvars
+++ b/terraform/environments/aws/github-prod.tfvars
@@ -24,8 +24,10 @@ lambda_reserved_concurrency   = -1
 lambda_log_retention_days     = 30
 lambda_enable_function_url    = true
 lambda_function_url_auth_type = "NONE"
-# TODO: restrict to actual production domain, e.g. ["https://cudly.example.com"]
-lambda_allowed_origins = ["*"]
+# Set to the production CloudFront distribution domain or the Lambda Function URL.
+# Wildcard origins are rejected by the module (allow_credentials=true + * = any-origin CSRF).
+# Example: ["https://app.cudly.io"] or ["https://<fn-url-id>.lambda-url.us-east-1.on.aws"]
+lambda_allowed_origins = ["https://app.cudly.io"]
 
 # Fargate Configuration (when compute_platform = "fargate")
 fargate_cpu           = 1024

--- a/terraform/environments/aws/github-prod.tfvars
+++ b/terraform/environments/aws/github-prod.tfvars
@@ -24,10 +24,10 @@ lambda_reserved_concurrency   = -1
 lambda_log_retention_days     = 30
 lambda_enable_function_url    = true
 lambda_function_url_auth_type = "NONE"
-# Set to the production CloudFront distribution domain or the Lambda Function URL.
-# Wildcard origins are rejected by the module (allow_credentials=true + * = any-origin CSRF).
-# Example: ["https://app.cudly.io"] or ["https://<fn-url-id>.lambda-url.us-east-1.on.aws"]
-lambda_allowed_origins = ["https://app.cudly.io"]
+# TODO(env-not-deployed): prod environment is not yet provisioned. Update this
+# to the actual prod origin (e.g. the customer-facing dashboard domain) when
+# the env exists. .invalid placeholder fails fast on accidental apply.
+lambda_allowed_origins = ["https://prod-not-yet-deployed.invalid"]
 
 # Fargate Configuration (when compute_platform = "fargate")
 fargate_cpu           = 1024

--- a/terraform/environments/aws/github-staging.tfvars
+++ b/terraform/environments/aws/github-staging.tfvars
@@ -24,7 +24,9 @@ lambda_reserved_concurrency   = -1
 lambda_log_retention_days     = 14
 lambda_enable_function_url    = true
 lambda_function_url_auth_type = "NONE"
-lambda_allowed_origins        = ["*"]
+# Restrict CORS to the staging Lambda Function URL itself. Wildcard + allow_credentials
+# reflects any Origin with credentials allowed, enabling cross-site request forgery.
+lambda_allowed_origins = ["https://33pz7pombdqwu3bdlxp4lqxyra0bsriy.lambda-url.us-east-1.on.aws"]
 
 # Fargate Configuration (when compute_platform = "fargate")
 fargate_cpu           = 1024

--- a/terraform/environments/aws/github-staging.tfvars
+++ b/terraform/environments/aws/github-staging.tfvars
@@ -24,9 +24,10 @@ lambda_reserved_concurrency   = -1
 lambda_log_retention_days     = 14
 lambda_enable_function_url    = true
 lambda_function_url_auth_type = "NONE"
-# Restrict CORS to the staging Lambda Function URL itself. Wildcard + allow_credentials
-# reflects any Origin with credentials allowed, enabling cross-site request forgery.
-lambda_allowed_origins = ["https://33pz7pombdqwu3bdlxp4lqxyra0bsriy.lambda-url.us-east-1.on.aws"]
+# TODO(env-not-deployed): staging environment is not yet provisioned. Update this
+# to the actual staging origin when the env exists. Until then the .invalid TLD
+# ensures any accidental terraform apply fails fast on hostname resolution.
+lambda_allowed_origins = ["https://staging-not-yet-deployed.invalid"]
 
 # Fargate Configuration (when compute_platform = "fargate")
 fargate_cpu           = 1024

--- a/terraform/modules/compute/aws/lambda/variables.tf
+++ b/terraform/modules/compute/aws/lambda/variables.tf
@@ -96,13 +96,27 @@ variable "function_url_auth_type" {
 }
 
 variable "allowed_origins" {
-  description = "Allowed origins for CORS. Must be non-empty — Lambda Function URL CORS is infrastructure-enforced and rejects all requests with empty allow_origins."
+  description = <<-EOT
+    Explicit CORS origin allowlist for the Lambda Function URL. Must be non-empty
+    and must not contain the wildcard "*". The Function URL CORS block uses
+    allow_credentials = true; AWS reflects the inbound Origin header verbatim for
+    each listed origin, which the browser treats as a trusted cross-origin endpoint.
+    A wildcard origin combined with credentials is equivalent to any-origin CSRF:
+    any website can read the response with credentials included.
+    Set this to the actual CloudFront or frontend domain for each environment,
+    e.g. ["https://app.example.com"] or ["https://<lambda-url-id>.lambda-url.us-east-1.on.aws"].
+  EOT
   type        = list(string)
   default     = []
 
   validation {
     condition     = length(var.allowed_origins) > 0
     error_message = "allowed_origins must not be empty for Lambda Function URL CORS — set an explicit origin list in tfvars."
+  }
+
+  validation {
+    condition     = !contains(var.allowed_origins, "*")
+    error_message = "allowed_origins must not contain \"*\". The Function URL uses allow_credentials=true; a wildcard origin reflects any inbound Origin header with credentials allowed, enabling cross-site request forgery from any website."
   }
 }
 


### PR DESCRIPTION
## Summary

- Add a `validation` block to the lambda module's `allowed_origins` variable that rejects `"*"`. The Function URL CORS block has `allow_credentials = true`; AWS reflects the inbound `Origin` header verbatim for each listed origin, so a wildcard is equivalent to trusting any origin with credentials -- any-origin CSRF.
- Replace `["*"]` in all three environment tfvars with explicit origins. The Lambda Function URL `https://33pz7pombdqwu3bdlxp4lqxyra0bsriy.lambda-url.us-east-1.on.aws` is the **dev** deployment (it was previously mislabeled as staging). Corrected: dev now carries the real URL plus `http://localhost:3000` for the Webpack dev server; staging and prod carry `.invalid` placeholders that fail fast on accidental `terraform apply` until those environments are provisioned.
- A pre-apply plan now fails with a clear error if an operator accidentally sets `["*"]`, preventing future regressions.

## Security impact

**#390 / #424**: With `allowed_origins = ["*"]` and `allow_credentials = true`, AWS reflects whatever `Origin` header the client sends, with `Access-Control-Allow-Credentials: true`. A browser treats this as a trusted cross-origin endpoint and forwards session cookies. Any website can issue `fetch(lambdaUrl, {credentials:"include"})` and read authenticated responses -- full account takeover via CSRF if a logged-in admin visits an attacker-controlled page.

## Test plan

- [ ] `terraform plan` with `allowed_origins = ["*"]` fails with the validation error message
- [ ] `terraform plan` with an explicit origin list succeeds
- [ ] Dev `terraform apply` deploys with the actual Lambda Function URL + localhost as CORS origins
- [ ] Staging and prod placeholder values produce a fast hostname-resolution failure on accidental apply
- [ ] `terraform fmt -check` passes (pre-commit verified)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Restricted API endpoint origin allowlists from permissive wildcard settings to explicitly configured domains across all environments
  * Added validation to prevent misconfiguration through wildcard origins

* **Documentation**
  * Expanded infrastructure documentation explaining CORS behavior and security risks associated with unrestricted origins

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/519?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->