### PR TITLE
sec(purchases): map GetExecutionByID not-found to 404 in getPurchaseDetails (closes #431)

### DIFF
--- a/internal/api/handler_purchases.go
+++ b/internal/api/handler_purchases.go
@@ -985,10 +985,12 @@ func (h *Handler) getPurchaseDetails(ctx context.Context, req *events.LambdaFunc
 
 	execution, err := h.config.GetExecutionByID(ctx, executionID)
 	if err != nil {
-		return nil, fmt.Errorf("execution not found: %w", err)
+		// Map any DB-level "not found" error to 404 so callers cannot infer
+		// whether a UUID exists by observing a 500 vs a 404 (issue #431).
+		return nil, NewClientError(404, "execution not found")
 	}
 	if execution == nil {
-		return nil, fmt.Errorf("execution not found: %s", executionID)
+		return nil, NewClientError(404, "execution not found")
 	}
 
 	// Scope: reject if the execution's plan isn't accessible to the session.

--- a/internal/api/handler_purchases_test.go
+++ b/internal/api/handler_purchases_test.go
@@ -970,6 +970,10 @@ func TestHandler_getPurchaseDetails_NotFound(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "execution not found")
+	// Regression #431: must be a 404 ClientError, not a 500.
+	ce, ok := IsClientError(err)
+	require.True(t, ok, "expected a client error")
+	assert.Equal(t, 404, ce.code)
 }
 
 func TestHandler_getPurchaseDetails_NilExecution(t *testing.T) {
@@ -997,6 +1001,43 @@ func TestHandler_getPurchaseDetails_NilExecution(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "execution not found")
+	// Regression #431: must be a 404 ClientError, not a 500.
+	ce, ok := IsClientError(err)
+	require.True(t, ok, "expected a client error")
+	assert.Equal(t, 404, ce.code)
+}
+
+// TestHandler_getPurchaseDetails_NotFound_IsClientError is a focused
+// regression for issue #431: a DB-level "not found" error from
+// GetExecutionByID must produce a 404 ClientError, never a 500, so that
+// unauthenticated callers cannot infer UUID existence by observing a
+// status-code difference.
+func TestHandler_getPurchaseDetails_NotFound_IsClientError(t *testing.T) {
+	ctx := context.Background()
+	mockStore := new(MockConfigStore)
+	mockAuth := new(MockAuthService)
+
+	adminSession := &Session{
+		UserID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+		Email:  "admin@example.com",
+		Role:   "admin",
+	}
+	mockAuth.On("ValidateSession", ctx, "admin-token").Return(adminSession, nil)
+
+	const missingID = "dddddddd-dddd-dddd-dddd-dddddddddddd"
+	// Simulate the DB returning a generic error (as pgx does on a missing row).
+	mockStore.On("GetExecutionByID", ctx, missingID).Return(nil, errors.New("no rows in result set"))
+
+	handler := &Handler{config: mockStore, auth: mockAuth}
+	req := &events.LambdaFunctionURLRequest{
+		Headers: map[string]string{"Authorization": "Bearer admin-token"},
+	}
+
+	_, err := handler.getPurchaseDetails(ctx, req, missingID)
+	require.Error(t, err)
+	ce, ok := IsClientError(err)
+	require.True(t, ok, "getPurchaseDetails must return a ClientError on not-found, not wrap into a 500")
+	assert.Equal(t, 404, ce.code, "not-found from GetExecutionByID must produce HTTP 404")
 }
 
 func TestHandler_getPurchaseDetails_WithTimestamps(t *testing.T) {


### PR DESCRIPTION
## Summary

- `getPurchaseDetails` wrapped any error from `GetExecutionByID` with `fmt.Errorf`, which the error handler converted to a 500. A status-code difference (500 vs 404) let callers probe for execution UUID existence without authentication.
- Map both not-found cases (error return and nil execution) to `NewClientError(404, "execution not found")` so the handler is silent about UUID existence.
- Update existing tests to assert the 404 status code; add `TestHandler_getPurchaseDetails_NotFound_IsClientError` as a focused regression.

## Test plan

- [x] `go test ./internal/api/... ./internal/auth/...` passes (1570 tests)
- [x] `TestHandler_getPurchaseDetails_NotFound_IsClientError` asserts `ce.code == 404`
- [x] Pre-commit hooks pass

Closes #431