### PR TITLE
fix(auth): GetUserByResetToken must surface expired rows so ResetTokenStatus can classify them (QA bug 11.2)

### DIFF
--- a/internal/auth/store_postgres.go
+++ b/internal/auth/store_postgres.go
@@ -279,7 +279,12 @@ func (s *PostgresStore) ListUsers(ctx context.Context) ([]User, error) {
 	return users, rows.Err()
 }
 
-// GetUserByResetToken retrieves a user by password reset token
+// GetUserByResetToken retrieves a user by password reset token without
+// filtering on expiry. Both callers (ResetTokenStatus and
+// validateResetToken) perform their own expiry check on the returned
+// row, so the SQL must surface expired rows; otherwise an expired
+// token returns pgx.ErrNoRows and ResetTokenStatus misclassifies it
+// as "used" instead of "expired" (QA bug 11.2).
 func (s *PostgresStore) GetUserByResetToken(ctx context.Context, token string) (*User, error) {
 	query := `
 		SELECT id, email, password_hash, salt, role, group_ids, active,
@@ -289,7 +294,6 @@ func (s *PostgresStore) GetUserByResetToken(ctx context.Context, token string) (
 		       created_at, updated_at, last_login_at
 		FROM users
 		WHERE password_reset_token = $1
-		  AND password_reset_expiry > NOW()
 	`
 
 	return s.scanUser(s.db.QueryRow(ctx, query, token))


### PR DESCRIPTION
## Summary

QA bug 11.2: clicking a Reset Password email link with an *expired* token landed on a "Password reset link already used" view instead of an "expired" view. The token had not been used, only expired.

## Root cause

`GetUserByResetToken` in `internal/auth/store_postgres.go` filtered on `AND password_reset_expiry > NOW()`. For an expired token the SQL returned `pgx.ErrNoRows`, which `ResetTokenStatus` then mapped to `ResetTokenStateUsed` (the fallback for "consumed or never issued"). The expired-token branch in `service_password.go:387` was unreachable in production despite being unit-tested via mocks.

## Fix

Remove the expiry filter from the SQL. Both callers already perform their own expiry check on the returned row, so this is safe:

- `ResetTokenStatus` (service_password.go:387) returns `ResetTokenStateExpired` when `user.PasswordResetExpiry` is in the past.
- `validateResetToken` (service_password.go:416) returns `"reset token has expired"` when the expiry is past, so the consumption path keeps rejecting expired tokens.

## Why no new test

The existing `TestService_ResetTokenStatus/expired token reports expired` already pins the corrected behaviour by mocking `GetUserByResetToken` to return a user with an expired `PasswordResetExpiry`. That test passes today only because the mock bypasses the SQL filter that broke production. With the SQL fix, prod now matches what the unit test assumes.

## Test plan

- [x] `go test ./internal/auth/...` — 497 tests pass.
- [ ] Manual after deploy: trigger a reset email, wait until token expiry, click the link, confirm the "Expired link" view renders instead of "Already used".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced password reset token validation to accurately identify and classify expired tokens rather than treating them as unavailable or used.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/562?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->