### PR TITLE
sec(auth): collapse MFA error paths to prevent enrollment status enumeration

### DIFF
--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -164,7 +164,17 @@ func (s *Service) getUserAndValidateStatus(ctx context.Context, email string) (*
 	return user, nil
 }
 
-// verifyPasswordAndMFA verifies password and MFA code if enabled
+// verifyPasswordAndMFA verifies password and MFA code if enabled.
+//
+// Security: all error paths after a successful password check use the same
+// generic message ("invalid email or password") to prevent MFA enrollment
+// status enumeration (issue #388). An attacker who submits the correct
+// password but no MFA code must not be able to distinguish that case from a
+// wrong-password attempt — doing so reveals that the account has MFA enabled
+// and that the password was correct.
+//
+// Internal log messages do distinguish the paths so operators can diagnose
+// failed logins from server logs without leaking information to HTTP clients.
 func (s *Service) verifyPasswordAndMFA(ctx context.Context, user *User, req LoginRequest) error {
 	// Use a generic error for missing password hash to avoid leaking account state
 	// (a distinct message would reveal that the account exists but has no password set)
@@ -179,16 +189,24 @@ func (s *Service) verifyPasswordAndMFA(ctx context.Context, user *User, req Logi
 
 	if user.MFAEnabled {
 		if req.MFACode == "" {
-			return fmt.Errorf("MFA code required")
+			// Password was correct but MFA code not supplied. Return the same
+			// generic message as a wrong-password attempt so callers cannot
+			// infer that the password was accepted (issue #388).
+			logging.Debugf("login: MFA code not supplied for MFA-enabled account")
+			return fmt.Errorf("invalid email or password")
 		}
 		if user.MFASecret == "" {
-			return fmt.Errorf("MFA is enabled but not configured")
+			// MFA is marked enabled but no secret exists — misconfiguration.
+			// Treat as an auth failure with the same generic message.
+			logging.Warnf("login: MFA enabled but secret not configured for account")
+			return fmt.Errorf("invalid email or password")
 		}
 		// verifyTOTP is panic-safe: a malformed secret causes generateTOTP to return ""
 		// (base32 decode error), resulting in a comparison miss rather than a panic.
 		if !verifyTOTP(user.MFASecret, req.MFACode) {
 			s.recordFailedLogin(ctx, user)
-			return fmt.Errorf("invalid MFA code")
+			logging.Debugf("login: invalid MFA code supplied")
+			return fmt.Errorf("invalid email or password")
 		}
 	}
 

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -189,6 +189,7 @@ func (s *Service) verifyPasswordAndMFA(ctx context.Context, user *User, req Logi
 
 	if user.MFAEnabled {
 		if req.MFACode == "" {
+			s.recordFailedLogin(ctx, user)
 			// Password was correct but MFA code not supplied. Return the same
 			// generic message as a wrong-password attempt so callers cannot
 			// infer that the password was accepted (issue #388).
@@ -196,7 +197,8 @@ func (s *Service) verifyPasswordAndMFA(ctx context.Context, user *User, req Logi
 			return fmt.Errorf("invalid email or password")
 		}
 		if user.MFASecret == "" {
-			// MFA is marked enabled but no secret exists — misconfiguration.
+			s.recordFailedLogin(ctx, user)
+			// MFA is marked enabled but no secret exists - misconfiguration.
 			// Treat as an auth failure with the same generic message.
 			logging.Warnf("login: MFA enabled but secret not configured for account")
 			return fmt.Errorf("invalid email or password")

--- a/internal/auth/service_lockout_test.go
+++ b/internal/auth/service_lockout_test.go
@@ -304,6 +304,64 @@ func TestLogin_AccountLockout_GenericErrorMessage(t *testing.T) {
 	mockStore.AssertExpectations(t)
 }
 
+// TestLogin_AccountLockout_MFAMissingCodePath verifies that repeatedly sending no MFA code
+// still increments the failed-login counter and triggers lockout after MaxFailedLoginAttempts.
+// Regression test for the lockout-bypass via the missing-code path.
+func TestLogin_AccountLockout_MFAMissingCodePath(t *testing.T) {
+	ctx := context.Background()
+
+	s := newTestService()
+	hash, _ := s.hashPassword("CorrectPassword123")
+
+	for attempt := 0; attempt < MaxFailedLoginAttempts; attempt++ {
+		t.Run(fmt.Sprintf("Attempt_%d", attempt+1), func(t *testing.T) {
+			mockStore := new(MockStore)
+			mockEmail := new(MockEmailSender)
+			service := createTestService(mockStore, mockEmail)
+
+			testUser := &User{
+				ID:                  "user-123",
+				Email:               "test@example.com",
+				PasswordHash:        hash,
+				Active:              true,
+				MFAEnabled:          true,
+				MFASecret:           "JBSWY3DPEHPK3PXP",
+				Role:                RoleUser,
+				FailedLoginAttempts: attempt,
+			}
+
+			var updatedUser *User
+			mockStore.On("GetUserByEmail", ctx, "test@example.com").Return(testUser, nil).Once()
+			mockStore.On("UpdateUser", ctx, mock.AnythingOfType("*auth.User")).
+				Run(func(args mock.Arguments) {
+					updatedUser = args.Get(1).(*User)
+				}).
+				Return(nil).Once()
+
+			req := LoginRequest{
+				Email:    "test@example.com",
+				Password: "CorrectPassword123",
+				MFACode:  "", // deliberately omit MFA code
+			}
+
+			_, err := service.Login(ctx, req)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid email or password")
+
+			require.NotNil(t, updatedUser, "recordFailedLogin must have been called")
+			assert.Equal(t, attempt+1, updatedUser.FailedLoginAttempts)
+
+			if attempt+1 >= MaxFailedLoginAttempts {
+				assert.NotNil(t, updatedUser.LockedUntil, "account must be locked after max failures via missing-code path")
+			} else {
+				assert.Nil(t, updatedUser.LockedUntil)
+			}
+
+			mockStore.AssertExpectations(t)
+		})
+	}
+}
+
 // TestRecordFailedLogin verifies recordFailedLogin function behavior
 func TestRecordFailedLogin(t *testing.T) {
 	ctx := context.Background()

--- a/internal/auth/service_lockout_test.go
+++ b/internal/auth/service_lockout_test.go
@@ -265,7 +265,8 @@ func TestLogin_AccountLockout_MFAFailure(t *testing.T) {
 
 	_, err := service.Login(ctx, req)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid MFA code")
+	// Regression test for #388: must return generic message even for wrong MFA code.
+	assert.Contains(t, err.Error(), "invalid email or password")
 
 	// Verify MFA failure incremented counter and locked account
 	require.NotNil(t, updatedUser)

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -327,7 +327,9 @@ func TestService_Login_MFA(t *testing.T) {
 		resp, err := service.Login(ctx, req)
 		assert.Error(t, err)
 		assert.Nil(t, resp)
-		assert.Contains(t, err.Error(), "MFA code required")
+		// Regression test for #388: must return a generic message even when the
+		// password is correct and MFA is enabled, to prevent enrollment enumeration.
+		assert.Contains(t, err.Error(), "invalid email or password")
 
 		mockStore.AssertExpectations(t)
 	})
@@ -409,7 +411,9 @@ func TestLogin_WithMFA_InvalidCode(t *testing.T) {
 	resp, err := service.Login(ctx, req)
 	assert.Error(t, err)
 	assert.Nil(t, resp)
-	assert.Contains(t, err.Error(), "invalid MFA code")
+	// Regression test for #388: invalid MFA code must return the same generic
+	// message as wrong password to prevent MFA enrollment status enumeration.
+	assert.Contains(t, err.Error(), "invalid email or password")
 }
 
 func TestLogin_WithMFA_MissingCode(t *testing.T) {
@@ -443,7 +447,9 @@ func TestLogin_WithMFA_MissingCode(t *testing.T) {
 	resp, err := service.Login(ctx, req)
 	assert.Error(t, err)
 	assert.Nil(t, resp)
-	assert.Contains(t, err.Error(), "MFA code required")
+	// Regression test for #388: must return a generic message even though the
+	// password was correct — "MFA code required" would reveal MFA enrollment status.
+	assert.Contains(t, err.Error(), "invalid email or password")
 }
 
 func TestLogin_WithMFA_NoSecret(t *testing.T) {
@@ -477,7 +483,74 @@ func TestLogin_WithMFA_NoSecret(t *testing.T) {
 	resp, err := service.Login(ctx, req)
 	assert.Error(t, err)
 	assert.Nil(t, resp)
-	assert.Contains(t, err.Error(), "MFA is enabled but not configured")
+	// Regression test for #388: misconfigured MFA must return the same generic
+	// message to avoid leaking MFA enrollment state.
+	assert.Contains(t, err.Error(), "invalid email or password")
+}
+
+// TestLogin_MFAErrorsAreGeneric is the primary regression test for issue #388.
+// It verifies that ALL MFA-related failure paths return the same generic message
+// as a wrong-password attempt so an attacker cannot enumerate MFA enrollment.
+func TestLogin_MFAErrorsAreGeneric(t *testing.T) {
+	ctx := context.Background()
+
+	s := newTestService()
+	hash, err := s.hashPassword("CorrectPassword")
+	if err != nil {
+		t.Fatalf("failed to hash password: %v", err)
+	}
+
+	mfaUser := &User{
+		ID:           "mfa-user-001",
+		Email:        "mfa-user@example.com",
+		PasswordHash: hash,
+		Active:       true,
+		MFAEnabled:   true,
+		MFASecret:    "JBSWY3DPEHPK3PXP",
+		Role:         RoleUser,
+	}
+
+	cases := []struct {
+		name    string
+		mfaCode string
+		secret  string
+		desc    string
+	}{
+		{"no_code_supplied", "", "JBSWY3DPEHPK3PXP", "missing MFA code reveals enrollment (issue #388)"},
+		{"wrong_code", "000000", "JBSWY3DPEHPK3PXP", "wrong MFA code reveals enrollment (issue #388)"},
+		{"no_secret_configured", "123456", "", "misconfigured MFA reveals enrollment (issue #388)"},
+	}
+
+	const genericMsg = "invalid email or password"
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockStore := new(MockStore)
+			mockEmail := new(MockEmailSender)
+			svc := createTestService(mockStore, mockEmail)
+
+			user := *mfaUser
+			user.MFASecret = tc.secret
+			mockStore.On("GetUserByEmail", ctx, user.Email).Return(&user, nil)
+			mockStore.On("UpdateUser", ctx, mock.AnythingOfType("*auth.User")).Return(nil).Maybe()
+
+			resp, loginErr := svc.Login(ctx, LoginRequest{
+				Email:    user.Email,
+				Password: "CorrectPassword",
+				MFACode:  tc.mfaCode,
+			})
+			if loginErr == nil {
+				t.Errorf("case %q: expected error, got successful login (regression of #388)", tc.name)
+				return
+			}
+			if resp != nil {
+				t.Errorf("case %q: expected nil response on error, got %+v", tc.name, resp)
+			}
+			if loginErr.Error() != genericMsg {
+				t.Errorf("case %q: %s\nwant error %q\ngot  %q", tc.name, tc.desc, genericMsg, loginErr.Error())
+			}
+		})
+	}
 }
 
 // Test UpdateUserProfile


### PR DESCRIPTION
Fixes #388

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized authentication responses so credential and MFA failures now return a single generic error message visible to users.
* **Tests**
  * Added regression tests to verify consistent generic MFA/error responses and that repeated MFA failures (including missing codes) still increment failed-login counters and trigger account lockout.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/532?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->