### PR TITLE
feat(providers/azure): add RI utilization reporting (closes #558)

### DIFF
--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -483,6 +483,41 @@ func (d SavingsPlanDetails) GetDetailDescription() string {
 	return d.PlanType
 }
 
+// RIUtilization holds utilization data for a single Reserved Instance over a
+// lookback period. The struct is defined here (rather than in a provider
+// package) so both AWS and Azure can return the same type and callers can
+// treat either provider's results uniformly without a cross-provider import.
+//
+// AWS field mapping (Cost Explorer GetReservationUtilization):
+//
+//	ReservedInstanceID  <- dimension key (SUBSCRIPTION_ID group value)
+//	PurchasedHours      <- UtilizationsByTime[].Groups[].Utilization.PurchasedHours
+//	TotalActualHours    <- UtilizationsByTime[].Groups[].Utilization.TotalActualHours
+//	UnusedHours         <- UtilizationsByTime[].Groups[].Utilization.UnusedHours
+//	UtilizationPercent  <- derived: (TotalActualHours / PurchasedHours) * 100
+//
+// Azure field mapping (Consumption ReservationsSummaries, monthly grain):
+//
+//	ReservedInstanceID  <- Properties.ReservationID
+//	PurchasedHours      <- Properties.ReservedHours  (sum across periods)
+//	TotalActualHours    <- Properties.UsedHours       (sum across periods)
+//	UnusedHours         <- PurchasedHours - TotalActualHours
+//	UtilizationPercent  <- derived: (TotalActualHours / PurchasedHours) * 100
+//	SKUName             <- Properties.SKUName (Azure-only; empty string for AWS)
+type RIUtilization struct {
+	ReservedInstanceID string  `json:"reserved_instance_id"`
+	UtilizationPercent float64 `json:"utilization_percent"`
+	PurchasedHours     float64 `json:"purchased_hours"`
+	TotalActualHours   float64 `json:"total_actual_hours"`
+	UnusedHours        float64 `json:"unused_hours"`
+	// SKUName is the Azure reservation SKU (e.g. "Standard_D2s_v3"). It is
+	// empty for AWS RIs because Cost Explorer does not return the instance
+	// type on the utilization response. Consumers that need it for Azure
+	// can populate downstream display from this field; AWS consumers can
+	// join on ReservedInstanceID via the EC2 DescribeReservedInstances API.
+	SKUName string `json:"sku_name,omitempty"`
+}
+
 // AuditRecord is one line in the JSON-lines audit log.
 // Status values: "success", "error", "skipped" (dry-run), "skipped_covered" (idempotency).
 type AuditRecord struct {

--- a/providers/aws/recommendations/utilization.go
+++ b/providers/aws/recommendations/utilization.go
@@ -10,16 +10,15 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/costexplorer"
 	"github.com/aws/aws-sdk-go-v2/service/costexplorer/types"
+
+	"github.com/LeanerCloud/CUDly/pkg/common"
 )
 
-// RIUtilization holds utilization data for a single Reserved Instance.
-type RIUtilization struct {
-	ReservedInstanceID string  `json:"reserved_instance_id"`
-	UtilizationPercent float64 `json:"utilization_percent"`
-	PurchasedHours     float64 `json:"purchased_hours"`
-	TotalActualHours   float64 `json:"total_actual_hours"`
-	UnusedHours        float64 `json:"unused_hours"`
-}
+// RIUtilization is an alias for common.RIUtilization so existing callers that
+// import this package continue to compile without changes. The canonical
+// definition lives in pkg/common so the Azure provider can return the same
+// type without a cross-provider dependency.
+type RIUtilization = common.RIUtilization
 
 // riAccumulator aggregates utilization hours across multiple daily entries for one RI.
 type riAccumulator struct {

--- a/providers/azure/mocks/azure_mocks.go
+++ b/providers/azure/mocks/azure_mocks.go
@@ -12,6 +12,34 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+// MockReservationsSummariesPager mocks the reservations summaries pager
+// returned by armconsumption.ReservationsSummariesClient.NewListPager.
+// Set Results + HasMore before use; Results are returned on the first
+// NextPage call and More() returns false on the second call.
+type MockReservationsSummariesPager struct {
+	Results   []*armconsumption.ReservationSummary
+	HasMore   bool
+	pageCount int
+}
+
+// More returns whether there are more pages.
+func (p *MockReservationsSummariesPager) More() bool {
+	if p.pageCount == 0 {
+		return p.HasMore
+	}
+	return false
+}
+
+// NextPage returns the next page of results.
+func (p *MockReservationsSummariesPager) NextPage(ctx context.Context) (armconsumption.ReservationsSummariesClientListResponse, error) {
+	p.pageCount++
+	return armconsumption.ReservationsSummariesClientListResponse{
+		ReservationSummariesListResult: armconsumption.ReservationSummariesListResult{
+			Value: p.Results,
+		},
+	}, nil
+}
+
 // MockRecommendationsPager mocks the recommendations pager
 type MockRecommendationsPager struct {
 	mock.Mock

--- a/providers/azure/ri_utilization.go
+++ b/providers/azure/ri_utilization.go
@@ -1,0 +1,174 @@
+package azure
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/consumption/armconsumption"
+
+	"github.com/LeanerCloud/CUDly/pkg/common"
+)
+
+// reservationsSummariesPager is the page-iterator interface returned by
+// armconsumption.ReservationsSummariesClient.NewListPager. Extracted as an
+// interface so tests can inject a stub without a real Azure connection.
+type reservationsSummariesPager interface {
+	More() bool
+	NextPage(ctx context.Context) (armconsumption.ReservationsSummariesClientListResponse, error)
+}
+
+// reservationsSummariesAPI is the narrow slice of
+// armconsumption.ReservationsSummariesClient that GetRIUtilization needs.
+// It lets tests inject a fake client that returns a controlled pager.
+type reservationsSummariesAPI interface {
+	newListPager(resourceScope string, grain armconsumption.Datagrain, startDate, endDate string) reservationsSummariesPager
+}
+
+// realReservationsSummariesAPI wraps the concrete Azure SDK client and
+// implements reservationsSummariesAPI using the real Consumption API.
+type realReservationsSummariesAPI struct {
+	client *armconsumption.ReservationsSummariesClient
+}
+
+func (r *realReservationsSummariesAPI) newListPager(resourceScope string, grain armconsumption.Datagrain, startDate, endDate string) reservationsSummariesPager {
+	return r.client.NewListPager(resourceScope, grain, &armconsumption.ReservationsSummariesClientListOptions{
+		StartDate: &startDate,
+		EndDate:   &endDate,
+	})
+}
+
+// riAccumulator collects hour totals across multiple monthly summary rows
+// for the same reservation ID so a single RIUtilization can be returned
+// per reservation regardless of how many calendar months fall in the window.
+type riAccumulator struct {
+	skuName        string
+	purchasedHours float64
+	usedHours      float64
+}
+
+// GetRIUtilization fetches per-reservation utilization data from the Azure
+// Consumption Reservations Summaries API for the subscription and returns it
+// in the same shape as the AWS recommendations.Client.GetRIUtilization so
+// callers can treat both providers uniformly.
+//
+// lookbackDays controls the date window: [today - lookbackDays, today].
+// Values <= 0 default to 30 days, matching the AWS implementation.
+//
+// The function uses monthly grain so the API returns one row per
+// reservation per calendar month. Rows are accumulated by ReservationID
+// across months and a single common.RIUtilization is returned per
+// reservation with derived UtilizationPercent = (UsedHours / ReservedHours) * 100.
+//
+// An empty result (no reservations in the subscription, or the subscription
+// has no active reservations in the date range) returns (nil, nil).
+func (r *RecommendationsClientAdapter) GetRIUtilization(ctx context.Context, lookbackDays int) ([]common.RIUtilization, error) {
+	if lookbackDays <= 0 {
+		lookbackDays = 30
+	}
+
+	end := time.Now().UTC()
+	start := end.AddDate(0, 0, -lookbackDays)
+	startDate := start.Format("2006-01-02")
+	endDate := end.Format("2006-01-02")
+
+	// Build the real client and wrap it in the interface so tests can substitute.
+	summariesClient, err := armconsumption.NewReservationsSummariesClient(r.cred, nil)
+	if err != nil {
+		return nil, fmt.Errorf("azure ri utilization: failed to create summaries client: %w", err)
+	}
+
+	api := &realReservationsSummariesAPI{client: summariesClient}
+	return r.getRIUtilizationViaAPI(ctx, api, startDate, endDate)
+}
+
+// getRIUtilizationViaAPI performs the actual pager loop. It is separate from
+// GetRIUtilization so tests can inject a fake reservationsSummariesAPI
+// without needing a real Azure credential.
+func (r *RecommendationsClientAdapter) getRIUtilizationViaAPI(
+	ctx context.Context,
+	api reservationsSummariesAPI,
+	startDate, endDate string,
+) ([]common.RIUtilization, error) {
+	// Subscription-scoped resource path: Azure's Consumption API accepts
+	// "/subscriptions/{id}" as the resourceScope for the List endpoint.
+	resourceScope := fmt.Sprintf("subscriptions/%s", r.subscriptionID)
+
+	pager := api.newListPager(resourceScope, armconsumption.DatagrainMonthlyGrain, startDate, endDate)
+
+	agg := make(map[string]*riAccumulator)
+
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("azure ri utilization: failed to fetch summaries page: %w", err)
+		}
+
+		for _, summary := range page.Value {
+			accumulateSummary(agg, summary)
+		}
+	}
+
+	return buildUtilizations(agg), nil
+}
+
+// accumulateSummary adds one ReservationSummary row into the aggregation map.
+// Rows with nil Properties or nil ReservationID are silently skipped.
+func accumulateSummary(agg map[string]*riAccumulator, summary *armconsumption.ReservationSummary) {
+	if summary == nil || summary.Properties == nil {
+		return
+	}
+	props := summary.Properties
+	if props.ReservationID == nil || *props.ReservationID == "" {
+		return
+	}
+
+	id := *props.ReservationID
+	a, ok := agg[id]
+	if !ok {
+		a = &riAccumulator{}
+		agg[id] = a
+	}
+
+	// Capture SKU on first non-empty occurrence.
+	if a.skuName == "" && props.SKUName != nil {
+		a.skuName = *props.SKUName
+	}
+
+	if props.ReservedHours != nil {
+		a.purchasedHours += *props.ReservedHours
+	}
+	if props.UsedHours != nil {
+		a.usedHours += *props.UsedHours
+	}
+}
+
+// buildUtilizations converts the per-reservation accumulator map into the
+// common.RIUtilization slice. UtilizationPercent is derived as
+// (usedHours / purchasedHours) * 100; it stays 0 when purchasedHours == 0
+// (defensive, avoids division by zero for zero-hour reservations).
+func buildUtilizations(agg map[string]*riAccumulator) []common.RIUtilization {
+	if len(agg) == 0 {
+		return nil
+	}
+	result := make([]common.RIUtilization, 0, len(agg))
+	for id, a := range agg {
+		pct := 0.0
+		if a.purchasedHours > 0 {
+			pct = (a.usedHours / a.purchasedHours) * 100
+		}
+		unusedHours := a.purchasedHours - a.usedHours
+		if unusedHours < 0 {
+			unusedHours = 0
+		}
+		result = append(result, common.RIUtilization{
+			ReservedInstanceID: id,
+			UtilizationPercent: pct,
+			PurchasedHours:     a.purchasedHours,
+			TotalActualHours:   a.usedHours,
+			UnusedHours:        unusedHours,
+			SKUName:            a.skuName,
+		})
+	}
+	return result
+}

--- a/providers/azure/ri_utilization.go
+++ b/providers/azure/ri_utilization.go
@@ -90,9 +90,12 @@ func (r *RecommendationsClientAdapter) getRIUtilizationViaAPI(
 	api reservationsSummariesAPI,
 	startDate, endDate string,
 ) ([]common.RIUtilization, error) {
-	// Subscription-scoped resource path: Azure's Consumption API accepts
-	// "/subscriptions/{id}" as the resourceScope for the List endpoint.
-	resourceScope := fmt.Sprintf("subscriptions/%s", r.subscriptionID)
+	// Subscription-scoped resource path: Azure's Consumption API requires
+	// "/subscriptions/{id}" (with leading slash) as the resourceScope for the
+	// List endpoint. The REST path is constructed as
+	// "management.azure.com/{resourceScope}/providers/Microsoft.Consumption/..."
+	// so the leading slash is essential for correct URL construction.
+	resourceScope := fmt.Sprintf("/subscriptions/%s", r.subscriptionID)
 
 	pager := api.newListPager(resourceScope, armconsumption.DatagrainMonthlyGrain, startDate, endDate)
 

--- a/providers/azure/ri_utilization_test.go
+++ b/providers/azure/ri_utilization_test.go
@@ -1,0 +1,273 @@
+package azure
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/consumption/armconsumption"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LeanerCloud/CUDly/pkg/common"
+	"github.com/LeanerCloud/CUDly/providers/azure/mocks"
+)
+
+// mockReservationsSummariesAPI implements reservationsSummariesAPI for testing.
+// It captures the resourceScope, grain, and date arguments passed to newListPager
+// so tests can assert they were formed correctly.
+type mockReservationsSummariesAPI struct {
+	pager         reservationsSummariesPager // accepts any pager implementation
+	capturedScope string
+	capturedGrain armconsumption.Datagrain
+	capturedStart string
+	capturedEnd   string
+}
+
+func (m *mockReservationsSummariesAPI) newListPager(resourceScope string, grain armconsumption.Datagrain, startDate, endDate string) reservationsSummariesPager {
+	m.capturedScope = resourceScope
+	m.capturedGrain = grain
+	m.capturedStart = startDate
+	m.capturedEnd = endDate
+	return m.pager
+}
+
+// helpers (local to this test file — recommendations_test.go declares strPtr,
+// so we use distinct names here to avoid a redeclaration compile error)
+func riStrPtr(s string) *string       { return &s }
+func riFloat64Ptr(f float64) *float64 { return &f }
+
+func TestGetRIUtilization_HappyPath(t *testing.T) {
+	skuA := "Standard_D2s_v3"
+	skuB := "Standard_E4s_v3"
+	idA := "reservation-aaa"
+	idB := "reservation-bbb"
+
+	summaries := []*armconsumption.ReservationSummary{
+		{
+			Properties: &armconsumption.ReservationSummaryProperties{
+				ReservationID: riStrPtr(idA),
+				SKUName:       riStrPtr(skuA),
+				ReservedHours: riFloat64Ptr(720.0),
+				UsedHours:     riFloat64Ptr(648.0), // 90%
+			},
+		},
+		{
+			Properties: &armconsumption.ReservationSummaryProperties{
+				ReservationID: riStrPtr(idB),
+				SKUName:       riStrPtr(skuB),
+				ReservedHours: riFloat64Ptr(744.0),
+				UsedHours:     riFloat64Ptr(0.0), // 0% (idle reservation)
+			},
+		},
+	}
+
+	mockPager := &mocks.MockReservationsSummariesPager{
+		Results: summaries,
+		HasMore: true,
+	}
+
+	api := &mockReservationsSummariesAPI{pager: mockPager}
+	adapter := &RecommendationsClientAdapter{subscriptionID: "sub-123"}
+
+	result, err := adapter.getRIUtilizationViaAPI(context.Background(), api, "2026-04-14", "2026-05-14")
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+
+	// Build a lookup map for order-independent assertion.
+	byID := make(map[string]common.RIUtilization, len(result))
+	for _, u := range result {
+		byID[u.ReservedInstanceID] = u
+	}
+
+	a := byID[idA]
+	assert.Equal(t, idA, a.ReservedInstanceID)
+	assert.Equal(t, skuA, a.SKUName)
+	assert.InDelta(t, 90.0, a.UtilizationPercent, 0.01)
+	assert.Equal(t, 720.0, a.PurchasedHours)
+	assert.Equal(t, 648.0, a.TotalActualHours)
+	assert.Equal(t, 72.0, a.UnusedHours)
+
+	b := byID[idB]
+	assert.Equal(t, idB, b.ReservedInstanceID)
+	assert.Equal(t, skuB, b.SKUName)
+	assert.Equal(t, 0.0, b.UtilizationPercent)
+	assert.Equal(t, 744.0, b.UnusedHours) // all hours unused: UsedHours=0, ReservedHours=744
+
+	// Verify the subscription scope was formatted correctly.
+	assert.Equal(t, "subscriptions/sub-123", api.capturedScope)
+	assert.Equal(t, armconsumption.DatagrainMonthlyGrain, api.capturedGrain)
+}
+
+func TestGetRIUtilization_MultiPageAggregation(t *testing.T) {
+	// Two monthly summary rows for the same reservation: the function must
+	// sum PurchasedHours and UsedHours across pages/rows.
+	id := "reservation-multi"
+	summaryPage1 := []*armconsumption.ReservationSummary{
+		{
+			Properties: &armconsumption.ReservationSummaryProperties{
+				ReservationID: riStrPtr(id),
+				SKUName:       riStrPtr("Standard_D4s_v3"),
+				ReservedHours: riFloat64Ptr(744.0), // March
+				UsedHours:     riFloat64Ptr(600.0),
+			},
+		},
+	}
+	summaryPage2 := []*armconsumption.ReservationSummary{
+		{
+			Properties: &armconsumption.ReservationSummaryProperties{
+				ReservationID: riStrPtr(id),
+				// SKUName deliberately absent in second row to test first-wins.
+				ReservedHours: riFloat64Ptr(720.0), // April
+				UsedHours:     riFloat64Ptr(700.0),
+			},
+		},
+	}
+
+	// Simulate two-page response with a multi-call pager.
+	pager := &twoPagePager{
+		page0: summaryPage1,
+		page1: summaryPage2,
+	}
+	api := &mockReservationsSummariesAPI{pager: pager}
+	adapter := &RecommendationsClientAdapter{subscriptionID: "sub-456"}
+
+	result, err := adapter.getRIUtilizationViaAPI(context.Background(), api, "2026-03-01", "2026-05-01")
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+
+	u := result[0]
+	assert.Equal(t, id, u.ReservedInstanceID)
+	assert.Equal(t, "Standard_D4s_v3", u.SKUName, "SKUName from first non-empty row should win")
+	assert.Equal(t, 744.0+720.0, u.PurchasedHours)
+	assert.Equal(t, 600.0+700.0, u.TotalActualHours)
+	assert.InDelta(t, (1300.0/1464.0)*100, u.UtilizationPercent, 0.01)
+	assert.Equal(t, 1464.0-1300.0, u.UnusedHours)
+}
+
+func TestGetRIUtilization_EmptyPage(t *testing.T) {
+	mockPager := &mocks.MockReservationsSummariesPager{
+		Results: []*armconsumption.ReservationSummary{},
+		HasMore: true,
+	}
+
+	api := &mockReservationsSummariesAPI{pager: mockPager}
+	adapter := &RecommendationsClientAdapter{subscriptionID: "sub-empty"}
+
+	result, err := adapter.getRIUtilizationViaAPI(context.Background(), api, "2026-04-14", "2026-05-14")
+	require.NoError(t, err)
+	assert.Nil(t, result, "empty summaries should return nil slice, not empty")
+}
+
+func TestGetRIUtilization_NilProperties(t *testing.T) {
+	// Rows with nil Properties must be skipped without panicking.
+	summaries := []*armconsumption.ReservationSummary{
+		nil,
+		{Properties: nil},
+		{
+			Properties: &armconsumption.ReservationSummaryProperties{
+				ReservationID: riStrPtr("reservation-ok"),
+				ReservedHours: riFloat64Ptr(720.0),
+				UsedHours:     riFloat64Ptr(360.0),
+			},
+		},
+	}
+
+	mockPager := &mocks.MockReservationsSummariesPager{
+		Results: summaries,
+		HasMore: true,
+	}
+
+	api := &mockReservationsSummariesAPI{pager: mockPager}
+	adapter := &RecommendationsClientAdapter{subscriptionID: "sub-niltest"}
+
+	result, err := adapter.getRIUtilizationViaAPI(context.Background(), api, "2026-04-14", "2026-05-14")
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, "reservation-ok", result[0].ReservedInstanceID)
+	assert.InDelta(t, 50.0, result[0].UtilizationPercent, 0.01)
+}
+
+func TestGetRIUtilization_NilReservationID(t *testing.T) {
+	// Rows with nil or empty ReservationID must be silently skipped.
+	summaries := []*armconsumption.ReservationSummary{
+		{
+			Properties: &armconsumption.ReservationSummaryProperties{
+				ReservationID: nil,
+				ReservedHours: riFloat64Ptr(720.0),
+				UsedHours:     riFloat64Ptr(360.0),
+			},
+		},
+		{
+			Properties: &armconsumption.ReservationSummaryProperties{
+				ReservationID: riStrPtr(""),
+				ReservedHours: riFloat64Ptr(100.0),
+				UsedHours:     riFloat64Ptr(50.0),
+			},
+		},
+	}
+
+	mockPager := &mocks.MockReservationsSummariesPager{
+		Results: summaries,
+		HasMore: true,
+	}
+
+	api := &mockReservationsSummariesAPI{pager: mockPager}
+	adapter := &RecommendationsClientAdapter{subscriptionID: "sub-nilid"}
+
+	result, err := adapter.getRIUtilizationViaAPI(context.Background(), api, "2026-04-14", "2026-05-14")
+	require.NoError(t, err)
+	assert.Nil(t, result, "rows with nil/empty ReservationID should be skipped")
+}
+
+func TestGetRIUtilization_ZeroPurchasedHours(t *testing.T) {
+	// When PurchasedHours is 0 the utilization percent should be 0, not NaN/Inf.
+	summaries := []*armconsumption.ReservationSummary{
+		{
+			Properties: &armconsumption.ReservationSummaryProperties{
+				ReservationID: riStrPtr("reservation-zero"),
+				ReservedHours: riFloat64Ptr(0.0),
+				UsedHours:     riFloat64Ptr(0.0),
+			},
+		},
+	}
+
+	mockPager := &mocks.MockReservationsSummariesPager{
+		Results: summaries,
+		HasMore: true,
+	}
+
+	api := &mockReservationsSummariesAPI{pager: mockPager}
+	adapter := &RecommendationsClientAdapter{subscriptionID: "sub-zero"}
+
+	result, err := adapter.getRIUtilizationViaAPI(context.Background(), api, "2026-04-14", "2026-05-14")
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, 0.0, result[0].UtilizationPercent)
+	assert.Equal(t, 0.0, result[0].UnusedHours)
+}
+
+// twoPagePager is a test helper that serves two fixed pages and then stops.
+type twoPagePager struct {
+	page0 []*armconsumption.ReservationSummary
+	page1 []*armconsumption.ReservationSummary
+	call  int
+}
+
+func (p *twoPagePager) More() bool {
+	return p.call < 2
+}
+
+func (p *twoPagePager) NextPage(ctx context.Context) (armconsumption.ReservationsSummariesClientListResponse, error) {
+	var rows []*armconsumption.ReservationSummary
+	if p.call == 0 {
+		rows = p.page0
+	} else {
+		rows = p.page1
+	}
+	p.call++
+	return armconsumption.ReservationsSummariesClientListResponse{
+		ReservationSummariesListResult: armconsumption.ReservationSummariesListResult{
+			Value: rows,
+		},
+	}, nil
+}

--- a/providers/azure/ri_utilization_test.go
+++ b/providers/azure/ri_utilization_test.go
@@ -93,8 +93,9 @@ func TestGetRIUtilization_HappyPath(t *testing.T) {
 	assert.Equal(t, 0.0, b.UtilizationPercent)
 	assert.Equal(t, 744.0, b.UnusedHours) // all hours unused: UsedHours=0, ReservedHours=744
 
-	// Verify the subscription scope was formatted correctly.
-	assert.Equal(t, "subscriptions/sub-123", api.capturedScope)
+	// Verify the subscription scope was formatted correctly (leading slash required
+	// by Azure's Consumption API resourceScope parameter).
+	assert.Equal(t, "/subscriptions/sub-123", api.capturedScope)
 	assert.Equal(t, armconsumption.DatagrainMonthlyGrain, api.capturedGrain)
 }
 


### PR DESCRIPTION
## Summary

- Adds `GetRIUtilization(ctx, lookbackDays)` to Azure's `RecommendationsClientAdapter`, returning `[]common.RIUtilization` - the same shape as the AWS `recommendations.Client.GetRIUtilization` implementation
- Moves the `RIUtilization` struct from `providers/aws/recommendations` to `pkg/common` (with a transparent type alias kept in the AWS package) so both providers share the type without a cross-provider import
- Azure implementation uses `armconsumption.ReservationsSummariesClient.NewListPager` (already a dependency) with monthly grain, subscription scope, and a date filter derived from `lookbackDays`

## What changed

- `pkg/common/types.go`: new `RIUtilization` struct with inline AWS+Azure field-mapping docs and `sku_name` field (Azure-only, empty for AWS)
- `providers/aws/recommendations/utilization.go`: replace struct definition with `type RIUtilization = common.RIUtilization` alias - zero impact to callers
- `providers/azure/ri_utilization.go`: `GetRIUtilization` + testable inner layer (`getRIUtilizationViaAPI`) behind a `reservationsSummariesAPI` interface; per-reservation accumulator aggregates hours across monthly rows
- `providers/azure/mocks/azure_mocks.go`: `MockReservationsSummariesPager`
- `providers/azure/ri_utilization_test.go`: 6 unit tests (happy path, multi-page aggregation, empty page, nil Properties, nil ReservationID, zero purchased hours)

## AWS vs Azure parity

| Field | AWS (Cost Explorer) | Azure (Consumption Summaries) |
|---|---|---|
| `ReservedInstanceID` | dimension key (SUBSCRIPTION_ID group) | `Properties.ReservationID` |
| `PurchasedHours` | `PurchasedHours` from CE | `ReservedHours` (summed across months) |
| `TotalActualHours` | `TotalActualHours` from CE | `UsedHours` (summed across months) |
| `UnusedHours` | `UnusedHours` from CE | derived: purchased - used |
| `UtilizationPercent` | derived by AWS client | derived: (used/purchased) * 100 |
| `SKUName` | (empty - CE doesn't return it) | `Properties.SKUName` |

Azure SDK endpoint: `armconsumption.ReservationsSummariesClient.NewListPager` (subscription scope, monthly grain)

## Test plan

- [x] `go build ./...` passes in worktree root
- [x] `go test ./providers/azure/... -count=1 -short` - 352 tests pass (6 new RI utilization tests)
- [x] `go test ./providers/aws/... -count=1 -short` - 647 tests pass (type alias verified)
- [ ] Integration test against a real Azure subscription with active reservations (requires live credentials - not available in CI)

Closes #558
Refs #473


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Azure Reserved Instance utilization metrics are now available, displaying utilization percentages, purchased hours, actual hours, and unused hours per reservation across configurable lookback periods.

* **Tests**
  * Added comprehensive unit tests for RI utilization retrieval, covering multi-page aggregation, edge cases, and calculation validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/563?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->