### PR TITLE
fix(gcp): downgrade compute.regions.list 403 to Warn, return empty recs

### DIFF
--- a/providers/gcp/recommendations.go
+++ b/providers/gcp/recommendations.go
@@ -7,9 +7,11 @@ import (
 	"os"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 
 	"golang.org/x/sync/errgroup"
+	"google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
 
 	"github.com/LeanerCloud/CUDly/pkg/common"
@@ -85,6 +87,15 @@ func (r *RecommendationsClientAdapter) GetRecommendations(ctx context.Context, p
 	// Get list of regions to check
 	regions, err := r.getRegions(ctx)
 	if err != nil {
+		// Permission errors (403 / missing compute.regions.list) mean the
+		// service account lacks Compute Viewer on this project. Log at Warn
+		// so it doesn't spam as ERROR in Lambda — the application-layer auth
+		// still works; only GCP recommendations for this account are skipped.
+		// See issue #247.
+		if isPermissionError(err) {
+			logging.Warnf("GCP account %s: skipping recommendations — insufficient Compute permission to list regions (grant roles/compute.viewer): %v", r.projectID, err)
+			return []common.Recommendation{}, nil
+		}
 		return nil, fmt.Errorf("failed to get regions: %w", err)
 	}
 
@@ -249,4 +260,50 @@ func shouldIncludeService(params common.RecommendationParams, service common.Ser
 
 	// Check if this is the requested service
 	return params.Service == service
+}
+
+// isPermissionError returns true when err is a GCP 403 "Required '...' permission"
+// error. These errors arise when the service account is missing an IAM role
+// (e.g. roles/compute.viewer for compute.regions.list). Callers can then log
+// at Warn rather than propagating an error that would be recorded as ERROR by
+// the Lambda handler — see issue #247.
+func isPermissionError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var gapiErr *googleapi.Error
+	if ok := errorAs(err, &gapiErr); ok && gapiErr.Code == 403 {
+		return true
+	}
+	// Fall back to string inspection for wrapped or non-googleapi 403s.
+	msg := err.Error()
+	return strings.Contains(msg, "403") && strings.Contains(msg, "permission")
+}
+
+// errorAs is a thin shim around errors.As so it can be stubbed in tests
+// without importing errors at the call site.
+var errorAs = func(err error, target interface{}) bool {
+	switch t := target.(type) {
+	case **googleapi.Error:
+		var gErr *googleapi.Error
+		if !isGoogleAPIError(err, &gErr) {
+			return false
+		}
+		*t = gErr
+		return true
+	}
+	return false
+}
+
+func isGoogleAPIError(err error, out **googleapi.Error) bool {
+	if gErr, ok := err.(*googleapi.Error); ok {
+		*out = gErr
+		return true
+	}
+	// Unwrap one level for fmt.Errorf("%w", ...) wrapping.
+	type unwrapper interface{ Unwrap() error }
+	if u, ok := err.(unwrapper); ok {
+		return isGoogleAPIError(u.Unwrap(), out)
+	}
+	return false
 }

--- a/providers/gcp/recommendations_test.go
+++ b/providers/gcp/recommendations_test.go
@@ -79,9 +79,19 @@ func TestRecommendationsClientAdapter_GetRecommendationsForService(t *testing.T)
 		projectID: "test-project",
 	}
 
-	// This will fail without credentials, but we're testing the structure
-	_, err := adapter.GetRecommendationsForService(ctx, common.ServiceCompute)
-	assert.Error(t, err) // Expected to fail without credentials/API access
+	// Without real GCP credentials the regions call will fail. Since issue
+	// #247, permission errors (403) return ([], nil) instead of an error, so
+	// we can only assert that the call does not panic. Non-permission errors
+	// (network timeout, invalid project) still propagate as errors — but we
+	// cannot predict which path the test environment will take without
+	// mocking the provider. Structure is verified in fields/context tests.
+	recs, err := adapter.GetRecommendationsForService(ctx, common.ServiceCompute)
+	if err != nil {
+		// non-permission failure: function returned an error as expected
+		return
+	}
+	// permission failure path (issue #247): returns empty slice, no error
+	assert.NotNil(t, recs)
 }
 
 func TestRecommendationsClientAdapter_GetAllRecommendations(t *testing.T) {
@@ -91,9 +101,14 @@ func TestRecommendationsClientAdapter_GetAllRecommendations(t *testing.T) {
 		projectID: "test-project",
 	}
 
-	// This will fail without credentials, but we're testing the structure
-	_, err := adapter.GetAllRecommendations(ctx)
-	assert.Error(t, err) // Expected to fail without credentials/API access
+	// Same environment-sensitivity caveat as GetRecommendationsForService.
+	// Assert no panic; accept either ([], nil) for permission errors or
+	// (nil, err) for other failures.
+	recs, err := adapter.GetAllRecommendations(ctx)
+	if err != nil {
+		return
+	}
+	assert.NotNil(t, recs)
 }
 
 func TestRecommendationsClientAdapter_Fields(t *testing.T) {


### PR DESCRIPTION
## Summary

When a GCP service account lacks `compute.regions.list` permission, `GetRecommendations` propagated the error to the Lambda handler which recorded it as ERROR in logs. These 403s are configuration noise, not application bugs.

- Add `isPermissionError()` detecting `googleapi.Error{Code:403}` with string-match fallback for wrapped errors
- When `getRegions` returns a permission error: log at Warn (noting the required IAM role `roles/compute.viewer`) and return an empty recommendations slice
- Non-permission errors continue to propagate as before
- Update `recommendations_test` to accept either `([], nil)` for the permission path or `(nil, err)` for other environment-specific failures

Closes #247

## Test plan

- [x] All 231 GCP provider Go tests pass (`go test ./...` in `providers/gcp/`)
- [x] Pre-commit hooks pass