### PR TITLE
fix(cli): reconstruct service Details from CSV  Engine/Deployment columns (closes #572)

### DIFF
--- a/cmd/multi_service_csv.go
+++ b/cmd/multi_service_csv.go
@@ -78,6 +78,14 @@ func parseCSVRecords(reader *csv.Reader, colIdx map[string]int) ([]common.Recomm
 			return nil, fmt.Errorf("failed to read CSV record: %w", err)
 		}
 
+		// Skip the trailing TOTAL summary row that writeMultiServiceCSVReport
+		// emits (label in the Service column). Without this, feeding the tool
+		// its own output parses TOTAL as a bogus recommendation with an
+		// unknown service type.
+		if getCSVField(record, colIdx, "Service") == "TOTAL" {
+			continue
+		}
+
 		rec, err := parseCSVRecord(record, colIdx)
 		if err != nil {
 			return nil, err
@@ -110,6 +118,37 @@ func parseCSVRecord(record []string, colIdx map[string]int) (common.Recommendati
 	// Parse float fields
 	if err := parseCSVFloat(record, colIdx, "EstimatedSavings", &rec.EstimatedSavings); err != nil {
 		return rec, err
+	}
+
+	// Reconstruct the service Details from the Engine/Deployment columns. The
+	// purchase path needs them: RDS findOfferingID rejects a rec with nil
+	// Details ("invalid service details for RDS"), and RI offerings are keyed
+	// by engine and Multi-AZ. This mirrors the writer side (extractEngine /
+	// extractDeployment emit DatabaseDetails / CacheDetails / ComputeDetails),
+	// so a CSV the tool wrote round-trips losslessly. Engine is stored in Cost
+	// Explorer format ("Aurora MySQL"); findOfferingID normalizes it. Guarded
+	// on a non-empty Engine so minimal CSVs and Savings Plans rows (no Engine
+	// column) keep their previous nil-Details behavior.
+	if engine := getCSVField(record, colIdx, "Engine"); engine != "" {
+		deployment := getCSVField(record, colIdx, "Deployment")
+		switch rec.Service {
+		case common.ServiceRDS, common.ServiceRelationalDB:
+			rec.Details = &common.DatabaseDetails{
+				Engine:        engine,
+				AZConfig:      deployment,
+				InstanceClass: rec.ResourceType,
+			}
+		case common.ServiceElastiCache, common.ServiceCache:
+			rec.Details = &common.CacheDetails{
+				Engine:   engine,
+				NodeType: rec.ResourceType,
+			}
+		case common.ServiceEC2, common.ServiceCompute:
+			rec.Details = &common.ComputeDetails{
+				InstanceType: rec.ResourceType,
+				Platform:     engine,
+			}
+		}
 	}
 
 	return rec, nil

--- a/cmd/multi_service_csv_test.go
+++ b/cmd/multi_service_csv_test.go
@@ -634,6 +634,64 @@ rds,us-east-1,db.t3.micro,2,`,
 			},
 		},
 		{
+			name: "Engine and Deployment reconstruct service Details",
+			csvContent: `Service,Region,ResourceType,Engine,Deployment,Count,Term,PaymentOption
+rds,us-east-1,db.t4g.medium,Aurora MySQL,single-az,3,3yr,partial-upfront
+rds,eu-west-2,db.r7g.large,MySQL,multi-az,2,3yr,partial-upfront
+elasticache,us-east-1,cache.r6g.large,redis,,4,1yr,no-upfront
+ec2,us-west-2,m5.large,Linux/UNIX,,5,1yr,all-upfront`,
+			wantErr: false,
+			validate: func(t *testing.T, recs []common.Recommendation) {
+				require.Len(t, recs, 4)
+
+				// RDS Aurora MySQL, single-az -> DatabaseDetails
+				rds0, ok := recs[0].Details.(*common.DatabaseDetails)
+				require.True(t, ok, "RDS rec should carry *DatabaseDetails")
+				assert.Equal(t, "Aurora MySQL", rds0.Engine)
+				assert.Equal(t, "single-az", rds0.AZConfig)
+				assert.Equal(t, "db.t4g.medium", rds0.InstanceClass)
+
+				// RDS MySQL, multi-az -> AZConfig carried through for offering lookup
+				rds1, ok := recs[1].Details.(*common.DatabaseDetails)
+				require.True(t, ok)
+				assert.Equal(t, "MySQL", rds1.Engine)
+				assert.Equal(t, "multi-az", rds1.AZConfig)
+
+				// ElastiCache -> CacheDetails (no Deployment column)
+				cache, ok := recs[2].Details.(*common.CacheDetails)
+				require.True(t, ok, "ElastiCache rec should carry *CacheDetails")
+				assert.Equal(t, "redis", cache.Engine)
+				assert.Equal(t, "cache.r6g.large", cache.NodeType)
+
+				// EC2 -> ComputeDetails, platform from the Engine column
+				ec2, ok := recs[3].Details.(*common.ComputeDetails)
+				require.True(t, ok, "EC2 rec should carry *ComputeDetails")
+				assert.Equal(t, "Linux/UNIX", ec2.Platform)
+				assert.Equal(t, "m5.large", ec2.InstanceType)
+			},
+		},
+		{
+			name: "No Engine column leaves Details nil (Savings Plans / minimal CSV)",
+			csvContent: `Service,Region,ResourceType,Count,Term,PaymentOption
+rds,us-east-1,db.t3.micro,2,3yr,partial-upfront`,
+			wantErr: false,
+			validate: func(t *testing.T, recs []common.Recommendation) {
+				require.Len(t, recs, 1)
+				assert.Nil(t, recs[0].Details, "Details must stay nil when Engine column is absent")
+			},
+		},
+		{
+			name: "TOTAL summary row is skipped",
+			csvContent: `Service,Region,ResourceType,Engine,Deployment,Count,Term,PaymentOption
+rds,us-east-1,db.t4g.medium,Aurora MySQL,single-az,3,3yr,partial-upfront
+TOTAL,,,,,3,,`,
+			wantErr: false,
+			validate: func(t *testing.T, recs []common.Recommendation) {
+				require.Len(t, recs, 1, "the trailing TOTAL row must not become a recommendation")
+				assert.Equal(t, common.ServiceRDS, recs[0].Service)
+			},
+		},
+		{
 			name: "CSV with different column order",
 			csvContent: `Count,Service,Region,ResourceType
 7,rds,ap-south-1,db.r5.large`,


### PR DESCRIPTION
## What

Make `--input-csv` purchasing work for RDS by reconstructing `rec.Details` from the CSV's `Engine` and `Deployment` columns.

## Why

`loadRecommendationsFromCSV` → `parseCSVRecord` parsed only `Service, Region, ResourceType, Account, AccountName, Term, PaymentOption, Count, EstimatedSavings`. It never read `Engine`/`Deployment`, so `rec.Details` stayed `nil`. The RDS purchase path can't proceed without it:

```go
// providers/aws/services/rds/client.go  findOfferingID
details, ok := rec.Details.(*common.DatabaseDetails)
if !ok || details == nil {
    return "", fmt.Errorf("invalid service details for RDS")
}
```

So every RDS row failed with `invalid service details for RDS` under `--input-csv … --purchase`, before any AWS call. This blocks the edit-the-CSV-then-purchase workflow (the tool has no in-flow exclusion flag).

## Change

- `parseCSVRecord` reconstructs `Details` from the `Engine`/`Deployment` columns, mirroring the writer (`extractEngine`/`extractDeployment` emit `DatabaseDetails` / `CacheDetails` / `ComputeDetails`), so a CSV the tool wrote round-trips losslessly. Guarded on a non-empty `Engine`, so minimal CSVs and Savings Plans rows keep their previous nil-Details behavior. `Engine` is stored in Cost Explorer format ("Aurora MySQL"); `findOfferingID` already normalizes it.
- `parseCSVRecords` skips the trailing `TOTAL` summary row, so feeding the tool its own output no longer parses `TOTAL` as a bogus recommendation ("Service client not yet implemented for TOTAL").

## Out of scope (by design)

Multi-account purchasing from a single CSV. Purchases run centrally in the `--profile` account; the `Account` column stays informational. This is the intended behavior, not a gap.

## Testing

- `go build ./cmd/...`, `go vet ./cmd/` clean.
- `go test ./cmd/` → 720 pass.
- New table cases in `TestLoadRecommendationsFromCSV`:
  - Engine + Deployment reconstruct `*DatabaseDetails` (Aurora MySQL/single-az, MySQL/multi-az), `*CacheDetails` (ElastiCache), `*ComputeDetails` (EC2 platform).
  - No `Engine` column leaves `Details` nil (Savings Plans / minimal CSV).
  - `TOTAL` summary row is skipped.
- Manual dry-run (`--input-csv … --profile shift-prd`, no `--purchase`): loads 22 recs / 85 instances cleanly and no longer emits the spurious "Processing TOTAL" block.

Closes #572


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CSV import now correctly ignores summary rows, preventing footer data from being interpreted as valid recommendations
  * Improved recommendation data reconstruction from CSV imports, properly mapping Engine and Deployment columns to the appropriate service-specific details for database, cache, and compute recommendations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/601?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->