### PR TITLE
sec(api): drop Secrets Manager ARN from unauthenticated /api/info (closes #437)

### DIFF
--- a/internal/api/handler_dashboard.go
+++ b/internal/api/handler_dashboard.go
@@ -4,7 +4,6 @@ package api
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/LeanerCloud/CUDly/internal/auth"
@@ -322,6 +321,11 @@ func (h *Handler) planIntersectsAllowed(ctx context.Context, planID string, allo
 
 // getPublicInfo returns public information about the CUDly instance (no auth required)
 // No rate limiting — this is hit by Terraform deployment checks and the frontend on every page load.
+//
+// Security: the Secrets Manager ARN (which contains the AWS account ID and
+// region) is intentionally NOT included in this response. It was previously
+// returned as api_key_secret_url but that leaked cloud identity to
+// unauthenticated callers (issue #437).
 func (h *Handler) getPublicInfo(ctx context.Context, req *events.LambdaFunctionURLRequest) (*PublicInfoResponse, error) {
 	// Check if admin exists
 	adminExists := false
@@ -332,22 +336,9 @@ func (h *Handler) getPublicInfo(ctx context.Context, req *events.LambdaFunctionU
 		}
 	}
 
-	// Build the API key secret URL for the console
-	var apiKeySecretURL string
-	if h.secretsARN != "" {
-		// Extract region from ARN: arn:aws:secretsmanager:region:account:secret:name
-		parts := strings.Split(h.secretsARN, ":")
-		if len(parts) >= 4 {
-			region := parts[3]
-			apiKeySecretURL = fmt.Sprintf("https://%s.console.aws.amazon.com/secretsmanager/secret?name=%s&region=%s",
-				region, h.secretsARN, region)
-		}
-	}
-
 	return &PublicInfoResponse{
-		Version:         "1.0.0",
-		AdminExists:     adminExists,
-		APIKeySecretURL: apiKeySecretURL,
+		Version:     "1.0.0",
+		AdminExists: adminExists,
 	}, nil
 }
 

--- a/internal/api/handler_dashboard_test.go
+++ b/internal/api/handler_dashboard_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -496,8 +497,6 @@ func TestHandler_getPublicInfo(t *testing.T) {
 
 		assert.Equal(t, "1.0.0", result.Version)
 		assert.True(t, result.AdminExists)
-		assert.Contains(t, result.APIKeySecretURL, "us-east-1")
-		assert.Contains(t, result.APIKeySecretURL, "secretsmanager")
 	})
 
 	t.Run("with auth service and no admin", func(t *testing.T) {
@@ -512,7 +511,6 @@ func TestHandler_getPublicInfo(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.False(t, result.AdminExists)
-		assert.Empty(t, result.APIKeySecretURL)
 	})
 
 	t.Run("auth service check error still returns response", func(t *testing.T) {
@@ -539,37 +537,6 @@ func TestHandler_getPublicInfo(t *testing.T) {
 		assert.False(t, result.AdminExists)
 	})
 
-	t.Run("ARN parsing for different regions", func(t *testing.T) {
-		mockAuth := new(MockAuthService)
-		mockAuth.On("CheckAdminExists", ctx).Return(true, nil)
-
-		handler := &Handler{
-			auth:       mockAuth,
-			secretsARN: "arn:aws:secretsmanager:eu-west-1:987654321098:secret:my-secret-xyz789",
-		}
-
-		result, err := handler.getPublicInfo(ctx, createMockLambdaRequest("192.168.1.1"))
-		require.NoError(t, err)
-
-		assert.Contains(t, result.APIKeySecretURL, "eu-west-1")
-	})
-
-	t.Run("invalid ARN format", func(t *testing.T) {
-		mockAuth := new(MockAuthService)
-		mockAuth.On("CheckAdminExists", ctx).Return(true, nil)
-
-		handler := &Handler{
-			auth:       mockAuth,
-			secretsARN: "invalid-arn",
-		}
-
-		result, err := handler.getPublicInfo(ctx, createMockLambdaRequest("192.168.1.1"))
-		require.NoError(t, err)
-
-		// Invalid ARN should result in empty URL
-		assert.Empty(t, result.APIKeySecretURL)
-	})
-
 	t.Run("with rate limiting - allowed", func(t *testing.T) {
 		mockAuth := new(MockAuthService)
 		mockRateLimiter := new(MockRateLimiter)
@@ -584,6 +551,30 @@ func TestHandler_getPublicInfo(t *testing.T) {
 		result, err := handler.getPublicInfo(ctx, createMockLambdaRequest("192.168.1.1"))
 		require.NoError(t, err)
 		assert.True(t, result.AdminExists)
+	})
+
+	// Regression test: issue #437 - Secrets Manager ARN (which embeds AWS
+	// account ID and region) must NOT appear in the unauthenticated response
+	// regardless of whether secretsARN is configured.
+	t.Run("regression #437: secrets ARN not leaked to unauthenticated callers", func(t *testing.T) {
+		mockAuth := new(MockAuthService)
+		mockAuth.On("CheckAdminExists", ctx).Return(true, nil)
+
+		handler := &Handler{
+			auth:       mockAuth,
+			secretsARN: "arn:aws:secretsmanager:eu-west-1:987654321098:secret:my-secret-xyz789",
+		}
+
+		result, err := handler.getPublicInfo(ctx, createMockLambdaRequest("192.168.1.1"))
+		require.NoError(t, err)
+
+		// Marshal to JSON and confirm the ARN is absent from the wire format.
+		wire, err := json.Marshal(result)
+		require.NoError(t, err)
+		assert.NotContains(t, string(wire), "987654321098",
+			"AWS account ID must not appear in unauthenticated /api/info response")
+		assert.NotContains(t, string(wire), "secretsmanager",
+			"Secrets Manager ARN must not appear in unauthenticated /api/info response")
 	})
 
 }

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -397,9 +397,11 @@ type EmptyServiceConfigResponse struct{}
 
 // PublicInfoResponse holds public information about the CUDly instance
 type PublicInfoResponse struct {
-	Version         string `json:"version"`
-	AdminExists     bool   `json:"admin_exists"`
-	APIKeySecretURL string `json:"api_key_secret_url,omitempty"`
+	Version     string `json:"version"`
+	AdminExists bool   `json:"admin_exists"`
+	// APIKeySecretURL was removed: the Secrets Manager ARN embeds the AWS
+	// account ID and region, which must not be served to unauthenticated
+	// callers (issue #437).
 }
 
 // DashboardSummaryResponse holds the dashboard summary data


### PR DESCRIPTION
## Summary

- `/api/info` previously returned `api_key_secret_url` which embedded the full Secrets Manager ARN, including the AWS account ID and region, to unauthenticated callers.
- Remove `APIKeySecretURL` from `PublicInfoResponse` and the construction logic from `getPublicInfo`. The ARN is no longer present in the wire format for any caller.
- Add a regression test that marshals the response to JSON and asserts neither the account ID nor "secretsmanager" appear.

## Test plan

- [x] `go test ./internal/api/... ./internal/auth/...` passes (1568 tests)
- [x] `TestHandler_getPublicInfo/regression_#437` asserts ARN is absent from JSON
- [x] Pre-commit hooks pass (gofmt, go vet, gosec, trivy)

Closes #437