### PR TITLE
fix(frontend/api): preserve details + engine on purchase POST (closes #597)

### DIFF
--- a/frontend/src/__tests__/purchase-execution-toast.test.ts
+++ b/frontend/src/__tests__/purchase-execution-toast.test.ts
@@ -273,6 +273,87 @@ describe('handleExecutePurchase — single-record path', () => {
     expect(lastToastKind()).toBe('error');
     expect(archera.openArcheraOfferModal).not.toHaveBeenCalled();
   });
+
+  // Issue #597: details must be preserved in the POST body on the single-rec path.
+  test('#597 single-rec — details blob preserved for EC2 Windows rec', async () => {
+    const windowsDetails = { platform: 'Windows', tenancy: 'dedicated', scope: 'Region' };
+    (recs.getPurchaseModalRecommendations as jest.Mock).mockReturnValue([
+      {
+        id: 'rec-win-single',
+        provider: 'aws' as const,
+        service: 'ec2',
+        region: 'us-east-1',
+        resource_type: 'm5.xlarge',
+        engine: undefined,
+        details: windowsDetails,
+        count: 1,
+        term: 1,
+        payment: 'all-upfront',
+        upfront_cost: 400,
+        monthly_cost: 40,
+        savings: 80,
+      },
+    ]);
+
+    (api.executePurchase as jest.Mock).mockResolvedValue({
+      execution_id: 'exec-win-single',
+      status: 'queued',
+      email_sent: true,
+      approval_recipient: 'approver@example.com',
+    });
+
+    const btn = setup();
+    btn.click();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(api.executePurchase).toHaveBeenCalledTimes(1);
+    const [submittedRecs] = (api.executePurchase as jest.Mock).mock.calls[0] as [
+      Array<{ details?: unknown }>,
+      number,
+    ];
+    expect(submittedRecs[0]?.details).toEqual(windowsDetails);
+  });
+
+  // Issue #597: details must be preserved in the POST body on the single-rec path.
+  test('#597 single-rec — details blob preserved for RDS Postgres rec', async () => {
+    const rdsDetails = { engine: 'postgres', multi_az: false };
+    (recs.getPurchaseModalRecommendations as jest.Mock).mockReturnValue([
+      {
+        id: 'rec-rds-single',
+        provider: 'aws' as const,
+        service: 'rds',
+        region: 'ap-southeast-1',
+        resource_type: 'db.r5.large',
+        engine: 'postgres',
+        details: rdsDetails,
+        count: 1,
+        term: 3,
+        payment: 'no-upfront',
+        upfront_cost: 0,
+        monthly_cost: 120,
+        savings: 90,
+      },
+    ]);
+
+    (api.executePurchase as jest.Mock).mockResolvedValue({
+      execution_id: 'exec-rds-single',
+      status: 'queued',
+      email_sent: true,
+      approval_recipient: 'approver@example.com',
+    });
+
+    const btn = setup();
+    btn.click();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(api.executePurchase).toHaveBeenCalledTimes(1);
+    const [submittedRecs] = (api.executePurchase as jest.Mock).mock.calls[0] as [
+      Array<{ details?: unknown; engine?: string }>,
+      number,
+    ];
+    expect(submittedRecs[0]?.details).toEqual(rdsDetails);
+    expect(submittedRecs[0]?.engine).toBe('postgres');
+  });
 });
 
 describe('handleFanOutExecute — fan-out path', () => {
@@ -479,5 +560,104 @@ describe('handleFanOutExecute — fan-out path', () => {
 
     expect(archera.openArcheraOfferModal).toHaveBeenCalledTimes(1);
     expect(archera.openArcheraOfferModal).toHaveBeenCalledWith('purchase');
+  });
+
+  // Issue #597: details must be preserved in the POST body on the fan-out path.
+  // Windows EC2 rec with a non-trivial details blob.
+  test('#597 fan-out — details blob preserved for EC2 Windows rec', async () => {
+    const windowsDetails = { platform: 'Windows', tenancy: 'default', scope: 'Region' };
+    (recs.getFanOutBuckets as jest.Mock).mockReturnValue([
+      {
+        key: 'key-win',
+        label: 'Windows EC2',
+        payment: 'all-upfront' as const,
+        capacityPercent: 100,
+        recs: [
+          {
+            id: 'rec-win-1',
+            provider: 'aws' as const,
+            service: 'ec2',
+            region: 'us-east-1',
+            resource_type: 'm5.large',
+            engine: undefined,
+            details: windowsDetails,
+            count: 2,
+            term: 1,
+            payment: 'all-upfront',
+            upfront_cost: 500,
+            monthly_cost: 50,
+            savings: 100,
+          },
+        ],
+      },
+    ]);
+
+    (api.executePurchase as jest.Mock).mockResolvedValueOnce({
+      execution_id: 'exec-win',
+      status: 'queued',
+      email_sent: true,
+      approval_recipient: 'approver@example.com',
+    });
+
+    const btn = setup();
+    btn.click();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(api.executePurchase).toHaveBeenCalledTimes(1);
+    const [submittedRecs] = (api.executePurchase as jest.Mock).mock.calls[0] as [
+      Array<{ details?: unknown }>,
+      number,
+    ];
+    expect(submittedRecs[0]?.details).toEqual(windowsDetails);
+  });
+
+  // Issue #597: details must be preserved in the POST body on the fan-out path.
+  // RDS Postgres rec.
+  test('#597 fan-out — details blob preserved for RDS Postgres rec', async () => {
+    const postgresDetails = { engine: 'postgres', multi_az: true };
+    (recs.getFanOutBuckets as jest.Mock).mockReturnValue([
+      {
+        key: 'key-rds',
+        label: 'RDS Postgres',
+        payment: 'partial-upfront' as const,
+        capacityPercent: 100,
+        recs: [
+          {
+            id: 'rec-rds-1',
+            provider: 'aws' as const,
+            service: 'rds',
+            region: 'eu-west-1',
+            resource_type: 'db.t3.medium',
+            engine: 'postgres',
+            details: postgresDetails,
+            count: 1,
+            term: 1,
+            payment: 'partial-upfront',
+            upfront_cost: 300,
+            monthly_cost: 80,
+            savings: 60,
+          },
+        ],
+      },
+    ]);
+
+    (api.executePurchase as jest.Mock).mockResolvedValueOnce({
+      execution_id: 'exec-rds',
+      status: 'queued',
+      email_sent: true,
+      approval_recipient: 'approver@example.com',
+    });
+
+    const btn = setup();
+    btn.click();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(api.executePurchase).toHaveBeenCalledTimes(1);
+    const [submittedRecs] = (api.executePurchase as jest.Mock).mock.calls[0] as [
+      Array<{ details?: unknown; engine?: string }>,
+      number,
+    ];
+    expect(submittedRecs[0]?.details).toEqual(postgresDetails);
+    expect(submittedRecs[0]?.engine).toBe('postgres');
   });
 });

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -89,6 +89,14 @@ export interface Recommendation {
   region: string;
   resource_type: string;
   engine?: string;
+  // Opaque ServiceDetails payload from the backend (json.RawMessage).
+  // The frontend treats this as a pass-through blob: it is stashed when
+  // the GET /api/recommendations response is parsed and forwarded unchanged
+  // in the POST /api/purchases/execute body so the backend can reconstruct
+  // the correct typed *Details pointer (Platform, Tenancy, Scope, Engine
+  // etc.) for each cloud service client. Absent on pre-#597 cached rows;
+  // those fall back to zero-valued defaults on the backend. See #597, #453.
+  details?: unknown;
   count: number;
   term: number;
   payment: string;

--- a/frontend/src/app.ts
+++ b/frontend/src/app.ts
@@ -315,27 +315,21 @@ async function handleExecutePurchase(): Promise<void> {
   });
   if (!ok) return;
 
-  // Map LocalRecommendation to API Recommendation format. The counts +
-  // costs here are already scaled by the bulk-toolbar's capacity % so
-  // the backend records exactly what the user saw in the preview.
-  // Issue #111 (iii): payment now reads `r.payment` (set by
-  // `openPurchaseModal`'s per-row seed and live edits), replacing the
-  // historical hardcoded 'all-upfront' that silently dropped the
-  // toolbar's Payment for the single-bucket path. The `?? 'all-upfront'`
-  // is defensive only — direct test-harness callers that bypass the
-  // modal may not set `payment`; the production path always does.
+  // Build the POST body recs by spreading the server-provided rec so that
+  // all fields (including `details`, `engine`, `cloud_account_id`, and any
+  // future additions) flow through unchanged. Only `payment`, `selected`,
+  // and `purchased` are overridden: `payment` uses the user-edited value
+  // (issue #111), and `selected`/`purchased` are forced to the canonical
+  // purchase-intent values. The `?? 'all-upfront'` on payment is defensive
+  // only — direct test-harness callers that bypass the modal may not set
+  // `payment`; the production path always does. Passing `details` ensures
+  // Windows EC2, dedicated-tenancy, AZ-scoped RIs, and non-default-engine
+  // RDS/Cache recs reach the backend with the correct ServiceDetails payload
+  // instead of falling back to Linux/regional/default (issue #597).
   const apiRecs: api.Recommendation[] = localRecs.map((r) => ({
-    id: r.id,
-    provider: r.provider,
-    service: r.service,
-    region: r.region,
-    resource_type: r.resource_type,
-    count: r.count,
-    term: r.term,
-    payment: r.payment ?? 'all-upfront',
-    upfront_cost: r.upfront_cost,
+    ...r,
     monthly_cost: r.monthly_cost ?? null,
-    savings: r.savings,
+    payment: r.payment ?? 'all-upfront',
     selected: true,
     purchased: false,
   }));
@@ -433,21 +427,21 @@ async function handleFanOutExecute(buckets: FanOutBucket[]): Promise<void> {
 
   // Fire all POSTs in parallel via allSettled so one failure doesn't
   // cascade. Each bucket's recs are already scaled by its capacity %;
-  // the POST body records capacity_percent for audit.
+  // the POST body records capacity_percent for audit. Spread the full
+  // server-provided rec so `details`, `engine`, `cloud_account_id`, and
+  // any future additions flow through unchanged. Only `payment`,
+  // `monthly_cost`, `selected`, and `purchased` are overridden: `payment`
+  // comes from the bucket (user's per-bucket choice), `monthly_cost` is
+  // coerced to null for absent values, and the purchase-intent flags are
+  // forced to their canonical values. Passing `details` ensures
+  // non-default platforms (Windows EC2, dedicated tenancy, AZ-scoped RIs,
+  // non-default-engine RDS/Cache) reach the backend correctly (issue #597).
   const promises = buckets.map((b) =>
     api.executePurchase(
       b.recs.map((r) => ({
-        id: r.id,
-        provider: r.provider,
-        service: r.service,
-        region: r.region,
-        resource_type: r.resource_type,
-        count: r.count,
-        term: r.term,
-        payment: b.payment,
-        upfront_cost: r.upfront_cost,
+        ...r,
         monthly_cost: r.monthly_cost ?? null,
-        savings: r.savings,
+        payment: b.payment,
         selected: true,
         purchased: false,
       })),

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -62,6 +62,12 @@ export interface LocalRecommendation {
   service: string;
   resource_type: string;
   engine?: string;
+  // Opaque ServiceDetails payload from the backend (json.RawMessage).
+  // Stashed when the GET /api/recommendations response is parsed and
+  // forwarded unchanged in the POST /api/purchases/execute body so the
+  // backend can reconstruct the correct typed *Details pointer. Absent
+  // on pre-#597 cached rows. See #597, #453.
+  details?: unknown;
   region: string;
   count: number;
   term: number;


### PR DESCRIPTION
## Summary

The dashboard purchase flow was silently dropping the `details` (and `engine`, `cloud_account_id`) fields from every recommendation before POSTing to `/api/purchases/execute`. Both `handleExecutePurchase` and `handleFanOutExecute` in `app.ts` reconstructed the recommendation object field-by-field, leaving `details` out. The backend's `DecodeServiceDetailsFor` received `nil` and fell back to zero-valued defaults: `Platform=Linux/UNIX`, `Tenancy=default`, `Scope=Region`. Windows EC2, dedicated-tenancy, and AZ-scoped RIs mis-purchased as Linux/regional/default; non-default-engine RDS/Cache rows failed with "no offerings found for <type> Linux/UNIX default". Only Linux/regional/shared recs accidentally worked. The `details` field itself was missing from both the `Recommendation` API interface and the `LocalRecommendation` front-end type, making the omission invisible to TypeScript.

## What changed

- **`frontend/src/api/types.ts`**: Added `details?: unknown` to `Recommendation` interface. The field is typed as opaque `unknown` (not a strict union) because the frontend treats it as a pass-through blob matching the backend's `json.RawMessage` field.
- **`frontend/src/types.ts`**: Added `details?: unknown` to `LocalRecommendation` interface so the field is preserved in the local cache from the GET /api/recommendations response.
- **`frontend/src/app.ts`**: Replaced the field-by-field `map()` reconstructions in both `handleExecutePurchase` (single-rec path) and `handleFanOutExecute` (fan-out path) with spread syntax: `{ ...r, monthly_cost: r.monthly_cost ?? null, payment: ..., selected: true, purchased: false }`. All server-provided fields including `details`, `engine`, `cloud_account_id`, and any future additions now flow through unchanged.
- **`frontend/src/__tests__/purchase-execution-toast.test.ts`**: Added 4 regression tests asserting `executePurchase` is called with `details` (and `engine`) preserved for an EC2 Windows fixture and an RDS Postgres fixture on both the single-rec and fan-out paths.

## Why it matters

This is a P0 silent mis-purchase bug affecting every dashboard purchase that is NOT Linux/regional/shared-tenancy. Windows EC2, dedicated-tenancy RIs, AZ-scoped RIs, and non-default-engine RDS/ElastiCache rows were either purchasing the wrong configuration or failing outright. The backend codec fix in #454 completed the server-side round-trip but the frontend was never sending `details` in the first place.

## Test plan

- [x] `npm test -- --testPathPattern=purchase-execution-toast` - all 15 tests pass (11 existing + 4 new)
- [x] Full test suite: `npm test --no-coverage` - 1902 tests, 0 failures
- [x] TypeScript: `tsc --noEmit` - 0 errors
- [ ] Manual: open dashboard Network tab, select a Windows EC2 or RDS recommendation, click purchase, verify POST body includes `details` key
- [ ] Manual: confirm Windows EC2 / dedicated-tenancy / AZ-scoped RI purchases succeed end-to-end

Closes #597
Refs #453, #454


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Ensured additional recommendation details are properly preserved and forwarded during purchase execution operations.

* **Tests**
  * Added comprehensive test coverage for purchase execution detail handling across all execution paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/600?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->