### PR TITLE
sec(database): redact plaintext credentials from logs + tighten env-var handling (closes #440, #441, #444, #446)

### DIFF
--- a/internal/database/config.go
+++ b/internal/database/config.go
@@ -103,6 +103,14 @@ func (c *Config) validateRequiredFields() error {
 	if c.Password == "" && c.PasswordSecret == "" {
 		return fmt.Errorf("either DB_PASSWORD or DB_PASSWORD_SECRET must be set")
 	}
+	// Warn when both are set: plaintext DB_PASSWORD is visible in Lambda/ECS config
+	// (readable by lambda:GetFunction) without needing secretsmanager:GetSecretValue.
+	// Prefer DB_PASSWORD_SECRET for production deployments.
+	if c.Password != "" && c.PasswordSecret != "" {
+		fmt.Fprintf(os.Stderr, "WARNING: both DB_PASSWORD and DB_PASSWORD_SECRET are set; "+
+			"DB_PASSWORD_SECRET will be used. Remove DB_PASSWORD from environment to avoid "+
+			"storing plaintext credentials in Lambda/ECS task configuration.\n")
+	}
 	return nil
 }
 

--- a/internal/database/connection.go
+++ b/internal/database/connection.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"os"
 	"sync"
 	"time"
 
@@ -191,14 +192,21 @@ func createConnectionPoolWithRetry(ctx context.Context, poolConfig *pgxpool.Conf
 
 // buildPoolConfig creates a pgxpool.Config from our Config
 func buildPoolConfig(config *Config, password string) (*pgxpool.Config, error) {
-	// Build connection string
-	dsn := config.DSN(password)
+	// Parse a redacted DSN so that any pgxpool.ParseConfig error never
+	// echoes the plaintext password into the error chain (pgconn.parseConfig
+	// includes the input URI in its error message). After successful parsing
+	// the real password is injected directly into ConnConfig.Password so it
+	// is never present in a string that could be logged.
+	redactedDSN := config.DSN("REDACTED")
 
-	// Parse DSN into pgxpool config
-	poolConfig, err := pgxpool.ParseConfig(dsn)
+	poolConfig, err := pgxpool.ParseConfig(redactedDSN)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse DSN: %w", err)
 	}
+
+	// Overwrite the placeholder with the real password. ConnConfig.Password
+	// is used by pgx at connect time and is never serialised back to a string.
+	poolConfig.ConnConfig.Password = password
 
 	// Set pool configuration
 	if config.MaxConnections > math.MaxInt32 {
@@ -368,16 +376,32 @@ func parseLogLevel(level string) tracelog.LogLevel {
 // stdLogger implements pgx tracelog.Logger using the logging package
 type stdLogger struct{}
 
-func (l *stdLogger) Log(ctx context.Context, level tracelog.LogLevel, msg string, data map[string]any) {
-	// Filter out sensitive data from logs
-	safeData := make(map[string]any)
+// isSensitiveKey reports whether a pgx data-map key should always be redacted.
+func isSensitiveKey(k string) bool {
+	return k == "password" || k == "secret" || k == "token"
+}
+
+// sanitizeLogData returns a copy of data with sensitive fields removed.
+// At debug level, the pgx "args" key (SQL bound parameters) is also removed
+// unless DB_LOG_BIND_PARAMETERS=true is set, because bound values can carry
+// session tokens, bcrypt hashes, or approval tokens.
+func sanitizeLogData(level tracelog.LogLevel, data map[string]any) map[string]any {
+	bindParams := os.Getenv("DB_LOG_BIND_PARAMETERS") == "true"
+	safe := make(map[string]any, len(data))
 	for k, v := range data {
-		// Skip potentially sensitive fields
-		if k == "password" || k == "secret" || k == "token" {
+		if isSensitiveKey(k) {
 			continue
 		}
-		safeData[k] = v
+		if k == "args" && level == tracelog.LogLevelDebug && !bindParams {
+			continue
+		}
+		safe[k] = v
 	}
+	return safe
+}
+
+func (l *stdLogger) Log(ctx context.Context, level tracelog.LogLevel, msg string, data map[string]any) {
+	safeData := sanitizeLogData(level, data)
 
 	switch level {
 	case tracelog.LogLevelDebug:

--- a/internal/database/postgres/migrations/migrate.go
+++ b/internal/database/postgres/migrations/migrate.go
@@ -59,7 +59,7 @@ func RunMigrations(ctx context.Context, pool *pgxpool.Pool, migrationsPath strin
 		return fmt.Errorf("database is in dirty state at version %d", version)
 	}
 
-	fmt.Printf("Database migrations completed successfully (version: %d)\n", version)
+	log.Printf("Database migrations completed successfully (version: %d)", version)
 
 	// Create admin user if email provided (after migrations complete)
 	if adminEmail != "" {
@@ -79,7 +79,7 @@ func ensureAdminUser(ctx context.Context, pool *pgxpool.Pool, email string, pass
 		return ensureAdminUserWithPassword(ctx, pool, email, password)
 	}
 
-	fmt.Printf("Ensuring admin user exists: %s (user will need to reset password to login)\n", email)
+	log.Printf("Ensuring admin user exists: %s (user will need to reset password to login)", email)
 
 	// Create admin user with no password - account is inactive until password is set via reset flow
 	// Use ON CONFLICT to prevent race conditions when multiple instances run migrations
@@ -97,9 +97,9 @@ func ensureAdminUser(ctx context.Context, pool *pgxpool.Pool, email string, pass
 	}
 
 	if result.RowsAffected() > 0 {
-		fmt.Printf("Admin user created: %s (password not set - user must reset)\n", email)
+		log.Printf("Admin user created: %s (password not set - user must reset)", email)
 	} else {
-		fmt.Printf("Admin user already exists: %s\n", email)
+		log.Printf("Admin user already exists: %s", email)
 	}
 	return nil
 }
@@ -107,7 +107,7 @@ func ensureAdminUser(ctx context.Context, pool *pgxpool.Pool, email string, pass
 // ensureAdminUserWithPassword creates or updates the admin with a hashed password and active=true.
 // If the admin already exists with an empty password_hash, the password and active flag are updated.
 func ensureAdminUserWithPassword(ctx context.Context, pool *pgxpool.Pool, email string, password string) error {
-	fmt.Printf("Ensuring admin user exists with password: %s\n", email)
+	log.Printf("Ensuring admin user exists with password: %s", email)
 
 	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(password), bcryptCost)
 	if err != nil {
@@ -133,9 +133,9 @@ func ensureAdminUserWithPassword(ctx context.Context, pool *pgxpool.Pool, email 
 	}
 
 	if result.RowsAffected() > 0 {
-		fmt.Printf("Admin user created/activated with password: %s\n", email)
+		log.Printf("Admin user created/activated: %s", email)
 	} else {
-		fmt.Printf("Admin user already has a password set: %s (skipping)\n", email)
+		log.Printf("Admin user already has a password set: %s (skipping)", email)
 	}
 	return nil
 }
@@ -200,7 +200,7 @@ func RollbackMigrations(ctx context.Context, pool *pgxpool.Pool, migrationsPath 
 
 	// Log current version before rollback
 	currentVersion, _, _ := m.Version()
-	fmt.Printf("Rolling back %d migration(s) from version %d...\n", steps, currentVersion)
+	log.Printf("Rolling back %d migration(s) from version %d...", steps, currentVersion)
 
 	// Rollback steps
 	if err := m.Steps(-steps); err != nil && err != migrate.ErrNoChange {
@@ -216,7 +216,7 @@ func RollbackMigrations(ctx context.Context, pool *pgxpool.Pool, migrationsPath 
 		return fmt.Errorf("database is in dirty state at version %d", version)
 	}
 
-	fmt.Printf("Rolled back %d migration(s) (current version: %d)\n", steps, version)
+	log.Printf("Rolled back %d migration(s) (current version: %d)", steps, version)
 	return nil
 }
 

--- a/internal/database/postgres/migrations/migrate_security_test.go
+++ b/internal/database/postgres/migrations/migrate_security_test.go
@@ -2,68 +2,83 @@ package migrations
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"log"
 	"os"
-	"strings"
 	"testing"
 
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// newUnreachablePool returns a *pgxpool.Pool pointed at a port that will
+// immediately refuse connections. pgxpool v5 is lazy -- it does not dial
+// until the first Acquire/Exec call -- so construction succeeds and the
+// pool can be passed to functions whose logging fires before any DB access.
+func newUnreachablePool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	cfg, err := pgxpool.ParseConfig("postgres://user:pass@127.0.0.1:1/db?sslmode=disable")
+	require.NoError(t, err, "pgxpool.ParseConfig must succeed for unreachable DSN")
+	pool, err := pgxpool.NewWithConfig(context.Background(), cfg)
+	require.NoError(t, err, "pgxpool.NewWithConfig must succeed (lazy -- no dial yet)")
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+// captureLogOutput redirects the standard logger output to a buffer for the
+// duration of the test, restoring the original flags and writer on cleanup.
+func captureLogOutput(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	origFlags := log.Flags()
+	origOutput := log.Writer()
+	log.SetFlags(0)
+	log.SetOutput(&buf)
+	t.Cleanup(func() {
+		log.SetFlags(origFlags)
+		log.SetOutput(origOutput)
+	})
+	return &buf
+}
+
+// captureStdout redirects os.Stdout to a pipe and returns a function that
+// closes the pipe, restores stdout, and returns everything that was written.
+func captureStdout(t *testing.T) func() string {
+	t.Helper()
+	origStdout := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err, "os.Pipe must succeed")
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = origStdout })
+	return func() string {
+		w.Close()
+		os.Stdout = origStdout
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(r)
+		r.Close()
+		return buf.String()
+	}
+}
 
 // TestEnsureAdminUserWithPassword_LogsToStderr_NotStdout is a regression test
 // for issue #440: admin password activity must not be echoed to stdout.
 // Previously the function used fmt.Printf which writes to stdout; it now uses
 // log.Printf which writes to stderr.
 func TestEnsureAdminUserWithPassword_LogsToStderr_NotStdout(t *testing.T) {
-	// Capture stdout by redirecting os.Stdout to a pipe.
-	origStdout := os.Stdout
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("pipe: %v", err)
-	}
-	os.Stdout = w
+	readStdout := captureStdout(t)
+	logBuf := captureLogOutput(t)
 
-	// Capture log output (log.Printf writes to stderr by default, but the
-	// standard logger's output can be redirected for testing).
-	var logBuf bytes.Buffer
-	origLogFlags := log.Flags()
-	origLogOutput := log.Writer()
-	log.SetFlags(0)
-	log.SetOutput(&logBuf)
-	t.Cleanup(func() {
-		log.SetFlags(origLogFlags)
-		log.SetOutput(origLogOutput)
-	})
+	// Call the real function. It logs before touching the pool so the log
+	// assertions below are valid regardless of the subsequent Exec error.
+	pool := newUnreachablePool(t)
+	// The function returns an error (connection refused) but that is expected.
+	_ = ensureAdminUserWithPassword(context.Background(), pool, "admin@example.com", "supersecretpassword")
 
-	// Call the functions that previously wrote to stdout. They will fail with
-	// a nil-pool panic unless we guard, so exercise only the log path by
-	// triggering bcrypt and the log line before the DB call would happen.
-	// We check that the log output goes to our log buffer (stderr path) and
-	// NOT to the captured stdout pipe.
-
-	// Exercise ensureAdminUserWithPassword up to the bcrypt step by calling
-	// buildMigrateDSN indirectly; instead verify at the logging layer.
-	// The simplest regression-proof approach: assert the log message format
-	// matches and that stdout receives nothing password-related.
-
-	// Simulate the log call that the fixed code makes:
-	log.Printf("Ensuring admin user exists with password: %s", "admin@example.com")
-	log.Printf("Admin user created/activated: %s", "admin@example.com")
-
-	// Close the write-end of the pipe and restore stdout before reading.
-	w.Close()
-	os.Stdout = origStdout
-
-	// Read what (if anything) landed on stdout.
-	var stdoutBuf bytes.Buffer
-	if _, err := stdoutBuf.ReadFrom(r); err != nil {
-		t.Fatalf("read from pipe: %v", err)
-	}
-	r.Close()
+	stdoutContent := readStdout()
 
 	// Assertion: nothing about admin password activity on stdout.
-	stdoutContent := stdoutBuf.String()
 	assert.Empty(t, stdoutContent,
 		"log.Printf must not write to stdout; found on stdout: %q", stdoutContent)
 
@@ -71,8 +86,7 @@ func TestEnsureAdminUserWithPassword_LogsToStderr_NotStdout(t *testing.T) {
 	logContent := logBuf.String()
 	assert.Contains(t, logContent, "admin@example.com",
 		"admin email must appear in log output (stderr path)")
-	// The message describes the operation ("with password") but must NOT include
-	// the actual password value. The email is not a credential.
+	// The message describes the operation but must NOT include the actual password.
 	assert.NotContains(t, logContent, "supersecretpassword",
 		"log messages must never include the actual password value")
 }
@@ -80,35 +94,16 @@ func TestEnsureAdminUserWithPassword_LogsToStderr_NotStdout(t *testing.T) {
 // TestEnsureAdminUser_NoPasswordVariant_LogsToStderr is a companion regression
 // test for the no-password variant of ensureAdminUser (issue #440).
 func TestEnsureAdminUser_NoPasswordVariant_LogsToStderr(t *testing.T) {
-	origStdout := os.Stdout
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("pipe: %v", err)
-	}
-	os.Stdout = w
+	readStdout := captureStdout(t)
+	logBuf := captureLogOutput(t)
 
-	var logBuf bytes.Buffer
-	origLogFlags := log.Flags()
-	origLogOutput := log.Writer()
-	log.SetFlags(0)
-	log.SetOutput(&logBuf)
-	t.Cleanup(func() {
-		log.SetFlags(origLogFlags)
-		log.SetOutput(origLogOutput)
-	})
+	// Call the real function with empty password (no-password path).
+	pool := newUnreachablePool(t)
+	_ = ensureAdminUser(context.Background(), pool, "admin@example.com", "")
 
-	log.Printf("Ensuring admin user exists: %s (user will need to reset password to login)", "admin@example.com")
+	stdoutContent := readStdout()
 
-	w.Close()
-	os.Stdout = origStdout
-
-	var stdoutBuf bytes.Buffer
-	if _, err := stdoutBuf.ReadFrom(r); err != nil {
-		t.Fatalf("read from pipe: %v", err)
-	}
-	r.Close()
-
-	assert.Empty(t, stdoutBuf.String(),
+	assert.Empty(t, stdoutContent,
 		"log.Printf must not write to stdout")
 	assert.Contains(t, logBuf.String(), "admin@example.com")
 }
@@ -117,69 +112,45 @@ func TestEnsureAdminUser_NoPasswordVariant_LogsToStderr(t *testing.T) {
 // the password only in the returned string and not in any log call, serving as
 // a structural guard against accidental log emission of the DSN.
 func TestBuildMigrateDSN_PasswordNotInLogs(t *testing.T) {
-	var logBuf bytes.Buffer
-	origLogFlags := log.Flags()
-	origLogOutput := log.Writer()
-	log.SetFlags(0)
-	log.SetOutput(&logBuf)
-	t.Cleanup(func() {
-		log.SetFlags(origLogFlags)
-		log.SetOutput(origLogOutput)
-	})
-
-	// buildMigrateDSN is a pure builder — it must not log anything.
-	// We call it with a recognisable sentinel password.
-	// If the implementation ever adds a log line with the DSN, this test catches it.
 	const sentinelPassword = "SUPER_SECRET_SENTINEL_XYZ"
 
-	// Build a minimal fake pgxpool.Config via pgxpool.ParseConfig so we have a
-	// *pgxpool.Config to pass. Use a URL that embeds the sentinel password.
-	dsn := fmt.Sprintf("postgres://user:%s@localhost:5432/db?sslmode=disable", sentinelPassword)
+	logBuf := captureLogOutput(t)
 
-	// We can't easily call pgxpool.ParseConfig here without importing pgxpool in the
-	// migrations package test (it's already imported in migrate.go). Instead verify
-	// that the function under test does not write to the log buffer indirectly.
-	// The real guard is the log.SetOutput capture above.
+	// Build a real *pgxpool.Config whose ConnConfig.Password holds the sentinel.
+	rawDSN := fmt.Sprintf("postgres://user:%s@localhost:5432/db?sslmode=disable", sentinelPassword)
+	poolCfg, err := pgxpool.ParseConfig(rawDSN)
+	require.NoError(t, err, "pgxpool.ParseConfig must accept the sentinel DSN")
 
-	// Construct the DSN the way buildMigrateDSN would and confirm it contains the password
-	// (in the return value) but does not show up in logs.
-	_ = dsn // DSN is intentionally constructed but not further asserted here
+	// Call the function under test.
+	result := buildMigrateDSN(poolCfg, "")
 
-	logContent := logBuf.String()
-	assert.NotContains(t, logContent, sentinelPassword,
+	// The sentinel must appear in the returned DSN (proves the function embeds it).
+	assert.Contains(t, result, sentinelPassword,
+		"buildMigrateDSN return value must contain the password")
+
+	// The sentinel must NOT have leaked into the log buffer.
+	assert.NotContains(t, logBuf.String(), sentinelPassword,
 		"buildMigrateDSN must not emit the database password to the log output")
 }
 
-// TestMaybeForceVersion_InvalidValue ensures a non-numeric
+// TestMaybeForceVersion_NonNumericError ensures a non-numeric
 // CUDLY_FORCE_MIGRATION_VERSION produces an error without logging the
 // bad value to stdout.
 func TestMaybeForceVersion_NonNumericError(t *testing.T) {
-	origStdout := os.Stdout
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("pipe: %v", err)
-	}
-	os.Stdout = w
+	readStdout := captureStdout(t)
 
 	t.Setenv("CUDLY_FORCE_MIGRATION_VERSION", "not-a-number")
 
-	// maybeForceMigrationVersion takes a *migrate.Migrate, which we can't
-	// construct without a live DB. Test the value-parsing logic indirectly by
-	// simulating the Atoi + negative check branch.
-	value := os.Getenv("CUDLY_FORCE_MIGRATION_VERSION")
+	// maybeForceMigrationVersion returns an error from strconv.Atoi before it
+	// ever calls m.Force(), so nil is safe to pass for the non-numeric path.
+	err := maybeForceMigrationVersion(nil)
 
-	w.Close()
-	os.Stdout = origStdout
+	stdoutContent := readStdout()
 
-	var stdoutBuf bytes.Buffer
-	if _, err := stdoutBuf.ReadFrom(r); err != nil {
-		t.Fatalf("read from pipe: %v", err)
-	}
-	r.Close()
-
-	// The parsing path should have produced an error (Atoi fails for "not-a-number").
-	assert.True(t, strings.ContainsAny(value, "abcdefghijklmnopqrstuvwxyz"),
-		"sentinel value must be non-numeric so the code path is exercised")
-	assert.Empty(t, stdoutBuf.String(),
+	require.Error(t, err,
+		"non-numeric CUDLY_FORCE_MIGRATION_VERSION must return an error")
+	assert.Contains(t, err.Error(), "not-a-number",
+		"error message must echo back the bad value for operator clarity")
+	assert.Empty(t, stdoutContent,
 		"error handling must not write to stdout")
 }

--- a/internal/database/postgres/migrations/migrate_security_test.go
+++ b/internal/database/postgres/migrations/migrate_security_test.go
@@ -1,0 +1,185 @@
+package migrations
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestEnsureAdminUserWithPassword_LogsToStderr_NotStdout is a regression test
+// for issue #440: admin password activity must not be echoed to stdout.
+// Previously the function used fmt.Printf which writes to stdout; it now uses
+// log.Printf which writes to stderr.
+func TestEnsureAdminUserWithPassword_LogsToStderr_NotStdout(t *testing.T) {
+	// Capture stdout by redirecting os.Stdout to a pipe.
+	origStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+
+	// Capture log output (log.Printf writes to stderr by default, but the
+	// standard logger's output can be redirected for testing).
+	var logBuf bytes.Buffer
+	origLogFlags := log.Flags()
+	origLogOutput := log.Writer()
+	log.SetFlags(0)
+	log.SetOutput(&logBuf)
+	t.Cleanup(func() {
+		log.SetFlags(origLogFlags)
+		log.SetOutput(origLogOutput)
+	})
+
+	// Call the functions that previously wrote to stdout. They will fail with
+	// a nil-pool panic unless we guard, so exercise only the log path by
+	// triggering bcrypt and the log line before the DB call would happen.
+	// We check that the log output goes to our log buffer (stderr path) and
+	// NOT to the captured stdout pipe.
+
+	// Exercise ensureAdminUserWithPassword up to the bcrypt step by calling
+	// buildMigrateDSN indirectly; instead verify at the logging layer.
+	// The simplest regression-proof approach: assert the log message format
+	// matches and that stdout receives nothing password-related.
+
+	// Simulate the log call that the fixed code makes:
+	log.Printf("Ensuring admin user exists with password: %s", "admin@example.com")
+	log.Printf("Admin user created/activated: %s", "admin@example.com")
+
+	// Close the write-end of the pipe and restore stdout before reading.
+	w.Close()
+	os.Stdout = origStdout
+
+	// Read what (if anything) landed on stdout.
+	var stdoutBuf bytes.Buffer
+	if _, err := stdoutBuf.ReadFrom(r); err != nil {
+		t.Fatalf("read from pipe: %v", err)
+	}
+	r.Close()
+
+	// Assertion: nothing about admin password activity on stdout.
+	stdoutContent := stdoutBuf.String()
+	assert.Empty(t, stdoutContent,
+		"log.Printf must not write to stdout; found on stdout: %q", stdoutContent)
+
+	// Assertion: the log messages landed in the stderr-bound log buffer.
+	logContent := logBuf.String()
+	assert.Contains(t, logContent, "admin@example.com",
+		"admin email must appear in log output (stderr path)")
+	// The message describes the operation ("with password") but must NOT include
+	// the actual password value. The email is not a credential.
+	assert.NotContains(t, logContent, "supersecretpassword",
+		"log messages must never include the actual password value")
+}
+
+// TestEnsureAdminUser_NoPasswordVariant_LogsToStderr is a companion regression
+// test for the no-password variant of ensureAdminUser (issue #440).
+func TestEnsureAdminUser_NoPasswordVariant_LogsToStderr(t *testing.T) {
+	origStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+
+	var logBuf bytes.Buffer
+	origLogFlags := log.Flags()
+	origLogOutput := log.Writer()
+	log.SetFlags(0)
+	log.SetOutput(&logBuf)
+	t.Cleanup(func() {
+		log.SetFlags(origLogFlags)
+		log.SetOutput(origLogOutput)
+	})
+
+	log.Printf("Ensuring admin user exists: %s (user will need to reset password to login)", "admin@example.com")
+
+	w.Close()
+	os.Stdout = origStdout
+
+	var stdoutBuf bytes.Buffer
+	if _, err := stdoutBuf.ReadFrom(r); err != nil {
+		t.Fatalf("read from pipe: %v", err)
+	}
+	r.Close()
+
+	assert.Empty(t, stdoutBuf.String(),
+		"log.Printf must not write to stdout")
+	assert.Contains(t, logBuf.String(), "admin@example.com")
+}
+
+// TestBuildMigrateDSN_PasswordNotInLogs verifies that buildMigrateDSN embeds
+// the password only in the returned string and not in any log call, serving as
+// a structural guard against accidental log emission of the DSN.
+func TestBuildMigrateDSN_PasswordNotInLogs(t *testing.T) {
+	var logBuf bytes.Buffer
+	origLogFlags := log.Flags()
+	origLogOutput := log.Writer()
+	log.SetFlags(0)
+	log.SetOutput(&logBuf)
+	t.Cleanup(func() {
+		log.SetFlags(origLogFlags)
+		log.SetOutput(origLogOutput)
+	})
+
+	// buildMigrateDSN is a pure builder — it must not log anything.
+	// We call it with a recognisable sentinel password.
+	// If the implementation ever adds a log line with the DSN, this test catches it.
+	const sentinelPassword = "SUPER_SECRET_SENTINEL_XYZ"
+
+	// Build a minimal fake pgxpool.Config via pgxpool.ParseConfig so we have a
+	// *pgxpool.Config to pass. Use a URL that embeds the sentinel password.
+	dsn := fmt.Sprintf("postgres://user:%s@localhost:5432/db?sslmode=disable", sentinelPassword)
+
+	// We can't easily call pgxpool.ParseConfig here without importing pgxpool in the
+	// migrations package test (it's already imported in migrate.go). Instead verify
+	// that the function under test does not write to the log buffer indirectly.
+	// The real guard is the log.SetOutput capture above.
+
+	// Construct the DSN the way buildMigrateDSN would and confirm it contains the password
+	// (in the return value) but does not show up in logs.
+	_ = dsn // DSN is intentionally constructed but not further asserted here
+
+	logContent := logBuf.String()
+	assert.NotContains(t, logContent, sentinelPassword,
+		"buildMigrateDSN must not emit the database password to the log output")
+}
+
+// TestMaybeForceVersion_InvalidValue ensures a non-numeric
+// CUDLY_FORCE_MIGRATION_VERSION produces an error without logging the
+// bad value to stdout.
+func TestMaybeForceVersion_NonNumericError(t *testing.T) {
+	origStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+
+	t.Setenv("CUDLY_FORCE_MIGRATION_VERSION", "not-a-number")
+
+	// maybeForceMigrationVersion takes a *migrate.Migrate, which we can't
+	// construct without a live DB. Test the value-parsing logic indirectly by
+	// simulating the Atoi + negative check branch.
+	value := os.Getenv("CUDLY_FORCE_MIGRATION_VERSION")
+
+	w.Close()
+	os.Stdout = origStdout
+
+	var stdoutBuf bytes.Buffer
+	if _, err := stdoutBuf.ReadFrom(r); err != nil {
+		t.Fatalf("read from pipe: %v", err)
+	}
+	r.Close()
+
+	// The parsing path should have produced an error (Atoi fails for "not-a-number").
+	assert.True(t, strings.ContainsAny(value, "abcdefghijklmnopqrstuvwxyz"),
+		"sentinel value must be non-numeric so the code path is exercised")
+	assert.Empty(t, stdoutBuf.String(),
+		"error handling must not write to stdout")
+}

--- a/internal/database/security_test.go
+++ b/internal/database/security_test.go
@@ -146,13 +146,13 @@ func TestBuildPoolConfig_ParseError_NoPasswordLeak(t *testing.T) {
 	}
 
 	_, err := buildPoolConfig(cfg, realPassword)
-	// This may or may not error depending on pgx version — if it does error,
-	// the real password must not appear in the error message.
-	if err != nil {
-		assert.NotContains(t, err.Error(), realPassword,
-			"parse error must not expose the real DB password in the error chain")
-		// The placeholder "REDACTED" may appear, which is acceptable.
-	}
+	// pgx rejects an unknown sslmode during ParseConfig, so an error is
+	// guaranteed here. The real password must never surface in the error text.
+	require.Error(t, err,
+		"pgxpool.ParseConfig must reject sslmode=invalid-ssl-mode")
+	assert.NotContains(t, err.Error(), realPassword,
+		"parse error must not expose the real DB password in the error chain")
+	// The placeholder "REDACTED" may appear, which is acceptable.
 }
 
 // TestSanitizeLogData_ArgsKeyStrippedAtDebugByDefault is a regression test for

--- a/internal/database/security_test.go
+++ b/internal/database/security_test.go
@@ -1,0 +1,295 @@
+package database
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/tracelog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateRequiredFields_BothPasswordAndSecret_WarnOnStderr is a
+// regression test for issue #441: when both DB_PASSWORD and DB_PASSWORD_SECRET
+// are set, a warning must be emitted to stderr (not silently accepted, and not
+// a hard error that breaks local-dev workflows).
+func TestValidateRequiredFields_BothPasswordAndSecret_WarnOnStderr(t *testing.T) {
+	// Capture stderr
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stderr = w
+
+	cfg := &Config{
+		Host:           "localhost",
+		Database:       "testdb",
+		User:           "testuser",
+		Password:       "plaintext-pass",
+		PasswordSecret: "arn:aws:secretsmanager:us-east-1:123:secret:mydb",
+	}
+
+	validateErr := cfg.validateRequiredFields()
+
+	w.Close()
+	os.Stderr = origStderr
+
+	var stderrBuf bytes.Buffer
+	_, _ = io.Copy(&stderrBuf, r)
+	r.Close()
+
+	// Must not return an error (should not break existing workflows).
+	assert.NoError(t, validateErr,
+		"both password sources set must not return an error (local-dev workflows must still work)")
+
+	// Must emit a warning to stderr.
+	stderrContent := stderrBuf.String()
+	assert.Contains(t, stderrContent, "WARNING",
+		"a warning must appear on stderr when both DB_PASSWORD and DB_PASSWORD_SECRET are set")
+	assert.Contains(t, stderrContent, "DB_PASSWORD_SECRET",
+		"warning must mention DB_PASSWORD_SECRET as the preferred path")
+}
+
+// TestValidateRequiredFields_OnlySecret_NoWarning verifies that using only
+// DB_PASSWORD_SECRET (the preferred production path) produces no warning.
+func TestValidateRequiredFields_OnlySecret_NoWarning(t *testing.T) {
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stderr = w
+
+	cfg := &Config{
+		Host:           "localhost",
+		Database:       "testdb",
+		User:           "testuser",
+		Password:       "",
+		PasswordSecret: "arn:aws:secretsmanager:us-east-1:123:secret:mydb",
+	}
+
+	validateErr := cfg.validateRequiredFields()
+
+	w.Close()
+	os.Stderr = origStderr
+
+	var stderrBuf bytes.Buffer
+	_, _ = io.Copy(&stderrBuf, r)
+	r.Close()
+
+	assert.NoError(t, validateErr)
+	assert.NotContains(t, stderrBuf.String(), "WARNING",
+		"no warning when only DB_PASSWORD_SECRET is set (preferred path)")
+}
+
+// TestBuildPoolConfig_ParseConfigUsesRedactedPassword is a regression test for
+// issue #444: pgxpool.ParseConfig must never receive a DSN that contains the
+// real password. If the parse fails, the error chain must not expose the
+// plaintext credential.
+//
+// The fix parses a DSN containing the placeholder "REDACTED" and then sets
+// ConnConfig.Password to the real credential. We verify that the real password
+// does not appear in the poolConfig's DSN-derived fields by confirming that a
+// deliberately bad host/DSN triggers a parse error whose text does not contain
+// the real password.
+func TestBuildPoolConfig_ParseConfigDoesNotExposePassword(t *testing.T) {
+	const realPassword = "SUPER_SENSITIVE_DB_PASS_12345"
+
+	// Valid config — parse must succeed.
+	cfg := &Config{
+		Host:           "localhost",
+		Port:           5432,
+		User:           "testuser",
+		Password:       realPassword,
+		Database:       "testdb",
+		SSLMode:        "disable",
+		MaxConnections: 10,
+		MinConnections: 1,
+		ConnectTimeout: 5 * time.Second,
+		LogLevel:       "info",
+	}
+
+	poolConfig, err := buildPoolConfig(cfg, realPassword)
+	require.NoError(t, err)
+	require.NotNil(t, poolConfig)
+
+	// The real password must be present in ConnConfig.Password (used at connect time).
+	assert.Equal(t, realPassword, poolConfig.ConnConfig.Password,
+		"ConnConfig.Password must hold the real password for actual connections")
+
+	// ConnConfig.Host must be set correctly (proves DSN was parsed successfully).
+	assert.Equal(t, "localhost", poolConfig.ConnConfig.Host)
+}
+
+// TestBuildPoolConfig_ParseError_NoPasswordLeak verifies that when the DSN
+// contains a structurally invalid piece (beyond what pgx can parse) any error
+// returned does not expose the real password. This tests the defence-in-depth
+// goal of issue #444: by passing "REDACTED" to ParseConfig, even an error from
+// pgx's URI parser only shows "REDACTED", not the real credential.
+func TestBuildPoolConfig_ParseError_NoPasswordLeak(t *testing.T) {
+	const realPassword = "SUPER_SENSITIVE_DB_PASS_12345"
+
+	// Use an invalid SSL mode to provoke an error from pgxpool.ParseConfig.
+	// (pgx validates the sslmode string during parsing.)
+	cfg := &Config{
+		Host:           "localhost",
+		Port:           5432,
+		User:           "testuser",
+		Password:       realPassword,
+		Database:       "testdb",
+		SSLMode:        "invalid-ssl-mode",
+		MaxConnections: 10,
+		MinConnections: 1,
+		ConnectTimeout: 5 * time.Second,
+		LogLevel:       "info",
+	}
+
+	_, err := buildPoolConfig(cfg, realPassword)
+	// This may or may not error depending on pgx version — if it does error,
+	// the real password must not appear in the error message.
+	if err != nil {
+		assert.NotContains(t, err.Error(), realPassword,
+			"parse error must not expose the real DB password in the error chain")
+		// The placeholder "REDACTED" may appear, which is acceptable.
+	}
+}
+
+// TestSanitizeLogData_ArgsKeyStrippedAtDebugByDefault is a regression test for
+// issue #446: pgx logs SQL bound parameters under the "args" key at debug
+// level. Without the fix, these would be included in log output and could
+// expose session tokens, bcrypt hashes, or approval tokens.
+//
+// By default (DB_LOG_BIND_PARAMETERS not set) the "args" key must be stripped
+// from debug-level log data.
+func TestSanitizeLogData_ArgsKeyStrippedAtDebugByDefault(t *testing.T) {
+	t.Setenv("DB_LOG_BIND_PARAMETERS", "")
+
+	tests := []struct {
+		name          string
+		inputData     map[string]any
+		level         tracelog.LogLevel
+		wantArgsInOut bool
+	}{
+		{
+			name: "args stripped at debug level by default",
+			inputData: map[string]any{
+				"args": []any{"session-token-abc", "bcrypt-hash-xyz"},
+				"sql":  "SELECT * FROM users WHERE token = $1",
+			},
+			level:         tracelog.LogLevelDebug,
+			wantArgsInOut: false,
+		},
+		{
+			name: "args kept at warn level",
+			inputData: map[string]any{
+				"args": []any{"value"},
+				"sql":  "SELECT 1",
+			},
+			level:         tracelog.LogLevelWarn,
+			wantArgsInOut: true,
+		},
+		{
+			name: "args kept at error level",
+			inputData: map[string]any{
+				"args": []any{"value"},
+			},
+			level:         tracelog.LogLevelError,
+			wantArgsInOut: true,
+		},
+		{
+			name: "password always stripped at warn level",
+			inputData: map[string]any{
+				"password": "secret",
+				"safe":     "ok",
+			},
+			level:         tracelog.LogLevelWarn,
+			wantArgsInOut: false, // "args" key not in input, not relevant
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			safe := sanitizeLogData(tc.level, tc.inputData)
+			_, hasArgs := safe["args"]
+			assert.Equal(t, tc.wantArgsInOut, hasArgs,
+				"args key presence mismatch for level %v", tc.level)
+		})
+	}
+}
+
+// TestSanitizeLogData_ArgsKeyKeptWhenOptedIn verifies that setting
+// DB_LOG_BIND_PARAMETERS=true allows the "args" key through at debug level.
+func TestSanitizeLogData_ArgsKeyKeptWhenOptedIn(t *testing.T) {
+	t.Setenv("DB_LOG_BIND_PARAMETERS", "true")
+
+	inputData := map[string]any{
+		"args": []any{"param1", "param2"},
+		"sql":  "SELECT 1",
+	}
+
+	safe := sanitizeLogData(tracelog.LogLevelDebug, inputData)
+	_, hasArgs := safe["args"]
+	assert.True(t, hasArgs,
+		"args key must be preserved when DB_LOG_BIND_PARAMETERS=true")
+}
+
+// TestIsSensitiveKey verifies the sensitive-key predicate covers all expected names.
+func TestIsSensitiveKey(t *testing.T) {
+	assert.True(t, isSensitiveKey("password"))
+	assert.True(t, isSensitiveKey("secret"))
+	assert.True(t, isSensitiveKey("token"))
+	assert.False(t, isSensitiveKey("sql"))
+	assert.False(t, isSensitiveKey("args"))
+	assert.False(t, isSensitiveKey("host"))
+}
+
+// TestStdLogger_DoesNotPanicWithArgsKey exercises the live stdLogger.Log path
+// with an "args" entry to confirm it does not panic when the key is filtered.
+func TestStdLogger_DoesNotPanicWithArgsKey(t *testing.T) {
+	t.Setenv("DB_LOG_BIND_PARAMETERS", "")
+
+	logger := &stdLogger{}
+	ctx := context.Background()
+
+	data := map[string]any{
+		"args":     []any{"session-token", "hash-value"},
+		"sql":      "INSERT INTO sessions VALUES ($1, $2)",
+		"password": "should-be-stripped",
+	}
+
+	assert.NotPanics(t, func() {
+		logger.Log(ctx, tracelog.LogLevelDebug, "Query", data)
+	})
+	assert.NotPanics(t, func() {
+		logger.Log(ctx, tracelog.LogLevelInfo, "Query", data)
+	})
+}
+
+// TestSanitizeLogData_PasswordStrippedAtAllLevels confirms password/secret/token
+// keys are removed regardless of log level.
+func TestSanitizeLogData_PasswordStrippedAtAllLevels(t *testing.T) {
+	t.Setenv("DB_LOG_BIND_PARAMETERS", "")
+
+	sensitive := map[string]any{
+		"password": "my-password",
+		"secret":   "my-secret",
+		"token":    "my-token",
+		"safe":     "visible",
+	}
+
+	for _, level := range []tracelog.LogLevel{
+		tracelog.LogLevelDebug,
+		tracelog.LogLevelInfo,
+		tracelog.LogLevelWarn,
+		tracelog.LogLevelError,
+	} {
+		t.Run(level.String(), func(t *testing.T) {
+			safe := sanitizeLogData(level, sensitive)
+			assert.NotContains(t, safe, "password")
+			assert.NotContains(t, safe, "secret")
+			assert.NotContains(t, safe, "token")
+			assert.Contains(t, safe, "safe")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- **#440 (P1)**: Replace `fmt.Printf` with `log.Printf` in the migration runner so admin password-processing activity goes to stderr (the log sink) rather than stdout, which CloudWatch ingests into persistent log groups. Also remove the phrase "with password" from the created/activated confirmation line to reduce correlation with Secrets Manager access logs.
- **#441 (P2)**: Emit a stderr warning when both `DB_PASSWORD` and `DB_PASSWORD_SECRET` are set. Plaintext `DB_PASSWORD` is readable via `lambda:GetFunction` without requiring `secretsmanager:GetSecretValue`. Local-dev workflows still work (not a hard error).
- **#444 (P2)**: Pass a redacted DSN (`password=REDACTED`) to `pgxpool.ParseConfig` so that any parse error never echoes the real credential in the error chain. The real password is injected directly into `ConnConfig.Password` after successful parsing.
- **#446 (P2)**: Suppress the pgx `"args"` key (SQL bound parameters) at debug level in `stdLogger.Log`. Parameters can carry session tokens, bcrypt hashes, or approval tokens. Operators who need parameter tracing must opt in via `DB_LOG_BIND_PARAMETERS=true`.

The `stdLogger.Log` function was refactored into two pure helpers (`isSensitiveKey`, `sanitizeLogData`) to keep cyclomatic complexity below the project's gocyclo limit of 10.

## Test plan

- [ ] `go test ./internal/database/... ./internal/server/...` passes (172 + 325 tests green)
- [ ] `TestValidateRequiredFields_BothPasswordAndSecret_WarnOnStderr` - regression for #441: warning on stderr, no error returned
- [ ] `TestBuildPoolConfig_ParseConfigDoesNotExposePassword` - regression for #444: real password in `ConnConfig.Password`, parse succeeds
- [ ] `TestBuildPoolConfig_ParseError_NoPasswordLeak` - regression for #444: parse errors do not echo the real password
- [ ] `TestSanitizeLogData_ArgsKeyStrippedAtDebugByDefault` - regression for #446: `args` stripped at debug level
- [ ] `TestSanitizeLogData_ArgsKeyKeptWhenOptedIn` - regression for #446: `args` preserved with `DB_LOG_BIND_PARAMETERS=true`
- [ ] `TestEnsureAdminUserWithPassword_LogsToStderr_NotStdout` - regression for #440: log.Printf does not write to stdout
- [ ] All pre-commit hooks pass (gofmt, go vet, gocyclo, gosec, trivy)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sensitive credentials (passwords, secrets, tokens) are now redacted from logs and error messages to prevent accidental exposure.
  * Database passwords no longer appear in error chains during connection failures.

* **New Features**
  * Warning emitted when both plaintext and secret-based password methods are configured; the secret method takes precedence.

* **Tests**
  * Added security regression tests to prevent credential leaks in logs and error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/520?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->