### PR TITLE
feat(azure/ri-exchange): list exchangeable Azure VM reservations (refs #473)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -124,6 +124,7 @@ require (
 	dario.cat/mergo v1.0.2 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal v0.7.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos/v2 v2.7.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/reservations/armreservations v1.1.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0 h1:PTFG
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0/go.mod h1:LRr2FzBTQlONPPa5HREE5+RjSCTXl7BwOvYOaWTqCaI=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3 v3.0.0 h1:zp+znRAHKLSewbw+WWKIMgCaFNxEXt9AwjxmW5fCnck=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3 v3.0.0/go.mod h1:nEvLUni7GO5ukfEYtmrUfz08Puqd2FP9d8sCZazm5W4=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/reservations/armreservations v1.1.0 h1:0OO/3K+SKt45gXiOU4gHRILOLeNOUZdqeNO47Mq6iN8=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/reservations/armreservations v1.1.0/go.mod h1:2FDnHkGwh1BFK1ZQt+iDJU47Cg9Y28F0W3FSI389NOA=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 h1:Dd+RhdJn0OTtVGaeDLZpcumkIVCtA/3/Fo42+eoYvVM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0/go.mod h1:5kakwfW5CjC9KK+Q4wjXAg+ShuIm2mBMua0ZFj2C8PE=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.3.0 h1:wxQx2Bt4xzPIKvW59WQf1tJNx/ZZKPfN+EhPX3Z6CYY=

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -71,6 +71,12 @@ type Handler struct {
 	reshapeEC2Factory  func(aws.Config) reshapeEC2Client
 	reshapeRecsFactory func(aws.Config) reshapeRecsClient
 
+	// Optional Azure exchange client factory injected by tests. When nil
+	// (the production default), buildAzureExchangeClient uses
+	// azidentity.NewDefaultAzureCredential to construct a real
+	// armreservations-backed client.
+	azureExchangeFactory func(subscriptionID string) azureExchangeClient
+
 	// Optional account-resolver injection point used by the reshape
 	// handler integration test. When nil (the production default), the
 	// handler calls h.resolveAWSCloudAccountID which in turn invokes

--- a/internal/api/handler_ri_exchange.go
+++ b/internal/api/handler_ri_exchange.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
@@ -21,6 +22,7 @@ import (
 	awsprovider "github.com/LeanerCloud/CUDly/providers/aws"
 	"github.com/LeanerCloud/CUDly/providers/aws/recommendations"
 	ec2svc "github.com/LeanerCloud/CUDly/providers/aws/services/ec2"
+	azurecompute "github.com/LeanerCloud/CUDly/providers/azure/services/compute"
 )
 
 // reshapeEC2Client is the narrow slice of the EC2 client that
@@ -62,6 +64,58 @@ func (h *Handler) buildReshapeRecsClient(cfg aws.Config) reshapeRecsClient {
 		return h.reshapeRecsFactory(cfg)
 	}
 	return awsprovider.NewRecommendationsClientDirect(cfg)
+}
+
+// azureExchangeClient is the narrow interface that listExchangeableAzureRIs
+// needs from the Azure compute client. Satisfied by
+// *azurecompute.ComputeClient; a stub can be injected via
+// Handler.azureExchangeFactory for tests.
+type azureExchangeClient interface {
+	ListExchangeableReservations(ctx context.Context) ([]azurecompute.ExchangeableReservation, error)
+}
+
+// buildAzureExchangeClient returns the injected factory result when one has
+// been set (test path), or constructs a real Azure compute client otherwise
+// (production path). Returns an error when the real Azure credential cannot
+// be obtained.
+func (h *Handler) buildAzureExchangeClient(subscriptionID string) (azureExchangeClient, error) {
+	if h.azureExchangeFactory != nil {
+		return h.azureExchangeFactory(subscriptionID), nil
+	}
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		return nil, fmt.Errorf("azure: obtain default credential: %w", err)
+	}
+	// Region is left empty -- ListExchangeableReservations uses the tenant-
+	// wide armreservations API which is not scoped to a region.
+	return azurecompute.NewClient(cred, subscriptionID, ""), nil
+}
+
+// listExchangeableAzureRIs returns all active Azure VM reservations that are
+// eligible for the cross-SKU/cross-region exchange flow (InstanceFlexibility
+// == On, ProvisioningState == Succeeded). Requires "view:purchases" permission.
+//
+// The optional ?subscription_id= query parameter scopes the client to a
+// specific subscription for the capacity-provider registration check; the
+// listing itself is tenant-wide.
+func (h *Handler) listExchangeableAzureRIs(ctx context.Context, req *events.LambdaFunctionURLRequest) (any, error) {
+	if _, err := h.requirePermission(ctx, req, "view", "purchases"); err != nil {
+		return nil, err
+	}
+
+	subscriptionID := req.QueryStringParameters["subscription_id"]
+
+	client, err := h.buildAzureExchangeClient(subscriptionID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build Azure exchange client: %w", err)
+	}
+
+	reservations, err := client.ListExchangeableReservations(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list exchangeable Azure reservations: %w", err)
+	}
+
+	return &ExchangeableAzureRIsResponse{Reservations: reservations}, nil
 }
 
 // getBaseAWSConfig returns the cached base AWS config, loading it once via sync.Once.
@@ -412,6 +466,12 @@ func (h *Handler) executeExchange(ctx context.Context, req *events.LambdaFunctio
 // ConvertibleRIsResponse holds the list of convertible RIs.
 type ConvertibleRIsResponse struct {
 	Instances []ec2svc.ConvertibleRI `json:"instances"`
+}
+
+// ExchangeableAzureRIsResponse holds the list of Azure VM reservations that
+// are eligible for the cross-SKU/cross-region exchange flow.
+type ExchangeableAzureRIsResponse struct {
+	Reservations []azurecompute.ExchangeableReservation `json:"reservations"`
 }
 
 // RIUtilizationResponse holds per-RI utilization data.

--- a/internal/api/handler_ri_exchange_test.go
+++ b/internal/api/handler_ri_exchange_test.go
@@ -2,12 +2,14 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/LeanerCloud/CUDly/internal/config"
 	"github.com/LeanerCloud/CUDly/providers/aws/recommendations"
 	ec2svc "github.com/LeanerCloud/CUDly/providers/aws/services/ec2"
+	azurecompute "github.com/LeanerCloud/CUDly/providers/azure/services/compute"
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/stretchr/testify/assert"
@@ -490,6 +492,116 @@ func TestGetReshapeRecommendations_EmptyRegionUsesConfigRegion(t *testing.T) {
 var _ = mock.Anything
 var _ = time.Now
 var _ = config.RIExchangeRecord{}
+
+// --- Azure exchangeable RI tests ---
+
+// stubAzureExchangeClient is a minimal implementation of azureExchangeClient
+// for unit tests.
+type stubAzureExchangeClient struct {
+	reservations []azurecompute.ExchangeableReservation
+	err          error
+}
+
+func (s *stubAzureExchangeClient) ListExchangeableReservations(_ context.Context) ([]azurecompute.ExchangeableReservation, error) {
+	return s.reservations, s.err
+}
+
+func TestListExchangeableAzureRIs_RequiresPermission(t *testing.T) {
+	h := &Handler{} // no auth configured
+	_, err := h.listExchangeableAzureRIs(context.Background(), &events.LambdaFunctionURLRequest{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "authentication")
+}
+
+func TestListExchangeableAzureRIs_EmptyList(t *testing.T) {
+	stub := &stubAzureExchangeClient{reservations: []azurecompute.ExchangeableReservation{}}
+	h := &Handler{
+		auth: &mockAuthForExchange{},
+		azureExchangeFactory: func(_ string) azureExchangeClient {
+			return stub
+		},
+	}
+
+	res, err := h.listExchangeableAzureRIs(context.Background(), &events.LambdaFunctionURLRequest{
+		Headers: map[string]string{"authorization": "Bearer test-token"},
+	})
+	require.NoError(t, err)
+	resp, ok := res.(*ExchangeableAzureRIsResponse)
+	require.True(t, ok)
+	assert.Empty(t, resp.Reservations)
+}
+
+func TestListExchangeableAzureRIs_PopulatedList(t *testing.T) {
+	want := []azurecompute.ExchangeableReservation{
+		{
+			ReservationOrderID:  "order-1111",
+			ReservationID:       "/providers/Microsoft.Capacity/reservationOrders/order-1111/reservations/res-aaaa",
+			SKU:                 "Standard_D2s_v3",
+			Quantity:            2,
+			Region:              "eastus",
+			Term:                "P1Y",
+			InstanceFlexibility: "On",
+			DisplayName:         "my-reservation",
+		},
+	}
+	stub := &stubAzureExchangeClient{reservations: want}
+	h := &Handler{
+		auth: &mockAuthForExchange{},
+		azureExchangeFactory: func(_ string) azureExchangeClient {
+			return stub
+		},
+	}
+
+	res, err := h.listExchangeableAzureRIs(context.Background(), &events.LambdaFunctionURLRequest{
+		Headers: map[string]string{"authorization": "Bearer test-token"},
+	})
+	require.NoError(t, err)
+	resp, ok := res.(*ExchangeableAzureRIsResponse)
+	require.True(t, ok)
+	require.Len(t, resp.Reservations, 1)
+	r := resp.Reservations[0]
+	assert.Equal(t, "order-1111", r.ReservationOrderID)
+	assert.Equal(t, "Standard_D2s_v3", r.SKU)
+	assert.Equal(t, int32(2), r.Quantity)
+	assert.Equal(t, "eastus", r.Region)
+	assert.Equal(t, "P1Y", r.Term)
+	assert.Equal(t, "On", r.InstanceFlexibility)
+}
+
+func TestListExchangeableAzureRIs_ClientError(t *testing.T) {
+	stub := &stubAzureExchangeClient{err: fmt.Errorf("azure api unavailable")}
+	h := &Handler{
+		auth: &mockAuthForExchange{},
+		azureExchangeFactory: func(_ string) azureExchangeClient {
+			return stub
+		},
+	}
+
+	_, err := h.listExchangeableAzureRIs(context.Background(), &events.LambdaFunctionURLRequest{
+		Headers: map[string]string{"authorization": "Bearer test-token"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "azure api unavailable")
+}
+
+func TestListExchangeableAzureRIs_SubscriptionIDPassedToFactory(t *testing.T) {
+	var capturedSubID string
+	stub := &stubAzureExchangeClient{reservations: []azurecompute.ExchangeableReservation{}}
+	h := &Handler{
+		auth: &mockAuthForExchange{},
+		azureExchangeFactory: func(subID string) azureExchangeClient {
+			capturedSubID = subID
+			return stub
+		},
+	}
+
+	_, err := h.listExchangeableAzureRIs(context.Background(), &events.LambdaFunctionURLRequest{
+		Headers:               map[string]string{"authorization": "Bearer test-token"},
+		QueryStringParameters: map[string]string{"subscription_id": "sub-abc"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "sub-abc", capturedSubID)
+}
 
 // mockAuthForExchange is a minimal auth mock that returns an admin session.
 type mockAuthForExchange struct{}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -257,6 +257,7 @@ func (r *Router) registerRoutes() {
 		// RI Exchange endpoints — GETs are AuthUser (Convertible RIs,
 		// Reshape Recommendations, Exchange History pages all need this);
 		// quote / execute / config writes stay AuthAdmin.
+		{ExactPath: "/api/ri-exchange/azure-instances", Method: "GET", Handler: r.listExchangeableAzureRIsHandler, Auth: AuthUser},
 		{ExactPath: "/api/ri-exchange/instances", Method: "GET", Handler: r.listConvertibleRIsHandler, Auth: AuthUser},
 		{ExactPath: "/api/ri-exchange/utilization", Method: "GET", Handler: r.getRIUtilizationHandler, Auth: AuthUser},
 		{ExactPath: "/api/ri-exchange/reshape-recommendations", Method: "GET", Handler: r.getReshapeRecommendationsHandler, Auth: AuthUser},
@@ -667,6 +668,10 @@ func (r *Router) docsHandler(ctx context.Context, req *events.LambdaFunctionURLR
 
 func (r *Router) listInventoryCommitmentsHandler(ctx context.Context, req *events.LambdaFunctionURLRequest, params map[string]string) (any, error) {
 	return r.h.listActiveCommitments(ctx, req, req.QueryStringParameters)
+}
+
+func (r *Router) listExchangeableAzureRIsHandler(ctx context.Context, req *events.LambdaFunctionURLRequest, params map[string]string) (any, error) {
+	return r.h.listExchangeableAzureRIs(ctx, req)
 }
 
 func (r *Router) listConvertibleRIsHandler(ctx context.Context, req *events.LambdaFunctionURLRequest, params map[string]string) (any, error) {

--- a/providers/azure/go.mod
+++ b/providers/azure/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/consumption/armconsumption v1.1.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos/v2 v2.7.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3 v3.0.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/reservations/armreservations v1.1.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/search/armsearch v1.4.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql v1.2.0

--- a/providers/azure/go.sum
+++ b/providers/azure/go.sum
@@ -22,6 +22,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v3 v3.1.0 h1:2qsI
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v3 v3.1.0/go.mod h1:AW8VEadnhw9xox+VaVd9sP7NjzOAnaZBLRH6Tq3cJ38=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3 v3.0.0 h1:zp+znRAHKLSewbw+WWKIMgCaFNxEXt9AwjxmW5fCnck=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3 v3.0.0/go.mod h1:nEvLUni7GO5ukfEYtmrUfz08Puqd2FP9d8sCZazm5W4=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/reservations/armreservations v1.1.0 h1:0OO/3K+SKt45gXiOU4gHRILOLeNOUZdqeNO47Mq6iN8=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/reservations/armreservations v1.1.0/go.mod h1:2FDnHkGwh1BFK1ZQt+iDJU47Cg9Y28F0W3FSI389NOA=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 h1:Dd+RhdJn0OTtVGaeDLZpcumkIVCtA/3/Fo42+eoYvVM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0/go.mod h1:5kakwfW5CjC9KK+Q4wjXAg+ShuIm2mBMua0ZFj2C8PE=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.3.0 h1:wxQx2Bt4xzPIKvW59WQf1tJNx/ZZKPfN+EhPX3Z6CYY=

--- a/providers/azure/services/compute/client.go
+++ b/providers/azure/services/compute/client.go
@@ -90,6 +90,12 @@ type ComputeClient struct {
 	// matches cache/cosmosdb/database from PR #81).
 	skuCacheOnce sync.Once
 	skuCacheMap  map[string]vmSKUEntry
+
+	// Optional injected pager for ListExchangeableReservations. When nil
+	// (the production default) the method creates a real
+	// armreservations.ReservationClient. Tests inject a stub to run
+	// hermetically without Azure credentials.
+	exchangeablePager ExchangeableReservationPager
 }
 
 // NewClient creates a new Azure Compute client

--- a/providers/azure/services/compute/exchange.go
+++ b/providers/azure/services/compute/exchange.go
@@ -1,0 +1,233 @@
+// Package compute provides Azure VM Reserved Instances client.
+// This file implements the "list exchangeable reservations" half of Azure
+// Convertible RI exchange parity with AWS EC2 (refs #473).
+//
+// Azure VM reservations are exchangeable when ALL of the following hold:
+//  1. ReservedResourceType == VirtualMachines
+//  2. ProvisioningState == Succeeded
+//  3. InstanceFlexibility == On  (nil or Off means the reservation is NOT
+//     eligible for the cross-SKU/cross-region exchange path)
+//
+// Listings use armreservations.ReservationClient.NewListAllPager which
+// enumerates all reservations across the tenant (not scoped to a single
+// subscription), matching what the Azure portal shows on the
+// "Reservations" blade.
+package compute
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/reservations/armreservations"
+)
+
+// ExchangeableReservation represents an Azure VM reservation that is
+// eligible for exchange.
+type ExchangeableReservation struct {
+	// ReservationOrderID is the GUID of the parent reservation order,
+	// parsed from the ARM resource ID. Required by CalculateExchange.
+	ReservationOrderID string `json:"reservation_order_id"`
+
+	// ReservationID is the full ARM resource ID of the reservation item,
+	// e.g. /providers/Microsoft.Capacity/reservationOrders/{orderID}/reservations/{resID}.
+	// Used as the source identifier in CalculateExchange.ReservationsToExchange.
+	ReservationID string `json:"reservation_id"`
+
+	// SKU is the VM size (e.g. "Standard_D2s_v3").
+	SKU string `json:"sku"`
+
+	// Quantity is the number of VM instances covered.
+	Quantity int32 `json:"quantity"`
+
+	// Region is the ARM region name (e.g. "eastus"). May be empty for
+	// reservations with AppliedScopeType == Shared.
+	Region string `json:"region,omitempty"`
+
+	// Term is the reservation term in ISO 8601 duration format ("P1Y" or "P3Y").
+	Term string `json:"term,omitempty"`
+
+	// ExpiryDate is when the reservation expires. Zero if not set by Azure.
+	ExpiryDate time.Time `json:"expiry_date,omitempty"`
+
+	// InstanceFlexibility reports the instance size flexibility setting.
+	// Always "On" for reservations returned by this function.
+	InstanceFlexibility string `json:"instance_flexibility"`
+
+	// DisplayName is the human-readable reservation name set at purchase time.
+	DisplayName string `json:"display_name,omitempty"`
+}
+
+// ExchangeableReservationPager defines the paging contract for listing
+// reservations. Satisfied by the pager returned from
+// armreservations.ReservationClient.NewListAllPager; a stub can be
+// injected for tests via SetExchangeablePager.
+//
+// Each page carries a ListResult whose Value slice holds
+// *armreservations.ReservationResponse items.
+type ExchangeableReservationPager interface {
+	More() bool
+	NextPage(ctx context.Context) (armreservations.ReservationClientListAllResponse, error)
+}
+
+// SetExchangeablePager injects a mock pager for unit tests. Tests call
+// this instead of providing real Azure credentials.
+func (c *ComputeClient) SetExchangeablePager(p ExchangeableReservationPager) {
+	c.exchangeablePager = p
+}
+
+// ListExchangeableReservations returns all active VM reservations in the
+// tenant that are eligible for exchange.
+//
+// Eligibility requires ProvisioningState == Succeeded AND
+// InstanceFlexibility == On. Reservations with nil InstanceFlexibility
+// or InstanceFlexibility == Off are excluded.
+//
+// The listing is tenant-wide (not scoped to c.subscriptionID) because
+// the Azure Capacity exchange API operates on reservation order IDs
+// which span subscriptions.
+//
+// Returns an empty non-nil slice when no eligible reservations are found.
+func (c *ComputeClient) ListExchangeableReservations(ctx context.Context) ([]ExchangeableReservation, error) {
+	pager, err := c.createExchangeablePager()
+	if err != nil {
+		return nil, fmt.Errorf("compute: list exchangeable reservations: create pager: %w", err)
+	}
+	return c.collectExchangeableReservations(ctx, pager)
+}
+
+// createExchangeablePager returns an injected mock pager when one has
+// been set via SetExchangeablePager, or constructs a real
+// armreservations.ReservationClient pager otherwise.
+func (c *ComputeClient) createExchangeablePager() (ExchangeableReservationPager, error) {
+	if c.exchangeablePager != nil {
+		return c.exchangeablePager, nil
+	}
+	client, err := armreservations.NewReservationClient(c.cred, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create armreservations client: %w", err)
+	}
+	return client.NewListAllPager(nil), nil
+}
+
+// collectExchangeableReservations iterates the pager and applies the
+// eligibility filter. Any pagination error is returned immediately
+// (partial results are unsafe -- a missing reservation could lead to a
+// duplicate exchange attempt upstream).
+func (c *ComputeClient) collectExchangeableReservations(ctx context.Context, pager ExchangeableReservationPager) ([]ExchangeableReservation, error) {
+	result := make([]ExchangeableReservation, 0)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("compute: list exchangeable reservations: page: %w", err)
+		}
+		for _, item := range page.ListResult.Value {
+			r := convertToExchangeableReservation(item)
+			if r != nil {
+				result = append(result, *r)
+			}
+		}
+	}
+	return result, nil
+}
+
+// isExchangeEligible reports whether the reservation passes the Azure
+// exchange eligibility criteria:
+//
+//   - ReservedResourceType == VirtualMachines
+//   - ProvisioningState == Succeeded
+//   - InstanceFlexibility == On  (nil is treated as Off)
+func isExchangeEligible(item *armreservations.ReservationResponse) bool {
+	if item == nil || item.Properties == nil {
+		return false
+	}
+	props := item.Properties
+	if props.ReservedResourceType == nil || *props.ReservedResourceType != armreservations.ReservedResourceTypeVirtualMachines {
+		return false
+	}
+	if props.ProvisioningState == nil || *props.ProvisioningState != armreservations.ProvisioningStateSucceeded {
+		return false
+	}
+	return props.InstanceFlexibility != nil && *props.InstanceFlexibility == armreservations.InstanceFlexibilityOn
+}
+
+// extractReservationFields reads the optional pointer fields from item and its
+// Properties, returning safe zero values for any nil pointers.
+func extractReservationFields(item *armreservations.ReservationResponse) (id, sku, region, term, displayName string, quantity int32, expiryDate time.Time) {
+	props := item.Properties // guaranteed non-nil by isExchangeEligible
+	if item.ID != nil {
+		id = *item.ID
+	}
+	if item.SKU != nil && item.SKU.Name != nil {
+		sku = *item.SKU.Name
+	}
+	if item.Location != nil {
+		region = *item.Location
+	}
+	if props.Quantity != nil {
+		quantity = *props.Quantity
+	}
+	if props.Term != nil {
+		term = string(*props.Term)
+	}
+	if props.ExpiryDate != nil {
+		expiryDate = *props.ExpiryDate
+	}
+	if props.DisplayName != nil {
+		displayName = *props.DisplayName
+	}
+	return
+}
+
+// convertToExchangeableReservation converts a single armreservations item
+// to the CUDly type, returning nil when the item fails the eligibility
+// criteria.
+func convertToExchangeableReservation(item *armreservations.ReservationResponse) *ExchangeableReservation {
+	if !isExchangeEligible(item) {
+		return nil
+	}
+	id, sku, region, term, displayName, quantity, expiryDate := extractReservationFields(item)
+	return &ExchangeableReservation{
+		ReservationOrderID:  parseReservationOrderID(id),
+		ReservationID:       id,
+		SKU:                 sku,
+		Quantity:            quantity,
+		Region:              region,
+		Term:                term,
+		ExpiryDate:          expiryDate,
+		InstanceFlexibility: string(armreservations.InstanceFlexibilityOn),
+		DisplayName:         displayName,
+	}
+}
+
+// parseReservationOrderID extracts the reservation order GUID from a
+// full ARM resource ID of the form:
+//
+//	/providers/Microsoft.Capacity/reservationOrders/{orderID}/reservations/{resID}
+//
+// Returns an empty string when the ID is blank or does not match the
+// expected format, rather than returning an error (graceful degradation --
+// the reservation is still returned with an empty order ID and the caller
+// can skip it for exchange operations that require the order ID).
+func parseReservationOrderID(resourceID string) string {
+	if resourceID == "" {
+		return ""
+	}
+	// Normalise to lower-case for case-insensitive segment matching.
+	lower := strings.ToLower(resourceID)
+	const marker = "/reservationorders/"
+	idx := strings.Index(lower, marker)
+	if idx < 0 {
+		return ""
+	}
+	rest := resourceID[idx+len(marker):]
+	// The next path segment is the order GUID; subsequent segments follow
+	// a "/" separator.
+	end := strings.IndexByte(rest, '/')
+	if end < 0 {
+		// Trailing segment -- the whole rest is the order ID.
+		return rest
+	}
+	return rest[:end]
+}

--- a/providers/azure/services/compute/exchange_test.go
+++ b/providers/azure/services/compute/exchange_test.go
@@ -1,0 +1,266 @@
+package compute_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/reservations/armreservations"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LeanerCloud/CUDly/providers/azure/services/compute"
+)
+
+// --- mock pager helpers ---
+
+// staticExchangeablePager returns the provided pages in order and then
+// reports More() == false. Used for all tests that don't need to exercise
+// error paths.
+type staticExchangeablePager struct {
+	pages []*armreservations.ListResult
+	idx   int
+}
+
+func (p *staticExchangeablePager) More() bool {
+	return p.idx < len(p.pages)
+}
+
+func (p *staticExchangeablePager) NextPage(_ context.Context) (armreservations.ReservationClientListAllResponse, error) {
+	if p.idx >= len(p.pages) {
+		return armreservations.ReservationClientListAllResponse{}, errors.New("no more pages")
+	}
+	lr := p.pages[p.idx]
+	p.idx++
+	resp := armreservations.ReservationClientListAllResponse{}
+	resp.ListResult = *lr
+	return resp, nil
+}
+
+// errorExchangeablePager always returns the provided error from NextPage.
+type errorExchangeablePager struct {
+	err error
+}
+
+func (p *errorExchangeablePager) More() bool { return true }
+func (p *errorExchangeablePager) NextPage(_ context.Context) (armreservations.ReservationClientListAllResponse, error) {
+	return armreservations.ReservationClientListAllResponse{}, p.err
+}
+
+// --- builders ---
+
+func provStateSuc() *armreservations.ProvisioningState {
+	s := armreservations.ProvisioningStateSucceeded
+	return &s
+}
+
+func provStatePend() *armreservations.ProvisioningState {
+	s := armreservations.ProvisioningStatePendingBilling
+	return &s
+}
+
+func ifOn() *armreservations.InstanceFlexibility {
+	v := armreservations.InstanceFlexibilityOn
+	return &v
+}
+
+func ifOff() *armreservations.InstanceFlexibility {
+	v := armreservations.InstanceFlexibilityOff
+	return &v
+}
+
+func resTypeVM() *armreservations.ReservedResourceType {
+	v := armreservations.ReservedResourceTypeVirtualMachines
+	return &v
+}
+
+func resTypeSQL() *armreservations.ReservedResourceType {
+	v := armreservations.ReservedResourceTypeSQLDatabases
+	return &v
+}
+
+func makeReservation(id, sku string, qty int32, provState *armreservations.ProvisioningState, resType *armreservations.ReservedResourceType, instanceFlex *armreservations.InstanceFlexibility) *armreservations.ReservationResponse {
+	return &armreservations.ReservationResponse{
+		ID:       to.Ptr(id),
+		Location: to.Ptr("eastus"),
+		SKU:      &armreservations.SKUName{Name: to.Ptr(sku)},
+		Properties: &armreservations.Properties{
+			ReservedResourceType: resType,
+			ProvisioningState:    provState,
+			InstanceFlexibility:  instanceFlex,
+			Quantity:             to.Ptr(qty),
+			DisplayName:          to.Ptr("test-reservation"),
+			Term:                 to.Ptr(armreservations.ReservationTermP1Y),
+			ExpiryDate:           to.Ptr(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)),
+		},
+	}
+}
+
+const vmID1 = "/providers/Microsoft.Capacity/reservationOrders/order-1111/reservations/res-aaaa"
+const vmID2 = "/providers/Microsoft.Capacity/reservationOrders/order-2222/reservations/res-bbbb"
+const sqlID = "/providers/Microsoft.Capacity/reservationOrders/order-3333/reservations/res-cccc"
+
+func newClient() *compute.ComputeClient {
+	// nil credential is fine -- tests inject a pager so no real API call
+	// is ever made.
+	return compute.NewClient(nil, "test-sub", "eastus")
+}
+
+// --- tests ---
+
+func TestListExchangeableReservations_Empty(t *testing.T) {
+	t.Parallel()
+	c := newClient()
+	c.SetExchangeablePager(&staticExchangeablePager{
+		pages: []*armreservations.ListResult{
+			{Value: []*armreservations.ReservationResponse{}},
+		},
+	})
+
+	result, err := c.ListExchangeableReservations(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestListExchangeableReservations_NonVMFiltered(t *testing.T) {
+	t.Parallel()
+	c := newClient()
+	c.SetExchangeablePager(&staticExchangeablePager{
+		pages: []*armreservations.ListResult{
+			{Value: []*armreservations.ReservationResponse{
+				makeReservation(sqlID, "Standard_D2s_v3", 1, provStateSuc(), resTypeSQL(), ifOn()),
+			}},
+		},
+	})
+
+	result, err := c.ListExchangeableReservations(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, result, "non-VM reservation must be filtered out")
+}
+
+func TestListExchangeableReservations_FlexOffFiltered(t *testing.T) {
+	t.Parallel()
+	c := newClient()
+	c.SetExchangeablePager(&staticExchangeablePager{
+		pages: []*armreservations.ListResult{
+			{Value: []*armreservations.ReservationResponse{
+				makeReservation(vmID1, "Standard_D2s_v3", 1, provStateSuc(), resTypeVM(), ifOff()),
+			}},
+		},
+	})
+
+	result, err := c.ListExchangeableReservations(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, result, "InstanceFlexibility==Off must be filtered out")
+}
+
+func TestListExchangeableReservations_NilFlexFiltered(t *testing.T) {
+	t.Parallel()
+	c := newClient()
+	c.SetExchangeablePager(&staticExchangeablePager{
+		pages: []*armreservations.ListResult{
+			{Value: []*armreservations.ReservationResponse{
+				makeReservation(vmID1, "Standard_D2s_v3", 1, provStateSuc(), resTypeVM(), nil),
+			}},
+		},
+	})
+
+	result, err := c.ListExchangeableReservations(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, result, "nil InstanceFlexibility must be filtered out")
+}
+
+func TestListExchangeableReservations_ProvisioningNotSucceededFiltered(t *testing.T) {
+	t.Parallel()
+	c := newClient()
+	c.SetExchangeablePager(&staticExchangeablePager{
+		pages: []*armreservations.ListResult{
+			{Value: []*armreservations.ReservationResponse{
+				makeReservation(vmID1, "Standard_D2s_v3", 1, provStatePend(), resTypeVM(), ifOn()),
+			}},
+		},
+	})
+
+	result, err := c.ListExchangeableReservations(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, result, "non-Succeeded provisioning state must be filtered out")
+}
+
+func TestListExchangeableReservations_EligibleIncluded(t *testing.T) {
+	t.Parallel()
+	c := newClient()
+	c.SetExchangeablePager(&staticExchangeablePager{
+		pages: []*armreservations.ListResult{
+			{Value: []*armreservations.ReservationResponse{
+				makeReservation(vmID1, "Standard_D2s_v3", 2, provStateSuc(), resTypeVM(), ifOn()),
+			}},
+		},
+	})
+
+	result, err := c.ListExchangeableReservations(context.Background())
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	r := result[0]
+	assert.Equal(t, "order-1111", r.ReservationOrderID)
+	assert.Equal(t, vmID1, r.ReservationID)
+	assert.Equal(t, "Standard_D2s_v3", r.SKU)
+	assert.Equal(t, int32(2), r.Quantity)
+	assert.Equal(t, "eastus", r.Region)
+	assert.Equal(t, "P1Y", r.Term)
+	assert.Equal(t, "On", r.InstanceFlexibility)
+	assert.Equal(t, "test-reservation", r.DisplayName)
+	assert.Equal(t, time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), r.ExpiryDate)
+}
+
+func TestListExchangeableReservations_MultiPage(t *testing.T) {
+	t.Parallel()
+	c := newClient()
+	c.SetExchangeablePager(&staticExchangeablePager{
+		pages: []*armreservations.ListResult{
+			{Value: []*armreservations.ReservationResponse{
+				makeReservation(vmID1, "Standard_D2s_v3", 1, provStateSuc(), resTypeVM(), ifOn()),
+			}},
+			{Value: []*armreservations.ReservationResponse{
+				makeReservation(vmID2, "Standard_F4s_v2", 3, provStateSuc(), resTypeVM(), ifOn()),
+			}},
+		},
+	})
+
+	result, err := c.ListExchangeableReservations(context.Background())
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+	assert.Equal(t, "order-1111", result[0].ReservationOrderID)
+	assert.Equal(t, "order-2222", result[1].ReservationOrderID)
+}
+
+func TestListExchangeableReservations_MixedEligibility(t *testing.T) {
+	t.Parallel()
+	c := newClient()
+	c.SetExchangeablePager(&staticExchangeablePager{
+		pages: []*armreservations.ListResult{
+			{Value: []*armreservations.ReservationResponse{
+				makeReservation(vmID1, "Standard_D2s_v3", 1, provStateSuc(), resTypeVM(), ifOn()),  // eligible
+				makeReservation(sqlID, "Standard_D2s_v3", 1, provStateSuc(), resTypeSQL(), ifOn()), // not VM
+				makeReservation(vmID2, "Standard_F4s_v2", 2, provStateSuc(), resTypeVM(), ifOff()), // flex off
+			}},
+		},
+	})
+
+	result, err := c.ListExchangeableReservations(context.Background())
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, vmID1, result[0].ReservationID)
+}
+
+func TestListExchangeableReservations_PagerError(t *testing.T) {
+	t.Parallel()
+	c := newClient()
+	wantErr := errors.New("azure api error")
+	c.SetExchangeablePager(&errorExchangeablePager{err: wantErr})
+
+	_, err := c.ListExchangeableReservations(context.Background())
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "azure api error")
+}


### PR DESCRIPTION
## Summary

- Adds `ListExchangeableReservations` to the Azure compute client, filtering tenant-wide VM reservations to those with `ProvisioningState==Succeeded` and `InstanceFlexibility==On` (the Azure exchange eligibility criteria)
- Wires a new `GET /api/ri-exchange/azure-instances` route protected by `view:purchases` permission; accepts optional `?subscription_id=` query parameter
- Covers both layers with unit tests using injected stubs -- no live Azure credentials needed in CI

This is the list half of Azure Convertible RI exchange parity. The find-compatible-offerings (CalculateExchange) and execute steps are tracked in a follow-up issue.

## Test plan

- [x] `providers/azure` module: `go test ./...` -- 361 pass
- [x] `internal/api` package: `go test ./internal/api/...` -- 1158 pass
- [x] Pre-commit hooks pass (gofmt, go vet, go mod tidy, gocyclo, gosec, trivy)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new REST API endpoint enabling users to query and list exchangeable Azure reserved instances with optional subscription ID filtering.
  * Integrated Azure reserved instances exchange functionality to retrieve and display instance eligibility information based on provisioning status and configuration requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/595?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->