### PR TITLE
fix(ci/lambda): fetch Function URL from AWS in test job (cross-job output masked)

### DIFF
--- a/.github/workflows/deploy-aws-lambda.yml
+++ b/.github/workflows/deploy-aws-lambda.yml
@@ -227,14 +227,32 @@ jobs:
     runs-on: ubuntu-latest
     needs: [prepare, build-and-deploy]
     if: always() && needs.build-and-deploy.result == 'success'
+    # Bind to the same named environment as build-and-deploy so that
+    # vars.AWS_ROLE_TO_ASSUME resolves to the per-environment scoped value.
+    environment: ${{ needs.prepare.outputs.environment }}
 
     steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ env.AWS_REGION }}
+
       - name: Get Function URL
         id: get-url
+        env:
+          FUNCTION_NAME: ${{ needs.build-and-deploy.outputs.function_name }}
         run: |
-          FUNCTION_URL="${{ needs.build-and-deploy.outputs.function_url }}"
-          if [ -z "$FUNCTION_URL" ]; then
-            echo "Failed to get function URL from deploy outputs"
+          if [ -z "$FUNCTION_NAME" ]; then
+            echo "Failed to get function name from deploy outputs"
+            exit 1
+          fi
+          FUNCTION_URL=$(aws lambda get-function-url-config \
+            --function-name "$FUNCTION_NAME" \
+            --query 'FunctionUrl' \
+            --output text)
+          if [ -z "$FUNCTION_URL" ] || [ "$FUNCTION_URL" = "None" ]; then
+            echo "Failed to get function URL from AWS Lambda API for $FUNCTION_NAME"
             exit 1
           fi
           echo "url=$FUNCTION_URL" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-aws-lambda.yml
+++ b/.github/workflows/deploy-aws-lambda.yml
@@ -233,7 +233,7 @@ jobs:
 
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885  # v6.1.1 — pinned per SC review
         with:
           role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ env.AWS_REGION }}


### PR DESCRIPTION
## Summary

- The `Test Deployment` job was failing on `Get Function URL` because GitHub Actions silently drops cross-job outputs whose value matches a registered repository secret (security behavior added in late 2024). The `function_url` value equalled `DASHBOARD_URL`, so it arrived as an empty string in the downstream job.
- The fix replaces the cross-job output read with a direct `aws lambda get-function-url-config` call using `function_name`, which is unmasked and survives the hop. AWS is the source of truth; this also avoids stale-Terraform-output races.
- Added `environment:` binding and an `aws-actions/configure-aws-credentials` step to `test-deployment` -- the job was previously unauthenticated and therefore couldn't have called the Lambda API anyway. `lambda:GetFunctionUrlConfig` was already present in the deploy role policy (`terraform/environments/aws/ci-cd-permissions/policy_compute.tf` line 19); no IAM changes were needed.

## Failed run

https://github.com/LeanerCloud/CUDly/actions/runs/26155592348/job/76934647098

## Root cause detail

GitHub Actions propagates job outputs through its internal context store. When a value matches any registered secret (by content, not by name), the platform masks it to `***` in logs and drops it to empty string when crossing the job boundary. `function_url` matched `DASHBOARD_URL` verbatim. `function_name` (`cudly-dev-426fc8af-api`) did not match, confirming the masking-guard diagnosis.

Fetching from AWS bypasses the masking guard entirely. It is more reliable than either (a) encoding the URL in the producer and decoding in the consumer (fragile, leaks implementation into the workflow) or (b) storing the URL in a workflow artifact (an extra upload/download step for what is a runtime-available API call).

## Test plan

- [ ] Trigger the `Deploy to AWS Lambda` workflow and confirm `Test Deployment / Get Function URL` retrieves a non-empty URL from the Lambda API
- [ ] Confirm `Test health endpoint` and `Run smoke tests` pass using the retrieved URL
- [ ] Verify no new IAM policy changes are needed (policy_compute.tf already lists `lambda:GetFunctionUrlConfig`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Lambda deployment workflow reliability by ensuring environment-scoped variables resolve correctly across deployment steps.
  * Added validation of deployed Lambda function name and URL, and enhanced error handling to fail the deployment when function information is missing or invalid.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/552?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->