### PR TITLE
fix(providers/aws): use canonical EC2 RI enum casing for Tenancy + Scope (closes #598)

### DIFF
--- a/providers/aws/recommendations/parser_services.go
+++ b/providers/aws/recommendations/parser_services.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/costexplorer/types"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 
 	"github.com/LeanerCloud/CUDly/pkg/common"
 )
@@ -85,16 +86,21 @@ func (c *Client) parseEC2Details(rec *common.Recommendation, details *types.Rese
 	if ec2Details.Region != nil {
 		rec.Region = normalizeRegionName(*ec2Details.Region)
 	}
-	if ec2Details.Tenancy != nil {
-		ec2Info.Tenancy = *ec2Details.Tenancy
+	// Tenancy: CE returns "shared" for default tenancy; the EC2 RI filter API
+	// expects "default" (types.TenancyDefault). CE "dedicated" maps directly.
+	// Any nil or unrecognised value is treated as default.
+	if ec2Details.Tenancy != nil && *ec2Details.Tenancy == "dedicated" {
+		ec2Info.Tenancy = string(ec2types.TenancyDedicated)
 	} else {
-		ec2Info.Tenancy = "shared"
+		ec2Info.Tenancy = string(ec2types.TenancyDefault)
 	}
 
+	// Scope: the EC2 RI filter API expects "Region" (types.ScopeRegional) or
+	// "Availability Zone" (types.ScopeAvailabilityZone) - not lowercase/hyphenated.
 	if ec2Details.AvailabilityZone != nil && *ec2Details.AvailabilityZone != "" {
-		ec2Info.Scope = "availability-zone"
+		ec2Info.Scope = string(ec2types.ScopeAvailabilityZone)
 	} else {
-		ec2Info.Scope = "region"
+		ec2Info.Scope = string(ec2types.ScopeRegional)
 	}
 
 	rec.Details = ec2Info

--- a/providers/aws/recommendations/parser_services_test.go
+++ b/providers/aws/recommendations/parser_services_test.go
@@ -205,7 +205,10 @@ func TestParseEC2Details(t *testing.T) {
 		validate    func(t *testing.T, rec *common.Recommendation)
 	}{
 		{
-			name: "Complete EC2 details with AZ scope",
+			// CE returns Tenancy="shared" for default; parser must normalise to
+			// the EC2 API canonical value "default" (types.TenancyDefault).
+			// Scope with an AZ must be "Availability Zone" (types.ScopeAvailabilityZone).
+			name: "Complete EC2 details with AZ scope, CE tenancy=shared",
 			details: &types.ReservationPurchaseRecommendationDetail{
 				InstanceDetails: &types.InstanceDetails{
 					EC2InstanceDetails: &types.EC2InstanceDetails{
@@ -226,8 +229,10 @@ func TestParseEC2Details(t *testing.T) {
 				require.True(t, ok, "Details should be ComputeDetails type")
 				assert.Equal(t, "m5.large", ec2Details.InstanceType)
 				assert.Equal(t, "Linux/UNIX", ec2Details.Platform)
-				assert.Equal(t, "shared", ec2Details.Tenancy)
-				assert.Equal(t, "availability-zone", ec2Details.Scope)
+				// CE "shared" must be written as EC2 API canonical "default"
+				assert.Equal(t, "default", ec2Details.Tenancy)
+				// AZ present -> "Availability Zone" (not "availability-zone")
+				assert.Equal(t, "Availability Zone", ec2Details.Scope)
 			},
 		},
 		{
@@ -247,7 +252,8 @@ func TestParseEC2Details(t *testing.T) {
 			validate: func(t *testing.T, rec *common.Recommendation) {
 				ec2Details, ok := rec.Details.(*common.ComputeDetails)
 				require.True(t, ok)
-				assert.Equal(t, "region", ec2Details.Scope)
+				// No AZ -> "Region" (not "region")
+				assert.Equal(t, "Region", ec2Details.Scope)
 			},
 		},
 		{
@@ -267,7 +273,8 @@ func TestParseEC2Details(t *testing.T) {
 			validate: func(t *testing.T, rec *common.Recommendation) {
 				ec2Details, ok := rec.Details.(*common.ComputeDetails)
 				require.True(t, ok)
-				assert.Equal(t, "region", ec2Details.Scope)
+				// Empty AZ string treated same as nil -> "Region"
+				assert.Equal(t, "Region", ec2Details.Scope)
 			},
 		},
 		{
@@ -288,11 +295,14 @@ func TestParseEC2Details(t *testing.T) {
 				ec2Details, ok := rec.Details.(*common.ComputeDetails)
 				require.True(t, ok)
 				assert.Equal(t, "Windows", ec2Details.Platform)
+				// "dedicated" is already the canonical EC2 API value
 				assert.Equal(t, "dedicated", ec2Details.Tenancy)
 			},
 		},
 		{
-			name: "EC2 without tenancy defaults to shared",
+			// nil Tenancy in CE response must yield EC2 API canonical "default"
+			// (not "shared" as the old parser wrote).
+			name: "EC2 without tenancy defaults to default",
 			details: &types.ReservationPurchaseRecommendationDetail{
 				InstanceDetails: &types.InstanceDetails{
 					EC2InstanceDetails: &types.EC2InstanceDetails{
@@ -307,7 +317,7 @@ func TestParseEC2Details(t *testing.T) {
 			validate: func(t *testing.T, rec *common.Recommendation) {
 				ec2Details, ok := rec.Details.(*common.ComputeDetails)
 				require.True(t, ok)
-				assert.Equal(t, "shared", ec2Details.Tenancy)
+				assert.Equal(t, "default", ec2Details.Tenancy)
 			},
 		},
 		{

--- a/providers/aws/services/ec2/client.go
+++ b/providers/aws/services/ec2/client.go
@@ -197,19 +197,64 @@ func (c *Client) tagReservedInstance(ctx context.Context, riID string, rec commo
 	})
 }
 
+// canonicalizeEC2Tenancy maps legacy lowercase/hyphenated tenancy values that
+// were written by parser versions before fix #598 to the canonical EC2 API enum
+// values. New parser output already carries the correct casing, so this is a
+// defensive shim for pre-fix-collected recommendations persisted in the DB.
+//
+// Canonical mappings (per types.Tenancy in the AWS SDK):
+//
+//	"shared"    -> "default"  (CE-to-EC2 mismatch that the old parser passed through)
+//	"default"   -> "default"  (already canonical; no-op)
+//	"dedicated" -> "dedicated" (already canonical; no-op)
+func canonicalizeEC2Tenancy(t string) string {
+	switch strings.ToLower(t) {
+	case "shared", "default":
+		return string(types.TenancyDefault)
+	case "dedicated":
+		return string(types.TenancyDedicated)
+	default:
+		return t
+	}
+}
+
+// canonicalizeEC2Scope maps legacy lowercase/hyphenated scope values that were
+// written by parser versions before fix #598 to the canonical EC2 API enum
+// values. New parser output already carries the correct casing.
+//
+// Canonical mappings (per types.Scope in the AWS SDK):
+//
+//	"region"            -> "Region"           (lowercase, old parser)
+//	"availability-zone" -> "Availability Zone" (hyphenated, old parser)
+//	"Region"            -> "Region"            (no-op)
+//	"Availability Zone" -> "Availability Zone" (no-op)
+func canonicalizeEC2Scope(s string) string {
+	switch strings.ToLower(s) {
+	case "region":
+		return string(types.ScopeRegional)
+	case "availability-zone", "availability zone":
+		return string(types.ScopeAvailabilityZone)
+	default:
+		return s
+	}
+}
+
 // buildOfferingFilters constructs the EC2 API filters for finding an RI offering.
 func (c *Client) buildOfferingFilters(rec common.Recommendation, details *common.ComputeDetails) []types.Filter {
 	platform := details.Platform
 	if platform == "" {
 		platform = "Linux/UNIX"
 	}
-	tenancy := details.Tenancy
+	// Canonicalize tenancy and scope: new recs from parser>=fix/598 already carry
+	// the correct casing; older persisted recs carry lowercase/hyphenated values
+	// that the AWS RI filter API rejects. The helpers are no-ops for canonical values.
+	tenancy := canonicalizeEC2Tenancy(details.Tenancy)
 	if tenancy == "" {
-		tenancy = "default"
+		tenancy = string(types.TenancyDefault)
 	}
-	scope := details.Scope
+	scope := canonicalizeEC2Scope(details.Scope)
 	if scope == "" {
-		scope = "Region"
+		scope = string(types.ScopeRegional)
 	}
 
 	return []types.Filter{

--- a/providers/aws/services/ec2/client_test.go
+++ b/providers/aws/services/ec2/client_test.go
@@ -516,3 +516,143 @@ func TestClient_GetDurationValue(t *testing.T) {
 		})
 	}
 }
+
+// TestCanonicalizeEC2Tenancy verifies that legacy lowercase/hyphenated tenancy
+// values written by pre-fix/598 parser versions are mapped to the canonical EC2
+// API enum values so that already-persisted recommendations still purchase correctly.
+func TestCanonicalizeEC2Tenancy(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		// Legacy values from the old parser (CE "shared" passed through as-is)
+		{"legacy shared -> default", "shared", "default"},
+		// Already-canonical values must pass through unchanged
+		{"canonical default -> default", "default", "default"},
+		{"canonical dedicated -> dedicated", "dedicated", "dedicated"},
+		// Mixed-case inputs should also normalise
+		{"uppercase SHARED -> default", "SHARED", "default"},
+		{"uppercase DEFAULT -> default", "DEFAULT", "default"},
+		{"uppercase DEDICATED -> dedicated", "DEDICATED", "dedicated"},
+		// Unknown values are returned unchanged (defensive)
+		{"unknown host passthrough", "host", "host"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := canonicalizeEC2Tenancy(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestCanonicalizeEC2Scope verifies that legacy lowercase/hyphenated scope
+// values written by pre-fix/598 parser versions are mapped to the canonical EC2
+// API enum values so that already-persisted recommendations still purchase correctly.
+func TestCanonicalizeEC2Scope(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		// Legacy values from the old parser
+		{"legacy region -> Region", "region", "Region"},
+		{"legacy availability-zone -> Availability Zone", "availability-zone", "Availability Zone"},
+		// Already-canonical values must pass through unchanged
+		{"canonical Region -> Region", "Region", "Region"},
+		{"canonical Availability Zone -> Availability Zone", "Availability Zone", "Availability Zone"},
+		// Space-separated variant (defensive)
+		{"lowercase availability zone -> Availability Zone", "availability zone", "Availability Zone"},
+		// Unknown values are returned unchanged (defensive)
+		{"unknown passthrough", "unknown-scope", "unknown-scope"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := canonicalizeEC2Scope(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestBuildOfferingFilters_LegacyCanonicalization verifies that buildOfferingFilters
+// canonicalizes legacy tenancy and scope values from pre-fix/598 persisted recs
+// so that DescribeReservedInstancesOfferings returns matches instead of zero results.
+func TestBuildOfferingFilters_LegacyCanonicalization(t *testing.T) {
+	t.Parallel()
+	client := &Client{region: "us-east-1"}
+
+	tests := []struct {
+		name        string
+		tenancy     string
+		scope       string
+		wantTenancy string
+		wantScope   string
+	}{
+		{
+			name:        "legacy shared+region -> default+Region",
+			tenancy:     "shared",
+			scope:       "region",
+			wantTenancy: "default",
+			wantScope:   "Region",
+		},
+		{
+			name:        "legacy availability-zone -> Availability Zone",
+			tenancy:     "default",
+			scope:       "availability-zone",
+			wantTenancy: "default",
+			wantScope:   "Availability Zone",
+		},
+		{
+			name:        "canonical values pass through unchanged",
+			tenancy:     "default",
+			scope:       "Region",
+			wantTenancy: "default",
+			wantScope:   "Region",
+		},
+		{
+			name:        "dedicated tenancy canonical",
+			tenancy:     "dedicated",
+			scope:       "Availability Zone",
+			wantTenancy: "dedicated",
+			wantScope:   "Availability Zone",
+		},
+		{
+			name:        "empty tenancy and scope use defaults",
+			tenancy:     "",
+			scope:       "",
+			wantTenancy: "default",
+			wantScope:   "Region",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := common.Recommendation{
+				ResourceType:  "m5.large",
+				PaymentOption: "all-upfront",
+				Term:          "1yr",
+			}
+			details := &common.ComputeDetails{
+				Platform: "Linux/UNIX",
+				Tenancy:  tt.tenancy,
+				Scope:    tt.scope,
+			}
+
+			filters := client.buildOfferingFilters(rec, details)
+
+			filterMap := make(map[string]string)
+			for _, f := range filters {
+				if f.Name != nil && len(f.Values) > 0 {
+					filterMap[*f.Name] = f.Values[0]
+				}
+			}
+
+			assert.Equal(t, tt.wantTenancy, filterMap["instance-tenancy"], "tenancy filter mismatch")
+			assert.Equal(t, tt.wantScope, filterMap["scope"], "scope filter mismatch")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `parseEC2Details` was writing `Tenancy="shared"` and `Scope="region"`/`"availability-zone"` - values that the AWS EC2 `DescribeReservedInstancesOfferings` filter API silently rejects, returning zero results and causing a "no offerings found" error for every dedicated-tenancy or AZ-scoped EC2 RI purchase.
- Fixed to write the SDK-canonical values: `Tenancy="default"` (`types.TenancyDefault`), `Scope="Region"` (`types.ScopeRegional`), `Scope="Availability Zone"` (`types.ScopeAvailabilityZone`).
- Added a defensive read-side canonicalizer in `buildOfferingFilters` so recommendations already persisted in the DB with the old parser values continue to purchase correctly without a re-collection.

## What changed

**`providers/aws/recommendations/parser_services.go`**
- `parseEC2Details`: CE `Tenancy=nil` or `"shared"` -> `"default"`; CE `Tenancy="dedicated"` -> `"dedicated"`. No-AZ -> `"Region"`; AZ present -> `"Availability Zone"`. Uses `ec2/types` constants directly so future SDK enum changes stay in sync.

**`providers/aws/services/ec2/client.go`**
- `canonicalizeEC2Tenancy`: maps `"shared"` and `"default"` (case-insensitive) -> `"default"`, `"dedicated"` -> `"dedicated"`.
- `canonicalizeEC2Scope`: maps `"region"` -> `"Region"`, `"availability-zone"` -> `"Availability Zone"`.
- `buildOfferingFilters`: applies the canonicalize helpers before building the AWS API filter; handles empty values with the same defaults as before.

## Why it matters

Every EC2 RI purchase for a dedicated-tenancy or AZ-scoped recommendation would fail at `findOfferingID` with "no offerings found", even though the offering exists. The wrong filter value causes AWS to return an empty result set.

## Test plan

- [x] `TestParseEC2Details`: nil Tenancy -> `"default"`, CE `"shared"` -> `"default"`, `"dedicated"` -> `"dedicated"`, nil AZ -> `"Region"`, AZ present -> `"Availability Zone"`
- [x] `TestCanonicalizeEC2Tenancy`: table-driven, all legacy->canonical mappings + case-insensitivity
- [x] `TestCanonicalizeEC2Scope`: table-driven, all legacy->canonical mappings
- [x] `TestBuildOfferingFilters_LegacyCanonicalization`: end-to-end filter construction with legacy values
- [x] Full `./providers/aws/...` suite: 668 tests pass

## Notes

Visible end-user impact requires #597 (frontend `details` round-trip) to also land. This fix is independent and can merge first; the two PRs do not conflict on any file.

Closes #598
Refs #597


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved EC2 Reserved Instance recommendation filtering accuracy by fixing tenancy and scope value normalization.
  * Enhanced handling of legacy recommendation data for improved AWS API compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/599?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->