### PR TITLE
fix(scheduler/aws): tag ambient-path rec rows with registered host-account UUID (closes #604)

### DIFF
--- a/internal/analytics/collector_test.go
+++ b/internal/analytics/collector_test.go
@@ -237,6 +237,9 @@ func (m *mockConfigStore) CreateCloudAccount(ctx context.Context, account *confi
 func (m *mockConfigStore) GetCloudAccount(ctx context.Context, id string) (*config.CloudAccount, error) {
 	return nil, nil
 }
+func (m *mockConfigStore) GetCloudAccountByExternalID(ctx context.Context, provider, externalID string) (*config.CloudAccount, error) {
+	return nil, nil
+}
 func (m *mockConfigStore) UpdateCloudAccount(ctx context.Context, account *config.CloudAccount) error {
 	return nil
 }

--- a/internal/api/mocks_test.go
+++ b/internal/api/mocks_test.go
@@ -18,6 +18,8 @@ type MockConfigStore struct {
 	mock.Mock
 	// GetCloudAccountFn overrides GetCloudAccount when non-nil (used in not-found tests).
 	GetCloudAccountFn func(ctx context.Context, id string) (*config.CloudAccount, error)
+	// GetCloudAccountByExternalIDFn overrides GetCloudAccountByExternalID when non-nil.
+	GetCloudAccountByExternalIDFn func(ctx context.Context, provider, externalID string) (*config.CloudAccount, error)
 	// DeleteCloudAccountFn overrides DeleteCloudAccount when non-nil (used to assert
 	// delete was/was not invoked).
 	DeleteCloudAccountFn func(ctx context.Context, id string) error
@@ -281,6 +283,12 @@ func (m *MockConfigStore) GetCloudAccount(ctx context.Context, id string) (*conf
 		return m.GetCloudAccountFn(ctx, id)
 	}
 	return &config.CloudAccount{ID: id, Provider: "aws", AWSAuthMode: "access_keys"}, nil
+}
+func (m *MockConfigStore) GetCloudAccountByExternalID(ctx context.Context, provider, externalID string) (*config.CloudAccount, error) {
+	if m.GetCloudAccountByExternalIDFn != nil {
+		return m.GetCloudAccountByExternalIDFn(ctx, provider, externalID)
+	}
+	return nil, nil
 }
 func (m *MockConfigStore) UpdateCloudAccount(ctx context.Context, account *config.CloudAccount) error {
 	return nil

--- a/internal/config/interfaces.go
+++ b/internal/config/interfaces.go
@@ -66,6 +66,17 @@ type StoreInterface interface {
 	// Cloud accounts
 	CreateCloudAccount(ctx context.Context, account *CloudAccount) error
 	GetCloudAccount(ctx context.Context, id string) (*CloudAccount, error)
+	// GetCloudAccountByExternalID looks up a cloud account by its
+	// (provider, external_id) pair. Used by the scheduler's ambient
+	// collector path to tag rec rows with the registered host-account's
+	// UUID when the Lambda's STS identity matches a registered (but
+	// possibly disabled) account — so the approve-modal Account column
+	// shows the account name instead of `(ambient)`. Returns
+	// (nil, nil) when no row matches (the caller treats this as the
+	// genuine orphan case). The underlying
+	// `UNIQUE(provider, external_id)` constraint on cloud_accounts
+	// guarantees the lookup hits an index.
+	GetCloudAccountByExternalID(ctx context.Context, provider, externalID string) (*CloudAccount, error)
 	UpdateCloudAccount(ctx context.Context, account *CloudAccount) error
 	DeleteCloudAccount(ctx context.Context, id string) error
 	ListCloudAccounts(ctx context.Context, filter CloudAccountFilter) ([]CloudAccount, error)

--- a/internal/config/store_postgres.go
+++ b/internal/config/store_postgres.go
@@ -1579,6 +1579,56 @@ func (s *PostgresStore) GetCloudAccount(ctx context.Context, id string) (*CloudA
 	return &account, nil
 }
 
+// GetCloudAccountByExternalID returns a single cloud account matched by
+// (provider, external_id). Used by the scheduler ambient-path tagging fix
+// for issue #604 — when the Lambda's STS identity matches a registered
+// account (regardless of enabled state), rec rows are stamped with that
+// account's UUID so the approve modal shows the account name instead of
+// `(ambient)`. Returns (nil, nil) when no row matches.
+//
+// The cloud_accounts table declares `UNIQUE(provider, external_id)`
+// (migration 000011), which guarantees the lookup hits an index.
+func (s *PostgresStore) GetCloudAccountByExternalID(ctx context.Context, provider, externalID string) (*CloudAccount, error) {
+	query := `
+		SELECT
+			ca.id, ca.name, COALESCE(ca.description,''), COALESCE(ca.contact_email,''),
+			ca.enabled, ca.provider, ca.external_id,
+			COALESCE(ca.aws_auth_mode,''), COALESCE(ca.aws_role_arn,''),
+			COALESCE(ca.aws_external_id,''), COALESCE(ca.aws_bastion_id::text,''),
+			COALESCE(ca.aws_web_identity_token_file,''),
+			ca.aws_is_org_root,
+			COALESCE(ca.azure_subscription_id,''), COALESCE(ca.azure_tenant_id,''),
+			COALESCE(ca.azure_client_id,''), COALESCE(ca.azure_auth_mode,''),
+			COALESCE(ca.gcp_project_id,''), COALESCE(ca.gcp_client_email,''), COALESCE(ca.gcp_auth_mode,''),
+			COALESCE(ca.gcp_wif_audience,''),
+			ca.created_at, ca.updated_at, COALESCE(ca.created_by::text,''),
+			EXISTS(SELECT 1 FROM account_credentials ac WHERE ac.account_id = ca.id) AS credentials_configured
+		FROM cloud_accounts ca
+		WHERE ca.provider = $1 AND ca.external_id = $2
+	`
+
+	var account CloudAccount
+	err := s.db.QueryRow(ctx, query, provider, externalID).Scan(
+		&account.ID, &account.Name, &account.Description, &account.ContactEmail,
+		&account.Enabled, &account.Provider, &account.ExternalID,
+		&account.AWSAuthMode, &account.AWSRoleARN, &account.AWSExternalID, &account.AWSBastionID,
+		&account.AWSWebIdentityTokenFile,
+		&account.AWSIsOrgRoot,
+		&account.AzureSubscriptionID, &account.AzureTenantID, &account.AzureClientID, &account.AzureAuthMode,
+		&account.GCPProjectID, &account.GCPClientEmail, &account.GCPAuthMode,
+		&account.GCPWIFAudience,
+		&account.CreatedAt, &account.UpdatedAt, &account.CreatedBy,
+		&account.CredentialsConfigured,
+	)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get cloud account by external id: %w", err)
+	}
+	return &account, nil
+}
+
 // UpdateCloudAccount updates mutable fields of a cloud account.
 func (s *PostgresStore) UpdateCloudAccount(ctx context.Context, account *CloudAccount) error {
 	account.UpdatedAt = time.Now()

--- a/internal/config/store_postgres_pgxmock_test.go
+++ b/internal/config/store_postgres_pgxmock_test.go
@@ -791,6 +791,38 @@ func TestPGXMock_GetCloudAccount_Error(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to get cloud account")
 }
 
+// ─── GetCloudAccountByExternalID (issue #604) ─────────────────────────────────
+
+func TestPGXMock_GetCloudAccountByExternalID_Success(t *testing.T) {
+	mock := newMock(t)
+	store := storeWith(mock)
+	ctx := context.Background()
+
+	now := time.Now().Truncate(time.Second)
+	rows := pgxmock.NewRows(cloudAccountCols).AddRow(cloudAccountRow(now)...)
+	mock.ExpectQuery("SELECT").WithArgs("aws", "123456789012").WillReturnRows(rows)
+
+	acct, err := store.GetCloudAccountByExternalID(ctx, "aws", "123456789012")
+	require.NoError(t, err)
+	require.NotNil(t, acct)
+	assert.Equal(t, "acct-id", acct.ID)
+	assert.Equal(t, "123456789012", acct.ExternalID)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestPGXMock_GetCloudAccountByExternalID_NotFound(t *testing.T) {
+	mock := newMock(t)
+	store := storeWith(mock)
+	ctx := context.Background()
+
+	mock.ExpectQuery("SELECT").WithArgs("aws", "missing").
+		WillReturnError(errNoRows())
+
+	acct, err := store.GetCloudAccountByExternalID(ctx, "aws", "missing")
+	require.NoError(t, err, "not-found must return (nil, nil), not an error")
+	assert.Nil(t, acct)
+}
+
 // ─── UpdateCloudAccount ───────────────────────────────────────────────────────
 
 func TestPGXMock_UpdateCloudAccount_Success(t *testing.T) {

--- a/internal/mocks/stores.go
+++ b/internal/mocks/stores.go
@@ -447,6 +447,14 @@ func (m *MockConfigStore) GetCloudAccount(ctx context.Context, id string) (*conf
 	return args.Get(0).(*config.CloudAccount), args.Error(1)
 }
 
+func (m *MockConfigStore) GetCloudAccountByExternalID(ctx context.Context, provider, externalID string) (*config.CloudAccount, error) {
+	args := m.Called(ctx, provider, externalID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*config.CloudAccount), args.Error(1)
+}
+
 func (m *MockConfigStore) UpdateCloudAccount(ctx context.Context, account *config.CloudAccount) error {
 	args := m.Called(ctx, account)
 	return args.Error(0)

--- a/internal/purchase/mocks_test.go
+++ b/internal/purchase/mocks_test.go
@@ -400,6 +400,18 @@ func (m *MockConfigStore) GetCloudAccount(ctx context.Context, id string) (*conf
 	}
 	return nil, nil
 }
+func (m *MockConfigStore) GetCloudAccountByExternalID(ctx context.Context, provider, externalID string) (*config.CloudAccount, error) {
+	for _, call := range m.ExpectedCalls {
+		if call.Method == "GetCloudAccountByExternalID" {
+			args := m.Called(ctx, provider, externalID)
+			if args.Get(0) == nil {
+				return nil, args.Error(1)
+			}
+			return args.Get(0).(*config.CloudAccount), args.Error(1)
+		}
+	}
+	return nil, nil
+}
 func (m *MockConfigStore) UpdateCloudAccount(ctx context.Context, account *config.CloudAccount) error {
 	return nil
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -620,7 +620,9 @@ func (s *Scheduler) resolveAmbientHostAccountID(ctx context.Context) string {
 	if s.stsClient == nil {
 		return ""
 	}
-	out, err := s.stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+	stsCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+	out, err := s.stsClient.GetCallerIdentity(stsCtx, &sts.GetCallerIdentityInput{})
 	if err != nil {
 		logging.Warnf("ambient host-account lookup: STS GetCallerIdentity failed: %v", err)
 		return ""

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -24,9 +24,19 @@ import (
 	"github.com/LeanerCloud/CUDly/pkg/provider"
 	azureprovider "github.com/LeanerCloud/CUDly/providers/azure"
 	gcpprovider "github.com/LeanerCloud/CUDly/providers/gcp"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
 )
+
+// STSClient is the minimal AWS STS surface the scheduler uses to discover
+// the Lambda's own AWS account ID for the ambient-path account-tagging fix
+// (issue #604). Mirrors purchase.STSClient deliberately — both packages
+// need the same single call, and cross-package imports would tangle the
+// purchase ↔ scheduler dependency.
+type STSClient interface {
+	GetCallerIdentity(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error)
+}
 
 // SchedulerConfig holds configuration for the scheduler
 type SchedulerConfig struct {
@@ -41,6 +51,16 @@ type SchedulerConfig struct {
 	OIDCSigner      oidc.Signer
 	OIDCIssuerURL   string
 	AssumeRoleSTS   credentials.STSClient
+
+	// STSClient is the runtime AWS STS client used to discover the
+	// Lambda's own AWS account ID on the ambient collection path. When
+	// the discovered ID matches a registered cloud_accounts row (by
+	// external_id), the ambient path stamps that account's UUID onto
+	// every rec it returns so the approve modal shows the registered
+	// name instead of `(ambient)`. Optional — when nil, the ambient
+	// path keeps its pre-fix behaviour (CloudAccountID = nil), which
+	// preserves the truly-orphan case.
+	STSClient STSClient
 
 	// IsLambda gates the stale-while-revalidate background goroutine.
 	// On Lambda, goroutines freeze between invocations — firing one from
@@ -80,6 +100,7 @@ type Scheduler struct {
 	oidcSigner      oidc.Signer
 	oidcIssuerURL   string
 	assumeRoleSTS   credentials.STSClient
+	stsClient       STSClient
 
 	// isLambda gates the stale-while-revalidate background goroutine. See
 	// SchedulerConfig.IsLambda for the rationale.
@@ -117,6 +138,7 @@ func NewScheduler(cfg SchedulerConfig) *Scheduler {
 		oidcSigner:      cfg.OIDCSigner,
 		oidcIssuerURL:   cfg.OIDCIssuerURL,
 		assumeRoleSTS:   cfg.AssumeRoleSTS,
+		stsClient:       cfg.STSClient,
 		isLambda:        cfg.IsLambda,
 		cacheTTL:        cacheTTLFromEnv(),
 	}
@@ -442,6 +464,16 @@ func (s *Scheduler) collectAWSRecommendations(ctx context.Context, globalCfg *co
 		if err != nil {
 			return nil, nil, err
 		}
+		// Issue #604: if the Lambda's STS identity matches a registered
+		// (possibly disabled) cloud_accounts row, tag every rec with that
+		// account's UUID so the approve modal renders the account name
+		// instead of `(ambient)`. Best-effort — STS or store errors must
+		// NOT fail the collection; we just keep the pre-fix nil tagging
+		// in those cases.
+		if acctID := s.resolveAmbientHostAccountID(ctx); acctID != "" {
+			recs = s.tagAccount(recs, acctID)
+			return recs, []string{acctID}, nil
+		}
 		return recs, []string{""}, nil
 	}
 
@@ -572,6 +604,42 @@ func (s *Scheduler) collectAWSAmbient(ctx context.Context, globalCfg *config.Glo
 		return nil, fmt.Errorf("failed to create AWS provider: %w", err)
 	}
 	return s.fetchAndConvert(ctx, prov, "aws", nil, globalCfg)
+}
+
+// resolveAmbientHostAccountID looks up the Lambda's own AWS account ID
+// (via STS GetCallerIdentity) and, if it matches a registered
+// cloud_accounts row by (provider="aws", external_id), returns that
+// row's UUID. Returns "" when STS is unavailable, the lookup fails, or
+// no registered account matches — callers fall back to the pre-fix
+// nil tagging in that case, preserving the truly-orphan deployment.
+//
+// All errors are intentionally swallowed (logged at debug/warn) — this
+// is a best-effort UX improvement on the ambient path and must not
+// break the collection.
+func (s *Scheduler) resolveAmbientHostAccountID(ctx context.Context) string {
+	if s.stsClient == nil {
+		return ""
+	}
+	out, err := s.stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+	if err != nil {
+		logging.Warnf("ambient host-account lookup: STS GetCallerIdentity failed: %v", err)
+		return ""
+	}
+	if out == nil || out.Account == nil || *out.Account == "" {
+		return ""
+	}
+	hostAcctID := *out.Account
+
+	acct, err := s.config.GetCloudAccountByExternalID(ctx, "aws", hostAcctID)
+	if err != nil {
+		logging.Warnf("ambient host-account lookup: GetCloudAccountByExternalID(aws,%s) failed: %v", hostAcctID, err)
+		return ""
+	}
+	if acct == nil {
+		// Truly orphan deployment — preserve pre-fix nil tagging.
+		return ""
+	}
+	return acct.ID
 }
 
 func (s *Scheduler) collectAWSForAccount(ctx context.Context, globalCfg *config.GlobalConfig, acct config.CloudAccount) ([]config.RecommendationRecord, error) {

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync/atomic"
 	"testing"
@@ -12,6 +13,8 @@ import (
 	"github.com/LeanerCloud/CUDly/internal/purchase"
 	"github.com/LeanerCloud/CUDly/pkg/common"
 	"github.com/LeanerCloud/CUDly/pkg/provider"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -256,6 +259,18 @@ func (m *MockConfigStore) CreateCloudAccount(ctx context.Context, account *confi
 	return nil
 }
 func (m *MockConfigStore) GetCloudAccount(ctx context.Context, id string) (*config.CloudAccount, error) {
+	return nil, nil
+}
+func (m *MockConfigStore) GetCloudAccountByExternalID(ctx context.Context, provider, externalID string) (*config.CloudAccount, error) {
+	// Default returns (nil, nil); tests that exercise the ambient
+	// host-account tagging path set an explicit expectation via .On().
+	if m.hasExpectation("GetCloudAccountByExternalID") {
+		args := m.Called(ctx, provider, externalID)
+		if args.Get(0) == nil {
+			return nil, args.Error(1)
+		}
+		return args.Get(0).(*config.CloudAccount), args.Error(1)
+	}
 	return nil, nil
 }
 func (m *MockConfigStore) UpdateCloudAccount(ctx context.Context, account *config.CloudAccount) error {
@@ -1897,3 +1912,187 @@ func (m *MockConfigStore) SavePurchaseExecutionTx(ctx context.Context, _ pgx.Tx,
 	return m.SavePurchaseExecution(ctx, e)
 }
 func (m *MockConfigStore) WithTx(_ context.Context, fn func(tx pgx.Tx) error) error { return fn(nil) }
+
+// fakeSTSClient is a minimal in-test STSClient implementation used by the
+// ambient host-account tagging tests (issue #604). The fakeAccountID + err
+// fields are set by each test case to drive the GetCallerIdentity response
+// shape (success with an account ID, or an error).
+type fakeSTSClient struct {
+	accountID string
+	err       error
+}
+
+func (f *fakeSTSClient) GetCallerIdentity(ctx context.Context, _ *sts.GetCallerIdentityInput, _ ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	if f.accountID == "" {
+		return &sts.GetCallerIdentityOutput{}, nil
+	}
+	return &sts.GetCallerIdentityOutput{Account: aws.String(f.accountID)}, nil
+}
+
+// Issue #604: AWS ambient-path tagging fix — when the Lambda's STS
+// identity matches a registered cloud_accounts row (regardless of
+// enabled flag), rec rows should be tagged with that account's UUID
+// instead of nil so the approve modal shows the registered name
+// instead of `(ambient)`.
+func TestScheduler_CollectAWSRecommendations_AmbientTagging_HappyPath(t *testing.T) {
+	ctx := context.Background()
+	mockStore := new(MockConfigStore)
+	mockFactory := new(MockProviderFactory)
+	mockProvider := new(MockProvider)
+	mockRecClient := new(MockRecommendationsClient)
+
+	globalCfg := &config.GlobalConfig{
+		DefaultTerm:    3,
+		DefaultPayment: "all-upfront",
+	}
+
+	// No enabled AWS accounts → ambient fallback fires.
+	mockStore.On("ListCloudAccounts", mock.Anything, mock.Anything).Return([]config.CloudAccount{}, nil)
+
+	recommendations := []common.Recommendation{
+		{
+			Provider:         common.ProviderAWS,
+			Service:          common.ServiceEC2,
+			Region:           "us-east-1",
+			ResourceType:     "t4g.nano",
+			Count:            1,
+			Term:             "1yr",
+			EstimatedSavings: 12.0,
+		},
+	}
+
+	mockFactory.On("CreateAndValidateProvider", mock.Anything, "aws", mock.Anything).Return(mockProvider, nil)
+	mockProvider.On("GetRecommendationsClient", ctx).Return(mockRecClient, nil)
+	mockRecClient.On("GetAllRecommendations", ctx).Return(recommendations, nil)
+
+	// Registered host account (enabled=false on purpose — registration
+	// alone is the signal, not enabled state).
+	registered := &config.CloudAccount{
+		ID:         "abc-uuid",
+		Provider:   "aws",
+		ExternalID: "123456789012",
+		Enabled:    false,
+	}
+	mockStore.On("GetCloudAccountByExternalID", mock.Anything, "aws", "123456789012").Return(registered, nil)
+
+	scheduler := &Scheduler{
+		config:          mockStore,
+		providerFactory: mockFactory,
+		stsClient:       &fakeSTSClient{accountID: "123456789012"},
+	}
+
+	recs, acctIDs, err := scheduler.collectAWSRecommendations(ctx, globalCfg)
+	require.NoError(t, err)
+	require.Len(t, recs, 1)
+	require.NotNil(t, recs[0].CloudAccountID, "rec must be tagged with registered account UUID, not nil")
+	assert.Equal(t, "abc-uuid", *recs[0].CloudAccountID)
+	assert.Equal(t, []string{"abc-uuid"}, acctIDs,
+		"eviction account-keys must be the registered UUID, not the ambient sentinel")
+}
+
+// Issue #604: when STS reports an account ID that is NOT in the
+// registered cloud_accounts table, the ambient path must keep
+// CloudAccountID = nil — preserving the truly-orphan deployment case.
+func TestScheduler_CollectAWSRecommendations_AmbientTagging_NoRegisteredAccount(t *testing.T) {
+	ctx := context.Background()
+	mockStore := new(MockConfigStore)
+	mockFactory := new(MockProviderFactory)
+	mockProvider := new(MockProvider)
+	mockRecClient := new(MockRecommendationsClient)
+
+	globalCfg := &config.GlobalConfig{DefaultTerm: 3, DefaultPayment: "all-upfront"}
+
+	mockStore.On("ListCloudAccounts", mock.Anything, mock.Anything).Return([]config.CloudAccount{}, nil)
+
+	recommendations := []common.Recommendation{
+		{Provider: common.ProviderAWS, Service: common.ServiceEC2, Region: "us-east-1", ResourceType: "t4g.nano", Count: 1, Term: "1yr"},
+	}
+	mockFactory.On("CreateAndValidateProvider", mock.Anything, "aws", mock.Anything).Return(mockProvider, nil)
+	mockProvider.On("GetRecommendationsClient", ctx).Return(mockRecClient, nil)
+	mockRecClient.On("GetAllRecommendations", ctx).Return(recommendations, nil)
+
+	// Store has NO matching registered row.
+	mockStore.On("GetCloudAccountByExternalID", mock.Anything, "aws", "999888777666").Return(nil, nil)
+
+	scheduler := &Scheduler{
+		config:          mockStore,
+		providerFactory: mockFactory,
+		stsClient:       &fakeSTSClient{accountID: "999888777666"},
+	}
+
+	recs, acctIDs, err := scheduler.collectAWSRecommendations(ctx, globalCfg)
+	require.NoError(t, err)
+	require.Len(t, recs, 1)
+	assert.Nil(t, recs[0].CloudAccountID, "truly-orphan ambient deployment must keep CloudAccountID = nil")
+	assert.Equal(t, []string{""}, acctIDs, "eviction account-keys must keep the ambient sentinel")
+}
+
+// Issue #604: an STS hiccup must NOT fail the collection — recs are
+// returned with the pre-fix nil tagging and the run succeeds.
+func TestScheduler_CollectAWSRecommendations_AmbientTagging_STSFailure(t *testing.T) {
+	ctx := context.Background()
+	mockStore := new(MockConfigStore)
+	mockFactory := new(MockProviderFactory)
+	mockProvider := new(MockProvider)
+	mockRecClient := new(MockRecommendationsClient)
+
+	globalCfg := &config.GlobalConfig{DefaultTerm: 3, DefaultPayment: "all-upfront"}
+
+	mockStore.On("ListCloudAccounts", mock.Anything, mock.Anything).Return([]config.CloudAccount{}, nil)
+
+	recommendations := []common.Recommendation{
+		{Provider: common.ProviderAWS, Service: common.ServiceEC2, Region: "us-east-1", ResourceType: "t4g.nano", Count: 1, Term: "1yr"},
+	}
+	mockFactory.On("CreateAndValidateProvider", mock.Anything, "aws", mock.Anything).Return(mockProvider, nil)
+	mockProvider.On("GetRecommendationsClient", ctx).Return(mockRecClient, nil)
+	mockRecClient.On("GetAllRecommendations", ctx).Return(recommendations, nil)
+
+	scheduler := &Scheduler{
+		config:          mockStore,
+		providerFactory: mockFactory,
+		stsClient:       &fakeSTSClient{err: errors.New("sts unreachable")},
+	}
+
+	recs, acctIDs, err := scheduler.collectAWSRecommendations(ctx, globalCfg)
+	require.NoError(t, err, "STS failure must NOT fail the collection")
+	require.Len(t, recs, 1)
+	assert.Nil(t, recs[0].CloudAccountID, "STS failure must leave the pre-fix nil tagging in place")
+	assert.Equal(t, []string{""}, acctIDs)
+
+	// Sanity: GetCloudAccountByExternalID must not be called when STS fails.
+	mockStore.AssertNotCalled(t, "GetCloudAccountByExternalID", mock.Anything, mock.Anything, mock.Anything)
+}
+
+// Issue #604: resolveAmbientHostAccountID must skip cleanly when no STS
+// client is wired (e.g. NewScheduler was given a nil STSClient — the
+// pre-fix construction path). Confirms the helper degrades gracefully
+// rather than panicking on nil deref.
+func TestScheduler_ResolveAmbientHostAccountID_NoSTSClient(t *testing.T) {
+	mockStore := new(MockConfigStore)
+	scheduler := &Scheduler{
+		config:    mockStore,
+		stsClient: nil,
+	}
+	got := scheduler.resolveAmbientHostAccountID(context.Background())
+	assert.Empty(t, got, "must return empty when STS client is nil")
+	mockStore.AssertNotCalled(t, "GetCloudAccountByExternalID", mock.Anything, mock.Anything, mock.Anything)
+}
+
+// Issue #604: when GetCloudAccountByExternalID returns a non-nil store
+// error (DB blip), resolveAmbientHostAccountID must NOT propagate it —
+// it returns "" so the collection falls back to the pre-fix nil tagging.
+func TestScheduler_ResolveAmbientHostAccountID_StoreError(t *testing.T) {
+	mockStore := new(MockConfigStore)
+	mockStore.On("GetCloudAccountByExternalID", mock.Anything, "aws", "123456789012").
+		Return(nil, errors.New("db unreachable"))
+
+	scheduler := &Scheduler{
+		config:    mockStore,
+		stsClient: &fakeSTSClient{accountID: "123456789012"},
+	}
+	got := scheduler.resolveAmbientHostAccountID(context.Background())
+	assert.Empty(t, got, "store error must collapse to empty result (don't fail the collection)")
+}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1932,6 +1932,16 @@ func (f *fakeSTSClient) GetCallerIdentity(ctx context.Context, _ *sts.GetCallerI
 	return &sts.GetCallerIdentityOutput{Account: aws.String(f.accountID)}, nil
 }
 
+// slowSTSClient simulates an STS endpoint that hangs longer than the
+// 3-second deadline applied by resolveAmbientHostAccountID. It blocks
+// until ctx is cancelled so the test can verify timeout behaviour.
+type slowSTSClient struct{}
+
+func (s *slowSTSClient) GetCallerIdentity(ctx context.Context, _ *sts.GetCallerIdentityInput, _ ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
 // Issue #604: AWS ambient-path tagging fix — when the Lambda's STS
 // identity matches a registered cloud_accounts row (regardless of
 // enabled flag), rec rows should be tagged with that account's UUID
@@ -2095,4 +2105,25 @@ func TestScheduler_ResolveAmbientHostAccountID_StoreError(t *testing.T) {
 	}
 	got := scheduler.resolveAmbientHostAccountID(context.Background())
 	assert.Empty(t, got, "store error must collapse to empty result (don't fail the collection)")
+}
+
+// Issue #604 / CR pass-1: resolveAmbientHostAccountID must not block
+// scheduler startup when STS is slow. The function wraps the call in a
+// 3-second context; a hung STS must therefore return "" well inside that
+// window rather than stalling forever.
+func TestScheduler_ResolveAmbientHostAccountID_STSTimeout(t *testing.T) {
+	mockStore := new(MockConfigStore)
+	scheduler := &Scheduler{
+		config:    mockStore,
+		stsClient: &slowSTSClient{},
+	}
+
+	start := time.Now()
+	got := scheduler.resolveAmbientHostAccountID(context.Background())
+	elapsed := time.Since(start)
+
+	assert.Empty(t, got, "STS timeout must return empty so the collection falls through to nil tagging")
+	// The internal deadline is 3 s; allow a small margin for scheduling jitter.
+	assert.Less(t, elapsed, 4*time.Second, "resolveAmbientHostAccountID must not block beyond its internal 3s deadline")
+	mockStore.AssertNotCalled(t, "GetCloudAccountByExternalID", mock.Anything, mock.Anything, mock.Anything)
 }

--- a/internal/server/app.go
+++ b/internal/server/app.go
@@ -381,6 +381,7 @@ func NewApplicationFromDeps(ctx context.Context, cfg ApplicationConfig, deps Ext
 		ConfigStore:     deps.ConfigStore,
 		PurchaseManager: purchaseManager,
 		EmailSender:     deps.EmailSender,
+		STSClient:       deps.STSClient,
 		IsLambda:        isLambdaRuntime(),
 	})
 
@@ -672,6 +673,7 @@ func (app *Application) reinitializeAfterConnect(ctx context.Context, dbConn *da
 		OIDCSigner:      app.signer,
 		OIDCIssuerURL:   resolveOIDCIssuerURL(app.appConfig),
 		AssumeRoleSTS:   sts.NewFromConfig(awsCfg),
+		STSClient:       sts.NewFromConfig(awsCfg),
 		IsLambda:        app.appConfig.IsLambda,
 	})
 

--- a/internal/server/test_helpers_test.go
+++ b/internal/server/test_helpers_test.go
@@ -136,6 +136,9 @@ func (m *mockConfigStoreForHealth) CreateCloudAccount(ctx context.Context, accou
 func (m *mockConfigStoreForHealth) GetCloudAccount(ctx context.Context, id string) (*config.CloudAccount, error) {
 	return nil, nil
 }
+func (m *mockConfigStoreForHealth) GetCloudAccountByExternalID(ctx context.Context, provider, externalID string) (*config.CloudAccount, error) {
+	return nil, nil
+}
 func (m *mockConfigStoreForHealth) UpdateCloudAccount(ctx context.Context, account *config.CloudAccount) error {
 	return nil
 }


### PR DESCRIPTION
## Summary

Closes #604.

When the AWS recommendation collector falls back to the ambient credentials path (no enabled accounts registered), it previously saved every rec with `CloudAccountID = nil`. The approve modal then rendered the Account column as `(ambient)` even when the deployment had a registered cloud account whose `external_id` matched the Lambda's own STS identity — confusing because the purchase actually hits that registered account.

### Forward-fix

In `internal/scheduler/scheduler.go::collectAWSRecommendations`, after the ambient branch fetches recs, call STS `GetCallerIdentity` to discover the Lambda's host account ID, then look it up via the new `GetCloudAccountByExternalID(ctx, "aws", externalID)` store method. If a row is returned — regardless of `enabled` flag, since registration itself is the operator signal — every rec is tagged with that account's UUID and the eviction account-keys slice carries the UUID instead of the ambient sentinel.

If STS or the store lookup fails (or no row matches), the pre-fix `nil` tagging is preserved so the truly-orphan deployment case is unaffected and the collection never fails on an STS hiccup.

### No new migration

The new `GetCloudAccountByExternalID` query uses the existing `UNIQUE(provider, external_id)` constraint on `cloud_accounts` (migration `000011_cloud_accounts.up.sql`) as its index — no DDL needed.

### Forward-fix only — no backfill

Existing pending purchases with `CloudAccountID = nil` created **before** this fix will continue to show `(ambient)` until they're approved/cancelled or until the next collection cycle re-upserts the recommendation row. A migration that backfills would need a deployment-specific account ID (varies per install) and would risk over-tagging; natural re-collection is safer and self-heals on the next scheduler tick.

## Test plan

Regression tests added in `internal/scheduler/scheduler_test.go` and `internal/config/store_postgres_pgxmock_test.go` (7 new tests):

- [x] STS identity matches a registered (disabled) cloud account → every rec tagged with that UUID, eviction keys carry the UUID.
- [x] STS identity is **not** in the registered table → recs keep `CloudAccountID = nil` (truly-orphan case preserved).
- [x] STS call returns an error → recs keep `nil`, collection succeeds, store lookup is never invoked.
- [x] `resolveAmbientHostAccountID` with `nil` STS client → returns `""` without panicking.
- [x] `resolveAmbientHostAccountID` with store error → returns `""` without propagating, preserving collection.
- [x] `GetCloudAccountByExternalID` happy path returns the row.
- [x] `GetCloudAccountByExternalID` not-found returns `(nil, nil)` (not an error).

All targeted package tests pass: `go test ./internal/scheduler/... ./internal/config/... ./internal/api/...` (2 pre-existing failures in `TestPGXMock_GetExecutionByID_*` are unrelated and present on `feat/multicloud-web-frontend` before this change).

## Follow-up

- Azure / GCP collectors have the same ambient-fallback shape (`collectAzureRecommendations` and `collectGCPRecommendations`). I kept this PR AWS-only as scoped; a follow-up issue can extend the pattern if confirmed identical for those providers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scheduler now best-effort discovers the AWS account identity (via STS) and, when a matching registered cloud account exists, tags ambient AWS recommendations with that account for improved scoping and eviction.

* **Tests**
  * Added extensive tests and mock support for cloud-account lookups, STS integration, timeout/error cases, and ambient-account tagging behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/607?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->