### PR TITLE
ux(auth): soften login error copy (closes #550)

### DIFF
--- a/frontend/src/__tests__/api-mfa.test.ts
+++ b/frontend/src/__tests__/api-mfa.test.ts
@@ -53,8 +53,9 @@ describe('login() MFA error branch', () => {
   });
 
   test('non-MFA login error throws plain Error', async () => {
-    mockFetchErr(401, { error: 'invalid email or password' });
-    await expect(login('u@x.com', 'pw')).rejects.toThrow('invalid email or password');
+    const errMsg = 'Check your email address and password and try again';
+    mockFetchErr(401, { error: errMsg });
+    await expect(login('u@x.com', 'pw')).rejects.toThrow(errMsg);
     await expect(login('u@x.com', 'pw')).rejects.not.toBeInstanceOf(MFALoginError);
   });
 

--- a/frontend/src/__tests__/auth.test.ts
+++ b/frontend/src/__tests__/auth.test.ts
@@ -184,18 +184,20 @@ describe('Auth Module', () => {
       expect(api.login).not.toHaveBeenCalled();
     });
 
-    test('backend "authentication failed" maps to "Incorrect email or password"', async () => {
+    test('backend "authentication failed" maps to softened copy', async () => {
       (api.login as jest.Mock).mockRejectedValue(new Error('authentication failed'));
       await showLoginModal();
       const text = await submitLogin('user@example.com', 'wrongpassword');
-      expect(text).toBe('Incorrect email or password');
+      expect(text).toBe('Check your email address and password and try again');
     });
 
-    test('backend "invalid email or password" maps to "Incorrect email or password"', async () => {
-      (api.login as jest.Mock).mockRejectedValue(new Error('invalid email or password'));
+    test('backend "Check your email address and password and try again" passes through unchanged', async () => {
+      (api.login as jest.Mock).mockRejectedValue(
+        new Error('Check your email address and password and try again'),
+      );
       await showLoginModal();
       const text = await submitLogin('user@example.com', 'wrongpassword');
-      expect(text).toBe('Incorrect email or password');
+      expect(text).toBe('Check your email address and password and try again');
     });
 
     test('backend "invalid email format" maps to "Incorrect email format"', async () => {

--- a/frontend/src/auth.ts
+++ b/frontend/src/auth.ts
@@ -638,9 +638,10 @@ function validateLoginInputs(email: string, password: string): string | null {
 /**
  * Translate the known generic backend error strings into clearer
  * user-facing copy. The mapping deliberately collapses both
- * "authentication failed" (user not found) and "invalid email or
- * password" (wrong password) into the same client-side message so we do
- * not regress the account-enumeration mitigation called out in #456.
+ * "authentication failed" (user not found) and "check your email address
+ * and password" (wrong password / inactive / locked) into the same
+ * client-side message so we do not regress the account-enumeration
+ * mitigation called out in #456 / #550.
  * Anything else (MFA prompts, rate-limit, server errors) passes through
  * unchanged so operational signals are not suppressed.
  */
@@ -649,8 +650,11 @@ function mapServerLoginError(message: string): string {
   if (lower.includes('invalid email format')) {
     return 'Incorrect email format';
   }
-  if (lower.includes('authentication failed') || lower.includes('invalid email or password')) {
-    return 'Incorrect email or password';
+  if (
+    lower.includes('authentication failed') ||
+    lower.includes('check your email address and password')
+  ) {
+    return 'Check your email address and password and try again';
   }
   return message;
 }

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -140,18 +140,18 @@ func (s *Service) getUserAndValidateStatus(ctx context.Context, email string) (*
 		return nil, fmt.Errorf("authentication failed")
 	}
 	if user == nil {
-		return nil, fmt.Errorf("invalid email or password")
+		return nil, fmt.Errorf("Check your email address and password and try again")
 	}
 
 	if !user.Active {
-		return nil, fmt.Errorf("invalid email or password")
+		return nil, fmt.Errorf("Check your email address and password and try again")
 	}
 
 	if user.LockedUntil != nil && time.Now().Before(*user.LockedUntil) {
 		remainingTime := time.Until(*user.LockedUntil).Round(time.Minute)
 		// Omit user.ID from log to avoid leaking internal identifiers to log
 		logging.Warnf("Login attempt for locked account (locked for %v more)", remainingTime)
-		return nil, fmt.Errorf("invalid email or password")
+		return nil, fmt.Errorf("Check your email address and password and try again")
 	}
 	// NOTE: when LockedUntil is set but the window has already expired, the user falls
 	// through here with FailedLoginAttempts and LockedUntil still set in memory.
@@ -182,12 +182,12 @@ func (s *Service) verifyPasswordAndMFA(ctx context.Context, user *User, req Logi
 	// Use a generic error for missing password hash to avoid leaking account state
 	// (a distinct message would reveal that the account exists but has no password set)
 	if user.PasswordHash == "" {
-		return fmt.Errorf("invalid email or password")
+		return fmt.Errorf("Check your email address and password and try again")
 	}
 
 	if !s.verifyPassword(req.Password, user.PasswordHash) {
 		s.recordFailedLogin(ctx, user)
-		return fmt.Errorf("invalid email or password")
+		return fmt.Errorf("Check your email address and password and try again")
 	}
 
 	if user.MFAEnabled {

--- a/internal/auth/service_lockout_test.go
+++ b/internal/auth/service_lockout_test.go
@@ -36,7 +36,7 @@ func TestLogin_AccountLockout_BeforePasswordCheck(t *testing.T) {
 	resp, err := service.Login(ctx, req)
 	assert.Error(t, err)
 	assert.Nil(t, resp)
-	assert.Contains(t, err.Error(), "invalid email or password") // Generic error to prevent user enumeration
+	assert.Contains(t, err.Error(), "Check your email address and password and try again") // Generic error to prevent user enumeration
 
 	mockStore.AssertExpectations(t)
 	// Verify UpdateUser was NOT called - lockout check happens first
@@ -298,7 +298,7 @@ func TestLogin_AccountLockout_GenericErrorMessage(t *testing.T) {
 
 	// Error message should be generic to prevent user enumeration
 	// Should NOT reveal that account is locked
-	assert.Equal(t, "invalid email or password", err.Error())
+	assert.Equal(t, "Check your email address and password and try again", err.Error())
 
 	mockStore.AssertExpectations(t)
 }
@@ -358,4 +358,82 @@ func TestRecordFailedLogin(t *testing.T) {
 
 		mockStore.AssertExpectations(t)
 	})
+}
+
+// TestLogin_OWASPEnumerationInvariant guards against regression that re-introduces
+// distinct error messages for the 5 authentication failure modes (OWASP ASVS V3.3.4
+// / V14.2). All 5 paths MUST return an identical string so the login endpoint cannot
+// be used as an email-existence oracle.
+//
+// If this test fails after a code change, that change almost certainly re-introduced
+// a username-enumeration vulnerability and MUST be reverted or fixed before landing.
+func TestLogin_OWASPEnumerationInvariant(t *testing.T) {
+	const wantMsg = "Check your email address and password and try again"
+	ctx := context.Background()
+
+	lockUntil := time.Now().Add(10 * time.Minute)
+
+	type scenario struct {
+		name    string
+		getUser func(t *testing.T) *User // nil means "user not found"
+	}
+
+	scenarios := []scenario{
+		{
+			name:    "user not found",
+			getUser: func(t *testing.T) *User { return nil },
+		},
+		{
+			name: "inactive account",
+			getUser: func(t *testing.T) *User {
+				u := createTestUser(t, "Correct1!")
+				u.Active = false
+				return u
+			},
+		},
+		{
+			name: "account locked (within lockout window)",
+			getUser: func(t *testing.T) *User {
+				u := createTestUser(t, "Correct1!")
+				u.LockedUntil = &lockUntil
+				return u
+			},
+		},
+		{
+			name: "empty password hash (no password set)",
+			getUser: func(t *testing.T) *User {
+				u := createTestUser(t, "Correct1!")
+				u.PasswordHash = ""
+				return u
+			},
+		},
+		{
+			name: "wrong password",
+			getUser: func(t *testing.T) *User {
+				return createTestUser(t, "Correct1!")
+			},
+		},
+	}
+
+	for _, sc := range scenarios {
+		t.Run(sc.name, func(t *testing.T) {
+			mockStore := new(MockStore)
+			mockEmail := new(MockEmailSender)
+			service := createTestService(mockStore, mockEmail)
+
+			user := sc.getUser(t)
+			mockStore.On("GetUserByEmail", ctx, "test@example.com").Return(user, nil).Once()
+			mockStore.On("UpdateUser", ctx, mock.AnythingOfType("*auth.User")).Return(nil).Maybe()
+
+			req := LoginRequest{
+				Email:    "test@example.com",
+				Password: "WrongPassword9!",
+			}
+
+			_, err := service.Login(ctx, req)
+			require.Error(t, err, "expected login to fail for scenario %q", sc.name)
+			assert.Equal(t, wantMsg, err.Error(),
+				"scenario %q must return the uniform copy; distinct messages leak enumeration signal", sc.name)
+		})
+	}
 }

--- a/internal/auth/service_lockout_test.go
+++ b/internal/auth/service_lockout_test.go
@@ -434,6 +434,9 @@ func TestLogin_OWASPEnumerationInvariant(t *testing.T) {
 			require.Error(t, err, "expected login to fail for scenario %q", sc.name)
 			assert.Equal(t, wantMsg, err.Error(),
 				"scenario %q must return the uniform copy; distinct messages leak enumeration signal", sc.name)
+
+		mockStore.AssertExpectations(t)
+		mockEmail.AssertExpectations(t)
 		})
 	}
 }

--- a/internal/auth/service_lockout_test.go
+++ b/internal/auth/service_lockout_test.go
@@ -435,8 +435,8 @@ func TestLogin_OWASPEnumerationInvariant(t *testing.T) {
 			assert.Equal(t, wantMsg, err.Error(),
 				"scenario %q must return the uniform copy; distinct messages leak enumeration signal", sc.name)
 
-		mockStore.AssertExpectations(t)
-		mockEmail.AssertExpectations(t)
+			mockStore.AssertExpectations(t)
+			mockEmail.AssertExpectations(t)
 		})
 	}
 }

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -54,7 +54,7 @@ func TestService_Login(t *testing.T) {
 		resp, err := service.Login(ctx, req)
 		assert.Error(t, err)
 		assert.Nil(t, resp)
-		assert.Contains(t, err.Error(), "invalid email or password")
+		assert.Contains(t, err.Error(), "Check your email address and password and try again")
 
 		mockStore.AssertExpectations(t)
 	})
@@ -77,7 +77,7 @@ func TestService_Login(t *testing.T) {
 		resp, err := service.Login(ctx, req)
 		assert.Error(t, err)
 		assert.Nil(t, resp)
-		assert.Contains(t, err.Error(), "invalid email or password")
+		assert.Contains(t, err.Error(), "Check your email address and password and try again")
 
 		mockStore.AssertExpectations(t)
 	})
@@ -101,7 +101,7 @@ func TestService_Login(t *testing.T) {
 		resp, err := service.Login(ctx, req)
 		assert.Error(t, err)
 		assert.Nil(t, resp)
-		assert.Contains(t, err.Error(), "invalid email or password")
+		assert.Contains(t, err.Error(), "Check your email address and password and try again")
 
 		mockStore.AssertExpectations(t)
 	})
@@ -778,7 +778,7 @@ func TestService_Login_LockedUser(t *testing.T) {
 	resp, err := service.Login(ctx, req)
 	assert.Error(t, err)
 	assert.Nil(t, resp)
-	assert.Contains(t, err.Error(), "invalid email or password")
+	assert.Contains(t, err.Error(), "Check your email address and password and try again")
 
 	mockStore.AssertExpectations(t)
 }
@@ -804,7 +804,7 @@ func TestService_Login_EmptyPasswordHash(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 	// Must return generic error, not a message that leaks account state
-	assert.Contains(t, err.Error(), "invalid email or password")
+	assert.Contains(t, err.Error(), "Check your email address and password and try again")
 
 	mockStore.AssertExpectations(t)
 }


### PR DESCRIPTION
## Summary

- Replaces the terse `"invalid email or password"` with the friendlier `"Check your email address and password and try again"` across all 5 authentication failure paths in `internal/auth/service.go` (user-not-found, inactive, locked, empty-password-hash, wrong-password).
- Frontend `mapServerLoginError` in `auth.ts` updated to match and surface the new copy; the function still collapses both `"authentication failed"` and the new backend string into the same display message, preserving the OWASP non-enumeration invariant (closes #456 regression risk noted in #550).
- All existing backend and frontend tests updated to assert on the new string.

## OWASP rationale (closing note on #550 suggestions)

QA suggestions #1, #3, and #4 in issue #550 (distinct per-scenario messages) were explicitly rejected because they would turn the login endpoint into an email-existence oracle (OWASP ASVS V3.3.4 / V14.2). This PR ships only the copy softening: semantics unchanged, no info leak, friendlier tone.

## OWASP invariant regression guard

Added `TestLogin_OWASPEnumerationInvariant` in `internal/auth/service_lockout_test.go` -- a table-driven test that exercises all 5 failure modes and asserts each returns the same error string. Any future PR that accidentally re-introduces a path-specific message will fail this test.

## Test plan

- [x] `go test ./internal/auth/... ./internal/api/...` -- all pass (497 + 1151 tests)
- [x] `go vet ./...` -- clean
- [x] Frontend jest (`auth`, `api-mfa` suites) -- 76 tests pass
- [x] `npx tsc --noEmit` -- no type errors
- [x] `git grep "invalid email or password" internal/ pkg/ frontend/src/` -- no hits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Login error messages now show a single, consistent generic message for all authentication failures (including MFA and non-MFA cases), reducing account-enumeration risk.

* **Tests**
  * Updated tests to assert the standardized user-facing error text across multiple failure scenarios.
  * Added a comprehensive table-driven test covering various login failure modes to ensure invariant behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/551?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->