### PR TITLE
sec(iac): scope kms:GetKeyPolicy away from Resource=*

### DIFF
--- a/terraform/environments/aws/ci-cd-permissions/policy_compute.tf
+++ b/terraform/environments/aws/ci-cd-permissions/policy_compute.tf
@@ -295,10 +295,13 @@ resource "aws_iam_policy" "compute" {
         Resource = "*"
       },
       {
-        # KMS create + read-only actions don't accept a key ARN at API
-        # level (key ARNs are only known after CreateKey). Read-only
-        # actions are also broad because terraform plan needs to
-        # enumerate key state.
+        # kms:CreateKey and the list/describe actions that don't accept
+        # a key ARN at the API level (key ARN is only known after
+        # CreateKey; ListAliases lists all aliases account-wide).
+        # kms:GetKeyPolicy is intentionally NOT here — it exposes the
+        # full trust model of a key and is scoped to Project=CUDly keys
+        # in policy_compute_b.tf KMSReadTaggedOnly to prevent account-wide
+        # key-policy reconnaissance via a compromised deploy token.
         # kms:CreateAlias is NOT here — it moved to KMSMutateTaggedOnly
         # below (key-side check, tag-gated) and policy_compute_b.tf
         # KMSAliasMutate (alias-side check, ARN-scoped). KMS evaluates
@@ -308,7 +311,6 @@ resource "aws_iam_policy" "compute" {
         Action = [
           "kms:CreateKey",
           "kms:DescribeKey",
-          "kms:GetKeyPolicy",
           "kms:GetKeyRotationStatus",
           "kms:ListAliases",
           "kms:ListResourceTags",

--- a/terraform/environments/aws/ci-cd-permissions/policy_compute_b.tf
+++ b/terraform/environments/aws/ci-cd-permissions/policy_compute_b.tf
@@ -21,6 +21,13 @@
 #    against BOTH the alias and the target key, so the alias-side
 #    check lives here (ARN-scoped) and the key-side check lives in
 #    policy_compute.tf KMSMutateTaggedOnly (tag-gated to CUDly keys).
+#
+#  - KMSReadTaggedOnly: kms:GetKeyPolicy exposes the full trust model
+#    of a CMK (key policy document reveals all principals and conditions).
+#    Moving it here with aws:ResourceTag/Project=CUDly prevents the deploy
+#    SA from enumerating key policies of unrelated workloads sharing the
+#    account (account-wide key-policy reconnaissance). Split from the main
+#    policy because the 6144-char limit was reached.
 
 resource "aws_iam_policy" "compute_b" {
   name        = "cudly-deploy-compute-b"
@@ -61,6 +68,22 @@ resource "aws_iam_policy" "compute_b" {
           "kms:UpdateAlias",
         ]
         Resource = "arn:aws:kms:*:*:alias/cudly-*"
+      },
+      {
+        # kms:GetKeyPolicy reveals the full trust model of a CMK and is
+        # therefore gated on the key being tagged Project=CUDly. This
+        # prevents the deploy SA from reading key policies of unrelated
+        # workloads sharing the account. Split from policy_compute.tf
+        # because the 6144-char managed-policy limit was reached.
+        Sid      = "KMSReadTaggedOnly"
+        Effect   = "Allow"
+        Action   = ["kms:GetKeyPolicy"]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "aws:ResourceTag/Project" = "CUDly"
+          }
+        }
       },
     ]
   })


### PR DESCRIPTION
## Summary

- **policy_compute.tf**: remove `kms:GetKeyPolicy` from `KMSCreateAndRead` (`Resource="*"`) — this action reveals the full trust model of a CMK (all principals and conditions).
- **policy_compute_b.tf**: add new `KMSReadTaggedOnly` statement for `kms:GetKeyPolicy` gated on `aws:ResourceTag/Project=CUDly`. A compromised deploy token can now only read key policies of CUDly-owned CMKs, not enumerate the key policies of every CMK in the account.

The tag condition works correctly because `aws_kms_key` sets the `Project=CUDly` tag at `CreateKey` time (via the `Tags` parameter), before `GetKeyPolicy` is ever called on the new key.

Split to `policy_compute_b.tf` because `policy_compute.tf` is at the AWS 6144-char managed-policy limit.

## Test plan

- [ ] `terraform fmt -check -recursive` passes (pre-commit verified)
- [ ] `terraform validate` in ci-cd-permissions passes
- [ ] Confirm Terraform plan and apply still succeed for KMS operations on CUDly keys

Closes #427.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated KMS permissions in compute infrastructure IAM policies by removing specific key-related API operations, refining access controls, and improving documentation for permission boundaries and access restrictions.
  * Added new conditional KMS read-only permissions with resource-level restrictions limiting access exclusively to resources matching specific attributes, providing enhanced security and fine-grained access control.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/525?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->