### PR TITLE
sec(api): restrict SourceIdentity to admin sessions in GET /api/config (closes #407)

### DIFF
--- a/internal/api/handler_config.go
+++ b/internal/api/handler_config.go
@@ -23,7 +23,7 @@ func sourceCloud() string {
 }
 
 // Configuration handlers
-func (h *Handler) getConfig(ctx context.Context) (*ConfigResponse, error) {
+func (h *Handler) getConfig(ctx context.Context, req *events.LambdaFunctionURLRequest) (*ConfigResponse, error) {
 	globalCfg, err := h.config.GetGlobalConfig(ctx)
 	if err != nil {
 		return nil, err
@@ -34,12 +34,21 @@ func (h *Handler) getConfig(ctx context.Context) (*ConfigResponse, error) {
 		return nil, err
 	}
 
-	return &ConfigResponse{
-		Global:         globalCfg,
-		Services:       services,
-		SourceCloud:    sourceCloud(),
-		SourceIdentity: h.resolveSourceIdentity(ctx),
-	}, nil
+	resp := &ConfigResponse{
+		Global:      globalCfg,
+		Services:    services,
+		SourceCloud: sourceCloud(),
+	}
+
+	// SourceIdentity contains the host cloud account ID (AWS account number,
+	// Azure tenant ID, etc.). Only expose it to admin sessions so that
+	// non-admin users cannot extract the cloud identity of the CUDly host
+	// account (issue #407).
+	if _, adminErr := h.requireAdmin(ctx, req); adminErr == nil {
+		resp.SourceIdentity = h.resolveSourceIdentity(ctx)
+	}
+
+	return resp, nil
 }
 
 // preserveOmittedRecommendationFields merges persisted GlobalConfig values

--- a/internal/api/handler_config_test.go
+++ b/internal/api/handler_config_test.go
@@ -14,6 +14,13 @@ import (
 func TestHandler_getConfig(t *testing.T) {
 	ctx := context.Background()
 	mockStore := new(MockConfigStore)
+	mockAuth := new(MockAuthService)
+
+	adminSession := &Session{
+		UserID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+		Email:  "admin@example.com",
+		Role:   "admin",
+	}
 
 	globalCfg := &config.GlobalConfig{
 		EnabledProviders: []string{"aws"},
@@ -25,12 +32,16 @@ func TestHandler_getConfig(t *testing.T) {
 		{Provider: "aws", Service: "rds", Enabled: true},
 	}
 
+	mockAuth.On("ValidateSession", ctx, "admin-token").Return(adminSession, nil)
 	mockStore.On("GetGlobalConfig", ctx).Return(globalCfg, nil)
 	mockStore.On("ListServiceConfigs", ctx).Return(serviceConfigs, nil)
 
-	handler := &Handler{config: mockStore}
+	handler := &Handler{config: mockStore, auth: mockAuth}
 
-	result, err := handler.getConfig(ctx)
+	req := &events.LambdaFunctionURLRequest{
+		Headers: map[string]string{"Authorization": "Bearer admin-token"},
+	}
+	result, err := handler.getConfig(ctx, req)
 	require.NoError(t, err)
 
 	assert.NotNil(t, result.Global)
@@ -327,7 +338,8 @@ func TestHandler_getConfig_GlobalConfigError(t *testing.T) {
 
 	handler := &Handler{config: mockStore}
 
-	result, err := handler.getConfig(ctx)
+	req := &events.LambdaFunctionURLRequest{}
+	result, err := handler.getConfig(ctx, req)
 	assert.Error(t, err)
 	assert.Nil(t, result)
 }
@@ -345,9 +357,54 @@ func TestHandler_getConfig_ListServiceConfigsError(t *testing.T) {
 
 	handler := &Handler{config: mockStore}
 
-	result, err := handler.getConfig(ctx)
+	req := &events.LambdaFunctionURLRequest{}
+	result, err := handler.getConfig(ctx, req)
 	assert.Error(t, err)
 	assert.Nil(t, result)
+}
+
+// Regression tests for issue #407: SourceIdentity (cloud account ID, Azure
+// tenant ID) must only be included in responses for admin sessions.
+
+func TestHandler_getConfig_SourceIdentity_AdminOnly(t *testing.T) {
+	ctx := context.Background()
+	mockStore := new(MockConfigStore)
+	mockAuth := new(MockAuthService)
+
+	adminSession := &Session{Role: "admin", UserID: "admin-user"}
+	userSession := &Session{Role: "user", UserID: "regular-user"}
+
+	globalCfg := &config.GlobalConfig{EnabledProviders: []string{"aws"}}
+	mockStore.On("GetGlobalConfig", ctx).Return(globalCfg, nil)
+	mockStore.On("ListServiceConfigs", ctx).Return([]config.ServiceConfig{}, nil)
+	mockAuth.On("ValidateSession", ctx, "admin-token").Return(adminSession, nil)
+	mockAuth.On("ValidateSession", ctx, "user-token").Return(userSession, nil)
+
+	handler := &Handler{config: mockStore, auth: mockAuth}
+
+	t.Run("admin sees SourceIdentity", func(t *testing.T) {
+		req := &events.LambdaFunctionURLRequest{
+			Headers: map[string]string{"Authorization": "Bearer admin-token"},
+		}
+		result, err := handler.getConfig(ctx, req)
+		require.NoError(t, err)
+		// SourceIdentity is set (may be a zero-value struct for the test
+		// env that lacks AWS credentials, but the field is non-nil for admin).
+		// We verify that a non-admin result is nil below, which is the key
+		// security invariant.
+		_ = result.SourceIdentity // may be nil or non-nil depending on cloud env
+	})
+
+	t.Run("regression #407: non-admin does not receive SourceIdentity", func(t *testing.T) {
+		mockAuth.On("HasPermissionAPI", ctx, "regular-user", mock.Anything, mock.Anything).Return(false, nil)
+		req := &events.LambdaFunctionURLRequest{
+			Headers: map[string]string{"Authorization": "Bearer user-token"},
+		}
+		result, err := handler.getConfig(ctx, req)
+		require.NoError(t, err)
+		assert.Nil(t, result.SourceIdentity,
+			"SourceIdentity must be nil for non-admin sessions (issue #407)")
+	})
 }
 
 func TestHandler_getServiceConfig_Error(t *testing.T) {

--- a/internal/api/handler_config_test.go
+++ b/internal/api/handler_config_test.go
@@ -19,7 +19,6 @@ func TestHandler_getConfig(t *testing.T) {
 	adminSession := &Session{
 		UserID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 		Email:  "admin@example.com",
-		Role:   "admin",
 	}
 
 	globalCfg := &config.GlobalConfig{
@@ -33,6 +32,7 @@ func TestHandler_getConfig(t *testing.T) {
 	}
 
 	mockAuth.On("ValidateSession", ctx, "admin-token").Return(adminSession, nil)
+	mockAuth.grantAdmin()
 	mockStore.On("GetGlobalConfig", ctx).Return(globalCfg, nil)
 	mockStore.On("ListServiceConfigs", ctx).Return(serviceConfigs, nil)
 
@@ -371,14 +371,15 @@ func TestHandler_getConfig_SourceIdentity_AdminOnly(t *testing.T) {
 	mockStore := new(MockConfigStore)
 	mockAuth := new(MockAuthService)
 
-	adminSession := &Session{Role: "admin", UserID: "admin-user"}
-	userSession := &Session{Role: "user", UserID: "regular-user"}
+	adminSession := &Session{UserID: "admin-user"}
+	userSession := &Session{UserID: "regular-user"}
 
 	globalCfg := &config.GlobalConfig{EnabledProviders: []string{"aws"}}
 	mockStore.On("GetGlobalConfig", ctx).Return(globalCfg, nil)
 	mockStore.On("ListServiceConfigs", ctx).Return([]config.ServiceConfig{}, nil)
 	mockAuth.On("ValidateSession", ctx, "admin-token").Return(adminSession, nil)
 	mockAuth.On("ValidateSession", ctx, "user-token").Return(userSession, nil)
+	mockAuth.On("HasPermissionAPI", mock.Anything, "admin-user", mock.Anything, mock.Anything).Return(true, nil)
 
 	handler := &Handler{config: mockStore, auth: mockAuth}
 
@@ -388,11 +389,10 @@ func TestHandler_getConfig_SourceIdentity_AdminOnly(t *testing.T) {
 		}
 		result, err := handler.getConfig(ctx, req)
 		require.NoError(t, err)
-		// SourceIdentity is set (may be a zero-value struct for the test
-		// env that lacks AWS credentials, but the field is non-nil for admin).
-		// We verify that a non-admin result is nil below, which is the key
-		// security invariant.
-		_ = result.SourceIdentity // may be nil or non-nil depending on cloud env
+		// resolveSourceIdentity always returns a non-nil struct (best-effort,
+		// returns an empty struct on failure). The key invariant is that admin
+		// sessions receive the field and non-admin sessions do not.
+		require.NotNil(t, result.SourceIdentity)
 	})
 
 	t.Run("regression #407: non-admin does not receive SourceIdentity", func(t *testing.T) {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -421,7 +421,7 @@ func (r *Router) upcomingPurchasesHandler(ctx context.Context, req *events.Lambd
 }
 
 func (r *Router) getConfigHandler(ctx context.Context, req *events.LambdaFunctionURLRequest, params map[string]string) (any, error) {
-	return r.h.getConfig(ctx)
+	return r.h.getConfig(ctx, req)
 }
 
 func (r *Router) updateConfigHandler(ctx context.Context, req *events.LambdaFunctionURLRequest, params map[string]string) (any, error) {


### PR DESCRIPTION
## Summary

- `GET /api/config` returned `SourceIdentity` (AWS account ID, Azure tenant ID/subscription ID, GCP project ID) to any authenticated user. Non-admin roles should not see the host cloud identity.
- Change `getConfig` to accept the request and call `requireAdmin`. Only populate `SourceIdentity` for admin sessions; non-admin responses get `SourceIdentity: nil`.
- `SourceCloud` (the plain string "aws"/"azure"/"gcp") is still returned to all authenticated users as it is needed for dashboard feature gating.
- Update the router wrapper and all test call sites; add regression tests confirming non-admin sessions receive `nil` SourceIdentity.

## Test plan

- [x] `go test ./internal/api/... ./internal/auth/...` passes (1572 tests)
- [x] `TestHandler_getConfig_SourceIdentity_AdminOnly/regression_#407` asserts `result.SourceIdentity == nil` for non-admin
- [x] Pre-commit hooks pass

Closes #407

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Configuration endpoint now properly restricts sensitive identity information to authorized admin users only. Non-admin users will no longer have access to identity details in configuration responses, improving security and enforcing proper permission boundaries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/530?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->