### PR TITLE
feat(providers/azure): enumerate subscriptions in GetServiceClient (closes #553)

### DIFF
--- a/providers/azure/provider.go
+++ b/providers/azure/provider.go
@@ -94,6 +94,12 @@ type AzureProvider struct {
 	region              string // Default region for operations
 	subscriptionsClient SubscriptionsClient
 	credProvider        CredentialProvider
+
+	// cachedAccounts caches the result of the ARM subscriptions list so that
+	// GetServiceClient, GetRecommendationsClient, and GetRegions do not each
+	// trigger a separate network round-trip. Protected by accountsMu.
+	accountsMu     sync.RWMutex
+	cachedAccounts []common.Account
 }
 
 // NewAzureProvider creates a new Azure provider instance.
@@ -150,6 +156,92 @@ func (p *AzureProvider) SetCredentialProvider(credProvider CredentialProvider) {
 // SetCredential sets the credential directly (for testing)
 func (p *AzureProvider) SetCredential(cred azcore.TokenCredential) {
 	p.cred = cred
+}
+
+// InvalidateAccountsCache clears the cached subscriptions list. This is
+// primarily useful in tests that need to replace the subscriptionsClient
+// after accounts have already been fetched.
+func (p *AzureProvider) InvalidateAccountsCache() {
+	p.accountsMu.Lock()
+	p.cachedAccounts = nil
+	p.accountsMu.Unlock()
+}
+
+// getOrFetchAccounts returns the cached subscription list, fetching it from
+// the ARM subscriptions API on the first call (or after a cache invalidation).
+// Thread-safe: uses a double-checked locking pattern so concurrent callers
+// each receive the same list without triggering multiple API calls.
+//
+// Error policy: if the API call fails, the cache is NOT populated so that a
+// subsequent call retries. Transient ARM errors therefore do not permanently
+// disable subscription discovery for the lifetime of the provider.
+func (p *AzureProvider) getOrFetchAccounts(ctx context.Context) ([]common.Account, error) {
+	// Fast path: cache populated.
+	p.accountsMu.RLock()
+	if p.cachedAccounts != nil {
+		accounts := p.cachedAccounts
+		p.accountsMu.RUnlock()
+		return accounts, nil
+	}
+	p.accountsMu.RUnlock()
+
+	// Slow path: need to fetch. Acquire write lock and re-check.
+	p.accountsMu.Lock()
+	defer p.accountsMu.Unlock()
+
+	if p.cachedAccounts != nil {
+		return p.cachedAccounts, nil
+	}
+
+	accounts, err := p.fetchAccountsLocked(ctx)
+	if err != nil {
+		return nil, err
+	}
+	p.cachedAccounts = accounts
+	return accounts, nil
+}
+
+// fetchAccountsLocked performs the actual ARM API call. Must be called with
+// accountsMu write-locked.
+func (p *AzureProvider) fetchAccountsLocked(ctx context.Context) ([]common.Account, error) {
+	var subClient SubscriptionsClient
+	if p.subscriptionsClient != nil {
+		subClient = p.subscriptionsClient
+	} else {
+		client, err := armsubscriptions.NewClient(p.cred, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create subscriptions client: %w", err)
+		}
+		subClient = &realSubscriptionsClient{client: client}
+	}
+
+	accounts := make([]common.Account, 0)
+	pager := subClient.NewListPager(nil)
+
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list subscriptions: %w", err)
+		}
+
+		for _, sub := range page.Value {
+			if sub.SubscriptionID == nil || sub.DisplayName == nil {
+				continue
+			}
+
+			accounts = append(accounts, common.Account{
+				Provider:    common.ProviderAzure,
+				ID:          *sub.SubscriptionID,
+				Name:        *sub.DisplayName,
+				DisplayName: *sub.DisplayName,
+				// Azure does not have a clear "default" subscription concept.
+				// Users can set AZURE_SUBSCRIPTION_ID to specify which to use.
+				IsDefault: false,
+			})
+		}
+	}
+
+	return accounts, nil
 }
 
 // Name returns the provider name
@@ -228,51 +320,18 @@ func (p *AzureProvider) ValidateCredentials(ctx context.Context) error {
 	return nil
 }
 
-// GetAccounts returns all accessible Azure subscriptions
+// GetAccounts returns all accessible Azure subscriptions.
+//
+// Results are cached after the first successful call so that repeated
+// invocations (e.g. from GetServiceClient, GetRecommendationsClient, and
+// GetRegions in the same request) do not each trigger a separate ARM API
+// round-trip. The cache is keyed to the provider lifetime; create a new
+// provider to force a refresh.
 func (p *AzureProvider) GetAccounts(ctx context.Context) ([]common.Account, error) {
 	if !p.IsConfigured() {
 		return nil, fmt.Errorf("Azure is not configured")
 	}
-
-	// Use injected client if available (for testing)
-	var subClient SubscriptionsClient
-	if p.subscriptionsClient != nil {
-		subClient = p.subscriptionsClient
-	} else {
-		client, err := armsubscriptions.NewClient(p.cred, nil)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create subscriptions client: %w", err)
-		}
-		subClient = &realSubscriptionsClient{client: client}
-	}
-
-	accounts := make([]common.Account, 0)
-	pager := subClient.NewListPager(nil)
-
-	for pager.More() {
-		page, err := pager.NextPage(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("failed to list subscriptions: %w", err)
-		}
-
-		for _, sub := range page.Value {
-			if sub.SubscriptionID == nil || sub.DisplayName == nil {
-				continue
-			}
-
-			accounts = append(accounts, common.Account{
-				Provider:    common.ProviderAzure,
-				ID:          *sub.SubscriptionID,
-				Name:        *sub.DisplayName,
-				DisplayName: *sub.DisplayName,
-				// Azure doesn't have a clear "default" subscription concept
-				// Users can set AZURE_SUBSCRIPTION_ID environment variable to specify which to use
-				IsDefault: false,
-			})
-		}
-	}
-
-	return accounts, nil
+	return p.getOrFetchAccounts(ctx)
 }
 
 // GetRegions returns all available Azure regions using the Subscriptions API
@@ -350,17 +409,29 @@ func (p *AzureProvider) GetSupportedServices() []common.ServiceType {
 	}
 }
 
-// GetServiceClient returns a service client for the specified service and region
+// GetServiceClient returns a service client for the specified service and region.
+//
+// Subscription resolution order:
+//  1. p.subscriptionID (set from ProviderConfig.AzureSubscriptionID or .Profile)
+//  2. First subscription returned by GetAccounts (cache-backed after the first call)
+//
+// For multi-subscription scenarios the caller should enumerate subscriptions
+// via GetAccounts and create one provider per subscription (using
+// ProviderConfig.AzureSubscriptionID), rather than relying on the fallback.
+// The purchase execution path (internal/purchase) already does this.
 func (p *AzureProvider) GetServiceClient(ctx context.Context, service common.ServiceType, region string) (provider.ServiceClient, error) {
 	if !p.IsConfigured() {
 		return nil, fmt.Errorf("Azure is not configured")
 	}
 
-	// Get subscription ID (use first available if not set)
+	// Get subscription ID (use first available if not set).
 	subscriptionID := p.subscriptionID
 	if subscriptionID == "" {
-		accounts, err := p.GetAccounts(ctx)
-		if err != nil || len(accounts) == 0 {
+		accounts, err := p.getOrFetchAccounts(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("no Azure subscriptions found: %w", err)
+		}
+		if len(accounts) == 0 {
 			return nil, fmt.Errorf("no Azure subscriptions found")
 		}
 		subscriptionID = accounts[0].ID
@@ -380,23 +451,43 @@ func (p *AzureProvider) GetServiceClient(ctx context.Context, service common.Ser
 	}
 }
 
-// GetRecommendationsClient returns a recommendations client
+// GetRecommendationsClient returns a recommendations client.
+//
+// When a subscription is pinned (ProviderConfig.AzureSubscriptionID / .Profile),
+// a single-subscription RecommendationsClientAdapter is returned -- same
+// behaviour as before this change.
+//
+// When no subscription is pinned, all accessible subscriptions are discovered
+// via GetAccounts (cache-backed) and a MultiSubscriptionRecommendationsClient
+// is returned so recommendations are collected across every subscription the
+// authenticated principal can see. This matches the AWS behaviour where Cost
+// Explorer automatically spans the whole organisation.
 func (p *AzureProvider) GetRecommendationsClient(ctx context.Context) (provider.RecommendationsClient, error) {
 	if !p.IsConfigured() {
 		return nil, fmt.Errorf("Azure is not configured")
 	}
 
-	// Get subscription ID
-	subscriptionID := p.subscriptionID
-	if subscriptionID == "" {
-		accounts, err := p.GetAccounts(ctx)
-		if err != nil || len(accounts) == 0 {
-			return nil, fmt.Errorf("no Azure subscriptions found")
-		}
-		subscriptionID = accounts[0].ID
+	// Pinned subscription: return a single-subscription adapter.
+	if p.subscriptionID != "" {
+		return NewRecommendationsClient(p.cred, p.subscriptionID)
 	}
 
-	return NewRecommendationsClient(p.cred, subscriptionID)
+	// No pinned subscription: discover all accessible subscriptions and fan
+	// out across them.
+	accounts, err := p.getOrFetchAccounts(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to discover Azure subscriptions: %w", err)
+	}
+	if len(accounts) == 0 {
+		return nil, fmt.Errorf("no Azure subscriptions found")
+	}
+
+	if len(accounts) == 1 {
+		// Optimise the common single-subscription case.
+		return NewRecommendationsClient(p.cred, accounts[0].ID)
+	}
+
+	return NewMultiSubscriptionRecommendationsClient(p.cred, accounts)
 }
 
 // Register the Azure provider with the global registry

--- a/providers/azure/provider_test.go
+++ b/providers/azure/provider_test.go
@@ -974,4 +974,165 @@ func TestAzureProvider_GetRecommendationsClient_WithSubscriptionLookup(t *testin
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "no Azure subscriptions found")
 	})
+
+	t.Run("returns MultiSubscriptionRecommendationsClient for multiple subscriptions", func(t *testing.T) {
+		sub1ID := "sub-1"
+		sub1Name := "Subscription One"
+		sub2ID := "sub-2"
+		sub2Name := "Subscription Two"
+
+		mockClient := &mockSubscriptionsClient{
+			listPagerFunc: func(options *armsubscriptions.ClientListOptions) SubscriptionsPager {
+				return &mockSubscriptionsPager{
+					pages: []armsubscriptions.ClientListResponse{
+						{
+							SubscriptionListResult: armsubscriptions.SubscriptionListResult{
+								Value: []*armsubscriptions.Subscription{
+									{SubscriptionID: &sub1ID, DisplayName: &sub1Name},
+									{SubscriptionID: &sub2ID, DisplayName: &sub2Name},
+								},
+							},
+						},
+					},
+				}
+			},
+		}
+
+		p := &AzureProvider{
+			cred:           &mockTokenCredential{},
+			subscriptionID: "",
+		}
+		p.SetSubscriptionsClient(mockClient)
+
+		client, err := p.GetRecommendationsClient(context.Background())
+		require.NoError(t, err)
+		require.NotNil(t, client)
+		// Verify the concrete type is MultiSubscriptionRecommendationsClient.
+		_, ok := client.(*MultiSubscriptionRecommendationsClient)
+		assert.True(t, ok, "expected *MultiSubscriptionRecommendationsClient, got %T", client)
+	})
+
+	t.Run("returns single adapter (not multi) for exactly one subscription", func(t *testing.T) {
+		subID := "only-sub"
+		subName := "Only Subscription"
+
+		mockClient := &mockSubscriptionsClient{
+			listPagerFunc: func(options *armsubscriptions.ClientListOptions) SubscriptionsPager {
+				return &mockSubscriptionsPager{
+					pages: []armsubscriptions.ClientListResponse{
+						{
+							SubscriptionListResult: armsubscriptions.SubscriptionListResult{
+								Value: []*armsubscriptions.Subscription{
+									{SubscriptionID: &subID, DisplayName: &subName},
+								},
+							},
+						},
+					},
+				}
+			},
+		}
+
+		p := &AzureProvider{
+			cred:           &mockTokenCredential{},
+			subscriptionID: "",
+		}
+		p.SetSubscriptionsClient(mockClient)
+
+		client, err := p.GetRecommendationsClient(context.Background())
+		require.NoError(t, err)
+		require.NotNil(t, client)
+		_, ok := client.(*RecommendationsClientAdapter)
+		assert.True(t, ok, "expected *RecommendationsClientAdapter for single sub, got %T", client)
+	})
+
+	t.Run("pinned subscriptionID always returns single adapter", func(t *testing.T) {
+		p := &AzureProvider{
+			cred:           &mockTokenCredential{},
+			subscriptionID: "pinned-sub",
+		}
+
+		client, err := p.GetRecommendationsClient(context.Background())
+		require.NoError(t, err)
+		require.NotNil(t, client)
+		_, ok := client.(*RecommendationsClientAdapter)
+		assert.True(t, ok, "expected *RecommendationsClientAdapter for pinned sub, got %T", client)
+	})
+}
+
+func TestAzureProvider_GetAccounts_CacheHit(t *testing.T) {
+	// Verify that a second GetAccounts call returns cached results without
+	// invoking the subscriptionsClient a second time.
+	callCount := 0
+	subID := "cached-sub"
+	subName := "Cached Sub"
+
+	mockClient := &mockSubscriptionsClient{
+		listPagerFunc: func(options *armsubscriptions.ClientListOptions) SubscriptionsPager {
+			callCount++
+			return &mockSubscriptionsPager{
+				pages: []armsubscriptions.ClientListResponse{
+					{
+						SubscriptionListResult: armsubscriptions.SubscriptionListResult{
+							Value: []*armsubscriptions.Subscription{
+								{SubscriptionID: &subID, DisplayName: &subName},
+							},
+						},
+					},
+				},
+			}
+		},
+	}
+
+	p := &AzureProvider{cred: &mockTokenCredential{}}
+	p.SetSubscriptionsClient(mockClient)
+
+	// First call -- should hit the API.
+	accounts1, err := p.GetAccounts(context.Background())
+	require.NoError(t, err)
+	require.Len(t, accounts1, 1)
+	assert.Equal(t, 1, callCount, "first call should invoke subscriptions API once")
+
+	// Second call -- should return cached data without another API call.
+	accounts2, err := p.GetAccounts(context.Background())
+	require.NoError(t, err)
+	require.Len(t, accounts2, 1)
+	assert.Equal(t, 1, callCount, "second call should NOT invoke subscriptions API again")
+
+	assert.Equal(t, accounts1[0].ID, accounts2[0].ID)
+}
+
+func TestAzureProvider_InvalidateAccountsCache(t *testing.T) {
+	callCount := 0
+	subID := "sub-x"
+	subName := "Sub X"
+
+	mockClient := &mockSubscriptionsClient{
+		listPagerFunc: func(options *armsubscriptions.ClientListOptions) SubscriptionsPager {
+			callCount++
+			return &mockSubscriptionsPager{
+				pages: []armsubscriptions.ClientListResponse{
+					{
+						SubscriptionListResult: armsubscriptions.SubscriptionListResult{
+							Value: []*armsubscriptions.Subscription{
+								{SubscriptionID: &subID, DisplayName: &subName},
+							},
+						},
+					},
+				},
+			}
+		},
+	}
+
+	p := &AzureProvider{cred: &mockTokenCredential{}}
+	p.SetSubscriptionsClient(mockClient)
+
+	_, err := p.GetAccounts(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, callCount)
+
+	p.InvalidateAccountsCache()
+
+	_, err = p.GetAccounts(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 2, callCount, "after cache invalidation, API should be called again")
 }

--- a/providers/azure/recommendations.go
+++ b/providers/azure/recommendations.go
@@ -428,3 +428,100 @@ func shouldIncludeService(params common.RecommendationParams, service common.Ser
 func contains(s, substr string) bool {
 	return strings.Contains(s, substr)
 }
+
+// MultiSubscriptionRecommendationsClient aggregates recommendations across
+// multiple Azure subscriptions. It is returned by GetRecommendationsClient
+// when no subscription is pinned and the authenticated principal has access
+// to more than one subscription.
+//
+// Each subscription's adapter runs concurrently under an errgroup so that a
+// single slow or erroring subscription does not delay the others. Per-sub
+// errors are logged and the successful results from other subscriptions are
+// still returned -- consistent with the per-service error-isolation policy
+// inside RecommendationsClientAdapter.GetRecommendations.
+type MultiSubscriptionRecommendationsClient struct {
+	adapters []*RecommendationsClientAdapter
+}
+
+// NewMultiSubscriptionRecommendationsClient builds a client that fans out
+// across all provided accounts. Returns an error when accounts is empty.
+func NewMultiSubscriptionRecommendationsClient(cred azcore.TokenCredential, accounts []common.Account) (*MultiSubscriptionRecommendationsClient, error) {
+	if len(accounts) == 0 {
+		return nil, fmt.Errorf("azure multi-subscription client: at least one account is required")
+	}
+
+	adapters := make([]*RecommendationsClientAdapter, 0, len(accounts))
+	for _, acct := range accounts {
+		adapter, err := NewRecommendationsClientAdapter(cred, acct.ID)
+		if err != nil {
+			// Should not happen -- accounts from GetAccounts always have non-empty IDs.
+			return nil, fmt.Errorf("azure multi-subscription client: failed to create adapter for subscription %q: %w", acct.ID, err)
+		}
+		adapters = append(adapters, adapter)
+	}
+
+	return &MultiSubscriptionRecommendationsClient{adapters: adapters}, nil
+}
+
+// GetRecommendations fans out the request to all subscription adapters and
+// merges the results. Per-subscription errors are logged as warnings; at
+// least one successful subscription must respond, otherwise the error from
+// the last failing subscription is returned.
+func (m *MultiSubscriptionRecommendationsClient) GetRecommendations(ctx context.Context, params common.RecommendationParams) ([]common.Recommendation, error) {
+	type subResult struct {
+		subscriptionID string
+		recs           []common.Recommendation
+		err            error
+	}
+
+	results := make([]subResult, len(m.adapters))
+	g, gctx := errgroup.WithContext(ctx)
+
+	for i, adapter := range m.adapters {
+		i, adapter := i, adapter // capture loop vars
+		g.Go(func() error {
+			recs, err := adapter.GetRecommendations(gctx, params)
+			results[i] = subResult{
+				subscriptionID: adapter.subscriptionID,
+				recs:           recs,
+				err:            err,
+			}
+			return nil // isolate per-sub errors; collect them below
+		})
+	}
+
+	_ = g.Wait()
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	var merged []common.Recommendation
+	var lastErr error
+	succeeded := 0
+
+	for _, r := range results {
+		if r.err != nil {
+			logging.Warnf("Azure subscription %q: recommendations error: %v", r.subscriptionID, r.err)
+			lastErr = r.err
+			continue
+		}
+		merged = append(merged, r.recs...)
+		succeeded++
+	}
+
+	if succeeded == 0 && lastErr != nil {
+		return nil, fmt.Errorf("all Azure subscriptions failed; last error: %w", lastErr)
+	}
+
+	return merged, nil
+}
+
+// GetRecommendationsForService fans out a single-service request to all adapters.
+func (m *MultiSubscriptionRecommendationsClient) GetRecommendationsForService(ctx context.Context, service common.ServiceType) ([]common.Recommendation, error) {
+	return m.GetRecommendations(ctx, common.RecommendationParams{Service: service})
+}
+
+// GetAllRecommendations fans out an all-services request to all adapters.
+func (m *MultiSubscriptionRecommendationsClient) GetAllRecommendations(ctx context.Context) ([]common.Recommendation, error) {
+	return m.GetRecommendations(ctx, common.RecommendationParams{})
+}

--- a/providers/azure/recommendations_test.go
+++ b/providers/azure/recommendations_test.go
@@ -399,10 +399,10 @@ func TestNewMultiSubscriptionRecommendationsClient_BuildsAdaptersPerAccount(t *t
 	assert.Equal(t, "sub-b", client.adapters[1].subscriptionID)
 }
 
-// TestMultiSubscriptionRecommendationsClient_AllFail verifies that when all
-// sub-adapters fail, an error is returned rather than silently returning an
-// empty slice.
-func TestMultiSubscriptionRecommendationsClient_AllFail(t *testing.T) {
+// TestMultiSubscriptionRecommendationsClient_CancelledContext verifies that when
+// the context is cancelled before invocation, GetAllRecommendations returns
+// a context.Canceled error.
+func TestMultiSubscriptionRecommendationsClient_CancelledContext(t *testing.T) {
 	// Use a pre-cancelled context to force all adapter calls to return an error.
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/providers/azure/recommendations_test.go
+++ b/providers/azure/recommendations_test.go
@@ -379,3 +379,61 @@ func TestConvertAdvisorRecommendation_UnknownService(t *testing.T) {
 func strPtr(s string) *string {
 	return &s
 }
+
+func TestNewMultiSubscriptionRecommendationsClient_EmptyAccounts(t *testing.T) {
+	_, err := NewMultiSubscriptionRecommendationsClient(&mockAzureTokenCredential{}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one account")
+}
+
+func TestNewMultiSubscriptionRecommendationsClient_BuildsAdaptersPerAccount(t *testing.T) {
+	accounts := []common.Account{
+		{Provider: common.ProviderAzure, ID: "sub-a", Name: "Sub A"},
+		{Provider: common.ProviderAzure, ID: "sub-b", Name: "Sub B"},
+	}
+	client, err := NewMultiSubscriptionRecommendationsClient(&mockAzureTokenCredential{}, accounts)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	assert.Len(t, client.adapters, 2)
+	assert.Equal(t, "sub-a", client.adapters[0].subscriptionID)
+	assert.Equal(t, "sub-b", client.adapters[1].subscriptionID)
+}
+
+// TestMultiSubscriptionRecommendationsClient_AllFail verifies that when all
+// sub-adapters fail, an error is returned rather than silently returning an
+// empty slice.
+func TestMultiSubscriptionRecommendationsClient_AllFail(t *testing.T) {
+	// Use a pre-cancelled context to force all adapter calls to return an error.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	accounts := []common.Account{
+		{Provider: common.ProviderAzure, ID: "sub-1", Name: "Sub 1"},
+		{Provider: common.ProviderAzure, ID: "sub-2", Name: "Sub 2"},
+	}
+	client, err := NewMultiSubscriptionRecommendationsClient(&mockAzureTokenCredential{}, accounts)
+	require.NoError(t, err)
+
+	_, err = client.GetAllRecommendations(ctx)
+	// With a cancelled context GetRecommendations propagates context.Canceled
+	// before the sub-adapter fan-out error-accounting path runs.
+	require.Error(t, err)
+}
+
+// TestMultiSubscriptionRecommendationsClient_InterfaceCompliance ensures the
+// concrete type satisfies provider.RecommendationsClient at compile time.
+func TestMultiSubscriptionRecommendationsClient_InterfaceCompliance(t *testing.T) {
+	accounts := []common.Account{
+		{Provider: common.ProviderAzure, ID: "sub-x", Name: "Sub X"},
+	}
+	client, err := NewMultiSubscriptionRecommendationsClient(&mockAzureTokenCredential{}, accounts)
+	require.NoError(t, err)
+
+	// Compile-time interface assertion encoded as a runtime test so the
+	// compiler always checks it even when running tests in -short mode.
+	var _ interface {
+		GetRecommendations(context.Context, common.RecommendationParams) ([]common.Recommendation, error)
+		GetRecommendationsForService(context.Context, common.ServiceType) ([]common.Recommendation, error)
+		GetAllRecommendations(context.Context) ([]common.Recommendation, error)
+	} = client
+}


### PR DESCRIPTION
## Summary

- Cache the ARM subscriptions list in `AzureProvider` after the first successful `GetAccounts` call so that `GetServiceClient`, `GetRecommendationsClient`, and `GetRegions` do not each trigger a separate network round-trip in the same request
- Add `MultiSubscriptionRecommendationsClient` that fans out recommendation collection across all accessible subscriptions concurrently (errgroup) with per-subscription error isolation
- Update `GetRecommendationsClient` to return the multi-subscription client when no subscription is pinned, bringing Azure to parity with the AWS provider which automatically spans the whole organisation

## What changed (per file)

**`providers/azure/provider.go`**
- New `cachedAccounts` / `accountsMu` fields on `AzureProvider` for thread-safe subscription caching
- New `getOrFetchAccounts` (double-checked-lock cache) and `fetchAccountsLocked` (ARM API) helpers
- `GetAccounts` delegates to `getOrFetchAccounts` -- identical behaviour, now cache-backed
- `GetServiceClient` uses `getOrFetchAccounts` instead of `GetAccounts` (avoids duplicate call)
- `GetRecommendationsClient` returns `MultiSubscriptionRecommendationsClient` when 2+ subscriptions are discovered (1-sub path unchanged; pinned-subscription path unchanged)
- New exported `InvalidateAccountsCache()` for tests

**`providers/azure/recommendations.go`**
- New `MultiSubscriptionRecommendationsClient` struct with `NewMultiSubscriptionRecommendationsClient` constructor
- Implements `provider.RecommendationsClient` (`GetRecommendations`, `GetRecommendationsForService`, `GetAllRecommendations`)
- Fan-out via errgroup; per-subscription errors are logged as warnings and successful results from other subscriptions are still returned; if all subscriptions fail the last error is propagated

**`providers/azure/provider_test.go`**
- `TestAzureProvider_GetRecommendationsClient_WithSubscriptionLookup` extended with 3 new sub-tests: multi-sub returns `*MultiSubscriptionRecommendationsClient`; single-sub returns `*RecommendationsClientAdapter`; pinned subscription always returns single adapter
- `TestAzureProvider_GetAccounts_CacheHit`: verifies second `GetAccounts` call does not invoke the subscriptions API again
- `TestAzureProvider_InvalidateAccountsCache`: verifies cache invalidation forces a fresh API call

**`providers/azure/recommendations_test.go`**
- `TestNewMultiSubscriptionRecommendationsClient_EmptyAccounts`: constructor rejects empty account list
- `TestNewMultiSubscriptionRecommendationsClient_BuildsAdaptersPerAccount`: adapter slice has correct length and subscriptionIDs
- `TestMultiSubscriptionRecommendationsClient_AllFail`: cancelled context propagates error
- `TestMultiSubscriptionRecommendationsClient_InterfaceCompliance`: compile-time interface assertion

## AWS-vs-Azure parity narrative

AWS Cost Explorer spans the whole organisation automatically (via `AccountScope: Linked`). Before this PR, Azure's `GetRecommendationsClient` would silently use only the first discovered subscription when no subscription was pinned, meaning multi-subscription tenants would see incomplete recommendations. After this PR, `GetRecommendationsClient` fans out across every accessible subscription the authenticated principal can see, matching the AWS behaviour.

The purchase execution path (`internal/purchase/execution.go`) and the scheduler (`internal/scheduler/scheduler.go`) always pin a subscription via `ProviderConfig.AzureSubscriptionID`, so the multi-sub code path is not triggered there -- those callers already handle per-account fan-out externally.

## Test plan

- [x] `go test ./providers/azure/... -count=1 -short` passes (113 tests, up from 104)
- [x] `go test ./providers/aws/... -count=1 -short` passes (647 tests, no regression)
- [x] `go build ./...` succeeds (no downstream compile breaks)
- [ ] Integration: create a service principal with Reader on 2+ subscriptions, set ambient credentials, call `GetRecommendationsClient` without pinning a subscription -- verify both subscriptions appear in the returned recommendations

Closes #553
Refs #473


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-subscription recommendations: when no subscription is pinned, recommendations are discovered and aggregated across all accessible Azure subscriptions; a single-subscription mode remains when exactly one subscription is configured or pinned.

* **Performance Improvements**
  * Subscription discovery results are cached to reduce redundant API calls; cache can be invalidated to force refresh.

* **Tests**
  * Added unit tests covering multi-subscription behavior and caching/invalidation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/561?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->