### PR TITLE
sec(ci): replace secrets:inherit and static Azure creds with OIDC

### DIFF
--- a/.github/workflows/database-migration.yml
+++ b/.github/workflows/database-migration.yml
@@ -9,7 +9,7 @@
 #   - DB_PASSWORD_AZURE: Database password for Azure Flexible Server
 #   - (AWS auth via OIDC: vars.AWS_ROLE_TO_ASSUME)
 #   - (GCP auth via WIF: vars.GCP_WORKLOAD_IDENTITY_PROVIDER + vars.GCP_SERVICE_ACCOUNT)
-#   - AZURE_CREDENTIALS: Azure credentials
+#   - AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID (OIDC federation)
 #
 # Required GitHub Variables:
 #   - DB_HOST_AWS_DEV: Aurora endpoint (dev)
@@ -283,7 +283,9 @@ jobs:
       - name: Azure Login
         uses: azure/login@v3
         with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Get database endpoint from Terraform
         id: get-endpoint

--- a/.github/workflows/deploy-all.yml
+++ b/.github/workflows/deploy-all.yml
@@ -122,7 +122,11 @@ jobs:
     uses: ./.github/workflows/deploy-aws-lambda.yml
     with:
       environment: ${{ needs.determine-deployment.outputs.environment }}
-    secrets: inherit
+    secrets:
+      ADMIN_EMAIL: ${{ secrets.ADMIN_EMAIL }}
+      DASHBOARD_URL: ${{ secrets.DASHBOARD_URL }}
+      FROM_EMAIL: ${{ secrets.FROM_EMAIL }}
+      TF_BACKEND_AWS: ${{ secrets.TF_BACKEND_AWS }}
 
   # Deploy to AWS Fargate
   deploy-aws-fargate:
@@ -132,7 +136,9 @@ jobs:
     uses: ./.github/workflows/deploy-aws-fargate.yml
     with:
       environment: ${{ needs.determine-deployment.outputs.environment }}
-    secrets: inherit
+    secrets:
+      ADMIN_EMAIL: ${{ secrets.ADMIN_EMAIL }}
+      TF_BACKEND_AWS: ${{ secrets.TF_BACKEND_AWS }}
 
   # Deploy to GCP Cloud Run
   deploy-gcp:
@@ -142,7 +148,9 @@ jobs:
     uses: ./.github/workflows/deploy-gcp.yml
     with:
       environment: ${{ needs.determine-deployment.outputs.environment }}
-    secrets: inherit
+    secrets:
+      ADMIN_EMAIL: ${{ secrets.ADMIN_EMAIL }}
+      TF_BACKEND_GCP: ${{ secrets.TF_BACKEND_GCP }}
 
   # Deploy to Azure Container Apps
   deploy-azure:
@@ -152,7 +160,12 @@ jobs:
     uses: ./.github/workflows/deploy-azure.yml
     with:
       environment: ${{ needs.determine-deployment.outputs.environment }}
-    secrets: inherit
+    secrets:
+      ADMIN_EMAIL: ${{ secrets.ADMIN_EMAIL }}
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      TF_BACKEND_AZURE: ${{ secrets.TF_BACKEND_AZURE }}
 
   # Aggregate results and notify
   notify:

--- a/.github/workflows/deploy-aws-fargate.yml
+++ b/.github/workflows/deploy-aws-fargate.yml
@@ -41,6 +41,11 @@ on:
       image_uri:
         required: false
         type: string
+    secrets:
+      ADMIN_EMAIL:
+        required: true
+      TF_BACKEND_AWS:
+        required: true
 
 env:
   AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}

--- a/.github/workflows/deploy-aws-lambda.yml
+++ b/.github/workflows/deploy-aws-lambda.yml
@@ -62,6 +62,15 @@ on:
       environment:
         required: true
         type: string
+    secrets:
+      ADMIN_EMAIL:
+        required: true
+      DASHBOARD_URL:
+        required: false
+      FROM_EMAIL:
+        required: false
+      TF_BACKEND_AWS:
+        required: true
 
 env:
   AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}

--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -45,6 +45,17 @@ on:
       environment:
         required: true
         type: string
+    secrets:
+      ADMIN_EMAIL:
+        required: true
+      AZURE_CLIENT_ID:
+        required: true
+      AZURE_SUBSCRIPTION_ID:
+        required: true
+      AZURE_TENANT_ID:
+        required: true
+      TF_BACKEND_AZURE:
+        required: true
 
 env:
   AZURE_LOCATION: ${{ vars.AZURE_LOCATION || 'westus2' }}

--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -43,6 +43,11 @@ on:
       environment:
         required: true
         type: string
+    secrets:
+      ADMIN_EMAIL:
+        required: true
+      TF_BACKEND_GCP:
+        required: true
 
 env:
   GCP_REGION: ${{ vars.GCP_REGION || 'us-central1' }}

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -158,7 +158,9 @@ jobs:
         if: inputs.cloud == 'azure'
         uses: azure/login@v3
         with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Verify Azure image
         if: inputs.cloud == 'azure'
@@ -328,7 +330,9 @@ jobs:
       - name: Azure Login
         uses: azure/login@v3
         with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v4


### PR DESCRIPTION
## Summary

- **deploy-all.yml**: Replace all four `secrets: inherit` blocks with explicit secret maps containing only the secrets each downstream workflow actually uses (audited from each callee's `${{ secrets.* }}` references). No downstream workflow can now receive secrets it does not need.
- **rollback.yml** (2 occurrences) and **database-migration.yml** (1 occurrence): Replace `creds: ${{ secrets.AZURE_CREDENTIALS }}` (long-lived static service-principal JSON blob) with the OIDC-federation form using `client-id`, `tenant-id`, and `subscription-id`. Both workflows already declare `id-token: write` at the top-level `permissions` block, so no permission change is required.

Closes #433

## Test plan

- [ ] Confirm `azure/login` OIDC form works by checking that `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID` secrets are configured in the repo (they are already used by `azure_sanity.yml`)
- [ ] Run a dry-run rollback dispatch targeting azure to confirm the OIDC login step succeeds
- [ ] Grep for remaining `secrets: inherit` in workflow files to confirm none remain: `grep -r "secrets: inherit" .github/workflows/`
- [ ] Grep for remaining `AZURE_CREDENTIALS` references: `grep -r "AZURE_CREDENTIALS" .github/workflows/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflows for database migrations, deployments, and rollback to use federated Azure authentication and explicit secret inputs.
  * Refined secret handling across deployment workflows with explicit mappings and newly required backend secrets for AWS, GCP, and Azure.
  * Declared additional optional/required secret inputs for AWS Lambda and Fargate, GCP, and Azure deployment callers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/538?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->