### PR TITLE
fix(api): serve docs headers on HEAD

### DIFF
--- a/internal/api/handler_docs.go
+++ b/internal/api/handler_docs.go
@@ -77,8 +77,22 @@ func (h *Handler) serveOpenAPISpec(_ context.Context, _ *events.LambdaFunctionUR
 // Requests ending in /openapi.yaml serve the raw spec; everything else serves the UI.
 func (h *Handler) docsHandler(ctx context.Context, req *events.LambdaFunctionURLRequest, params map[string]string) (any, error) {
 	path := req.RequestContext.HTTP.Path
+	var (
+		response any
+		err      error
+	)
 	if strings.HasSuffix(path, "/openapi.yaml") {
-		return h.serveOpenAPISpec(ctx, req, params)
+		response, err = h.serveOpenAPISpec(ctx, req, params)
+	} else {
+		response, err = h.serveDocsUI(ctx, req, params)
 	}
-	return h.serveDocsUI(ctx, req, params)
+	if err != nil || req.RequestContext.HTTP.Method != "HEAD" {
+		return response, err
+	}
+	if raw, ok := response.(*rawResponse); ok {
+		head := *raw
+		head.body = ""
+		return &head, nil
+	}
+	return response, nil
 }

--- a/internal/api/handler_docs.go
+++ b/internal/api/handler_docs.go
@@ -90,6 +90,7 @@ func (h *Handler) docsHandler(ctx context.Context, req *events.LambdaFunctionURL
 		return response, err
 	}
 	if raw, ok := response.(*rawResponse); ok {
+		// rawResponse currently contains only strings, so a shallow copy is safe.
 		head := *raw
 		head.body = ""
 		return &head, nil

--- a/internal/api/handler_security_test.go
+++ b/internal/api/handler_security_test.go
@@ -161,34 +161,67 @@ func TestDocsHandler_HEAD_ReturnsHeaders(t *testing.T) {
 	ctx := context.Background()
 	handler := &Handler{}
 
-	getReq := &events.LambdaFunctionURLRequest{
-		RequestContext: events.LambdaFunctionURLRequestContext{
-			HTTP: events.LambdaFunctionURLRequestContextHTTPDescription{
-				Method: "GET",
-				Path:   "/api/docs/",
-			},
-		},
-	}
-	headReq := &events.LambdaFunctionURLRequest{
-		RequestContext: events.LambdaFunctionURLRequestContext{
-			HTTP: events.LambdaFunctionURLRequestContextHTTPDescription{
-				Method: "HEAD",
-				Path:   "/api/docs/",
-			},
-		},
+	tests := []struct {
+		name string
+		path string
+	}{
+		{name: "api docs UI", path: "/api/docs/"},
+		{name: "root docs UI", path: "/docs/"},
+		{name: "openapi yaml", path: "/api/docs/openapi.yaml"},
 	}
 
-	getResp, err := handler.HandleRequest(ctx, getReq)
-	require.NoError(t, err)
-	require.Equal(t, 200, getResp.StatusCode)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			getReq := &events.LambdaFunctionURLRequest{
+				RequestContext: events.LambdaFunctionURLRequestContext{
+					HTTP: events.LambdaFunctionURLRequestContextHTTPDescription{
+						Method: "GET",
+						Path:   tt.path,
+					},
+				},
+			}
+			headReq := &events.LambdaFunctionURLRequest{
+				RequestContext: events.LambdaFunctionURLRequestContext{
+					HTTP: events.LambdaFunctionURLRequestContextHTTPDescription{
+						Method: "HEAD",
+						Path:   tt.path,
+					},
+				},
+			}
 
-	headResp, err := handler.HandleRequest(ctx, headReq)
-	require.NoError(t, err)
-	assert.Equal(t, 200, headResp.StatusCode)
-	assert.Equal(t, getResp.Headers, headResp.Headers)
-	assert.Equal(t, getResp.Headers["Content-Security-Policy"], headResp.Headers["Content-Security-Policy"])
-	assert.Equal(t, docsPageCSP, headResp.Headers["Content-Security-Policy"])
-	assert.Empty(t, headResp.Body)
+			getResp, err := handler.HandleRequest(ctx, getReq)
+			require.NoError(t, err)
+			assert.Equal(t, 200, getResp.StatusCode)
+
+			headResp, err := handler.HandleRequest(ctx, headReq)
+			require.NoError(t, err)
+			assert.Equal(t, 200, headResp.StatusCode)
+			assert.Equal(t, getResp.Headers, headResp.Headers)
+			assert.Equal(t, getResp.Headers["Content-Security-Policy"], headResp.Headers["Content-Security-Policy"])
+			assert.Empty(t, headResp.Body)
+		})
+	}
+}
+
+func TestDocsRoutes_RegisterHEAD(t *testing.T) {
+	router := NewRouter(&Handler{})
+	expected := map[string]bool{
+		"/api/docs": false,
+		"/docs":     false,
+	}
+
+	for _, route := range router.routes {
+		if route.Method == "HEAD" {
+			if _, ok := expected[route.PathPrefix]; ok {
+				expected[route.PathPrefix] = true
+				assert.Equal(t, AuthPublic, route.Auth)
+			}
+		}
+	}
+
+	for path, found := range expected {
+		assert.True(t, found, "missing HEAD route for %s", path)
+	}
 }
 
 // TestServeDocsUI_RelaxedCSP_RootDocs verifies the same relaxed CSP is

--- a/internal/api/handler_security_test.go
+++ b/internal/api/handler_security_test.go
@@ -157,6 +157,40 @@ func TestServeDocsUI_RelaxedCSP(t *testing.T) {
 	assert.Equal(t, "max-age=31536000; includeSubDomains", resp.Headers["Strict-Transport-Security"])
 }
 
+func TestDocsHandler_HEAD_ReturnsHeaders(t *testing.T) {
+	ctx := context.Background()
+	handler := &Handler{}
+
+	getReq := &events.LambdaFunctionURLRequest{
+		RequestContext: events.LambdaFunctionURLRequestContext{
+			HTTP: events.LambdaFunctionURLRequestContextHTTPDescription{
+				Method: "GET",
+				Path:   "/api/docs/",
+			},
+		},
+	}
+	headReq := &events.LambdaFunctionURLRequest{
+		RequestContext: events.LambdaFunctionURLRequestContext{
+			HTTP: events.LambdaFunctionURLRequestContextHTTPDescription{
+				Method: "HEAD",
+				Path:   "/api/docs/",
+			},
+		},
+	}
+
+	getResp, err := handler.HandleRequest(ctx, getReq)
+	require.NoError(t, err)
+	require.Equal(t, 200, getResp.StatusCode)
+
+	headResp, err := handler.HandleRequest(ctx, headReq)
+	require.NoError(t, err)
+	assert.Equal(t, 200, headResp.StatusCode)
+	assert.Equal(t, getResp.Headers, headResp.Headers)
+	assert.Equal(t, getResp.Headers["Content-Security-Policy"], headResp.Headers["Content-Security-Policy"])
+	assert.Equal(t, docsPageCSP, headResp.Headers["Content-Security-Policy"])
+	assert.Empty(t, headResp.Body)
+}
+
 // TestServeDocsUI_RelaxedCSP_RootDocs verifies the same relaxed CSP is
 // applied to the root /docs/ prefix path (no /api/ prefix). The router
 // dispatches both /docs and /api/docs to docsHandler, so both surfaces

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -301,7 +301,9 @@ func (r *Router) registerRoutes() {
 
 		// API documentation (Swagger UI + raw spec)
 		{PathPrefix: "/api/docs", Method: "GET", Handler: r.docsHandler, Auth: AuthPublic},
+		{PathPrefix: "/api/docs", Method: "HEAD", Handler: r.docsHandler, Auth: AuthPublic},
 		{PathPrefix: "/docs", Method: "GET", Handler: r.docsHandler, Auth: AuthPublic},
+		{PathPrefix: "/docs", Method: "HEAD", Handler: r.docsHandler, Auth: AuthPublic},
 	}
 }
 


### PR DESCRIPTION
## Summary
- register HEAD routes for /api/docs and /docs so docs probes no longer fall through to 404
- reuse the existing docs GET raw response metadata for HEAD while stripping the body
- add TestDocsHandler_HEAD_ReturnsHeaders for /api/docs/ header parity and empty body

Closes #369

## Tests
- go test ./internal/api -run TestDocsHandler_HEAD_ReturnsHeaders
- go test ./internal/api

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HTTP HEAD request support for documentation endpoints (`/api/docs` and `/docs`), allowing clients to retrieve response headers without the full response body.

* **Tests**
  * Added test to verify HEAD requests return correct headers and empty body.

* **Refactor**
  * Improved request handling logic for documentation endpoints to properly manage response body for different HTTP methods.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/610?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->