### PR TITLE
fix(credentials/aws): resolve Self account (empty role ARN) to ambient creds (closes #605)

### DIFF
--- a/internal/credentials/resolver.go
+++ b/internal/credentials/resolver.go
@@ -76,9 +76,17 @@ type STSClientFactory func(provider aws.CredentialsProvider) STSClient
 // self-resolve correctly; without them, bastion mode falls back to the
 // pre-self-loading behaviour (trusts the caller-supplied STS client) for
 // backward compatibility.
+//
+// AmbientProvider, when set, is returned for role_arn accounts whose
+// AWSRoleARN is empty (the "Self" account shape: auth_mode=role_arn with no
+// role ARN). This mirrors the scheduler's collectAWSForAccount logic, which
+// treats the same shape as an ambient-credentials case.
 type AWSResolveOptions struct {
 	AccountLookup    AccountLookupFunc
 	STSClientFactory STSClientFactory
+	// AmbientProvider is the host Lambda / EC2 instance credentials provider.
+	// Required when resolving a Self account (role_arn with empty AWSRoleARN).
+	AmbientProvider aws.CredentialsProvider
 }
 
 // ResolveAWSCredentialProvider is a back-compat wrapper that calls
@@ -113,7 +121,7 @@ func ResolveAWSCredentialProviderWithOpts(
 	case "access_keys":
 		return resolveAccessKeyProvider(ctx, account, store)
 	case "role_arn":
-		return resolveRoleARNProvider(ctx, account, stsClient, nil)
+		return resolveRoleARNProvider(ctx, account, stsClient, opts.AmbientProvider)
 	case "bastion":
 		return resolveBastionProvider(ctx, account, store, stsClient, opts)
 	case "workload_identity_federation":
@@ -145,14 +153,25 @@ func resolveAccessKeyProvider(ctx context.Context, account *config.CloudAccount,
 // assumes account.AWSRoleARN using stsClient. stscreds.AssumeRoleProvider
 // transparently refreshes credentials before they expire, avoiding the
 // 1-hour STS token expiry problem of static credentials.
+//
+// When AWSRoleARN is empty (the "Self" account shape: auth_mode=role_arn with
+// no role ARN), the ambient provider is returned directly so collection and
+// execution agree on what this shape means. If ambient is nil in that case,
+// a descriptive error is returned.
 func resolveRoleARNProvider(
 	_ context.Context,
 	account *config.CloudAccount,
 	stsClient STSClient,
-	_ aws.CredentialsProvider,
+	ambient aws.CredentialsProvider,
 ) (aws.CredentialsProvider, error) {
 	if account.AWSRoleARN == "" {
-		return nil, fmt.Errorf("credentials: aws_role_arn is required for role_arn auth mode (account %s)", account.ID)
+		// Self-account: auth_mode=role_arn with no role ARN means "use the
+		// CUDly Lambda's own credentials to access this account." The
+		// scheduler's collectAWSForAccount handles the same shape identically.
+		if ambient != nil {
+			return ambient, nil
+		}
+		return nil, fmt.Errorf("credentials: aws_role_arn is empty and no ambient credentials available (account %s)", account.ID)
 	}
 
 	sessionSuffix := account.ID

--- a/internal/credentials/resolver_extra_test.go
+++ b/internal/credentials/resolver_extra_test.go
@@ -43,7 +43,9 @@ func TestResolveBastionProvider_WithBastionAndRoleARN(t *testing.T) {
 }
 
 func TestResolveBastionProvider_NoRoleARN(t *testing.T) {
-	// bastion mode delegates to resolveRoleARNProvider; a missing ARN surfaces there.
+	// bastion mode (legacy fallback) delegates to resolveRoleARNProvider with nil
+	// ambient; an empty ARN now returns the ambient-creds error instead of the
+	// old "is required" message.
 	account := &config.CloudAccount{
 		ID:           "acct1",
 		AWSAuthMode:  "bastion",
@@ -52,7 +54,7 @@ func TestResolveBastionProvider_NoRoleARN(t *testing.T) {
 	}
 	_, err := ResolveAWSCredentialProvider(context.Background(), account, newMockStore(), &mockSTSClient{})
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "aws_role_arn is required")
+	assert.Contains(t, err.Error(), "aws_role_arn is empty and no ambient credentials available")
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/credentials/resolver_test.go
+++ b/internal/credentials/resolver_test.go
@@ -147,16 +147,76 @@ func TestResolveAWSCredentialProvider_RoleARN(t *testing.T) {
 	assert.NotNil(t, provider)
 }
 
-func TestResolveAWSCredentialProvider_RoleARN_NoARN(t *testing.T) {
+// TestResolveAWSCredentialProvider_RoleARN_NoARN_NilAmbient verifies that the
+// back-compat wrapper (which passes nil ambient) returns the descriptive error
+// for a Self-account shape when there is no ambient provider available.
+func TestResolveAWSCredentialProvider_RoleARN_NoARN_NilAmbient(t *testing.T) {
 	account := &config.CloudAccount{
 		ID:          "acct1",
 		AWSAuthMode: "role_arn",
-		AWSRoleARN:  "", // missing
+		AWSRoleARN:  "", // Self-account shape
 	}
 
+	// Back-compat wrapper passes nil ambient, so we expect the nil-ambient error.
 	_, err := ResolveAWSCredentialProvider(context.Background(), account, newMockStore(), &mockSTSClient{})
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "aws_role_arn is required")
+	assert.Contains(t, err.Error(), "aws_role_arn is empty and no ambient credentials available")
+}
+
+// TestResolveAWSCredentialProvider_SelfAccount_WithAmbient verifies that a
+// Self-account (auth_mode=role_arn, empty AWSRoleARN) returns the ambient
+// credentials provider when one is supplied via AWSResolveOptions.
+func TestResolveAWSCredentialProvider_SelfAccount_WithAmbient(t *testing.T) {
+	account := &config.CloudAccount{
+		ID:          "self-acct",
+		AWSAuthMode: "role_arn",
+		AWSRoleARN:  "", // Self-account shape
+	}
+
+	ambientCreds := aws.CredentialsProviderFunc(func(_ context.Context) (aws.Credentials, error) {
+		return aws.Credentials{
+			AccessKeyID:     "AMBIENTKEY",
+			SecretAccessKey: "ambientsecret",
+			Source:          "test-ambient",
+		}, nil
+	})
+
+	provider, err := ResolveAWSCredentialProviderWithOpts(
+		context.Background(),
+		account,
+		newMockStore(),
+		&mockSTSClient{},
+		AWSResolveOptions{AmbientProvider: ambientCreds},
+	)
+	require.NoError(t, err)
+	assert.NotNil(t, provider)
+
+	creds, err := provider.Retrieve(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "AMBIENTKEY", creds.AccessKeyID)
+	assert.Equal(t, "test-ambient", creds.Source)
+}
+
+// TestResolveAWSCredentialProvider_SelfAccount_NilAmbient verifies that a
+// Self-account with a nil AmbientProvider in AWSResolveOptions returns the
+// descriptive error instead of a panic or a misleading "aws_role_arn required" message.
+func TestResolveAWSCredentialProvider_SelfAccount_NilAmbient(t *testing.T) {
+	account := &config.CloudAccount{
+		ID:          "self-acct",
+		AWSAuthMode: "role_arn",
+		AWSRoleARN:  "", // Self-account shape
+	}
+
+	_, err := ResolveAWSCredentialProviderWithOpts(
+		context.Background(),
+		account,
+		newMockStore(),
+		&mockSTSClient{},
+		AWSResolveOptions{AmbientProvider: nil},
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "aws_role_arn is empty and no ambient credentials available")
+	assert.Contains(t, err.Error(), "self-acct")
 }
 
 func TestResolveAWSCredentialProvider_RoleARN_STSError(t *testing.T) {

--- a/internal/purchase/execution.go
+++ b/internal/purchase/execution.go
@@ -212,7 +212,8 @@ func (m *Manager) resolveAWSProvider(ctx context.Context, account config.CloudAc
 	if account.AWSAuthMode != "access_keys" && m.assumeRoleSTS == nil {
 		return nil, fmt.Errorf("credentials: STS client not configured for non-access_keys mode (account %s)", account.ID)
 	}
-	awsCreds, err := credentials.ResolveAWSCredentialProvider(ctx, &account, m.credStore, m.assumeRoleSTS)
+	awsCreds, err := credentials.ResolveAWSCredentialProviderWithOpts(ctx, &account, m.credStore, m.assumeRoleSTS,
+		credentials.AWSResolveOptions{AmbientProvider: m.ambientAWSCreds})
 	if err != nil {
 		return nil, fmt.Errorf("credentials: resolve AWS for account %s (%s): %w", account.ID, account.Name, err)
 	}

--- a/internal/purchase/manager.go
+++ b/internal/purchase/manager.go
@@ -12,6 +12,7 @@ import (
 	"github.com/LeanerCloud/CUDly/internal/oidc"
 	"github.com/LeanerCloud/CUDly/pkg/logging"
 	"github.com/LeanerCloud/CUDly/pkg/provider"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 )
 
@@ -34,6 +35,9 @@ type ManagerConfig struct {
 	DefaultCoverage        float64
 	DefaultRampSchedule    string
 	DashboardURL           string
+	// AmbientAWSCreds is the host Lambda / EC2 instance credentials provider,
+	// used when resolving a Self account (auth_mode=role_arn with empty role ARN).
+	AmbientAWSCreds aws.CredentialsProvider
 	// OIDCSigner and OIDCIssuerURL enable the secret-free Azure
 	// federated credential path. When both are set, Azure accounts in
 	// workload_identity_federation mode with no stored PEM are routed
@@ -49,6 +53,7 @@ type Manager struct {
 	email           email.SenderInterface
 	stsClient       STSClient
 	assumeRoleSTS   credentials.STSClient
+	ambientAWSCreds aws.CredentialsProvider
 	credStore       credentials.CredentialStore
 	providerFactory provider.FactoryInterface
 	notifyDays      int
@@ -91,6 +96,7 @@ func NewManager(cfg ManagerConfig) *Manager {
 		email:           cfg.EmailSender,
 		stsClient:       cfg.STSClient,
 		assumeRoleSTS:   cfg.AssumeRoleSTS,
+		ambientAWSCreds: cfg.AmbientAWSCreds,
 		credStore:       cfg.CredentialStore,
 		providerFactory: factory,
 		notifyDays:      cfg.NotificationDaysBefore,

--- a/internal/server/app.go
+++ b/internal/server/app.go
@@ -651,6 +651,7 @@ func (app *Application) reinitializeAfterConnect(ctx context.Context, dbConn *da
 		EmailSender:            app.Email,
 		STSClient:              sts.NewFromConfig(awsCfg),
 		AssumeRoleSTS:          sts.NewFromConfig(awsCfg),
+		AmbientAWSCreds:        awsCfg.Credentials,
 		CredentialStore:        credStore,
 		NotificationDaysBefore: app.appConfig.NotificationDaysBefore,
 		DefaultTerm:            app.appConfig.DefaultTerm,
@@ -686,7 +687,8 @@ func (app *Application) reinitializeAfterConnect(ctx context.Context, dbConn *da
 		app.Config,
 		func(ctx context.Context, acct *config.CloudAccount) (aws.Config, error) {
 			stsClient := sts.NewFromConfig(awsCfg)
-			prov, err := credentials.ResolveAWSCredentialProvider(ctx, acct, credStore, stsClient)
+			prov, err := credentials.ResolveAWSCredentialProviderWithOpts(ctx, acct, credStore, stsClient,
+				credentials.AWSResolveOptions{AmbientProvider: awsCfg.Credentials})
 			if err != nil {
 				return aws.Config{}, err
 			}


### PR DESCRIPTION
## Summary

- `resolveRoleARNProvider` returned a hard error when `AWSRoleARN==""` (the "Self" account shape), while the scheduler's `collectAWSForAccount` treated the same shape as the ambient-creds case, causing every approve action against the CUDly host account to fail.
- Fixed by using `opts.AmbientProvider` (new `AWSResolveOptions` field) when `AWSRoleARN` is empty; falls back to a descriptive error when ambient is nil.
- Threaded `awsCfg.Credentials` as `AmbientAWSCreds` through `purchase.Manager` (new field) and the commitment-opts closure in `server/app.go` so both callers supply a valid ambient provider.

## Test plan

- [x] `TestResolveAWSCredentialProvider_SelfAccount_WithAmbient` - Self shape + ambient returns ambient, no error
- [x] `TestResolveAWSCredentialProvider_SelfAccount_NilAmbient` - Self shape + nil ambient returns descriptive error
- [x] `TestResolveAWSCredentialProvider_RoleARN_NoARN_NilAmbient` - back-compat wrapper (nil ambient) returns descriptive error
- [x] Existing `role_arn`-with-ARN path regression: all 83 credential tests pass
- [x] All purchase tests pass (132)
- [x] Full build clean (`go build ./...`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Self account configuration using ambient AWS credentials, eliminating cross-account role ARN requirements in certain scenarios.

* **Bug Fixes**
  * Improved error messages during AWS credential resolution for better troubleshooting and diagnostics.

* **Tests**
  * Expanded test coverage for Self account credential resolution scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/612?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->