### PR TITLE
test(gcp): align mock harness with production client lifecycle

### DIFF
--- a/providers/gcp/provider_test.go
+++ b/providers/gcp/provider_test.go
@@ -294,10 +294,23 @@ func TestGCPProvider_GetServiceClient_UnsupportedService(t *testing.T) {
 	ctx := context.Background()
 	provider := NewProviderWithProject(ctx, "test-project")
 
-	// ServiceCache is not supported in GCP provider
-	_, err := provider.GetServiceClient(ctx, common.ServiceCache, "us-central1")
+	// Use a service type that is genuinely not in the GCP provider's switch
+	// statement. The previous version of this test used ServiceCache, which
+	// is now supported (Memorystore) — see issue #251.
+	_, err := provider.GetServiceClient(ctx, common.ServiceType("unsupported-service-xyz"), "us-central1")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported service type")
+}
+
+func TestGCPProvider_GetServiceClient_ServiceCache(t *testing.T) {
+	ctx := context.Background()
+	provider := NewProviderWithProject(ctx, "test-project")
+
+	// ServiceCache is supported via Memorystore — verify NewClient succeeds
+	// (it only allocates a struct, no network call).
+	client, err := provider.GetServiceClient(ctx, common.ServiceCache, "us-central1")
+	require.NoError(t, err)
+	require.NotNil(t, client)
 }
 
 func TestGCPProvider_GetRecommendationsClient(t *testing.T) {
@@ -448,7 +461,9 @@ func TestGCPProvider_IsConfigured_WithMock(t *testing.T) {
 
 	result := p.IsConfigured()
 	assert.True(t, result)
-	assert.True(t, mockClient.closed)
+	// Injected clients are not closed by IsConfigured — the injector owns the
+	// lifecycle. See the IsConfigured godoc (issue #251).
+	assert.False(t, mockClient.closed)
 }
 
 func TestGCPProvider_IsConfigured_Error(t *testing.T) {
@@ -478,7 +493,9 @@ func TestGCPProvider_ValidateCredentials_WithMock(t *testing.T) {
 
 	err := p.ValidateCredentials(ctx)
 	assert.NoError(t, err)
-	assert.True(t, mockClient.closed)
+	// Injected clients are not closed by ValidateCredentials — the injector
+	// owns the lifecycle. See the ValidateCredentials godoc (issue #251).
+	assert.False(t, mockClient.closed)
 }
 
 func TestGCPProvider_ValidateCredentials_Error(t *testing.T) {

--- a/providers/gcp/services/cloudsql/client_test.go
+++ b/providers/gcp/services/cloudsql/client_test.go
@@ -271,17 +271,31 @@ func TestSQLPricingStructure(t *testing.T) {
 	assert.Equal(t, 50.0, pricing.SavingsPercentage)
 }
 
-func TestCloudSQLClient_ValidateOffering_NoCredentials(t *testing.T) {
+// TestCloudSQLClient_ValidateOffering_TierListError verifies that an error
+// from the SQLAdmin tier-list call propagates through ValidateOffering.
+//
+// The previous variant of this test relied on absent application-default
+// credentials to trigger the error path. That approach is environment-
+// sensitive: machines with ADC configured (CI runners, developer laptops with
+// gcloud auth) return nil from sqladmin.NewService, causing a false pass.
+// Using an injected mock that always errors is deterministic regardless of
+// the host environment. See issue #251.
+func TestCloudSQLClient_ValidateOffering_TierListError(t *testing.T) {
 	ctx := context.Background()
 	client, _ := NewClient(ctx, "test-project", "us-central1")
+
+	mockService := &MockSQLAdminService{
+		err: errors.New("injected tier-list failure"),
+	}
+	client.SetSQLAdminService(mockService)
 
 	rec := common.Recommendation{
 		ResourceType: "db-n1-standard-1",
 	}
 
-	// Will fail without credentials
 	err := client.ValidateOffering(ctx, rec)
-	assert.Error(t, err)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list SQL tiers")
 }
 
 func TestCloudSQLClient_GetExistingCommitments_WithMock(t *testing.T) {

--- a/providers/gcp/services/memorystore/client_test.go
+++ b/providers/gcp/services/memorystore/client_test.go
@@ -289,87 +289,36 @@ func TestMemorystoreClient_ValidateOffering_InvalidTier(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid Memorystore tier")
 }
 
-func TestMemorystoreClient_GetExistingCommitments_WithMockService(t *testing.T) {
-	tests := []struct {
-		name        string
-		instances   []*redispb.Instance
-		err         error
-		wantLen     int
-		wantErr     bool
-		errContains string
-	}{
-		{
-			name: "returns commitments for instances with reserved IP",
-			instances: []*redispb.Instance{
-				{
-					Name:            "projects/test/locations/us-central1/instances/redis-1",
-					ReservedIpRange: "10.0.0.0/29",
-					State:           redispb.Instance_READY,
-					Tier:            redispb.Instance_STANDARD_HA,
-				},
-				{
-					Name:            "projects/test/locations/us-central1/instances/redis-2",
-					ReservedIpRange: "", // No reserved IP, should be skipped
-					State:           redispb.Instance_READY,
-					Tier:            redispb.Instance_BASIC,
-				},
-				{
-					Name:            "projects/test/locations/us-central1/instances/redis-3",
-					ReservedIpRange: "10.0.0.8/29",
-					State:           redispb.Instance_CREATING,
-					Tier:            redispb.Instance_BASIC,
-				},
-			},
-			wantLen: 2,
-			wantErr: false,
-		},
-		{
-			name:      "returns empty when no instances",
-			instances: []*redispb.Instance{},
-			wantLen:   0,
-			wantErr:   false,
-		},
-		{
-			name:        "returns error when list fails",
-			instances:   nil,
-			err:         errors.New("list failed"),
-			wantLen:     0,
-			wantErr:     true,
-			errContains: "failed to list redis instances",
-		},
+// TestMemorystoreClient_GetExistingCommitments_Stub verifies the documented
+// stub behaviour: the GCP Memorystore Redis API does not expose commitment
+// status — ReservedIpRange is the VPC-peering CIDR, not a commitment
+// indicator. The production code returns (nil, nil) and the injected
+// redisService is intentionally never called from this path.
+//
+// If a future implementation adds real commitment detection here, this test
+// must be updated to match — do NOT silently swap in the mock-based variant
+// that was previously merged (it asserted behaviour the production code never
+// implemented, causing false CI failures).
+func TestMemorystoreClient_GetExistingCommitments_Stub(t *testing.T) {
+	ctx := context.Background()
+	client, _ := NewClient(ctx, "test-project", "us-central1")
+
+	// Inject a service that would error if called — verifies the stub does
+	// not accidentally touch the redis service.
+	sentinel := &MockRedisService{
+		instancesErr: errors.New("redis service must not be called from stub"),
 	}
+	client.SetRedisService(sentinel)
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
-			client, _ := NewClient(ctx, "test-project", "us-central1")
+	commitments, err := client.GetExistingCommitments(ctx)
 
-			mockService := &MockRedisService{
-				instances:    tt.instances,
-				instancesErr: tt.err,
-			}
-			client.SetRedisService(mockService)
+	require.NoError(t, err, "stub must not error")
+	assert.Nil(t, commitments, "stub must return nil until real detection is implemented")
 
-			commitments, err := client.GetExistingCommitments(ctx)
-
-			if tt.wantErr {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.errContains)
-			} else {
-				require.NoError(t, err)
-				assert.Len(t, commitments, tt.wantLen)
-
-				for _, c := range commitments {
-					assert.Equal(t, common.ProviderGCP, c.Provider)
-					assert.Equal(t, common.ServiceCache, c.Service)
-					assert.Equal(t, "test-project", c.Account)
-					assert.Equal(t, "us-central1", c.Region)
-				}
-			}
-
-			assert.True(t, mockService.closeCalled)
-		})
-	}
+	// Close must NOT have been called: the stub returns before creating any
+	// client, so there is nothing to close. Asserting false here documents
+	// that the stub owns the lifecycle correctly.
+	assert.False(t, sentinel.closeCalled, "stub must not close a service it never opened")
 }
 
 func TestMemorystoreClient_PurchaseCommitment_WithMockService(t *testing.T) {


### PR DESCRIPTION
## Summary

Fix four divergences between the GCP mock harness and production code:

- `provider_test`: `GetServiceClient_UnsupportedService` used `ServiceCache` (now supported via Memorystore); changed to a genuinely unsupported type. Added `GetServiceClient_ServiceCache` to verify Memorystore wiring
- `provider_test`: `IsConfigured_WithMock` and `ValidateCredentials_WithMock` asserted injected clients are closed; production intentionally does not close injected clients (injector owns the lifecycle per godoc)
- `memorystore/client_test`: tests exercised `ListInstances` filtering that the production stub never performs; replaced with `TestGetExistingCommitments_Stub` that pins the documented `nil, nil` return and asserts the redis service is never called
- `cloudsql/client_test`: `ValidateOffering_NoCredentials` relied on absent ADC credentials (fragile on machines with ADC configured); replaced with injected mock that explicitly errors

Closes #251

## Test plan

- [x] All 231 GCP provider Go tests pass (`go test ./...` in `providers/gcp/`)
- [x] Pre-commit hooks pass