### PR TITLE
sec(frontend/docs): pin swagger-ui version + add SRI hashes (closes #447, #418)

### DIFF
--- a/frontend/src/docs.html
+++ b/frontend/src/docs.html
@@ -4,13 +4,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>CUDly API Documentation</title>
-    <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css">
+    <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@5.32.6/swagger-ui.css" integrity="sha384-9Q2fpS+xeS4ffJy6CagnwoUl+4ldAYhOs9pgZuEKxypVModhmZFzeMlvVsAjf7uT" crossorigin="anonymous">
     <link rel="stylesheet" type="text/css" href="./docs.css">
 </head>
 <body>
     <div id="swagger-ui"></div>
-    <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
-    <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-standalone-preset.js"></script>
+    <script src="https://unpkg.com/swagger-ui-dist@5.32.6/swagger-ui-bundle.js" integrity="sha384-EYdOaiRwn44zNjrw+Tfs06qYz9BGQVo2f4/pLY5i7VorbjnZNhdplAbTBk8FXHUJ" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/swagger-ui-dist@5.32.6/swagger-ui-standalone-preset.js" integrity="sha384-49fpFaVrAWI/qdgl9Vv5E/4NXxRUiJX5vGuLws1NUpTWGtEqzWEx8gHTw2UTehFK" crossorigin="anonymous"></script>
     <script>
         window.onload = function() {
             window.ui = SwaggerUIBundle({


### PR DESCRIPTION
## Summary

- Replaces unpinned CDN range (`@5`) in `frontend/src/docs.html` with exact version `5.32.6` for all three swagger-ui-dist resources
- Adds `integrity="sha384-..."` and `crossorigin="anonymous"` to the stylesheet `<link>` and both `<script>` tags
- SRI hashes verified by downloading each file from unpkg and jsdelivr at the pinned version and confirming sha384 digests match across both CDNs

Closes #447, #418

## Test plan

- [x] `npx jest` passes (one pre-existing unrelated failure in `settings-purchasing-grace.test.ts` confirmed present before this change)
- [x] `npx tsc --noEmit` passes with no errors
- [x] SRI hashes cross-validated against jsdelivr CDN for the same version