### PR TITLE
sec(iac): tighten CloudFormation Lambda Function URL CORS wildcards

### DIFF
--- a/cloudformation/stacks/CUDly/template.yaml
+++ b/cloudformation/stacks/CUDly/template.yaml
@@ -596,12 +596,23 @@ Resources:
       AuthType: AWS_IAM
       TargetFunctionArn: !GetAtt LambdaFunction.Arn
       Cors:
+        # When a custom domain is configured, restrict CORS to that origin.
+        # Without a custom domain the wildcard is unavoidable for testing,
+        # but production deployments should always set DashboardDomainName.
+        # AllowMethods and AllowHeaders match the Terraform lambda module
+        # (terraform/modules/compute/aws/lambda/main.tf cors block).
         AllowOrigins:
-          - "*"
+          - !If [HasCustomDomain, !Sub "https://${DashboardDomainName}", "*"]
         AllowMethods:
-          - "*"
+          - GET
+          - POST
+          - PUT
+          - DELETE
         AllowHeaders:
-          - "*"
+          - Content-Type
+          - Authorization
+          - X-CSRF-Token
+          - X-Session-Token
 
   # Permission for CloudFront OAC to invoke Lambda - must be created AFTER the distribution
   LambdaFunctionUrlPermission:


### PR DESCRIPTION
## Summary

- **cloudformation/stacks/CUDly/template.yaml** `LambdaFunctionUrl.Cors`:
  - `AllowOrigins`: replace hardcoded `["*"]` with `!If [HasCustomDomain, "https://${DashboardDomainName}", "*"]` — when a custom domain is set, CORS is locked to that origin only.
  - `AllowMethods`: replace `["*"]` with explicit list `[GET, POST, PUT, DELETE]` matching the Terraform lambda module.
  - `AllowHeaders`: replace `["*"]` with explicit list `[Content-Type, Authorization, X-CSRF-Token, X-Session-Token]` matching the Terraform lambda module.

The wildcard origin fallback is preserved only for deployments without a custom domain (testing/dev). Production deployments always set `DashboardDomainName`.

Note: the Terraform tfvars wildcard origins (#442) are handled by PR #519, which adds a validation block rejecting `["*"]` in the lambda module.

## Test plan

- [ ] YAML parses cleanly (verified with python3 yaml.load)
- [ ] CloudFormation change-set with `DashboardDomainName` set shows `AllowOrigins` scoped to the domain
- [ ] CloudFormation change-set without `DashboardDomainName` shows `AllowOrigins: ["*"]` (fallback for no-domain deployments)

Closes #435.