### PR TITLE
feat(azure/savings-plans): provider client + dispatch wiring (refs #473)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -123,9 +123,11 @@ require (
 	cloud.google.com/go/storage v1.56.0 // indirect
 	dario.cat/mergo v1.0.2 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal v0.7.1 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/billingbenefits/armbillingbenefits v1.0.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos/v2 v2.7.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/reservations/armreservations v1.1.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/search/armsearch v1.4.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -126,7 +126,6 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/billingbenefits/armbillingbenefits v1.0.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos/v2 v2.7.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/reservations/armreservations v1.1.0 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/search/armsearch v1.4.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal v0.7.1 h1:FbH3BbSb4bvGlu
 github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal v0.7.1/go.mod h1:9V2j0jn9jDEkCkv8w/bKTNppX/d0FVA1ud77xCIP4KA=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/advisor/armadvisor v1.2.0 h1:3ddjPq/3A/oB2u7LdohEr900EGP5l1MnAiNc3EbY1E4=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/advisor/armadvisor v1.2.0/go.mod h1:oZ73p8dR7aZI+TJo5Ul92oCoVubMYPBo39eTsWa0AiQ=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/billingbenefits/armbillingbenefits v1.0.0 h1:4JHm1qT4VKYZ8aGP1dJBg+wk/WgN/KitLNtQs6jFNfA=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/billingbenefits/armbillingbenefits v1.0.0/go.mod h1:GBFVpPKOTooUG7VM93ip046AqLf4qubcIEsU3js4v3g=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5 v5.4.0 h1:QfV5XZt6iNa2aWMAt96CZEbfJ7kgG/qYIpq465Shr5E=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5 v5.4.0/go.mod h1:uYt4CfhkJA9o0FN7jfE5minm/i4nUE4MjGUJkzB6Zs8=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/consumption/armconsumption v1.1.0 h1:pTIng5JZfGKPA4WT8QjEPGOD5KK2CoCBkecWgtq3Cuc=
@@ -60,6 +62,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal v1.1.2 h1:mLY+pNL
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal v1.1.2/go.mod h1:FbdwsQ2EzwvXxOPcMFYO8ogEc9uMMIj3YkmCdXdAFmk=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0 h1:PTFGRSlMKCQelWwxUyYVEUqseBJVemLyqWJjvMyt0do=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0/go.mod h1:LRr2FzBTQlONPPa5HREE5+RjSCTXl7BwOvYOaWTqCaI=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v3 v3.1.0 h1:2qsIIvxVT+uE6yrNldntJKlLRgxGbZ85kgtz5SNBhMw=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v3 v3.1.0/go.mod h1:AW8VEadnhw9xox+VaVd9sP7NjzOAnaZBLRH6Tq3cJ38=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3 v3.0.0 h1:zp+znRAHKLSewbw+WWKIMgCaFNxEXt9AwjxmW5fCnck=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3 v3.0.0/go.mod h1:nEvLUni7GO5ukfEYtmrUfz08Puqd2FP9d8sCZazm5W4=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/reservations/armreservations v1.1.0 h1:0OO/3K+SKt45gXiOU4gHRILOLeNOUZdqeNO47Mq6iN8=
@@ -68,6 +72,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0/go.mod h1:5kakwfW5CjC9KK+Q4wjXAg+ShuIm2mBMua0ZFj2C8PE=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.3.0 h1:wxQx2Bt4xzPIKvW59WQf1tJNx/ZZKPfN+EhPX3Z6CYY=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.3.0/go.mod h1:TpiwjwnW/khS0LKs4vW5UmmT9OWcxaveS8U7+tlknzo=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/search/armsearch v1.4.0 h1:zBdabY8pMSMLPb1XJnFSEdJi9Bd0h+VMjh1uU8B6Yp8=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/search/armsearch v1.4.0/go.mod h1:Y2Q3nB3UfSnG9nALOpPAjflXPM3jL/n2ZmYIu2Occ9g=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql v1.2.0 h1:S087deZ0kP1RUg4pU7w9U9xpUedTCbOtz+mnd0+hrkQ=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql v1.2.0/go.mod h1:B4cEyXrWBmbfMDAPnpJ1di7MAt5DKP57jPEObAvZChg=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.4.0 h1:E4MgwLBGeVB5f2MdcIVD3ELVAWpr+WD6MUe1i+tM/PA=

--- a/providers/azure/go.mod
+++ b/providers/azure/go.mod
@@ -22,6 +22,7 @@ require (
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.1 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/billingbenefits/armbillingbenefits v1.0.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.4.2 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.40.1 // indirect
 	github.com/aws/smithy-go v1.24.0 // indirect

--- a/providers/azure/go.sum
+++ b/providers/azure/go.sum
@@ -8,6 +8,8 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.1 h1:FPKJS1T+clwv+OLGt13a8U
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.1/go.mod h1:j2chePtV91HrC22tGoRX3sGY42uF13WzmmV80/OdVAA=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/advisor/armadvisor v1.2.0 h1:3ddjPq/3A/oB2u7LdohEr900EGP5l1MnAiNc3EbY1E4=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/advisor/armadvisor v1.2.0/go.mod h1:oZ73p8dR7aZI+TJo5Ul92oCoVubMYPBo39eTsWa0AiQ=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/billingbenefits/armbillingbenefits v1.0.0 h1:4JHm1qT4VKYZ8aGP1dJBg+wk/WgN/KitLNtQs6jFNfA=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/billingbenefits/armbillingbenefits v1.0.0/go.mod h1:GBFVpPKOTooUG7VM93ip046AqLf4qubcIEsU3js4v3g=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5 v5.4.0 h1:QfV5XZt6iNa2aWMAt96CZEbfJ7kgG/qYIpq465Shr5E=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5 v5.4.0/go.mod h1:uYt4CfhkJA9o0FN7jfE5minm/i4nUE4MjGUJkzB6Zs8=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/consumption/armconsumption v1.1.0 h1:pTIng5JZfGKPA4WT8QjEPGOD5KK2CoCBkecWgtq3Cuc=

--- a/providers/azure/provider.go
+++ b/providers/azure/provider.go
@@ -418,6 +418,8 @@ func (p *AzureProvider) GetSupportedServices() []common.ServiceType {
 		common.ServiceRelationalDB,
 		common.ServiceNoSQL,
 		common.ServiceCache,
+		common.ServiceSavingsPlans,
+		common.ServiceSearch,
 	}
 }
 
@@ -471,6 +473,10 @@ func (p *AzureProvider) newServiceClientForSubscription(service common.ServiceTy
 		return NewCacheClient(p.cred, subscriptionID, region), nil
 	case common.ServiceNoSQL:
 		return NewCosmosDBClient(p.cred, subscriptionID, region), nil
+	case common.ServiceSavingsPlans:
+		return NewSavingsPlansClient(p.cred, subscriptionID, region), nil
+	case common.ServiceSearch:
+		return NewSearchClient(p.cred, subscriptionID, region), nil
 	default:
 		return nil, fmt.Errorf("unsupported service: %s", service)
 	}

--- a/providers/azure/services.go
+++ b/providers/azure/services.go
@@ -8,6 +8,8 @@ import (
 	"github.com/LeanerCloud/CUDly/providers/azure/services/compute"
 	"github.com/LeanerCloud/CUDly/providers/azure/services/cosmosdb"
 	"github.com/LeanerCloud/CUDly/providers/azure/services/database"
+	"github.com/LeanerCloud/CUDly/providers/azure/services/savingsplans"
+	"github.com/LeanerCloud/CUDly/providers/azure/services/search"
 )
 
 // NewComputeClient creates a new Azure Compute (VM) client
@@ -28,6 +30,16 @@ func NewCacheClient(cred azcore.TokenCredential, subscriptionID, region string) 
 // NewCosmosDBClient creates a new Azure Cosmos DB client
 func NewCosmosDBClient(cred azcore.TokenCredential, subscriptionID, region string) provider.ServiceClient {
 	return cosmosdb.NewClient(cred, subscriptionID, region)
+}
+
+// NewSavingsPlansClient creates a new Azure Savings Plans client
+func NewSavingsPlansClient(cred azcore.TokenCredential, subscriptionID, region string) provider.ServiceClient {
+	return savingsplans.NewClient(cred, subscriptionID, region)
+}
+
+// NewSearchClient creates a new Azure Cognitive Search client
+func NewSearchClient(cred azcore.TokenCredential, subscriptionID, region string) provider.ServiceClient {
+	return search.NewClient(cred, subscriptionID, region)
 }
 
 // NewRecommendationsClient creates a new Azure recommendations client.

--- a/providers/azure/services/savingsplans/client.go
+++ b/providers/azure/services/savingsplans/client.go
@@ -83,6 +83,9 @@ func NewClient(cred azcore.TokenCredential, subscriptionID, region string) *Clie
 
 // NewClientWithHTTP creates a new Azure Savings Plans client with a custom HTTP client (for testing).
 func NewClientWithHTTP(cred azcore.TokenCredential, subscriptionID, region string, httpClient HTTPClient) *Client {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 30 * time.Second}
+	}
 	return &Client{
 		cred:           cred,
 		subscriptionID: subscriptionID,
@@ -391,11 +394,22 @@ func (c *Client) GetOfferingDetails(ctx context.Context, rec common.Recommendati
 	}
 
 	// Calculate term hours.
-	hoursInTerm := 8760.0 // 1 year
-	termStr := "1yr"
-	if rec.Term == "3yr" || rec.Term == "P3Y" {
-		hoursInTerm = 26280.0
-		termStr = "3yr"
+	azTerm, err := toAzureTerm(rec.Term)
+	if err != nil {
+		return nil, err
+	}
+
+	var hoursInTerm float64
+	var termStr string
+	switch azTerm {
+	case armbillingbenefits.TermP1Y:
+		hoursInTerm, termStr = 8760.0, "1yr"
+	case armbillingbenefits.TermP3Y:
+		hoursInTerm, termStr = 26280.0, "3yr"
+	case armbillingbenefits.TermP5Y:
+		hoursInTerm, termStr = 43800.0, "5yr"
+	default:
+		return nil, fmt.Errorf("unsupported savings plan term: %s", rec.Term)
 	}
 
 	totalCost := spDetails.HourlyCommitment * hoursInTerm

--- a/providers/azure/services/savingsplans/client.go
+++ b/providers/azure/services/savingsplans/client.go
@@ -1,0 +1,536 @@
+// Package savingsplans provides an Azure Savings Plans service client.
+package savingsplans
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/billingbenefits/armbillingbenefits"
+
+	"github.com/LeanerCloud/CUDly/pkg/common"
+)
+
+// SavingsPlanOrderAliasAPI defines operations on SavingsPlanOrderAlias (enables mocking).
+type SavingsPlanOrderAliasAPI interface {
+	BeginCreate(
+		ctx context.Context,
+		savingsPlanOrderAliasName string,
+		body armbillingbenefits.SavingsPlanOrderAliasModel,
+		options *armbillingbenefits.SavingsPlanOrderAliasClientBeginCreateOptions,
+	) (SavingsPlanOrderAliasPoller, error)
+}
+
+// SavingsPlanOrderAliasPoller abstracts the LRO poller returned by BeginCreate (enables mocking).
+type SavingsPlanOrderAliasPoller interface {
+	PollUntilDone(ctx context.Context, options *PollOptions) (armbillingbenefits.SavingsPlanOrderAliasClientCreateResponse, error)
+}
+
+// PollOptions mirrors arm/runtime.PollUntilDoneOptions to avoid a direct dependency.
+type PollOptions struct {
+	Frequency time.Duration
+}
+
+// SavingsPlanListAllPager abstracts the list-all pager (enables mocking).
+type SavingsPlanListAllPager interface {
+	More() bool
+	NextPage(ctx context.Context) (armbillingbenefits.SavingsPlanClientListAllResponse, error)
+}
+
+// RPValidateAPI defines the ValidatePurchase operation (enables mocking).
+type RPValidateAPI interface {
+	ValidatePurchase(
+		ctx context.Context,
+		body armbillingbenefits.SavingsPlanPurchaseValidateRequest,
+		options *armbillingbenefits.RPClientValidatePurchaseOptions,
+	) (armbillingbenefits.RPClientValidatePurchaseResponse, error)
+}
+
+// HTTPClient defines the interface for HTTP calls (enables mocking).
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// Client handles Azure Savings Plans.
+type Client struct {
+	cred           azcore.TokenCredential
+	subscriptionID string
+	region         string
+	httpClient     HTTPClient
+
+	// Injected in tests to avoid real Azure API calls.
+	orderAliasClient SavingsPlanOrderAliasAPI
+	listAllPager     SavingsPlanListAllPager
+	rpValidateClient RPValidateAPI
+}
+
+// NewClient creates a new Azure Savings Plans client.
+func NewClient(cred azcore.TokenCredential, subscriptionID, region string) *Client {
+	return &Client{
+		cred:           cred,
+		subscriptionID: subscriptionID,
+		region:         region,
+		httpClient:     &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// NewClientWithHTTP creates a new Azure Savings Plans client with a custom HTTP client (for testing).
+func NewClientWithHTTP(cred azcore.TokenCredential, subscriptionID, region string, httpClient HTTPClient) *Client {
+	return &Client{
+		cred:           cred,
+		subscriptionID: subscriptionID,
+		region:         region,
+		httpClient:     httpClient,
+	}
+}
+
+// SetOrderAliasClient injects a mock SavingsPlanOrderAliasAPI (for testing).
+func (c *Client) SetOrderAliasClient(api SavingsPlanOrderAliasAPI) {
+	c.orderAliasClient = api
+}
+
+// SetListAllPager injects a mock list-all pager (for testing).
+func (c *Client) SetListAllPager(pager SavingsPlanListAllPager) {
+	c.listAllPager = pager
+}
+
+// SetRPValidateClient injects a mock RPValidateAPI (for testing).
+func (c *Client) SetRPValidateClient(api RPValidateAPI) {
+	c.rpValidateClient = api
+}
+
+// GetServiceType returns the service type for this client.
+func (c *Client) GetServiceType() common.ServiceType {
+	return common.ServiceSavingsPlans
+}
+
+// GetRegion returns the region for this client.
+func (c *Client) GetRegion() string {
+	return c.region
+}
+
+// GetRecommendations returns an empty slice.
+//
+// Azure does not have a stable public API for Savings Plan purchase
+// recommendations (the Benefits Recommendations API is still in preview).
+// This mirrors the AWS Savings Plans client which also returns empty here and
+// delegates to Cost Explorer centrally.
+func (c *Client) GetRecommendations(_ context.Context, _ common.RecommendationParams) ([]common.Recommendation, error) {
+	return []common.Recommendation{}, nil
+}
+
+// GetExistingCommitments retrieves all active Azure Savings Plans.
+func (c *Client) GetExistingCommitments(ctx context.Context) ([]common.Commitment, error) {
+	var pager SavingsPlanListAllPager
+
+	if c.listAllPager != nil {
+		pager = c.listAllPager
+	} else {
+		spClient, err := armbillingbenefits.NewSavingsPlanClient(nil, c.cred, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create savings plan client: %w", err)
+		}
+		pager = spClient.NewListAllPager(nil)
+	}
+
+	commitments := make([]common.Commitment, 0)
+
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list savings plans: %w", err)
+		}
+
+		for _, sp := range page.Value {
+			commitment := convertSavingsPlan(sp, c.subscriptionID)
+			if commitment != nil {
+				commitments = append(commitments, *commitment)
+			}
+		}
+	}
+
+	return commitments, nil
+}
+
+// convertSavingsPlan maps an armbillingbenefits.SavingsPlanModel to a common.Commitment.
+func convertSavingsPlan(sp *armbillingbenefits.SavingsPlanModel, subscriptionID string) *common.Commitment {
+	if sp == nil || sp.ID == nil {
+		return nil
+	}
+
+	commitment := common.Commitment{
+		Provider:       common.ProviderAzure,
+		Account:        subscriptionID,
+		CommitmentID:   *sp.ID,
+		CommitmentType: common.CommitmentSavingsPlan,
+		Service:        common.ServiceSavingsPlans,
+		Count:          1,
+		State:          "active",
+	}
+
+	if sp.Name != nil {
+		commitment.ResourceType = *sp.Name
+	}
+
+	if sp.Properties != nil {
+		props := sp.Properties
+
+		if props.ProvisioningState != nil {
+			commitment.State = string(*props.ProvisioningState)
+		}
+
+		if props.EffectiveDateTime != nil {
+			commitment.StartDate = *props.EffectiveDateTime
+		}
+
+		if props.ExpiryDateTime != nil {
+			commitment.EndDate = *props.ExpiryDateTime
+		}
+
+		if props.Commitment != nil && props.Commitment.Amount != nil {
+			commitment.Cost = *props.Commitment.Amount
+		}
+	}
+
+	return &commitment
+}
+
+// PurchaseCommitment creates an Azure Savings Plan via the OrderAlias API.
+func (c *Client) PurchaseCommitment(ctx context.Context, rec common.Recommendation, _ common.PurchaseOptions) (common.PurchaseResult, error) {
+	result := common.PurchaseResult{
+		Recommendation: rec,
+		DryRun:         false,
+		Success:        false,
+		Timestamp:      time.Now(),
+	}
+
+	spDetails, ok := rec.Details.(*common.SavingsPlanDetails)
+	if !ok {
+		result.Error = fmt.Errorf("invalid service details for Azure Savings Plans")
+		return result, result.Error
+	}
+
+	term, err := toAzureTerm(rec.Term)
+	if err != nil {
+		result.Error = err
+		return result, result.Error
+	}
+
+	grain := armbillingbenefits.CommitmentGrainHourly
+	billingScopeID := fmt.Sprintf("/subscriptions/%s", c.subscriptionID)
+	appliedScope := armbillingbenefits.AppliedScopeTypeShared
+	hourlyAmount := spDetails.HourlyCommitment
+	displayName := fmt.Sprintf("cudly-%s-%s", spDetails.PlanType, rec.Term)
+
+	body := armbillingbenefits.SavingsPlanOrderAliasModel{
+		SKU: &armbillingbenefits.SKU{Name: toPtr(spDetails.PlanType)},
+		Properties: &armbillingbenefits.SavingsPlanOrderAliasProperties{
+			DisplayName:      &displayName,
+			BillingScopeID:   &billingScopeID,
+			Term:             &term,
+			AppliedScopeType: &appliedScope,
+			Commitment: &armbillingbenefits.Commitment{
+				Amount:       &hourlyAmount,
+				CurrencyCode: toPtr("USD"),
+				Grain:        &grain,
+			},
+		},
+	}
+
+	var aliasClient SavingsPlanOrderAliasAPI
+	if c.orderAliasClient != nil {
+		aliasClient = c.orderAliasClient
+	} else {
+		real, err := armbillingbenefits.NewSavingsPlanOrderAliasClient(c.cred, nil)
+		if err != nil {
+			result.Error = fmt.Errorf("failed to create order alias client: %w", err)
+			return result, result.Error
+		}
+		aliasClient = &realOrderAliasClient{client: real}
+	}
+
+	aliasName := fmt.Sprintf("cudly-%d", time.Now().UnixNano())
+	poller, err := aliasClient.BeginCreate(ctx, aliasName, body, nil)
+	if err != nil {
+		result.Error = fmt.Errorf("failed to begin savings plan purchase: %w", err)
+		return result, result.Error
+	}
+
+	resp, err := poller.PollUntilDone(ctx, nil)
+	if err != nil {
+		result.Error = fmt.Errorf("savings plan purchase failed: %w", err)
+		return result, result.Error
+	}
+
+	if resp.ID != nil {
+		result.CommitmentID = *resp.ID
+		result.Success = true
+	} else {
+		result.Error = fmt.Errorf("purchase response missing ID")
+		return result, result.Error
+	}
+
+	return result, nil
+}
+
+// ValidateOffering checks whether the Savings Plan configuration is valid.
+func (c *Client) ValidateOffering(ctx context.Context, rec common.Recommendation) error {
+	validateBody, err := c.buildValidateBody(rec)
+	if err != nil {
+		return err
+	}
+
+	rpClient, err := c.getRPValidateClient()
+	if err != nil {
+		return err
+	}
+
+	resp, err := rpClient.ValidatePurchase(ctx, validateBody, nil)
+	if err != nil {
+		return fmt.Errorf("failed to validate savings plan: %w", err)
+	}
+
+	return checkValidateResponse(resp)
+}
+
+// buildValidateBody constructs the SavingsPlanPurchaseValidateRequest from a recommendation.
+func (c *Client) buildValidateBody(rec common.Recommendation) (armbillingbenefits.SavingsPlanPurchaseValidateRequest, error) {
+	spDetails, ok := rec.Details.(*common.SavingsPlanDetails)
+	if !ok {
+		return armbillingbenefits.SavingsPlanPurchaseValidateRequest{}, fmt.Errorf("invalid service details for Azure Savings Plans")
+	}
+
+	term, err := toAzureTerm(rec.Term)
+	if err != nil {
+		return armbillingbenefits.SavingsPlanPurchaseValidateRequest{}, err
+	}
+
+	grain := armbillingbenefits.CommitmentGrainHourly
+	billingScopeID := fmt.Sprintf("/subscriptions/%s", c.subscriptionID)
+	appliedScope := armbillingbenefits.AppliedScopeTypeShared
+	hourlyAmount := spDetails.HourlyCommitment
+	displayName := "cudly-validate"
+
+	return armbillingbenefits.SavingsPlanPurchaseValidateRequest{
+		Benefits: []*armbillingbenefits.SavingsPlanOrderAliasModel{
+			{
+				SKU: &armbillingbenefits.SKU{Name: toPtr(spDetails.PlanType)},
+				Properties: &armbillingbenefits.SavingsPlanOrderAliasProperties{
+					DisplayName:      &displayName,
+					BillingScopeID:   &billingScopeID,
+					Term:             &term,
+					AppliedScopeType: &appliedScope,
+					Commitment: &armbillingbenefits.Commitment{
+						Amount:       &hourlyAmount,
+						CurrencyCode: toPtr("USD"),
+						Grain:        &grain,
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+// getRPValidateClient returns the injected mock or creates a real RPClient.
+func (c *Client) getRPValidateClient() (RPValidateAPI, error) {
+	if c.rpValidateClient != nil {
+		return c.rpValidateClient, nil
+	}
+	real, err := armbillingbenefits.NewRPClient(c.cred, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create RP client: %w", err)
+	}
+	return real, nil
+}
+
+// checkValidateResponse returns an error if any benefit in the response is invalid.
+func checkValidateResponse(resp armbillingbenefits.RPClientValidatePurchaseResponse) error {
+	for _, b := range resp.Benefits {
+		if b == nil || b.Valid == nil || *b.Valid {
+			continue
+		}
+		reason := ""
+		if b.Reason != nil {
+			reason = *b.Reason
+		}
+		return fmt.Errorf("savings plan offering invalid: %s", reason)
+	}
+	return nil
+}
+
+// AzureRetailPrice represents a pricing record from the Azure Retail Prices API.
+//
+// NOTE: this struct is also defined in services/compute and services/search.
+// Consolidating it into a shared internal package is tracked as a follow-up.
+type AzureRetailPrice struct {
+	Items []struct {
+		CurrencyCode    string  `json:"currencyCode"`
+		RetailPrice     float64 `json:"retailPrice"`
+		UnitPrice       float64 `json:"unitPrice"`
+		ArmRegionName   string  `json:"armRegionName"`
+		ProductName     string  `json:"productName"`
+		ServiceName     string  `json:"serviceName"`
+		ArmSKUName      string  `json:"armSkuName"`
+		ReservationTerm string  `json:"reservationTerm"`
+		Type            string  `json:"type"`
+	} `json:"Items"`
+}
+
+// GetOfferingDetails retrieves pricing details for an Azure Savings Plan offering.
+func (c *Client) GetOfferingDetails(ctx context.Context, rec common.Recommendation) (*common.OfferingDetails, error) {
+	spDetails, ok := rec.Details.(*common.SavingsPlanDetails)
+	if !ok {
+		return nil, fmt.Errorf("invalid service details for Azure Savings Plans")
+	}
+
+	// Calculate term hours.
+	hoursInTerm := 8760.0 // 1 year
+	termStr := "1yr"
+	if rec.Term == "3yr" || rec.Term == "P3Y" {
+		hoursInTerm = 26280.0
+		termStr = "3yr"
+	}
+
+	totalCost := spDetails.HourlyCommitment * hoursInTerm
+
+	var upfrontCost, recurringCost float64
+	switch rec.PaymentOption {
+	case "All Upfront", "all-upfront":
+		upfrontCost = totalCost
+		recurringCost = 0
+	case "Partial Upfront", "partial-upfront":
+		upfrontCost = totalCost * 0.5
+		recurringCost = (totalCost * 0.5) / hoursInTerm
+	default: // "No Upfront" / "no-upfront" and anything else
+		upfrontCost = 0
+		recurringCost = totalCost / hoursInTerm
+	}
+
+	return &common.OfferingDetails{
+		ResourceType:        spDetails.PlanType,
+		Term:                termStr,
+		PaymentOption:       rec.PaymentOption,
+		UpfrontCost:         upfrontCost,
+		RecurringCost:       recurringCost,
+		TotalCost:           totalCost,
+		EffectiveHourlyRate: spDetails.HourlyCommitment,
+		Currency:            "USD",
+	}, nil
+}
+
+// fetchOnDemandRate queries the Azure Retail Prices API for the on-demand hourly
+// rate for the given plan type. Returns 0 and an error if unavailable.
+func (c *Client) fetchOnDemandRate(ctx context.Context, planType string) (float64, error) {
+	filter := fmt.Sprintf(
+		"serviceFamily eq 'Compute' and priceType eq 'Consumption' and armSkuName eq '%s'",
+		url.QueryEscape(planType),
+	)
+	apiURL := fmt.Sprintf(
+		"https://prices.azure.com/api/retail/prices?$filter=%s",
+		filter,
+	)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return 0, err
+	}
+
+	// Attach Bearer token if credential is available.
+	if c.cred != nil {
+		tokenOpts := policy.TokenRequestOptions{Scopes: []string{"https://management.azure.com/.default"}}
+		token, err := c.cred.GetToken(ctx, tokenOpts)
+		if err == nil {
+			req.Header.Set("Authorization", "Bearer "+token.Token)
+		}
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, err
+	}
+
+	var pricing AzureRetailPrice
+	if err := json.Unmarshal(body, &pricing); err != nil {
+		return 0, err
+	}
+
+	for _, item := range pricing.Items {
+		if item.RetailPrice > 0 {
+			return item.RetailPrice, nil
+		}
+	}
+
+	return 0, nil
+}
+
+// GetValidResourceTypes returns the Azure Savings Plan types.
+func (c *Client) GetValidResourceTypes(_ context.Context) ([]string, error) {
+	return []string{
+		"Compute",
+		"MachineLearning",
+	}, nil
+}
+
+// toAzureTerm converts a CUDly term string to an armbillingbenefits.Term.
+func toAzureTerm(term string) (armbillingbenefits.Term, error) {
+	switch term {
+	case "1yr", "1", "P1Y", "":
+		return armbillingbenefits.TermP1Y, nil
+	case "3yr", "3", "P3Y":
+		return armbillingbenefits.TermP3Y, nil
+	case "5yr", "5", "P5Y":
+		return armbillingbenefits.TermP5Y, nil
+	default:
+		return "", fmt.Errorf("unsupported savings plan term: %s", term)
+	}
+}
+
+// toPtr returns a pointer to v.
+func toPtr[T any](v T) *T {
+	return &v
+}
+
+// realOrderAliasClient wraps armbillingbenefits.SavingsPlanOrderAliasClient to
+// satisfy SavingsPlanOrderAliasAPI.
+type realOrderAliasClient struct {
+	client *armbillingbenefits.SavingsPlanOrderAliasClient
+}
+
+func (r *realOrderAliasClient) BeginCreate(
+	ctx context.Context,
+	savingsPlanOrderAliasName string,
+	body armbillingbenefits.SavingsPlanOrderAliasModel,
+	options *armbillingbenefits.SavingsPlanOrderAliasClientBeginCreateOptions,
+) (SavingsPlanOrderAliasPoller, error) {
+	poller, err := r.client.BeginCreate(ctx, savingsPlanOrderAliasName, body, options)
+	if err != nil {
+		return nil, err
+	}
+	return &realPoller{poller: poller}, nil
+}
+
+// realPoller wraps the SDK LRO poller to satisfy SavingsPlanOrderAliasPoller.
+type realPoller struct {
+	poller *runtime.Poller[armbillingbenefits.SavingsPlanOrderAliasClientCreateResponse]
+}
+
+func (r *realPoller) PollUntilDone(ctx context.Context, _ *PollOptions) (armbillingbenefits.SavingsPlanOrderAliasClientCreateResponse, error) {
+	return r.poller.PollUntilDone(ctx, nil)
+}
+
+// SavingsPlanOrderAliasProperties mirrors armbillingbenefits for use in BeginCreate body.
+// Re-exporting via an alias for clarity.
+type SavingsPlanOrderAliasProperties = armbillingbenefits.SavingsPlanOrderAliasProperties

--- a/providers/azure/services/savingsplans/client.go
+++ b/providers/azure/services/savingsplans/client.go
@@ -422,9 +422,11 @@ func (c *Client) GetOfferingDetails(ctx context.Context, rec common.Recommendati
 	case "Partial Upfront", "partial-upfront":
 		upfrontCost = totalCost * 0.5
 		recurringCost = (totalCost * 0.5) / hoursInTerm
-	default: // "No Upfront" / "no-upfront" and anything else
+	case "No Upfront", "no-upfront":
 		upfrontCost = 0
 		recurringCost = totalCost / hoursInTerm
+	default:
+		return nil, fmt.Errorf("unsupported payment option: %s", rec.PaymentOption)
 	}
 
 	return &common.OfferingDetails{

--- a/providers/azure/services/savingsplans/client_test.go
+++ b/providers/azure/services/savingsplans/client_test.go
@@ -358,6 +358,37 @@ func TestGetOfferingDetails_3yr_AllUpfront(t *testing.T) {
 	assert.Equal(t, 0.0, details.RecurringCost)
 }
 
+func TestGetOfferingDetails_5yr_AllUpfront(t *testing.T) {
+	c := NewClient(nil, "sub", "eastus")
+	rec := common.Recommendation{
+		Term:          "5yr",
+		PaymentOption: "All Upfront",
+		Details:       &common.SavingsPlanDetails{PlanType: "Compute", HourlyCommitment: 1.0},
+	}
+
+	details, err := c.GetOfferingDetails(context.Background(), rec)
+	require.NoError(t, err)
+	require.NotNil(t, details)
+
+	assert.Equal(t, "5yr", details.Term)
+	assert.InDelta(t, 43800.0, details.UpfrontCost, 0.001)
+	assert.Equal(t, 0.0, details.RecurringCost)
+	assert.InDelta(t, 43800.0, details.TotalCost, 0.001)
+}
+
+func TestGetOfferingDetails_BadTerm(t *testing.T) {
+	c := NewClient(nil, "sub", "eastus")
+	rec := common.Recommendation{
+		Term:          "99yr",
+		PaymentOption: "No Upfront",
+		Details:       &common.SavingsPlanDetails{PlanType: "Compute", HourlyCommitment: 1.0},
+	}
+
+	_, err := c.GetOfferingDetails(context.Background(), rec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported savings plan term")
+}
+
 func TestGetOfferingDetails_WrongDetails(t *testing.T) {
 	c := NewClient(nil, "sub", "eastus")
 	rec := common.Recommendation{Term: "1yr", Details: nil}

--- a/providers/azure/services/savingsplans/client_test.go
+++ b/providers/azure/services/savingsplans/client_test.go
@@ -1,0 +1,401 @@
+package savingsplans
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/billingbenefits/armbillingbenefits"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LeanerCloud/CUDly/pkg/common"
+)
+
+// --- mock helpers ---
+
+// mockListAllPager is a simple struct-based mock for SavingsPlanListAllPager.
+type mockListAllPager struct {
+	results   []*armbillingbenefits.SavingsPlanModel
+	err       error
+	pageCount int
+}
+
+func (p *mockListAllPager) More() bool { return p.pageCount == 0 }
+
+func (p *mockListAllPager) NextPage(_ context.Context) (armbillingbenefits.SavingsPlanClientListAllResponse, error) {
+	p.pageCount++
+	if p.err != nil {
+		return armbillingbenefits.SavingsPlanClientListAllResponse{}, p.err
+	}
+	return armbillingbenefits.SavingsPlanClientListAllResponse{
+		SavingsPlanModelListResult: armbillingbenefits.SavingsPlanModelListResult{
+			Value: p.results,
+		},
+	}, nil
+}
+
+// mockOrderAliasClient is a struct-based mock for SavingsPlanOrderAliasAPI.
+type mockOrderAliasClient struct {
+	createPoller SavingsPlanOrderAliasPoller
+	createErr    error
+}
+
+func (m *mockOrderAliasClient) BeginCreate(
+	_ context.Context,
+	_ string,
+	_ armbillingbenefits.SavingsPlanOrderAliasModel,
+	_ *armbillingbenefits.SavingsPlanOrderAliasClientBeginCreateOptions,
+) (SavingsPlanOrderAliasPoller, error) {
+	if m.createErr != nil {
+		return nil, m.createErr
+	}
+	return m.createPoller, nil
+}
+
+// mockPoller is a struct-based mock for SavingsPlanOrderAliasPoller.
+type mockPoller struct {
+	resp armbillingbenefits.SavingsPlanOrderAliasClientCreateResponse
+	err  error
+}
+
+func (p *mockPoller) PollUntilDone(_ context.Context, _ *PollOptions) (armbillingbenefits.SavingsPlanOrderAliasClientCreateResponse, error) {
+	return p.resp, p.err
+}
+
+// mockRPValidate is a struct-based mock for RPValidateAPI.
+type mockRPValidate struct {
+	resp armbillingbenefits.RPClientValidatePurchaseResponse
+	err  error
+}
+
+func (m *mockRPValidate) ValidatePurchase(
+	_ context.Context,
+	_ armbillingbenefits.SavingsPlanPurchaseValidateRequest,
+	_ *armbillingbenefits.RPClientValidatePurchaseOptions,
+) (armbillingbenefits.RPClientValidatePurchaseResponse, error) {
+	return m.resp, m.err
+}
+
+// --- constructor tests ---
+
+func TestNewClient(t *testing.T) {
+	c := NewClient(nil, "sub-123", "eastus")
+	require.NotNil(t, c)
+	assert.Equal(t, "sub-123", c.subscriptionID)
+	assert.Equal(t, "eastus", c.region)
+	assert.NotNil(t, c.httpClient)
+}
+
+func TestGetServiceType(t *testing.T) {
+	c := NewClient(nil, "sub", "eastus")
+	assert.Equal(t, common.ServiceSavingsPlans, c.GetServiceType())
+}
+
+func TestGetRegion(t *testing.T) {
+	regions := []string{"eastus", "westeurope", "japaneast"}
+	for _, r := range regions {
+		c := NewClient(nil, "sub", r)
+		assert.Equal(t, r, c.GetRegion())
+	}
+}
+
+// --- GetRecommendations ---
+
+func TestGetRecommendations_AlwaysEmpty(t *testing.T) {
+	c := NewClient(nil, "sub", "eastus")
+	recs, err := c.GetRecommendations(context.Background(), common.RecommendationParams{})
+	require.NoError(t, err)
+	assert.Empty(t, recs)
+}
+
+// --- GetValidResourceTypes ---
+
+func TestGetValidResourceTypes(t *testing.T) {
+	c := NewClient(nil, "sub", "eastus")
+	types, err := c.GetValidResourceTypes(context.Background())
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"Compute", "MachineLearning"}, types)
+}
+
+// --- GetExistingCommitments ---
+
+func TestGetExistingCommitments_Empty(t *testing.T) {
+	c := NewClient(nil, "sub", "eastus")
+	c.SetListAllPager(&mockListAllPager{results: nil})
+
+	commitments, err := c.GetExistingCommitments(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, commitments)
+}
+
+func TestGetExistingCommitments_Happy(t *testing.T) {
+	now := time.Now().UTC()
+	expiry := now.Add(365 * 24 * time.Hour)
+	prov := armbillingbenefits.ProvisioningStateSucceeded
+	amount := 10.5
+	grain := armbillingbenefits.CommitmentGrainHourly
+	currCode := "USD"
+	spID := "/subscriptions/sub-abc/providers/Microsoft.BillingBenefits/savingsPlanOrders/ord1/savingsPlans/sp1"
+	spName := "my-savings-plan"
+
+	sp := &armbillingbenefits.SavingsPlanModel{
+		ID:   &spID,
+		Name: &spName,
+		Properties: &armbillingbenefits.SavingsPlanModelProperties{
+			ProvisioningState: &prov,
+			EffectiveDateTime: &now,
+			ExpiryDateTime:    &expiry,
+			Commitment: &armbillingbenefits.Commitment{
+				Amount:       &amount,
+				CurrencyCode: &currCode,
+				Grain:        &grain,
+			},
+		},
+	}
+
+	c := NewClient(nil, "sub-abc", "eastus")
+	c.SetListAllPager(&mockListAllPager{results: []*armbillingbenefits.SavingsPlanModel{sp}})
+
+	commitments, err := c.GetExistingCommitments(context.Background())
+	require.NoError(t, err)
+	require.Len(t, commitments, 1)
+
+	got := commitments[0]
+	assert.Equal(t, common.ProviderAzure, got.Provider)
+	assert.Equal(t, common.CommitmentSavingsPlan, got.CommitmentType)
+	assert.Equal(t, common.ServiceSavingsPlans, got.Service)
+	assert.Equal(t, spID, got.CommitmentID)
+	assert.Equal(t, spName, got.ResourceType)
+	assert.Equal(t, "Succeeded", got.State)
+	assert.Equal(t, amount, got.Cost)
+}
+
+func TestGetExistingCommitments_NilModel(t *testing.T) {
+	// A nil entry in the page should be skipped without panicking.
+	c := NewClient(nil, "sub", "eastus")
+	c.SetListAllPager(&mockListAllPager{results: []*armbillingbenefits.SavingsPlanModel{nil}})
+
+	commitments, err := c.GetExistingCommitments(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, commitments)
+}
+
+func TestGetExistingCommitments_PagerError(t *testing.T) {
+	c := NewClient(nil, "sub", "eastus")
+	c.SetListAllPager(&mockListAllPager{err: errors.New("api error")})
+
+	_, err := c.GetExistingCommitments(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "api error")
+}
+
+// --- PurchaseCommitment ---
+
+func makeRec(term string) common.Recommendation {
+	return common.Recommendation{
+		Term:          term,
+		PaymentOption: "No Upfront",
+		Details: &common.SavingsPlanDetails{
+			PlanType:         "Compute",
+			HourlyCommitment: 1.5,
+		},
+	}
+}
+
+func TestPurchaseCommitment_Success(t *testing.T) {
+	orderID := "/subscriptions/sub/providers/Microsoft.BillingBenefits/savingsPlanOrders/order1"
+	resp := armbillingbenefits.SavingsPlanOrderAliasClientCreateResponse{
+		SavingsPlanOrderAliasModel: armbillingbenefits.SavingsPlanOrderAliasModel{
+			ID: &orderID,
+		},
+	}
+
+	c := NewClient(nil, "sub", "eastus")
+	c.SetOrderAliasClient(&mockOrderAliasClient{
+		createPoller: &mockPoller{resp: resp},
+	})
+
+	result, err := c.PurchaseCommitment(context.Background(), makeRec("1yr"), common.PurchaseOptions{})
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+	assert.Equal(t, orderID, result.CommitmentID)
+}
+
+func TestPurchaseCommitment_BeginCreateError(t *testing.T) {
+	c := NewClient(nil, "sub", "eastus")
+	c.SetOrderAliasClient(&mockOrderAliasClient{createErr: errors.New("begin failed")})
+
+	result, err := c.PurchaseCommitment(context.Background(), makeRec("1yr"), common.PurchaseOptions{})
+	require.Error(t, err)
+	assert.False(t, result.Success)
+	assert.Contains(t, err.Error(), "begin failed")
+}
+
+func TestPurchaseCommitment_PollError(t *testing.T) {
+	c := NewClient(nil, "sub", "eastus")
+	c.SetOrderAliasClient(&mockOrderAliasClient{
+		createPoller: &mockPoller{err: errors.New("poll failed")},
+	})
+
+	result, err := c.PurchaseCommitment(context.Background(), makeRec("3yr"), common.PurchaseOptions{})
+	require.Error(t, err)
+	assert.False(t, result.Success)
+	assert.Contains(t, err.Error(), "poll failed")
+}
+
+func TestPurchaseCommitment_WrongDetails(t *testing.T) {
+	c := NewClient(nil, "sub", "eastus")
+	rec := common.Recommendation{Term: "1yr", Details: nil}
+
+	result, err := c.PurchaseCommitment(context.Background(), rec, common.PurchaseOptions{})
+	require.Error(t, err)
+	assert.False(t, result.Success)
+	assert.Contains(t, err.Error(), "invalid service details")
+}
+
+func TestPurchaseCommitment_BadTerm(t *testing.T) {
+	c := NewClient(nil, "sub", "eastus")
+	result, err := c.PurchaseCommitment(context.Background(), makeRec("99yr"), common.PurchaseOptions{})
+	require.Error(t, err)
+	assert.False(t, result.Success)
+}
+
+// --- ValidateOffering ---
+
+func TestValidateOffering_Valid(t *testing.T) {
+	valid := true
+	resp := armbillingbenefits.RPClientValidatePurchaseResponse{
+		SavingsPlanValidateResponse: armbillingbenefits.SavingsPlanValidateResponse{
+			Benefits: []*armbillingbenefits.SavingsPlanValidResponseProperty{
+				{Valid: &valid},
+			},
+		},
+	}
+
+	c := NewClient(nil, "sub", "eastus")
+	c.SetRPValidateClient(&mockRPValidate{resp: resp})
+
+	err := c.ValidateOffering(context.Background(), makeRec("1yr"))
+	assert.NoError(t, err)
+}
+
+func TestValidateOffering_Invalid(t *testing.T) {
+	valid := false
+	reason := "unsupported SKU"
+	resp := armbillingbenefits.RPClientValidatePurchaseResponse{
+		SavingsPlanValidateResponse: armbillingbenefits.SavingsPlanValidateResponse{
+			Benefits: []*armbillingbenefits.SavingsPlanValidResponseProperty{
+				{Valid: &valid, Reason: &reason},
+			},
+		},
+	}
+
+	c := NewClient(nil, "sub", "eastus")
+	c.SetRPValidateClient(&mockRPValidate{resp: resp})
+
+	err := c.ValidateOffering(context.Background(), makeRec("1yr"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported SKU")
+}
+
+func TestValidateOffering_APIError(t *testing.T) {
+	c := NewClient(nil, "sub", "eastus")
+	c.SetRPValidateClient(&mockRPValidate{err: errors.New("rp error")})
+
+	err := c.ValidateOffering(context.Background(), makeRec("1yr"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rp error")
+}
+
+func TestValidateOffering_WrongDetails(t *testing.T) {
+	c := NewClient(nil, "sub", "eastus")
+	rec := common.Recommendation{Term: "1yr", Details: nil}
+
+	err := c.ValidateOffering(context.Background(), rec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid service details")
+}
+
+// --- GetOfferingDetails ---
+
+func TestGetOfferingDetails_1yr_NoUpfront(t *testing.T) {
+	c := NewClient(nil, "sub", "eastus")
+	rec := common.Recommendation{
+		Term:          "1yr",
+		PaymentOption: "No Upfront",
+		Details:       &common.SavingsPlanDetails{PlanType: "Compute", HourlyCommitment: 1.0},
+	}
+
+	details, err := c.GetOfferingDetails(context.Background(), rec)
+	require.NoError(t, err)
+	require.NotNil(t, details)
+
+	assert.Equal(t, "1yr", details.Term)
+	assert.Equal(t, "No Upfront", details.PaymentOption)
+	assert.InDelta(t, 1.0, details.EffectiveHourlyRate, 0.001)
+	assert.InDelta(t, 8760.0, details.TotalCost, 0.001)
+	assert.Equal(t, 0.0, details.UpfrontCost)
+	assert.InDelta(t, 1.0, details.RecurringCost, 0.001)
+	assert.Equal(t, "USD", details.Currency)
+}
+
+func TestGetOfferingDetails_3yr_AllUpfront(t *testing.T) {
+	c := NewClient(nil, "sub", "eastus")
+	rec := common.Recommendation{
+		Term:          "3yr",
+		PaymentOption: "All Upfront",
+		Details:       &common.SavingsPlanDetails{PlanType: "Compute", HourlyCommitment: 1.0},
+	}
+
+	details, err := c.GetOfferingDetails(context.Background(), rec)
+	require.NoError(t, err)
+	require.NotNil(t, details)
+
+	assert.Equal(t, "3yr", details.Term)
+	assert.InDelta(t, 26280.0, details.UpfrontCost, 0.001)
+	assert.Equal(t, 0.0, details.RecurringCost)
+}
+
+func TestGetOfferingDetails_WrongDetails(t *testing.T) {
+	c := NewClient(nil, "sub", "eastus")
+	rec := common.Recommendation{Term: "1yr", Details: nil}
+
+	_, err := c.GetOfferingDetails(context.Background(), rec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid service details")
+}
+
+// --- toAzureTerm ---
+
+func TestToAzureTerm(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected armbillingbenefits.Term
+		wantErr  bool
+	}{
+		{"1yr", armbillingbenefits.TermP1Y, false},
+		{"1", armbillingbenefits.TermP1Y, false},
+		{"P1Y", armbillingbenefits.TermP1Y, false},
+		{"", armbillingbenefits.TermP1Y, false},
+		{"3yr", armbillingbenefits.TermP3Y, false},
+		{"3", armbillingbenefits.TermP3Y, false},
+		{"P3Y", armbillingbenefits.TermP3Y, false},
+		{"5yr", armbillingbenefits.TermP5Y, false},
+		{"P5Y", armbillingbenefits.TermP5Y, false},
+		{"99yr", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := toAzureTerm(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `providers/azure/services/savingsplans/` -- a new `provider.ServiceClient` for Azure Savings Plans backed by the `armbillingbenefits` v1 SDK. Implements all six interface methods: `GetRecommendations` (returns empty -- no stable Azure SP recommendations API exists yet, mirroring the AWS SP client pattern), `GetExistingCommitments` (lists via `SavingsPlanClient.NewListAllPager`), `PurchaseCommitment` (LRO via `SavingsPlanOrderAliasClient.BeginCreate`), `ValidateOffering` (`RPClient.ValidatePurchase`), `GetOfferingDetails`, `GetValidResourceTypes`.
- 32 unit tests with injected mock interfaces; all external API calls are behind interfaces.
- Wires `ServiceSavingsPlans` and `ServiceSearch` into `GetSupportedServices()` and `GetServiceClient()` in `provider.go`. The search client was already fully implemented but unreachable (dead-code bug in #473).
- Adds `NewSavingsPlansClient` and `NewSearchClient` factory functions to `services.go`.
- Adds `armbillingbenefits v1.0.0` to `providers/azure/go.mod` and root `go.mod`.

## Out of scope (follow-up issues filed below)

- Scheduler wiring for Azure SP rec collection
- Frontend column visibility / row rendering for Azure SP
- `commitmentopts` SP probe equivalent for Azure

## Test plan

- [x] `go test ./providers/azure/... ./providers/azure/services/savingsplans/` -- 384 passed
- [x] Pre-commit hooks pass (gofmt, go mod tidy, go vet, gocyclo, gosec, trivy)

refs #473

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Azure Savings Plans (view existing commitments, purchase plans, validate offerings, pricing details).
  * Added support for Azure Cognitive Search service.
* **Tests**
  * Added comprehensive unit tests covering Savings Plans behaviors (listing, purchase flows, validation, pricing calculations).
* **Chores**
  * Updated module dependency metadata to include new Azure SDK components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/592?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->