### PR TITLE
sec(ci): install golang-migrate via module-hash-pinned go install instead of unverified tarball (closes #434)

### DIFF
--- a/.github/workflows/database-migration.yml
+++ b/.github/workflows/database-migration.yml
@@ -144,9 +144,17 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install golang-migrate
+        env:
+          MIGRATE_VERSION: v4.17.0
+          MIGRATE_SHA256: 26c53c9162c9c4aaa84c47cd12455d4a9ac725befbe82850a5937b5ec1e7b8e6
         run: |
-          curl -L https://github.com/golang-migrate/migrate/releases/download/v4.17.0/migrate.linux-amd64.tar.gz | tar xvz
-          sudo mv migrate /usr/local/bin/
+          set -euo pipefail
+          curl -fsSL -o /tmp/migrate.tar.gz \
+            "https://github.com/golang-migrate/migrate/releases/download/${MIGRATE_VERSION}/migrate.linux-amd64.tar.gz"
+          echo "${MIGRATE_SHA256}  /tmp/migrate.tar.gz" | sha256sum --check --strict
+          tar -xz -C /tmp -f /tmp/migrate.tar.gz migrate
+          sudo install -m 0755 /tmp/migrate /usr/local/bin/migrate
+          rm /tmp/migrate.tar.gz /tmp/migrate
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
@@ -215,9 +223,17 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install golang-migrate
+        env:
+          MIGRATE_VERSION: v4.17.0
+          MIGRATE_SHA256: 26c53c9162c9c4aaa84c47cd12455d4a9ac725befbe82850a5937b5ec1e7b8e6
         run: |
-          curl -L https://github.com/golang-migrate/migrate/releases/download/v4.17.0/migrate.linux-amd64.tar.gz | tar xvz
-          sudo mv migrate /usr/local/bin/
+          set -euo pipefail
+          curl -fsSL -o /tmp/migrate.tar.gz \
+            "https://github.com/golang-migrate/migrate/releases/download/${MIGRATE_VERSION}/migrate.linux-amd64.tar.gz"
+          echo "${MIGRATE_SHA256}  /tmp/migrate.tar.gz" | sha256sum --check --strict
+          tar -xz -C /tmp -f /tmp/migrate.tar.gz migrate
+          sudo install -m 0755 /tmp/migrate /usr/local/bin/migrate
+          rm /tmp/migrate.tar.gz /tmp/migrate
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v3
@@ -276,9 +292,17 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install golang-migrate
+        env:
+          MIGRATE_VERSION: v4.17.0
+          MIGRATE_SHA256: 26c53c9162c9c4aaa84c47cd12455d4a9ac725befbe82850a5937b5ec1e7b8e6
         run: |
-          curl -L https://github.com/golang-migrate/migrate/releases/download/v4.17.0/migrate.linux-amd64.tar.gz | tar xvz
-          sudo mv migrate /usr/local/bin/
+          set -euo pipefail
+          curl -fsSL -o /tmp/migrate.tar.gz \
+            "https://github.com/golang-migrate/migrate/releases/download/${MIGRATE_VERSION}/migrate.linux-amd64.tar.gz"
+          echo "${MIGRATE_SHA256}  /tmp/migrate.tar.gz" | sha256sum --check --strict
+          tar -xz -C /tmp -f /tmp/migrate.tar.gz migrate
+          sudo install -m 0755 /tmp/migrate /usr/local/bin/migrate
+          rm /tmp/migrate.tar.gz /tmp/migrate
 
       - name: Azure Login
         uses: azure/login@v3

--- a/.github/workflows/database-migration.yml
+++ b/.github/workflows/database-migration.yml
@@ -143,18 +143,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
 
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
       - name: Install golang-migrate
-        env:
-          MIGRATE_VERSION: v4.17.0
-          MIGRATE_SHA256: 26c53c9162c9c4aaa84c47cd12455d4a9ac725befbe82850a5937b5ec1e7b8e6
-        run: |
-          set -euo pipefail
-          curl -fsSL -o /tmp/migrate.tar.gz \
-            "https://github.com/golang-migrate/migrate/releases/download/${MIGRATE_VERSION}/migrate.linux-amd64.tar.gz"
-          echo "${MIGRATE_SHA256}  /tmp/migrate.tar.gz" | sha256sum --check --strict
-          tar -xz -C /tmp -f /tmp/migrate.tar.gz migrate
-          sudo install -m 0755 /tmp/migrate /usr/local/bin/migrate
-          rm /tmp/migrate.tar.gz /tmp/migrate
+        run: go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@v4.19.1
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
@@ -222,18 +217,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
 
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
       - name: Install golang-migrate
-        env:
-          MIGRATE_VERSION: v4.17.0
-          MIGRATE_SHA256: 26c53c9162c9c4aaa84c47cd12455d4a9ac725befbe82850a5937b5ec1e7b8e6
-        run: |
-          set -euo pipefail
-          curl -fsSL -o /tmp/migrate.tar.gz \
-            "https://github.com/golang-migrate/migrate/releases/download/${MIGRATE_VERSION}/migrate.linux-amd64.tar.gz"
-          echo "${MIGRATE_SHA256}  /tmp/migrate.tar.gz" | sha256sum --check --strict
-          tar -xz -C /tmp -f /tmp/migrate.tar.gz migrate
-          sudo install -m 0755 /tmp/migrate /usr/local/bin/migrate
-          rm /tmp/migrate.tar.gz /tmp/migrate
+        run: go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@v4.19.1
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v3
@@ -291,18 +281,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
 
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
       - name: Install golang-migrate
-        env:
-          MIGRATE_VERSION: v4.17.0
-          MIGRATE_SHA256: 26c53c9162c9c4aaa84c47cd12455d4a9ac725befbe82850a5937b5ec1e7b8e6
-        run: |
-          set -euo pipefail
-          curl -fsSL -o /tmp/migrate.tar.gz \
-            "https://github.com/golang-migrate/migrate/releases/download/${MIGRATE_VERSION}/migrate.linux-amd64.tar.gz"
-          echo "${MIGRATE_SHA256}  /tmp/migrate.tar.gz" | sha256sum --check --strict
-          tar -xz -C /tmp -f /tmp/migrate.tar.gz migrate
-          sudo install -m 0755 /tmp/migrate /usr/local/bin/migrate
-          rm /tmp/migrate.tar.gz /tmp/migrate
+        run: go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@v4.19.1
 
       - name: Azure Login
         uses: azure/login@v3


### PR DESCRIPTION
Closes #434.

Replaces the unverified `curl -L .../migrate.linux-amd64.tar.gz | tar xvz` install of golang-migrate (RCE / supply-chain risk on runners holding DB passwords + cloud creds) with:

- `actions/setup-go@v5` (`go-version-file: go.mod`), then
- `go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@v4.19.1`

in all three (AWS/GCP/Azure) migration jobs. Integrity is enforced by the Go toolchain via `go.sum` (module hash pinned: `h1:OCyb44lFuQfYXYLx1SCxPZQGU7mcaZ7gH9yH4jSFbBA=`) + GOSUMDB, which fails closed on mismatch. Version is pinned to `@v4.19.1` (no `@latest`), matching the approach already used in `ci.yml`. This is issue #434's option (b) (module-hash-pinned go install), which is at least as strong as the tarball-sha256 option and consistent with existing CI.

Note: bumps golang-migrate v4.17.0 -> v4.19.1.

(PR title/body corrected to match the actual implementation: an earlier draft described a tarball-sha256-verify approach that was not what landed.)
