### PR TITLE
sec(iac): deny deploy-role self-pass and split rds:CreateDBProxy to Resource=*

### DIFF
--- a/terraform/environments/aws/ci-cd-permissions/policy_data.tf
+++ b/terraform/environments/aws/ci-cd-permissions/policy_data.tf
@@ -70,6 +70,22 @@ resource "aws_iam_policy" "data" {
         }
       },
       {
+        # The IAMPassRoleScopedByService Allow above still matches the deploy
+        # role itself (cudly-terraform-deploy is a cudly-* role) and permits
+        # lambda.amazonaws.com as a target. That leaves open the exact #426
+        # escalation: an actor holding the deploy role calls lambda:CreateFunction
+        # and passes cudly-terraform-deploy as the Lambda execution role, giving
+        # that Lambda the full deploy permissions (CreateRole, PassRole, KMS
+        # destructive, Secrets read, Terraform state R/W) as a persistent
+        # backdoor. An explicit Deny on passing the deploy role always wins over
+        # the conditional Allow, closing the self-pass loop while leaving
+        # legitimate execution-role passes (cudly-* exec roles) intact. (#542)
+        Sid      = "IAMDenyPassDeployRole"
+        Effect   = "Deny"
+        Action   = ["iam:PassRole"]
+        Resource = ["arn:aws:iam::*:role/cudly-terraform-deploy"]
+      },
+      {
         Sid    = "IAMReadForPassRole"
         Effect = "Allow"
         Action = [
@@ -109,7 +125,6 @@ resource "aws_iam_policy" "data" {
           "rds:DescribeDBInstances",
           "rds:DescribeDBSubnetGroups",
           "rds:ListTagsForResource",
-          "rds:CreateDBProxy",
           "rds:DeleteDBProxy",
           "rds:DeregisterDBProxyTargets",
           "rds:DescribeDBProxies",
@@ -120,6 +135,21 @@ resource "aws_iam_policy" "data" {
           "rds:RegisterDBProxyTargets",
           "rds:RemoveTagsFromResource",
         ]
+        Resource = "*"
+      },
+      {
+        # rds:CreateDBProxy has no resource type per the AWS Service
+        # Authorization Reference (Actions defined by Amazon RDS) and can only
+        # be granted on Resource="*"; constraining it to specific ARNs makes IAM
+        # unable to satisfy the request, so the grant is silently non-functional
+        # and any future terraform apply that creates a DB proxy gets
+        # AccessDenied. Keep it in its own wildcard statement so a later move of
+        # the resource-scopeable RDS actions onto cudly-* ARNs (see PR #524's
+        # RDSResourceScoped) does not sweep CreateDBProxy back into a scoped
+        # statement. (#547)
+        Sid      = "RDSCreateProxy"
+        Effect   = "Allow"
+        Action   = ["rds:CreateDBProxy"]
         Resource = "*"
       },
       {


### PR DESCRIPTION
## Summary

Two residual IAM-scoping defects in the CI/CD deploy policy
(`terraform/environments/aws/ci-cd-permissions/policy_data.tf`):

- **#542 (p1/high)** — `IAMPassRoleScopedByService` still matched
  `cudly-terraform-deploy` (a `cudly-*` role) with `lambda.amazonaws.com`
  allowed, so the deploy role could be self-passed to an attacker-created
  Lambda. That is the exact #426 escalation, residual after PR #518's
  service-condition. Fix: add an explicit `Deny` (`IAMDenyPassDeployRole`)
  on `iam:PassRole` for `arn:aws:iam::*:role/cudly-terraform-deploy`.
  Explicit Deny always wins over the conditional Allow, so the deploy role
  can never be passed to any service, while legitimate execution-role passes
  (other `cudly-*` exec roles) are unaffected.
- **#547 (p3)** — `rds:CreateDBProxy` has no resource type per the AWS
  Service Authorization Reference and must be granted on `Resource="*"`.
  Move it into its own `RDSCreateProxy` statement so a later move of the
  resource-scopeable RDS actions onto `cudly-*` ARNs (PR #524's
  `RDSResourceScoped`) cannot sweep it back into a scoped statement and
  silently break proxy creation with AccessDenied.

Both changes strictly tighten or are functionally neutral; neither weakens
the policy.

## Coordination

PR #524 (open, same base) rewrites the RDS block into `RDSResourceScoped`
and currently keeps `rds:CreateDBProxy` inside it (the #547 bug). When either
PR rebases, conflict resolution must keep `CreateDBProxy` in its own
`Resource="*"` statement.

## Test plan

- [x] `terraform fmt -check` clean
- [x] `terraform validate` succeeds
- [ ] `aws iam simulate-custom-policy`: passing `cudly-terraform-deploy` to
      `lambda.amazonaws.com` is **denied**; passing a legitimate
      `cudly-*` execution role is **allowed** (requires AWS credentials).
- [ ] A future `terraform apply` creating an `aws_db_proxy` succeeds
      (no proxy resource exists yet; latent until one is added).

Closes #542, #547.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated IAM policy to enforce additional access restrictions on role assumption permissions.
  * Restructured RDS permissions to isolate proxy creation resource controls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/568?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->