### PR TITLE
sec(iac/aws-target): validate thumbprint_list rejects all-zeros for custom OIDC issuers

### DIFF
--- a/iac/federation/aws-target/terraform/variables.tf
+++ b/iac/federation/aws-target/terraform/variables.tf
@@ -50,11 +50,12 @@ variable "role_name" {
 
 variable "thumbprint_list" {
   description = <<-EOT
-    TLS root CA thumbprints for the OIDC provider (40-character lowercase hex SHA-1).
-    AWS auto-validates well-known providers (Azure AD, Google); for those the all-zeros
-    placeholder works. For any other issuer you MUST supply the real root CA SHA-1
-    thumbprint — the module rejects all-zeros for custom issuers via the second
-    validation block.
+    TLS root CA thumbprints for the OIDC provider (40-character hex SHA-1).
+    AWS auto-validates well-known providers (Azure AD, Google); for those the
+    all-zeros placeholder is intentional and accepted.
+    For any other issuer you MUST supply the real root CA SHA-1 thumbprint.
+    Supplying the all-zeros placeholder for a custom issuer is rejected by this
+    module to prevent operators from silently bypassing CA-chain validation.
   EOT
   type        = list(string)
   default     = ["0000000000000000000000000000000000000000"]
@@ -69,6 +70,20 @@ variable "thumbprint_list" {
       for t in var.thumbprint_list : can(regex("^[0-9a-fA-F]{40}$", t))
     ])
     error_message = "Each thumbprint in thumbprint_list must be a 40-character SHA-1 hex string."
+  }
+
+  # Guard against copy-paste of the all-zeros placeholder for custom OIDC
+  # issuers. AWS natively validates Azure AD and Google endpoints, so
+  # all-zeros is safe for those. Any other issuer URL requires a real CA
+  # thumbprint; the all-zeros value bypasses the CA-chain check entirely.
+  validation {
+    condition = !(
+      length(var.thumbprint_list) == 1 &&
+      var.thumbprint_list[0] == "0000000000000000000000000000000000000000" &&
+      !startswith(var.oidc_issuer_url, "https://login.microsoftonline.com/") &&
+      !startswith(var.oidc_issuer_url, "https://accounts.google.com")
+    )
+    error_message = "thumbprint_list is the all-zeros placeholder, which is only safe for Azure AD (login.microsoftonline.com) and Google (accounts.google.com) issuers that AWS validates natively. For any other OIDC issuer you must supply the real root CA SHA-1 thumbprint."
   }
 }
 


### PR DESCRIPTION
## Summary

- Adds a third `validation` block to `thumbprint_list` in `iac/federation/aws-target/terraform/variables.tf`
- The new block rejects the all-zeros placeholder when `oidc_issuer_url` is not an Azure AD or Google endpoint (the two providers AWS validates natively)
- Fixes the description which incorrectly stated the guard already existed ("via the second validation block")
- Regression: `terraform fmt -check` passes with no changes

Without this guard, operators deploying against a self-hosted CUDly OIDC issuer who copy-paste the default value silently disable CA-chain validation, allowing AWS to accept JWTs from any HTTPS endpoint on the configured issuer URL.

Closes #409