### PR TITLE
sec(auth): add setup_admin rate-limit bucket and fix Lambda cold-start nil limiter

### DIFF
--- a/internal/api/inmemory_rate_limiter_test.go
+++ b/internal/api/inmemory_rate_limiter_test.go
@@ -233,3 +233,62 @@ func TestInMemoryRateLimiter_ConcurrentAccess(t *testing.T) {
 		<-done
 	}
 }
+
+// Regression test for #411: setup_admin must have a dedicated strict rate-limit
+// bucket (5/min/IP) and must NOT fall through to the permissive api_general
+// config (300/min).
+func TestGetDefaultRateLimits_SetupAdminHasDedicatedBucket(t *testing.T) {
+	limits := getDefaultRateLimits()
+
+	cfg, ok := limits["setup_admin"]
+	if !ok {
+		t.Fatal("setup_admin key missing from default rate limits (issue #411)")
+	}
+
+	// setup_admin should be far stricter than api_general (300/min)
+	apiGeneral := limits["api_general"]
+	if cfg.MaxAttempts >= apiGeneral.MaxAttempts {
+		t.Errorf("setup_admin limit (%d) is not stricter than api_general (%d); regression of #411",
+			cfg.MaxAttempts, apiGeneral.MaxAttempts)
+	}
+
+	// Verify the window is present
+	if cfg.Window == 0 {
+		t.Error("setup_admin rate limit has zero window duration")
+	}
+
+	// Verify the window matches the specification from issue #411 (5 per 15 minutes).
+	assert.Equal(t, 15*time.Minute, cfg.Window,
+		"setup_admin window must be 15 minutes per issue #411")
+}
+
+// Regression test for #420: NewInMemoryRateLimiter must be ready at construction
+// time (not after a slow lazy init) so Lambda cold-start first requests are protected.
+func TestNewInMemoryRateLimiter_ReadyImmediately(t *testing.T) {
+	rl := NewInMemoryRateLimiter()
+	ctx := context.Background()
+
+	// The limiter must be usable on the very first call without any further setup.
+	// Previously, Lambda started with a nil rate limiter that allowed all requests
+	// through until the DB connection was established (issue #420).
+	allowed, err := rl.AllowWithIP(ctx, "10.0.0.1", "login")
+	if err != nil {
+		t.Fatalf("AllowWithIP returned unexpected error on first call: %v", err)
+	}
+	if !allowed {
+		t.Fatal("first login attempt should be allowed by a fresh rate limiter")
+	}
+
+	// Exhaust the login limit (5 per 15 min)
+	loginLimit := getDefaultRateLimits()["login"]
+	for i := 1; i < loginLimit.MaxAttempts; i++ {
+		_, _ = rl.AllowWithIP(ctx, "10.0.0.1", "login")
+	}
+	blocked, err := rl.AllowWithIP(ctx, "10.0.0.1", "login")
+	if err != nil {
+		t.Fatalf("unexpected error after exhausting limit: %v", err)
+	}
+	if blocked {
+		t.Errorf("expected login to be blocked after %d attempts; rate limiter was not enforcing (regression of #420)", loginLimit.MaxAttempts)
+	}
+}

--- a/internal/api/rate_limiter.go
+++ b/internal/api/rate_limiter.go
@@ -31,6 +31,10 @@ func getDefaultRateLimits() map[string]RateLimitConfig {
 		"api_general":           NewRateLimitConfig(300, 60),   // 300 requests / minute / IP
 		"admin":                 NewRateLimitConfig(30, 60),    // 30 / minute / user
 		"approve_cancel_public": NewRateLimitConfig(30, 60),    // 30 / minute / IP for public approve/cancel/reject
+		// setup_admin should fire at most once per deployment. Issue #411 specifies
+		// 5 attempts per 15 minutes so a cold-start burst cannot brute-force the
+		// first-run endpoint before the DB-backed limiter is available.
+		"setup_admin": NewRateLimitConfig(5, 15*60), // 5 attempts / 15 minutes / IP
 	}
 }
 

--- a/internal/server/app.go
+++ b/internal/server/app.go
@@ -396,13 +396,17 @@ func NewApplicationFromDeps(ctx context.Context, cfg ApplicationConfig, deps Ext
 		DashboardURL:    cfg.DashboardURL,
 	})
 
-	// Initialize rate limiter based on runtime environment
-	var rateLimiter api.RateLimiterInterface
+	// Initialize rate limiter based on runtime environment.
+	// Lambda: start with an in-memory limiter immediately so the first cold-start
+	// request is protected. ensureDB() swaps it for the DB-backed limiter once the
+	// database connection is established (distributed state across warm containers).
+	// Fargate/containers: in-memory is the permanent implementation because the
+	// process is long-lived and single-instance.
+	rateLimiter := api.RateLimiterInterface(api.NewInMemoryRateLimiter())
 	if !cfg.IsLambda {
-		rateLimiter = api.NewInMemoryRateLimiter()
 		log.Println("Initialized in-memory rate limiter for single-instance deployment (Fargate/Container)")
 	} else {
-		log.Println("Lambda runtime detected - database rate limiter will be initialized on first request")
+		log.Println("Initialized in-memory rate limiter for Lambda cold-start (will be upgraded to DB-backed on first DB connect)")
 	}
 
 	// Initialize API handler

--- a/internal/server/app_test.go
+++ b/internal/server/app_test.go
@@ -415,7 +415,10 @@ func TestNewApplicationFromDeps(t *testing.T) {
 		testutil.AssertTrue(t, app.DB == nil, "DB should be nil (lazy init)")
 	})
 
-	t.Run("Lambda path with nil rate limiter", func(t *testing.T) {
+	// Regression test for issue #420: Lambda cold-start must have a non-nil
+	// in-memory rate limiter so the first requests are protected before the
+	// DB connection is established.
+	t.Run("Lambda path with in-memory rate limiter (issue #420)", func(t *testing.T) {
 		lambdaCfg := baseCfg
 		lambdaCfg.IsLambda = true
 
@@ -426,7 +429,7 @@ func TestNewApplicationFromDeps(t *testing.T) {
 
 		app, err := NewApplicationFromDeps(ctx, lambdaCfg, deps)
 		testutil.AssertNoError(t, err)
-		testutil.AssertTrue(t, app.RateLimiter == nil, "Rate limiter should be nil for Lambda (initialized after DB connect)")
+		testutil.AssertTrue(t, app.RateLimiter != nil, "Rate limiter must not be nil for Lambda (fix for issue #420: cold-start requests must be rate-limited)")
 	})
 
 	t.Run("nil dbConfig returns error", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fixes #411: setup_admin now has a dedicated 5/min/IP rate-limit bucket instead of falling through to api_general (300/min). The endpoint should fire at most once per deployment.
- Fixes #420: Lambda cold-start first requests previously ran with a nil rate limiter (allow-all). NewApplicationFromDeps now initialises an InMemoryRateLimiter unconditionally at startup. ensureDB() upgrades Lambda to DBRateLimiter on first DB connect.
- Regression tests added for both fixes.

## Test plan

- [ ] go test ./internal/api/... passes
- [ ] TestGetDefaultRateLimits_SetupAdminHasDedicatedBucket confirms setup_admin has a strict bucket
- [ ] TestNewInMemoryRateLimiter_ReadyImmediately confirms limiter enforces limits from first call

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  - Added regression tests validating default rate limits and that the rate limiter is usable immediately after startup.

* **Bug Fixes**
  - Rate limiter now initializes at application startup so first requests are protected.
  - Introduced a stricter, dedicated per‑IP limit for the setup admin flow (lower burst, 15‑minute window).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/522?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->