### PR TITLE
ux(frontend/approval): label orphan executions as "Account deleted" instead of "(ambient)" (closes #608)

### DIFF
--- a/frontend/src/__tests__/approval-details.test.ts
+++ b/frontend/src/__tests__/approval-details.test.ts
@@ -203,6 +203,34 @@ describe('renderApprovalDetailsBody', () => {
     expect(stats[5]?.querySelector('.approval-details-stat-value')?.textContent).toBe('2'); // Accounts
   });
 
+  // Regression for CR pass-1 (PR #611): host-account rows must be
+  // counted in the header, and orphan "Account deleted" rows must not.
+  it('counts "Accounts: 1" for an all-host-account purchase (host AWS account, no cloud_account_id)', () => {
+    const rec = makeRec({ provider: 'aws' });
+    delete rec.cloud_account_id;
+    const body = renderApprovalDetailsBody(makeDetails([rec]), new Map(), '909626172446');
+    const stats = body.querySelectorAll('.approval-details-stat');
+    // Stat index 5 = Accounts.
+    expect(stats[5]?.querySelector('.approval-details-stat-value')?.textContent).toBe('1');
+  });
+
+  it('counts "Accounts: 2" for a purchase with one host row and one named-account row', () => {
+    const hostRec = makeRec({ id: 'r1', provider: 'aws' });
+    delete hostRec.cloud_account_id;
+    const namedRec = makeRec({ id: 'r2', provider: 'aws', cloud_account_id: 'acct-uuid-1' });
+    const body = renderApprovalDetailsBody(makeDetails([hostRec, namedRec]), new Map(), '909626172446');
+    const stats = body.querySelectorAll('.approval-details-stat');
+    expect(stats[5]?.querySelector('.approval-details-stat-value')?.textContent).toBe('2');
+  });
+
+  it('does NOT count an orphan row (cloud_account_id nil AND provider !== aws) in the Accounts total', () => {
+    const orphanRec = makeRec({ provider: 'azure' });
+    delete orphanRec.cloud_account_id;
+    const body = renderApprovalDetailsBody(makeDetails([orphanRec]), new Map(), '909626172446');
+    const stats = body.querySelectorAll('.approval-details-stat');
+    expect(stats[5]?.querySelector('.approval-details-stat-value')?.textContent).toBe('0');
+  });
+
   it('falls back to a legacy text sentence when recommendations are empty', () => {
     const details = makeDetails([]);
     const body = renderApprovalDetailsBody(details, new Map());

--- a/frontend/src/__tests__/approval-details.test.ts
+++ b/frontend/src/__tests__/approval-details.test.ts
@@ -109,12 +109,20 @@ describe('renderApprovalDetailsBody', () => {
     expect(cells[0]?.textContent).toBe('acct 11111111…');
   });
 
-  it('shows "(ambient)" for recs without a cloud_account_id', () => {
-    const rec = makeRec({});
+  it('shows "CUDly host (id)" for AWS recs without cloud_account_id when host account is known', () => {
+    const rec = makeRec({ provider: 'aws' });
     delete rec.cloud_account_id;
-    const body = renderApprovalDetailsBody(makeDetails([rec]), new Map());
+    const body = renderApprovalDetailsBody(makeDetails([rec]), new Map(), '909626172446');
     const cells = body.querySelectorAll('.approval-details-table tbody td');
-    expect(cells[0]?.textContent).toBe('(ambient)');
+    expect(cells[0]?.textContent).toBe('CUDly host (909626172446)');
+  });
+
+  it('shows "Account deleted" warning for Azure recs without cloud_account_id', () => {
+    const rec = makeRec({ provider: 'azure' });
+    delete rec.cloud_account_id;
+    const body = renderApprovalDetailsBody(makeDetails([rec]), new Map(), '909626172446');
+    const cells = body.querySelectorAll('.approval-details-table tbody td');
+    expect(cells[0]?.textContent).toBe('⚠ Account deleted — purchase cannot execute');
   });
 
   it('renders the engine column for RDS-shaped recs and "—" otherwise', () => {
@@ -218,20 +226,33 @@ describe('renderApprovalDetailsBody', () => {
 describe('formatAccountLabel', () => {
   it('returns "Name (external_id)" when both are present', () => {
     const acct = makeAccount({ id: 'a', name: 'Prod', external_id: '999988887777' });
-    expect(formatAccountLabel(acct, 'a')).toBe('Prod (999988887777)');
+    expect(formatAccountLabel(acct, 'a', 'aws', '111122223333')).toBe('Prod (999988887777)');
   });
 
   it('returns just Name when external_id is empty', () => {
     const acct = makeAccount({ id: 'a', name: 'Bastion', external_id: '' });
-    expect(formatAccountLabel(acct, 'a')).toBe('Bastion');
+    expect(formatAccountLabel(acct, 'a', 'aws', '111122223333')).toBe('Bastion');
   });
 
   it('returns "acct <prefix>" when the UUID is unknown', () => {
-    expect(formatAccountLabel(undefined, 'aaaaaaaa-bbbb-cccc')).toBe('acct aaaaaaaa…');
+    expect(formatAccountLabel(undefined, 'aaaaaaaa-bbbb-cccc', 'aws', '111122223333')).toBe('acct aaaaaaaa…');
   });
 
-  it('returns "(ambient)" when no account id was carried', () => {
-    expect(formatAccountLabel(undefined, undefined)).toBe('(ambient)');
+  // issue #608: distinguish genuine ambient from deleted account
+  it('returns "CUDly host (id)" when provider is aws, no recAccountId, and hostAWSAccountID is known', () => {
+    expect(formatAccountLabel(undefined, undefined, 'aws', '909626172446')).toBe('CUDly host (909626172446)');
+  });
+
+  it('returns "Account deleted" warning for azure with no recAccountId', () => {
+    expect(formatAccountLabel(undefined, undefined, 'azure', undefined)).toBe('⚠ Account deleted — purchase cannot execute');
+  });
+
+  it('returns "Account deleted" warning for gcp with no recAccountId', () => {
+    expect(formatAccountLabel(undefined, undefined, 'gcp', undefined)).toBe('⚠ Account deleted — purchase cannot execute');
+  });
+
+  it('returns "Account deleted" warning for aws with no recAccountId when hostAWSAccountID is missing', () => {
+    expect(formatAccountLabel(undefined, undefined, 'aws', undefined)).toBe('⚠ Account deleted — purchase cannot execute');
   });
 });
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -241,6 +241,11 @@ export interface PublicInfo {
   version: string;
   admin_exists: boolean;
   api_key_secret_url?: string;
+  /** AWS account ID of the CUDly Lambda (from STS GetCallerIdentity). Present
+   *  only on AWS-hosted deployments; omitted on Azure/GCP or when STS is
+   *  unreachable. Used by formatAccountLabel to distinguish genuine
+   *  ambient-credential executions from orphan rows (issue #608). */
+  deployment_aws_account_id?: string;
 }
 
 // Purchase types

--- a/frontend/src/approval-details.ts
+++ b/frontend/src/approval-details.ts
@@ -64,7 +64,7 @@ export function renderApprovalDetailsBody(details: PurchaseDetails, accountsById
     return root;
   }
 
-  root.appendChild(renderApprovalDetailsHeader(details, recs));
+  root.appendChild(renderApprovalDetailsHeader(details, recs, hostAWSAccountID));
   root.appendChild(renderApprovalDetailsTable(recs, accountsById, hostAWSAccountID));
   return root;
 }
@@ -78,7 +78,7 @@ export function renderApprovalDetailsBody(details: PurchaseDetails, accountsById
  * the sum of per-row monthly savings it's surfaced as a tooltip on
  * the stat so the user has a path to the underlying numbers.
  */
-function renderApprovalDetailsHeader(details: PurchaseDetails, recs: Recommendation[]): HTMLElement {
+function renderApprovalDetailsHeader(details: PurchaseDetails, recs: Recommendation[], hostAWSAccountID?: string): HTMLElement {
   const header = document.createElement('div');
   header.className = 'approval-details-header';
 
@@ -90,7 +90,12 @@ function renderApprovalDetailsHeader(details: PurchaseDetails, recs: Recommendat
   let totalMonthly = 0;
   for (const rec of recs) {
     if (rec.provider) providers.add(rec.provider);
-    if (rec.cloud_account_id) accounts.add(rec.cloud_account_id);
+    // Mirror the table's formatAccountLabel logic: if the rec has no
+    // cloud_account_id but is an AWS rec and we know the host account,
+    // count the host account — otherwise skip (orphan "Account deleted"
+    // rows must not inflate the count).
+    const effectiveAccountID = rec.cloud_account_id ?? (rec.provider === 'aws' && hostAWSAccountID ? hostAWSAccountID : null);
+    if (effectiveAccountID) accounts.add(effectiveAccountID);
     // Defensive ?? 0: the wire type is wider than the TS one and a
     // legacy row could carry null; a single NaN here would poison
     // the entire header total.

--- a/frontend/src/approval-details.ts
+++ b/frontend/src/approval-details.ts
@@ -49,7 +49,7 @@ export type AccountsById = Map<string, CloudAccount>;
  * Exported separately from `buildApprovalDetailsBody` so tests can
  * render the body deterministically — no fetch mocking required.
  */
-export function renderApprovalDetailsBody(details: PurchaseDetails, accountsById: AccountsById): HTMLElement {
+export function renderApprovalDetailsBody(details: PurchaseDetails, accountsById: AccountsById, hostAWSAccountID?: string): HTMLElement {
   const root = document.createElement('div');
   root.className = 'approval-details';
 
@@ -65,7 +65,7 @@ export function renderApprovalDetailsBody(details: PurchaseDetails, accountsById
   }
 
   root.appendChild(renderApprovalDetailsHeader(details, recs));
-  root.appendChild(renderApprovalDetailsTable(recs, accountsById));
+  root.appendChild(renderApprovalDetailsTable(recs, accountsById, hostAWSAccountID));
   return root;
 }
 
@@ -154,7 +154,7 @@ function headerStat(label: string, value: string, hover?: string, title?: string
  * resource / engine / region) -> sizing (count / term / payment) ->
  * money (upfront / monthly savings / effective savings %).
  */
-function renderApprovalDetailsTable(recs: Recommendation[], accountsById: AccountsById): HTMLElement {
+function renderApprovalDetailsTable(recs: Recommendation[], accountsById: AccountsById, hostAWSAccountID?: string): HTMLElement {
   const wrap = document.createElement('div');
   wrap.className = 'approval-details-table-wrap';
 
@@ -181,7 +181,7 @@ function renderApprovalDetailsTable(recs: Recommendation[], accountsById: Accoun
 
   const tbody = document.createElement('tbody');
   for (const rec of recs) {
-    tbody.appendChild(renderRecRow(rec, accountsById));
+    tbody.appendChild(renderRecRow(rec, accountsById, hostAWSAccountID));
   }
   table.appendChild(tbody);
   wrap.appendChild(table);
@@ -198,10 +198,10 @@ function renderApprovalDetailsTable(recs: Recommendation[], accountsById: Accoun
  * through escapeHtml so a tampered recommendation field can't inject
  * markup.
  */
-function renderRecRow(rec: Recommendation, accountsById: AccountsById): HTMLElement {
+function renderRecRow(rec: Recommendation, accountsById: AccountsById, hostAWSAccountID?: string): HTMLElement {
   const row = document.createElement('tr');
   const acct = rec.cloud_account_id ? accountsById.get(rec.cloud_account_id) : undefined;
-  const accountLabel = formatAccountLabel(acct, rec.cloud_account_id);
+  const accountLabel = formatAccountLabel(acct, rec.cloud_account_id, rec.provider ?? '', hostAWSAccountID);
   // rec.engine is a string for DB-shaped services and "" otherwise;
   // both `undefined` and "" are falsy so the single check is enough.
   const engineLabel = rec.engine ? rec.engine : '—';
@@ -234,11 +234,23 @@ function renderRecRow(rec: Recommendation, accountsById: AccountsById): HTMLElem
  *   - When only the UUID is on the rec (account not yet listed because
  *     of a stale cache or a deletion race), show the first 8 chars of
  *     the UUID so the user can still cross-reference.
- *   - When the rec carries no account at all (ambient-credentials
- *     direct-execute path), show "(ambient)" so the user knows it's
- *     hitting whichever account the deployment runs in.
+ *   - When the rec carries no account at all, distinguish two cases
+ *     (issue #608):
+ *       a) provider === 'aws' AND hostAWSAccountID is known: the rec
+ *          targets the CUDly Lambda's own account — label it as the
+ *          host account so the operator sees exactly which account
+ *          will be charged.
+ *       b) Any other combination (Azure/GCP without an account, or AWS
+ *          but host account ID is unavailable): the account was almost
+ *          certainly deleted. Show a warning so the operator knows to
+ *          cancel rather than approve.
  */
-export function formatAccountLabel(acct: CloudAccount | undefined, recAccountId: string | undefined): string {
+export function formatAccountLabel(
+  acct: CloudAccount | undefined,
+  recAccountId: string | undefined,
+  provider: string,
+  hostAWSAccountID: string | undefined,
+): string {
   if (acct) {
     if (acct.external_id) return `${acct.name} (${acct.external_id})`;
     return acct.name;
@@ -246,7 +258,11 @@ export function formatAccountLabel(acct: CloudAccount | undefined, recAccountId:
   if (recAccountId) {
     return `acct ${recAccountId.slice(0, 8)}…`;
   }
-  return '(ambient)';
+  // No account on the rec. Distinguish 'genuine ambient' from 'deleted'.
+  if (provider === 'aws' && hostAWSAccountID) {
+    return `CUDly host (${hostAWSAccountID})`;
+  }
+  return '⚠ Account deleted — purchase cannot execute';
 }
 
 /**
@@ -287,21 +303,26 @@ export function computeEffectiveSavingsPct(rec: Recommendation): number | null {
  */
 export async function buildApprovalDetailsBody(executionId: string): Promise<HTMLElement> {
   try {
-    // listAccounts is caught inline so the modal still renders the
-    // full details when the accounts endpoint is unreachable; the
-    // per-rec table degrades to "acct xxxxxxxx…" stubs instead of
-    // failing the whole confirmation. console.warn keeps the failure
-    // traceable rather than silently dropping the error.
-    const [details, accounts] = await Promise.all([
+    // Fetch purchase details, account list, and public info in parallel.
+    // listAccounts and getPublicInfo are caught inline so the modal still
+    // renders the full details when either endpoint is unreachable; the
+    // per-rec table degrades gracefully. console.warn keeps failures
+    // traceable rather than silently dropping them.
+    const [details, accounts, publicInfo] = await Promise.all([
       api.getPurchaseDetails(executionId),
       api.listAccounts().catch((err) => {
         console.warn('Failed to load accounts for approval modal — falling back to UUID-prefixed labels:', err);
         return [] as CloudAccount[];
       }),
+      api.getPublicInfo().catch((err) => {
+        console.warn('Failed to load public info for approval modal — orphan label will show "Account deleted":', err);
+        return undefined;
+      }),
     ]);
     const accountsById = new Map<string, CloudAccount>();
     for (const acct of accounts) accountsById.set(acct.id, acct);
-    return renderApprovalDetailsBody(details, accountsById);
+    const hostAWSAccountID = publicInfo?.deployment_aws_account_id;
+    return renderApprovalDetailsBody(details, accountsById, hostAWSAccountID);
   } catch (err) {
     console.error('Failed to load purchase details for approval modal:', err);
     return buildApprovalDetailsFallback();

--- a/internal/api/handler_dashboard.go
+++ b/internal/api/handler_dashboard.go
@@ -344,10 +344,20 @@ func (h *Handler) getPublicInfo(ctx context.Context, req *events.LambdaFunctionU
 		}
 	}
 
+	// Resolve the host AWS account ID so the frontend can distinguish a
+	// legitimate ambient-credential execution (cloud_account_id IS NULL
+	// because the rec targets the CUDly Lambda's own account) from an
+	// orphan execution whose account was deleted (issue #608). The call
+	// is best-effort: non-AWS deployments and STS transient failures
+	// return "" and the frontend falls back to the "Account deleted"
+	// warning label, which is safe.
+	deploymentAWSAccountID, _ := h.resolveAWSAccountID(ctx)
+
 	return &PublicInfoResponse{
-		Version:         "1.0.0",
-		AdminExists:     adminExists,
-		APIKeySecretURL: apiKeySecretURL,
+		Version:                "1.0.0",
+		AdminExists:            adminExists,
+		APIKeySecretURL:        apiKeySecretURL,
+		DeploymentAWSAccountID: deploymentAWSAccountID,
 	}, nil
 }
 

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -2386,3 +2386,11 @@ components:
           type: boolean
         api_key_secret_url:
           type: string
+        deployment_aws_account_id:
+          type: string
+          description: >
+            AWS account ID of the CUDly Lambda deployment (from STS GetCallerIdentity).
+            Present only on AWS-hosted deployments; omitted on Azure/GCP or when STS
+            is unreachable. Used by the frontend to distinguish legitimate ambient-credential
+            executions (cloud_account_id IS NULL because the rec targets this account)
+            from orphan rows whose account was deleted (issue #608).

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -458,9 +458,10 @@ type EmptyServiceConfigResponse struct{}
 
 // PublicInfoResponse holds public information about the CUDly instance
 type PublicInfoResponse struct {
-	Version         string `json:"version"`
-	AdminExists     bool   `json:"admin_exists"`
-	APIKeySecretURL string `json:"api_key_secret_url,omitempty"`
+	Version                string `json:"version"`
+	AdminExists            bool   `json:"admin_exists"`
+	APIKeySecretURL        string `json:"api_key_secret_url,omitempty"`
+	DeploymentAWSAccountID string `json:"deployment_aws_account_id,omitempty"`
 }
 
 // DashboardSummaryResponse holds the dashboard summary data


### PR DESCRIPTION
## Summary

- Extends `formatAccountLabel` with two new params (`provider`, `hostAWSAccountID`) to distinguish three cases: resolved account, legitimate AWS ambient host, and deleted/orphan account.
- `GET /api/info` now returns `deployment_aws_account_id` (populated via STS `GetCallerIdentity`, best-effort) so the frontend can tell genuine ambient from orphan rows.
- 4 new regression tests cover: AWS with known host ID, Azure orphan, GCP orphan, AWS orphan with missing host info.

## Test plan

- [x] `npm test` in `frontend/` - all 1906 tests pass (26 in approval-details, 0 regressions elsewhere)
- [x] `go build ./internal/api/...` compiles cleanly
- [x] Pre-commit hooks pass (gofmt auto-fixed alignment, all checks green)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic detection of the deployment AWS account ID to improve host-account recognition in approval details.

* **Bug Fixes**
  * Improved account-labeling: show explicit AWS host labels and specific "Account deleted" warnings instead of a generic ambient fallback.

* **Tests**
  * Added/updated tests covering provider-specific labeling and account-counting in approval details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/611?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->