### PR TITLE
test(frontend/settings): align grace-toast expectation with #478 aggregation

### DIFF
--- a/frontend/src/__tests__/settings-purchasing-grace.test.ts
+++ b/frontend/src/__tests__/settings-purchasing-grace.test.ts
@@ -344,10 +344,12 @@ describe('Settings → Purchasing grace inputs: inline range validation', () => 
 
     expect(api.updateConfig).not.toHaveBeenCalled();
     expect(alertSpy).not.toHaveBeenCalled();
-    // The save-time toast carries the same text the inline indicator renders.
+    // The save-time toast aggregates failed providers per #478 (one toast
+    // naming every affected provider in input order, AWS/Azure/GCP). The
+    // inline indicator still carries the per-input error separately.
     expect(mockShowToast).toHaveBeenCalled();
     const toastArg = mockShowToast.mock.calls[0]![0] as { message: string; kind: string };
-    expect(toastArg.message).toBe('AWS grace period: Must be a whole number between 0 and 30');
+    expect(toastArg.message).toBe('Grace period must be a whole number between 0 and 30 days (AWS).');
     expect(toastArg.kind).toBe('error');
   });
 });


### PR DESCRIPTION
## Summary

`frontend-build-sentinel` has been failing on every push to `feat/multicloud-web-frontend` since the merge of #486 (`fix(ux/settings): three Settings-page UX fixes (#463 #466 #478)`). The fix for #478 deliberately changed the save-time grace-period toast from one-toast-per-failing-provider to a single aggregated toast (`Grace period must be a whole number between 0 and 30 days (AWS, Azure, GCP).`), but `settings-purchasing-grace.test.ts` still expected the old per-provider wording.

This test-only change aligns the expectation with the aggregated format and refreshes the explanatory comment.

## What changed

- `frontend/src/__tests__/settings-purchasing-grace.test.ts`: one-line assertion update + comment refresh. No source/behavior change.

## Why this matters

The failure is pre-existing on the shared branch (every PR run that gets rebased onto current HEAD also fails the sentinel until this is fixed). Unblocks `feat/multicloud-web-frontend` CI.

## Test plan

- [x] `cd frontend && npm test` — 56 suites / 1858 passed, 1 skipped
- [ ] Frontend-build-sentinel goes green after merge
