### PR TITLE
feat(commitmentopts): probe Savings Plans offerings live (closes #108)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.7.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.15 // indirect
-	github.com/aws/aws-sdk-go-v2/service/savingsplans v1.31.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/savingsplans v1.31.0
 	github.com/aws/aws-sdk-go-v2/service/sso v1.18.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.21.5 // indirect
 	github.com/aws/smithy-go v1.24.2 // indirect

--- a/internal/commitmentopts/probe.go
+++ b/internal/commitmentopts/probe.go
@@ -12,6 +12,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/opensearch"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	"github.com/aws/aws-sdk-go-v2/service/redshift"
+	"github.com/aws/aws-sdk-go-v2/service/savingsplans"
+	savingsplanstypes "github.com/aws/aws-sdk-go-v2/service/savingsplans/types"
 )
 
 // maxPages is the hard ceiling on paginated Describe*Offerings calls per
@@ -462,6 +464,142 @@ func (p *EC2Prober) client(cfg aws.Config) EC2DescribeOfferings {
 	return ec2.NewFromConfig(cfg)
 }
 
+// ---------------------------------------------------------------------------
+// Savings Plans
+// ---------------------------------------------------------------------------
+
+// spPlanKeys maps each AWS SavingsPlanType to the service key we persist in
+// commitment_options_combos and emit via GET /api/commitment-options. The
+// keys are aligned with SERVICE_FIELDS in the frontend's settings.ts so the
+// overlay in fetchAndPopulateCommitmentOptions lands on the right card.
+var spPlanKeys = []struct {
+	planType savingsplanstypes.SavingsPlanType
+	service  string
+}{
+	{savingsplanstypes.SavingsPlanTypeCompute, "savings-plans-compute"},
+	{savingsplanstypes.SavingsPlanTypeEc2Instance, "savings-plans-ec2instance"},
+	{savingsplanstypes.SavingsPlanTypeSagemaker, "savings-plans-sagemaker"},
+	{savingsplanstypes.SavingsPlanTypeDatabase, "savings-plans-database"},
+}
+
+// SavingsPlansDescribeOfferings is the minimal Savings Plans surface the
+// probe needs. It matches the relevant method on the generated client so
+// tests can substitute a mock without dragging in the full SavingsPlansAPI
+// interface.
+type SavingsPlansDescribeOfferings interface {
+	DescribeSavingsPlansOfferings(ctx context.Context, params *savingsplans.DescribeSavingsPlansOfferingsInput, optFns ...func(*savingsplans.Options)) (*savingsplans.DescribeSavingsPlansOfferingsOutput, error)
+}
+
+// SavingsPlansProber probes savingsplans:DescribeSavingsPlansOfferings once
+// per plan type (Compute, EC2Instance, SageMaker, Database) and emits
+// per-product service keys. The probe runs all four plan types in sequence
+// and returns all combos; Service.probeAndPersist fans them out concurrently
+// alongside the RI probers. Any plan type that returns zero offerings for a
+// given account is silently skipped — the frontend falls back to its
+// hardcoded rules for that key.
+type SavingsPlansProber struct {
+	// NewClient builds a client from the probe's aws.Config. Override in
+	// tests to return a mock.
+	NewClient func(cfg aws.Config) SavingsPlansDescribeOfferings
+}
+
+// Service returns "savings-plans" — a sentinel used only for error
+// wrapping. Each plan type emits its own per-product service key via
+// Probe; the umbrella name is never stored.
+func (p *SavingsPlansProber) Service() string { return "savings-plans" }
+
+// Probe calls DescribeSavingsPlansOfferings for each of the four plan
+// types and returns combos keyed with the per-product service slug. Empty
+// results for a plan type are silently dropped so the caller never stores
+// a zero-combo entry that would incorrectly suppress the fallback.
+func (p *SavingsPlansProber) Probe(ctx context.Context, cfg aws.Config) ([]Combo, error) {
+	client := p.client(cfg)
+	var all []Combo
+	for _, pk := range spPlanKeys {
+		combos, err := p.probeOnePlanType(ctx, client, pk.planType, pk.service)
+		if err != nil {
+			return nil, fmt.Errorf("savings-plans/%s: %w", pk.service, err)
+		}
+		all = append(all, combos...)
+	}
+	return all, nil
+}
+
+// probeOnePlanType fetches offerings for a single Savings Plan type and
+// returns normalised Combos. It uses walkPaginated with a planType filter
+// so each page only contains offerings for the requested product.
+func (p *SavingsPlansProber) probeOnePlanType(
+	ctx context.Context,
+	client SavingsPlansDescribeOfferings,
+	planType savingsplanstypes.SavingsPlanType,
+	serviceKey string,
+) ([]Combo, error) {
+	raw, err := walkPaginated(ctx, serviceKey, func(ctx context.Context, token *string) ([]rawOffer, *string, error) {
+		out, err := client.DescribeSavingsPlansOfferings(ctx, &savingsplans.DescribeSavingsPlansOfferingsInput{
+			PlanTypes:  []savingsplanstypes.SavingsPlanType{planType},
+			MaxResults: pageSize,
+			NextToken:  token,
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+		offers := make([]rawOffer, 0, len(out.SearchResults))
+		for _, o := range out.SearchResults {
+			offers = append(offers, rawOffer{
+				durationSeconds: o.DurationSeconds,
+				payment:         string(o.PaymentOption),
+			})
+		}
+		return offers, out.NextToken, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	raw = dedupeRaw(raw)
+	// Use collect but override the service key to the per-product slug.
+	combos := collectWithService(serviceKey, raw)
+	return combos, nil
+}
+
+// dedupeRaw removes duplicate (durationSeconds, payment) pairs so that
+// collect does not see the same pair multiple times across an SP type's
+// pages. SP offerings differ by ProductType (EC2, Lambda, Fargate ...) but
+// share the same (duration, payment) matrix — we only need unique combos.
+func dedupeRaw(raw []rawOffer) []rawOffer {
+	type key struct {
+		dur     int64
+		payment string
+	}
+	seen := make(map[key]struct{}, len(raw))
+	out := make([]rawOffer, 0, len(raw))
+	for _, r := range raw {
+		k := key{r.durationSeconds, r.payment}
+		if _, dup := seen[k]; dup {
+			continue
+		}
+		seen[k] = struct{}{}
+		out = append(out, r)
+	}
+	return out
+}
+
+// collectWithService is like collect but uses the supplied serviceKey
+// instead of the service embedded in each rawOffer (rawOffer has no
+// service field; collect() uses the `service` argument, which is the
+// per-prober name). Extracted to avoid a second copy of the
+// normalization loop when the service name comes from outside the
+// prober's Service() method (as it does for SP plan types).
+func collectWithService(service string, raw []rawOffer) []Combo {
+	return collect(service, raw)
+}
+
+func (p *SavingsPlansProber) client(cfg aws.Config) SavingsPlansDescribeOfferings {
+	if p.NewClient != nil {
+		return p.NewClient(cfg)
+	}
+	return savingsplans.NewFromConfig(cfg)
+}
+
 // DefaultProbers returns one prober instance per commitment-capable
 // service. The Service wires these up by default; tests override via a
 // custom slice.
@@ -473,5 +611,6 @@ func DefaultProbers() []Prober {
 		&RedshiftProber{},
 		&MemoryDBProber{},
 		&EC2Prober{},
+		&SavingsPlansProber{},
 	}
 }

--- a/internal/commitmentopts/probe_test.go
+++ b/internal/commitmentopts/probe_test.go
@@ -19,6 +19,8 @@ import (
 	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/aws/aws-sdk-go-v2/service/redshift"
 	redshifttypes "github.com/aws/aws-sdk-go-v2/service/redshift/types"
+	"github.com/aws/aws-sdk-go-v2/service/savingsplans"
+	savingsplanstypes "github.com/aws/aws-sdk-go-v2/service/savingsplans/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -345,7 +347,7 @@ func TestDefaultProbers(t *testing.T) {
 		services = append(services, p.Service())
 	}
 	sort.Strings(services)
-	assert.Equal(t, []string{"ec2", "elasticache", "memorydb", "opensearch", "rds", "redshift"}, services)
+	assert.Equal(t, []string{"ec2", "elasticache", "memorydb", "opensearch", "rds", "redshift", "savings-plans"}, services)
 }
 
 // ---------------------------------------------------------------------------
@@ -444,4 +446,221 @@ func TestWalkPaginated_AccumulatesAcrossPages(t *testing.T) {
 	assert.Equal(t, int64(1), got[0].durationSeconds)
 	assert.Equal(t, int64(2), got[1].durationSeconds)
 	assert.Equal(t, int64(3), got[2].durationSeconds)
+}
+
+// ---------------------------------------------------------------------------
+// Savings Plans
+// ---------------------------------------------------------------------------
+
+// fakeSavingsPlans stubs DescribeSavingsPlansOfferings so tests never hit AWS.
+type fakeSavingsPlans struct {
+	fn func(*savingsplans.DescribeSavingsPlansOfferingsInput) (*savingsplans.DescribeSavingsPlansOfferingsOutput, error)
+}
+
+func (f *fakeSavingsPlans) DescribeSavingsPlansOfferings(
+	_ context.Context,
+	in *savingsplans.DescribeSavingsPlansOfferingsInput,
+	_ ...func(*savingsplans.Options),
+) (*savingsplans.DescribeSavingsPlansOfferingsOutput, error) {
+	return f.fn(in)
+}
+
+// spOffering builds a SavingsPlanOffering with the requested duration and
+// payment for use in test fixtures.
+func spOffering(dur int64, pay savingsplanstypes.SavingsPlanPaymentOption) savingsplanstypes.SavingsPlanOffering {
+	return savingsplanstypes.SavingsPlanOffering{
+		DurationSeconds: dur,
+		PaymentOption:   pay,
+	}
+}
+
+func TestSavingsPlansProber_Service(t *testing.T) {
+	p := &SavingsPlansProber{}
+	assert.Equal(t, "savings-plans", p.Service())
+}
+
+// TestSavingsPlansProber_Probe verifies that a single Compute plan type with
+// standard offerings normalizes to the expected Combos and carries the right
+// per-product service key.
+func TestSavingsPlansProber_Probe(t *testing.T) {
+	// Only return offerings for the Compute plan type; all others return empty.
+	fake := &fakeSavingsPlans{
+		fn: func(in *savingsplans.DescribeSavingsPlansOfferingsInput) (*savingsplans.DescribeSavingsPlansOfferingsOutput, error) {
+			if len(in.PlanTypes) == 1 && in.PlanTypes[0] == savingsplanstypes.SavingsPlanTypeCompute {
+				return &savingsplans.DescribeSavingsPlansOfferingsOutput{
+					SearchResults: []savingsplanstypes.SavingsPlanOffering{
+						spOffering(oneYearSeconds, savingsplanstypes.SavingsPlanPaymentOptionAllUpfront),
+						spOffering(oneYearSeconds, savingsplanstypes.SavingsPlanPaymentOptionPartialUpfront),
+						spOffering(oneYearSeconds, savingsplanstypes.SavingsPlanPaymentOptionNoUpfront),
+						spOffering(threeYearSeconds, savingsplanstypes.SavingsPlanPaymentOptionAllUpfront),
+						spOffering(threeYearSeconds, savingsplanstypes.SavingsPlanPaymentOptionPartialUpfront),
+						// dup — same (dur, pay) seen twice, must collapse
+						spOffering(oneYearSeconds, savingsplanstypes.SavingsPlanPaymentOptionAllUpfront),
+					},
+				}, nil
+			}
+			return &savingsplans.DescribeSavingsPlansOfferingsOutput{}, nil
+		},
+	}
+	p := &SavingsPlansProber{NewClient: func(_ aws.Config) SavingsPlansDescribeOfferings { return fake }}
+
+	got, err := p.Probe(context.Background(), aws.Config{})
+	require.NoError(t, err)
+
+	var computeCombos []Combo
+	for _, c := range got {
+		if c.Service == "savings-plans-compute" {
+			computeCombos = append(computeCombos, c)
+		}
+	}
+	computeCombos = sortCombos(computeCombos)
+	want := []Combo{
+		{Provider: "aws", Service: "savings-plans-compute", TermYears: 1, Payment: "all-upfront"},
+		{Provider: "aws", Service: "savings-plans-compute", TermYears: 1, Payment: "no-upfront"},
+		{Provider: "aws", Service: "savings-plans-compute", TermYears: 1, Payment: "partial-upfront"},
+		{Provider: "aws", Service: "savings-plans-compute", TermYears: 3, Payment: "all-upfront"},
+		{Provider: "aws", Service: "savings-plans-compute", TermYears: 3, Payment: "partial-upfront"},
+	}
+	assert.Equal(t, want, computeCombos)
+}
+
+// TestSavingsPlansProber_AllPlanTypes verifies that the prober emits combos
+// for each of the four plan types independently and uses the correct service key.
+func TestSavingsPlansProber_AllPlanTypes(t *testing.T) {
+	// Return one 1yr no-upfront combo per plan type so each service key gets
+	// exactly one Combo in the output.
+	fake := &fakeSavingsPlans{
+		fn: func(in *savingsplans.DescribeSavingsPlansOfferingsInput) (*savingsplans.DescribeSavingsPlansOfferingsOutput, error) {
+			return &savingsplans.DescribeSavingsPlansOfferingsOutput{
+				SearchResults: []savingsplanstypes.SavingsPlanOffering{
+					spOffering(oneYearSeconds, savingsplanstypes.SavingsPlanPaymentOptionNoUpfront),
+				},
+			}, nil
+		},
+	}
+	p := &SavingsPlansProber{NewClient: func(_ aws.Config) SavingsPlansDescribeOfferings { return fake }}
+
+	got, err := p.Probe(context.Background(), aws.Config{})
+	require.NoError(t, err)
+
+	byService := make(map[string][]Combo)
+	for _, c := range got {
+		byService[c.Service] = append(byService[c.Service], c)
+	}
+	expectedKeys := []string{
+		"savings-plans-compute",
+		"savings-plans-ec2instance",
+		"savings-plans-sagemaker",
+		"savings-plans-database",
+	}
+	for _, key := range expectedKeys {
+		combos, ok := byService[key]
+		assert.True(t, ok, "expected service key %s in output", key)
+		require.Len(t, combos, 1)
+		assert.Equal(t, "aws", combos[0].Provider)
+		assert.Equal(t, key, combos[0].Service)
+		assert.Equal(t, 1, combos[0].TermYears)
+		assert.Equal(t, "no-upfront", combos[0].Payment)
+	}
+}
+
+// TestSavingsPlansProber_EmptyResultDropped verifies that a plan type with
+// no offerings contributes nothing to the output (no empty-combo key stored).
+func TestSavingsPlansProber_EmptyResultDropped(t *testing.T) {
+	fake := &fakeSavingsPlans{
+		fn: func(_ *savingsplans.DescribeSavingsPlansOfferingsInput) (*savingsplans.DescribeSavingsPlansOfferingsOutput, error) {
+			return &savingsplans.DescribeSavingsPlansOfferingsOutput{}, nil
+		},
+	}
+	p := &SavingsPlansProber{NewClient: func(_ aws.Config) SavingsPlansDescribeOfferings { return fake }}
+
+	got, err := p.Probe(context.Background(), aws.Config{})
+	require.NoError(t, err)
+	assert.Empty(t, got, "empty offerings should produce no combos")
+}
+
+// TestSavingsPlansProber_ErrorPropagates verifies that an API error on any
+// plan type bubbles up and halts the probe.
+func TestSavingsPlansProber_ErrorPropagates(t *testing.T) {
+	boom := errors.New("boom")
+	fake := &fakeSavingsPlans{
+		fn: func(_ *savingsplans.DescribeSavingsPlansOfferingsInput) (*savingsplans.DescribeSavingsPlansOfferingsOutput, error) {
+			return nil, boom
+		},
+	}
+	p := &SavingsPlansProber{NewClient: func(_ aws.Config) SavingsPlansDescribeOfferings { return fake }}
+
+	_, err := p.Probe(context.Background(), aws.Config{})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, boom)
+}
+
+// TestSavingsPlansProber_PageCap verifies the prober stops at maxPages even
+// if the API keeps returning a non-empty next-page token.
+func TestSavingsPlansProber_PageCap(t *testing.T) {
+	calls := 0
+	fake := &fakeSavingsPlans{
+		fn: func(_ *savingsplans.DescribeSavingsPlansOfferingsInput) (*savingsplans.DescribeSavingsPlansOfferingsOutput, error) {
+			calls++
+			return &savingsplans.DescribeSavingsPlansOfferingsOutput{
+				NextToken: aws.String("more"),
+				SearchResults: []savingsplanstypes.SavingsPlanOffering{
+					spOffering(oneYearSeconds, savingsplanstypes.SavingsPlanPaymentOptionAllUpfront),
+				},
+			}, nil
+		},
+	}
+	p := &SavingsPlansProber{NewClient: func(_ aws.Config) SavingsPlansDescribeOfferings { return fake }}
+
+	_, err := p.Probe(context.Background(), aws.Config{})
+	require.NoError(t, err)
+	// 4 plan types x maxPages calls each
+	assert.Equal(t, 4*maxPages, calls)
+}
+
+// TestSavingsPlansProber_DedupedAcrossProductTypes verifies that (duration,
+// payment) duplicates across multiple ProductType entries within one plan type
+// collapse to a single Combo rather than being stored N times.
+func TestSavingsPlansProber_DedupedAcrossProductTypes(t *testing.T) {
+	// Return the same (1yr, AllUpfront) offering twice to simulate the real
+	// API returning the same matrix for EC2 and Fargate product types.
+	fake := &fakeSavingsPlans{
+		fn: func(in *savingsplans.DescribeSavingsPlansOfferingsInput) (*savingsplans.DescribeSavingsPlansOfferingsOutput, error) {
+			if len(in.PlanTypes) == 1 && in.PlanTypes[0] == savingsplanstypes.SavingsPlanTypeCompute {
+				return &savingsplans.DescribeSavingsPlansOfferingsOutput{
+					SearchResults: []savingsplanstypes.SavingsPlanOffering{
+						spOffering(oneYearSeconds, savingsplanstypes.SavingsPlanPaymentOptionAllUpfront),
+						spOffering(oneYearSeconds, savingsplanstypes.SavingsPlanPaymentOptionAllUpfront),
+					},
+				}, nil
+			}
+			return &savingsplans.DescribeSavingsPlansOfferingsOutput{}, nil
+		},
+	}
+	p := &SavingsPlansProber{NewClient: func(_ aws.Config) SavingsPlansDescribeOfferings { return fake }}
+
+	got, err := p.Probe(context.Background(), aws.Config{})
+	require.NoError(t, err)
+
+	var compute []Combo
+	for _, c := range got {
+		if c.Service == "savings-plans-compute" {
+			compute = append(compute, c)
+		}
+	}
+	assert.Len(t, compute, 1, "duplicate (dur, pay) must collapse to one Combo")
+}
+
+// TestDefaultProbers_IncludesSavingsPlans verifies that SavingsPlansProber is
+// registered in DefaultProbers.
+func TestDefaultProbers_IncludesSavingsPlans(t *testing.T) {
+	probers := DefaultProbers()
+	found := false
+	for _, pr := range probers {
+		if pr.Service() == "savings-plans" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "DefaultProbers must include SavingsPlansProber")
 }


### PR DESCRIPTION
## Summary

- Adds `SavingsPlansProber` that calls `DescribeSavingsPlansOfferings` once per plan type (Compute, EC2Instance, SageMaker, Database) and emits per-product service keys aligned with `SERVICE_FIELDS` in `settings.ts`
- Reuses `walkPaginated`, `normalizePayment`, and `durationToTerm` from the existing RI probe infrastructure
- Introduces `dedupeRaw` to collapse duplicate `(duration, payment)` pairs that arise because the SP API returns one row per ProductType (EC2/Lambda/Fargate) within a plan type
- Registers `SavingsPlansProber` in `DefaultProbers()` alongside the six RI probers
- Empty plan-type results are silently dropped so the frontend falls back to hardcoded rules rather than treating an empty DB row as a probe sentinel

## Test plan

- [x] `go test ./internal/commitmentopts/...` passes (66 tests including 8 new SP prober tests)
- [x] `go test ./internal/api/... -short` passes (1151 tests)
- [x] New tests cover: standard combos, all four plan types, empty-result drop, error propagation, page cap, dedup across ProductType variants, DefaultProbers registration

Closes #108