### PR TITLE
fix(api/purchases): reject approval of non-AWS execution with deleted account (closes #609)

### DIFF
--- a/internal/api/handler_purchases.go
+++ b/internal/api/handler_purchases.go
@@ -263,18 +263,41 @@ func (h *Handler) deletePlannedPurchase(ctx context.Context, req *events.LambdaF
 	return &StatusResponse{Status: "cancelled"}, nil
 }
 
-// Purchase action handlers
-func (h *Handler) approvePurchase(ctx context.Context, req *events.LambdaFunctionURLRequest, execID, token string) (any, error) {
-	if err := validateUUID(execID); err != nil {
-		return nil, err
-	}
-
+// loadApproveExecution fetches an execution by ID, returns a 404 ClientError
+// when not found, and then runs the issue-#609 orphan preflight check.
+// Extracted from approvePurchase to keep that function below the gocyclo
+// threshold — same pattern as loadCancelableExecution in the purchase package.
+func (h *Handler) loadApproveExecution(ctx context.Context, execID string) (*config.PurchaseExecution, error) {
 	execution, err := h.config.GetExecutionByID(ctx, execID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get execution: %w", err)
 	}
 	if execution == nil {
 		return nil, NewClientError(404, "execution not found")
+	}
+	// Preflight (issue #609): reject non-AWS orphan executions before the
+	// cloud SDK is reached. AWS has the ambient-host-account fallback so
+	// only non-AWS providers are blocked. Empty provider = legacy AWS row.
+	if execution.CloudAccountID == nil && len(execution.Recommendations) > 0 {
+		if p := execution.Recommendations[0].Provider; p != "" && p != "aws" {
+			return nil, NewClientError(409, fmt.Sprintf(
+				"execution %s references an account that no longer exists (provider: %s). Cancel this purchase — it cannot execute.",
+				execution.ExecutionID, p,
+			))
+		}
+	}
+	return execution, nil
+}
+
+// Purchase action handlers
+func (h *Handler) approvePurchase(ctx context.Context, req *events.LambdaFunctionURLRequest, execID, token string) (any, error) {
+	if err := validateUUID(execID); err != nil {
+		return nil, err
+	}
+
+	execution, err := h.loadApproveExecution(ctx, execID)
+	if err != nil {
+		return nil, err
 	}
 
 	// Three-mode dispatch — same shape as cancelPurchase (issue #46) and

--- a/internal/api/handler_purchases.go
+++ b/internal/api/handler_purchases.go
@@ -12,6 +12,7 @@ import (
 	"github.com/LeanerCloud/CUDly/internal/auth"
 	"github.com/LeanerCloud/CUDly/internal/config"
 	"github.com/LeanerCloud/CUDly/internal/email"
+	"github.com/LeanerCloud/CUDly/internal/purchase"
 	"github.com/LeanerCloud/CUDly/pkg/common"
 	"github.com/LeanerCloud/CUDly/pkg/logging"
 	"github.com/aws/aws-lambda-go/events"
@@ -276,15 +277,10 @@ func (h *Handler) loadApproveExecution(ctx context.Context, execID string) (*con
 		return nil, NewClientError(404, "execution not found")
 	}
 	// Preflight (issue #609): reject non-AWS orphan executions before the
-	// cloud SDK is reached. AWS has the ambient-host-account fallback so
-	// only non-AWS providers are blocked. Empty provider = legacy AWS row.
-	if execution.CloudAccountID == nil && len(execution.Recommendations) > 0 {
-		if p := execution.Recommendations[0].Provider; p != "" && p != "aws" {
-			return nil, NewClientError(409, fmt.Sprintf(
-				"execution %s references an account that no longer exists (provider: %s). Cancel this purchase — it cannot execute.",
-				execution.ExecutionID, p,
-			))
-		}
+	// cloud SDK is reached. Delegates to the centralized predicate in the
+	// purchase package so the logic is maintained in one place.
+	if err := purchase.OrphanExecutionError(execution); err != nil {
+		return nil, NewClientError(409, err.Error())
 	}
 	return execution, nil
 }

--- a/internal/api/handler_purchases_test.go
+++ b/internal/api/handler_purchases_test.go
@@ -359,6 +359,156 @@ func TestHandler_approvePurchase_SessionExecuteFailureSurfacesAs409(t *testing.T
 	assert.Contains(t, ce.Error(), "could not be approved")
 }
 
+// --- Regression tests for issue #609 (orphan-account guard) ---
+
+// TestHandler_approvePurchase_AzureOrphanRejects409 is the regression guard
+// for issue #609: an execution whose CloudAccountID is nil and whose provider
+// is Azure must be rejected with 409 and a descriptive message before the
+// cloud SDK is ever reached. Pre-fix this surfaced an opaque IMDS /
+// missing-env-var error.
+func TestHandler_approvePurchase_AzureOrphanRejects409(t *testing.T) {
+	ctx := context.Background()
+	execID := "12345678-1234-1234-1234-123456789abc"
+
+	mockConfig := new(MockConfigStore)
+	exec := &config.PurchaseExecution{
+		ExecutionID:   execID,
+		ApprovalToken: "valid-token",
+		Status:        "pending",
+		// CloudAccountID intentionally nil — account was deleted.
+		Recommendations: []config.RecommendationRecord{{ID: "r1", Provider: "azure"}},
+	}
+	mockConfig.On("GetExecutionByID", ctx, execID).Return(exec, nil)
+
+	mockAuth := new(MockAuthService)
+	mockAuth.On("ValidateSession", ctx, "sess-tok").Return(&Session{Email: "admin@example.com", Role: "admin"}, nil)
+
+	mockPurchase := new(MockPurchaseManager)
+
+	handler := &Handler{purchase: mockPurchase, config: mockConfig, auth: mockAuth}
+
+	req := &events.LambdaFunctionURLRequest{
+		Headers: map[string]string{"authorization": "Bearer sess-tok"},
+	}
+	_, err := handler.approvePurchase(ctx, req, execID, "")
+	require.Error(t, err)
+	ce, ok := IsClientError(err)
+	require.True(t, ok, "expected a clientError")
+	assert.Equal(t, 409, ce.code)
+	assert.Contains(t, ce.Error(), "no longer exists")
+	assert.Contains(t, ce.Error(), "azure")
+	// Guard fires before the purchase manager is touched.
+	mockPurchase.AssertNotCalled(t, "ApproveAndExecute", mock.Anything, mock.Anything, mock.Anything)
+	mockPurchase.AssertNotCalled(t, "ApproveExecution", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+// TestHandler_approvePurchase_GCPOrphanRejects409 mirrors the Azure case for GCP.
+func TestHandler_approvePurchase_GCPOrphanRejects409(t *testing.T) {
+	ctx := context.Background()
+	execID := "12345678-1234-1234-1234-123456789abc"
+
+	mockConfig := new(MockConfigStore)
+	exec := &config.PurchaseExecution{
+		ExecutionID:     execID,
+		ApprovalToken:   "valid-token",
+		Status:          "pending",
+		Recommendations: []config.RecommendationRecord{{ID: "r1", Provider: "gcp"}},
+	}
+	mockConfig.On("GetExecutionByID", ctx, execID).Return(exec, nil)
+
+	mockAuth := new(MockAuthService)
+	mockAuth.On("ValidateSession", ctx, "sess-tok").Return(&Session{Email: "admin@example.com", Role: "admin"}, nil)
+
+	mockPurchase := new(MockPurchaseManager)
+
+	handler := &Handler{purchase: mockPurchase, config: mockConfig, auth: mockAuth}
+
+	req := &events.LambdaFunctionURLRequest{
+		Headers: map[string]string{"authorization": "Bearer sess-tok"},
+	}
+	_, err := handler.approvePurchase(ctx, req, execID, "")
+	require.Error(t, err)
+	ce, ok := IsClientError(err)
+	require.True(t, ok, "expected a clientError")
+	assert.Equal(t, 409, ce.code)
+	assert.Contains(t, ce.Error(), "no longer exists")
+	assert.Contains(t, ce.Error(), "gcp")
+	mockPurchase.AssertNotCalled(t, "ApproveAndExecute", mock.Anything, mock.Anything, mock.Anything)
+	mockPurchase.AssertNotCalled(t, "ApproveExecution", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+// TestHandler_approvePurchase_AWSOrphanFallsThrough confirms that an AWS
+// execution with nil CloudAccountID is NOT blocked by the issue-#609 guard.
+// AWS has an ambient-host-account fallback (PR #607/#604) that handles it.
+func TestHandler_approvePurchase_AWSOrphanFallsThrough(t *testing.T) {
+	ctx := context.Background()
+	execID := "12345678-1234-1234-1234-123456789abc"
+	adminEmail := "admin@example.com"
+
+	mockConfig := new(MockConfigStore)
+	exec := &config.PurchaseExecution{
+		ExecutionID:   execID,
+		ApprovalToken: "valid-token",
+		Status:        "pending",
+		// CloudAccountID nil — but provider is AWS, so fallback applies.
+		Recommendations: []config.RecommendationRecord{{ID: "r1", Provider: "aws"}},
+	}
+	mockConfig.On("GetExecutionByID", ctx, execID).Return(exec, nil)
+
+	mockAuth := new(MockAuthService)
+	mockAuth.On("ValidateSession", ctx, "sess-tok").Return(&Session{Email: adminEmail, Role: "admin"}, nil)
+
+	mockPurchase := new(MockPurchaseManager)
+	// Guard does not fire; ApproveAndExecute is called normally.
+	mockPurchase.On("ApproveAndExecute", ctx, execID, adminEmail).Return(nil)
+
+	handler := &Handler{purchase: mockPurchase, config: mockConfig, auth: mockAuth}
+
+	req := &events.LambdaFunctionURLRequest{
+		Headers: map[string]string{"authorization": "Bearer sess-tok"},
+	}
+	result, err := handler.approvePurchase(ctx, req, execID, "")
+	require.NoError(t, err)
+	assert.Equal(t, "completed", result.(map[string]string)["status"])
+	mockPurchase.AssertExpectations(t)
+}
+
+// TestHandler_approvePurchase_NonOrphanUnchanged confirms that an execution
+// with a populated CloudAccountID is not affected by the issue-#609 guard.
+func TestHandler_approvePurchase_NonOrphanUnchanged(t *testing.T) {
+	ctx := context.Background()
+	execID := "12345678-1234-1234-1234-123456789abc"
+	adminEmail := "admin@example.com"
+	accountID := "acct-azure-001"
+
+	mockConfig := new(MockConfigStore)
+	exec := &config.PurchaseExecution{
+		ExecutionID:   execID,
+		ApprovalToken: "valid-token",
+		Status:        "pending",
+		// CloudAccountID is set — normal case, guard must not fire.
+		Recommendations: []config.RecommendationRecord{{ID: "r1", Provider: "azure", CloudAccountID: &accountID}},
+		CloudAccountID:  &accountID,
+	}
+	mockConfig.On("GetExecutionByID", ctx, execID).Return(exec, nil)
+
+	mockAuth := new(MockAuthService)
+	mockAuth.On("ValidateSession", ctx, "sess-tok").Return(&Session{Email: adminEmail, Role: "admin"}, nil)
+
+	mockPurchase := new(MockPurchaseManager)
+	mockPurchase.On("ApproveAndExecute", ctx, execID, adminEmail).Return(nil)
+
+	handler := &Handler{purchase: mockPurchase, config: mockConfig, auth: mockAuth}
+
+	req := &events.LambdaFunctionURLRequest{
+		Headers: map[string]string{"authorization": "Bearer sess-tok"},
+	}
+	result, err := handler.approvePurchase(ctx, req, execID, "")
+	require.NoError(t, err)
+	assert.Equal(t, "completed", result.(map[string]string)["status"])
+	mockPurchase.AssertExpectations(t)
+}
+
 func TestHandler_approvePurchase_RejectsGlobalNotifyWhenContactSet(t *testing.T) {
 	// Regression: once an account has contact_email set, the global
 	// notification email is only CC'd — it should NOT be accepted as an

--- a/internal/purchase/approvals.go
+++ b/internal/purchase/approvals.go
@@ -47,7 +47,36 @@ func (m *Manager) ApproveExecution(ctx context.Context, executionID, token, acto
 		return fmt.Errorf("approval token has expired")
 	}
 
+	// Preflight guard (issue #609): reject non-AWS orphan executions before
+	// the cloud SDK is reached. See orphanExecutionError for the full rationale.
+	if err := orphanExecutionError(execution); err != nil {
+		return err
+	}
+
 	return m.ApproveAndExecute(ctx, executionID, actor)
+}
+
+// orphanExecutionError returns a descriptive error when the execution's
+// CloudAccountID is nil and the provider is explicitly non-AWS (issue #609).
+// AWS executions with a nil CloudAccountID are passed through because the
+// ambient-host-account fallback from PR #607/#604 handles them. Empty
+// provider is treated as AWS (legacy rows pre-dating multi-cloud support).
+//
+// Extracted from ApproveExecution to keep that function below the gocyclo
+// threshold — same pattern as loadCancelableExecution.
+func orphanExecutionError(execution *config.PurchaseExecution) error {
+	if execution.CloudAccountID != nil {
+		return nil
+	}
+	if len(execution.Recommendations) == 0 {
+		return nil
+	}
+	provider := execution.Recommendations[0].Provider
+	if provider == "" || provider == "aws" {
+		return nil
+	}
+	return fmt.Errorf("execution %s references an account that no longer exists (provider: %s): cancel this purchase — it cannot execute",
+		execution.ExecutionID, provider)
 }
 
 // ApproveAndExecute atomically flips a pending/notified execution to

--- a/internal/purchase/approvals.go
+++ b/internal/purchase/approvals.go
@@ -48,23 +48,29 @@ func (m *Manager) ApproveExecution(ctx context.Context, executionID, token, acto
 	}
 
 	// Preflight guard (issue #609): reject non-AWS orphan executions before
-	// the cloud SDK is reached. See orphanExecutionError for the full rationale.
-	if err := orphanExecutionError(execution); err != nil {
+	// the cloud SDK is reached. See OrphanExecutionError for the full rationale.
+	if err := OrphanExecutionError(execution); err != nil {
 		return err
 	}
 
 	return m.ApproveAndExecute(ctx, executionID, actor)
 }
 
-// orphanExecutionError returns a descriptive error when the execution's
-// CloudAccountID is nil and the provider is explicitly non-AWS (issue #609).
+// OrphanExecutionError returns a descriptive error when the execution has no
+// resolvable CloudAccountID and the provider is explicitly non-AWS (issue #609).
 // AWS executions with a nil CloudAccountID are passed through because the
 // ambient-host-account fallback from PR #607/#604 handles them. Empty
 // provider is treated as AWS (legacy rows pre-dating multi-cloud support).
 //
-// Extracted from ApproveExecution to keep that function below the gocyclo
-// threshold — same pattern as loadCancelableExecution.
-func orphanExecutionError(execution *config.PurchaseExecution) error {
+// An execution is NOT considered orphan if any individual recommendation
+// carries its own non-nil CloudAccountID — multi-rec fan-out executions can
+// have a nil execution-level field while individual recs still name the
+// target account.
+//
+// Exported so the HTTP layer (internal/api) can call the same guard without
+// duplicating the predicate. Extracted from ApproveExecution to keep that
+// function below the gocyclo threshold — same pattern as loadCancelableExecution.
+func OrphanExecutionError(execution *config.PurchaseExecution) error {
 	if execution.CloudAccountID != nil {
 		return nil
 	}
@@ -74,6 +80,13 @@ func orphanExecutionError(execution *config.PurchaseExecution) error {
 	provider := execution.Recommendations[0].Provider
 	if provider == "" || provider == "aws" {
 		return nil
+	}
+	// Any rec-level CloudAccountID means at least one recommendation has a
+	// concrete target account — the execution is not fully orphaned.
+	for i := range execution.Recommendations {
+		if execution.Recommendations[i].CloudAccountID != nil {
+			return nil
+		}
 	}
 	return fmt.Errorf("execution %s references an account that no longer exists (provider: %s): cancel this purchase — it cannot execute",
 		execution.ExecutionID, provider)

--- a/internal/purchase/approvals_test.go
+++ b/internal/purchase/approvals_test.go
@@ -562,6 +562,28 @@ func TestManager_ApproveExecution_AWSOrphanFallsThrough(t *testing.T) {
 	sender.AssertExpectations(t)
 }
 
+// TestOrphanExecutionError_RecLevelAccountIDPreventsOrphan is the regression
+// guard for CR pass-1 actionable 2: an execution with a nil execution-level
+// CloudAccountID and a non-AWS provider must NOT be treated as an orphan when
+// at least one recommendation carries its own non-nil CloudAccountID. The
+// multi-rec fan-out path stores account affinity at the rec level and leaves
+// the execution-level field nil.
+func TestOrphanExecutionError_RecLevelAccountIDPreventsOrphan(t *testing.T) {
+	accountID := "acct-azure-multi-001"
+	execution := &config.PurchaseExecution{
+		ExecutionID: "exec-multi-rec",
+		// Execution-level CloudAccountID is nil — fan-out shape.
+		Recommendations: []config.RecommendationRecord{
+			{ID: "r1", Provider: "azure", CloudAccountID: &accountID},
+			{ID: "r2", Provider: "azure", CloudAccountID: &accountID},
+		},
+	}
+	// Despite execution-level nil + non-AWS provider, the rec-level account
+	// ID means the execution is NOT orphaned. OrphanExecutionError must return nil.
+	err := OrphanExecutionError(execution)
+	assert.NoError(t, err, "rec-level CloudAccountID must prevent orphan classification")
+}
+
 // TestManager_CancelExecution_ExpiredToken is the cancel-path regression
 // guard for issue #397.
 func TestManager_CancelExecution_ExpiredToken(t *testing.T) {

--- a/internal/purchase/approvals_test.go
+++ b/internal/purchase/approvals_test.go
@@ -501,6 +501,67 @@ func TestManager_ApproveExecution_NilExpiresAt_LegacyRow(t *testing.T) {
 	store.AssertExpectations(t)
 }
 
+// --- Regression tests for issue #609 (orphan-account guard, ApproveExecution path) ---
+
+// TestManager_ApproveExecution_NonAWSOrphanReturnsError is the regression
+// guard for issue #609 on the token-authenticated ApproveExecution path (used
+// by the SQS approve worker and the legacy email-link flow). An execution
+// whose CloudAccountID is nil and whose provider is non-AWS must return a
+// descriptive error before the execute chain is entered, instead of surfacing
+// an opaque cloud-SDK credential error at runtime.
+func TestManager_ApproveExecution_NonAWSOrphanReturnsError(t *testing.T) {
+	ctx := context.Background()
+	manager, store, _ := newApproveManager(t)
+
+	execution := &config.PurchaseExecution{
+		ExecutionID:   "exec-orphan",
+		Status:        "pending",
+		ApprovalToken: "valid-token",
+		// CloudAccountID nil — account was deleted.
+		Recommendations: []config.RecommendationRecord{{ID: "r1", Provider: "azure"}},
+	}
+	store.On("GetExecutionByID", ctx, "exec-orphan").Return(execution, nil)
+
+	err := manager.ApproveExecution(ctx, "exec-orphan", "valid-token", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no longer exists")
+	assert.Contains(t, err.Error(), "azure")
+	// Execute chain must not run after the orphan guard fires.
+	store.AssertNotCalled(t, "TransitionExecutionStatus", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	store.AssertExpectations(t)
+}
+
+// TestManager_ApproveExecution_AWSOrphanFallsThrough confirms the AWS
+// ambient-fallback carve-out: nil CloudAccountID + AWS provider must NOT be
+// blocked by the issue-#609 guard. The execution proceeds normally.
+func TestManager_ApproveExecution_AWSOrphanFallsThrough(t *testing.T) {
+	ctx := context.Background()
+	manager, store, sender := newApproveManager(t)
+
+	execution := &config.PurchaseExecution{
+		ExecutionID:   "exec-aws-ambient",
+		PlanID:        "plan-aws",
+		Status:        "pending",
+		ApprovalToken: "valid-token",
+		// CloudAccountID nil but provider is AWS — ambient fallback applies.
+		Recommendations: []config.RecommendationRecord{{ID: "r1", Provider: "aws"}},
+	}
+	updated := &config.PurchaseExecution{
+		ExecutionID:   "exec-aws-ambient",
+		PlanID:        "plan-aws",
+		Status:        "approved",
+		ApprovalToken: "valid-token",
+	}
+	store.On("GetExecutionByID", ctx, "exec-aws-ambient").Return(execution, nil)
+	store.On("TransitionExecutionStatus", ctx, "exec-aws-ambient", approveFromStatuses, "approved").Return(updated, nil)
+	stubExecuteChain(t, store, sender, "plan-aws")
+
+	err := manager.ApproveExecution(ctx, "exec-aws-ambient", "valid-token", "")
+	require.NoError(t, err)
+	store.AssertExpectations(t)
+	sender.AssertExpectations(t)
+}
+
 // TestManager_CancelExecution_ExpiredToken is the cancel-path regression
 // guard for issue #397.
 func TestManager_CancelExecution_ExpiredToken(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds preflight guard in both approve entry points (`approvePurchase` in the HTTP handler and `ApproveExecution` in the purchase package) that returns a clear `409` with a descriptive message when an execution's `CloudAccountID` is `nil` and the provider is non-AWS
- AWS executions with `nil` `CloudAccountID` are left through (ambient-host-account fallback from PR #607/#604 handles them); empty provider is treated as AWS (legacy rows)
- Guard logic extracted into `loadApproveExecution` (handler) and `orphanExecutionError` (purchase package) helpers to stay below the gocyclo-10 threshold

## Fix approach

Without this guard, approving an orphan Azure/GCP execution surfaces an opaque chained-credential error from the cloud SDK (IMDS endpoint, missing env vars, CLIs absent from Lambda runtime). The `409` lets the frontend show a useful toast directing the operator to cancel the purchase instead.

## Test plan

- `TestHandler_approvePurchase_AzureOrphanRejects409` - Azure orphan returns 409 with descriptive message
- `TestHandler_approvePurchase_GCPOrphanRejects409` - GCP orphan returns same 409
- `TestHandler_approvePurchase_AWSOrphanFallsThrough` - AWS orphan does NOT trigger the guard
- `TestHandler_approvePurchase_NonOrphanUnchanged` - execution with valid account proceeds normally
- `TestManager_ApproveExecution_NonAWSOrphanReturnsError` - token path (SQS worker / email link) Azure orphan returns error
- `TestManager_ApproveExecution_AWSOrphanFallsThrough` - token path AWS orphan falls through

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Purchase approval now rejects with a clear error when attempting to execute for unavailable Azure and GCP cloud accounts.

* **Tests**
  * Added test coverage for purchase approval validation with unavailable accounts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/613?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->