### PR TITLE
fix(accounts): block deletion when pending executions reference account (closes #606)

### DIFF
--- a/frontend/src/__tests__/settings-accounts.test.ts
+++ b/frontend/src/__tests__/settings-accounts.test.ts
@@ -1501,6 +1501,25 @@ describe('deleteAccount — pending-executions 409 handling (issue #606)', () =>
     return err;
   }
 
+  // Variant: backend returned a count but no IDs (the server-side list
+  // call failed — see TestDeleteAccount_PendingListErr_StillReturns409
+  // on the Go side). The UI cannot auto-cancel without the ID list.
+  function pendingExecutionsApiErrorNoIDs(count: number): Error & {
+    status: number;
+    details: Record<string, unknown>;
+  } {
+    const err = new Error(
+      `cannot delete account: ${count} pending purchase(s) must be cancelled first`,
+    ) as Error & { status: number; details: Record<string, unknown> };
+    err.status = 409;
+    err.details = {
+      pending_count: count,
+      reason: 'pending_executions',
+      // No pending_execution_ids on this path.
+    };
+    return err;
+  }
+
   // Click the Delete button on the only row of the rendered accounts table.
   async function clickDeleteOnFirstAccount(): Promise<void> {
     const container = document.getElementById('aws-accounts-list')!;
@@ -1613,6 +1632,40 @@ describe('deleteAccount — pending-executions 409 handling (issue #606)', () =>
     const lastErrorMsg = (errorCalls[errorCalls.length - 1]![0] as { message: string }).message;
     expect(lastErrorMsg).toContain('1 failed');
     expect(lastErrorMsg).toContain('Account NOT deleted');
+  });
+
+  test('409 with empty pending_execution_ids surfaces History-page fallback', async () => {
+    (api.listAccounts as jest.Mock).mockResolvedValue([
+      { id: 'acc-1', name: 'Prod', external_id: '111111111111', enabled: true, provider: 'aws' },
+    ]);
+    // Only the first "Delete account?" confirm fires. There is no second
+    // confirm because the UI can't enumerate cancellations without IDs.
+    mockConfirmDialog.mockResolvedValueOnce(true);
+    (api.deleteAccount as jest.Mock).mockRejectedValueOnce(
+      pendingExecutionsApiErrorNoIDs(3),
+    );
+
+    await loadAccountsForProvider('aws');
+    await clickDeleteOnFirstAccount();
+    for (let i = 0; i < 5; i++) {
+      await new Promise(r => setTimeout(r, 0));
+    }
+
+    // Exactly one confirm dialog — no second one for cancellation.
+    expect(mockConfirmDialog).toHaveBeenCalledTimes(1);
+    // No cancelPurchase calls (we have no IDs to cancel).
+    expect(api.cancelPurchase).not.toHaveBeenCalled();
+    // deleteAccount called only once (initial attempt; no retry).
+    expect(api.deleteAccount).toHaveBeenCalledTimes(1);
+    // Error toast references the History page so the operator knows where
+    // to go next.
+    const errorCalls = mockShowToast.mock.calls.filter(c => {
+      const opts = c[0] as { kind?: string };
+      return opts.kind === 'error';
+    });
+    expect(errorCalls.length).toBeGreaterThan(0);
+    const lastErrorMsg = (errorCalls[errorCalls.length - 1]![0] as { message: string }).message;
+    expect(lastErrorMsg).toEqual(expect.stringContaining('History'));
   });
 
   test('non-409 error path keeps original behaviour (no second dialog)', async () => {

--- a/frontend/src/__tests__/settings-accounts.test.ts
+++ b/frontend/src/__tests__/settings-accounts.test.ts
@@ -20,7 +20,10 @@ jest.mock('../api', () => ({
   saveAccountCredentials: jest.fn(),
   listAccountServiceOverrides: jest.fn(),
   saveAccountServiceOverride: jest.fn(),
-  deleteAccountServiceOverride: jest.fn()
+  deleteAccountServiceOverride: jest.fn(),
+  // Issue #606 — Cancel-All-Then-Delete UX calls cancelPurchase per
+  // pending execution before retrying the account delete.
+  cancelPurchase: jest.fn()
 }));
 
 const mockShowToast = jest.fn<{ dismiss: () => void }, [unknown]>(() => ({ dismiss: jest.fn() }));
@@ -1466,5 +1469,171 @@ describe('Account overrides modal', () => {
       const opts2 = Array.from(pay.options).map(o => o.value);
       expect(opts2).toContain('no-upfront');
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #606 — Cancel-All-Then-Delete UX
+// ---------------------------------------------------------------------------
+
+describe('deleteAccount — pending-executions 409 handling (issue #606)', () => {
+  beforeEach(() => {
+    buildAccountsDOM();
+    jest.clearAllMocks();
+  });
+
+  // Helper to construct the 409 ApiError shape that client.ts attaches
+  // for backend ClientError responses. The status + details are what
+  // settings.ts branches on.
+  function pendingExecutionsApiError(count: number, ids: string[]): Error & {
+    status: number;
+    details: Record<string, unknown>;
+  } {
+    const err = new Error(
+      `cannot delete account: ${count} pending purchase(s) must be cancelled first`,
+    ) as Error & { status: number; details: Record<string, unknown> };
+    err.status = 409;
+    err.details = {
+      pending_count: count,
+      pending_execution_ids: ids,
+      reason: 'pending_executions',
+    };
+    return err;
+  }
+
+  // Click the Delete button on the only row of the rendered accounts table.
+  async function clickDeleteOnFirstAccount(): Promise<void> {
+    const container = document.getElementById('aws-accounts-list')!;
+    const buttons = Array.from(container.querySelectorAll('button'));
+    const deleteBtn = buttons.find(b => b.textContent === 'Delete');
+    expect(deleteBtn).toBeDefined();
+    deleteBtn!.click();
+    // The click handler is async; await microtask flushes so the chain
+    // (deleteAccount -> confirmDialog -> api.deleteAccount) starts.
+    await Promise.resolve();
+  }
+
+  test('409 → second confirm dialog renders with correct count + label', async () => {
+    (api.listAccounts as jest.Mock).mockResolvedValue([
+      { id: 'acc-1', name: 'Prod', external_id: '111111111111', enabled: true, provider: 'aws' },
+    ]);
+    // First confirm: "Delete account?" → user confirms.
+    // Second confirm: "Pending purchases must be cancelled" → user declines so
+    // we can inspect the opts without exercising the cancel + retry path.
+    mockConfirmDialog.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+    (api.deleteAccount as jest.Mock).mockRejectedValueOnce(
+      pendingExecutionsApiError(2, ['exec-1', 'exec-2']),
+    );
+
+    await loadAccountsForProvider('aws');
+    await clickDeleteOnFirstAccount();
+    // Wait for the confirmDialog promise chain to advance through both calls.
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(mockConfirmDialog).toHaveBeenCalledTimes(2);
+    const secondOpts = mockConfirmDialog.mock.calls[1]![0] as {
+      title: string;
+      body: string;
+      confirmLabel: string;
+      destructive: boolean;
+    };
+    expect(secondOpts.title).toBe('Pending purchases must be cancelled');
+    expect(secondOpts.body).toContain('2 pending purchases');
+    expect(secondOpts.confirmLabel).toBe('Cancel All 2 Pending + Delete');
+    expect(secondOpts.destructive).toBe(true);
+
+    // User declined the second confirm — no cancelPurchase calls fire.
+    expect(api.cancelPurchase).not.toHaveBeenCalled();
+    // And no retry of deleteAccount.
+    expect(api.deleteAccount).toHaveBeenCalledTimes(1);
+  });
+
+  test('confirm Cancel-All-Then-Delete posts cancel for each pending id then retries delete', async () => {
+    (api.listAccounts as jest.Mock).mockResolvedValue([
+      { id: 'acc-1', name: 'Prod', external_id: '111111111111', enabled: true, provider: 'aws' },
+    ]);
+    mockConfirmDialog.mockResolvedValueOnce(true).mockResolvedValueOnce(true);
+    (api.deleteAccount as jest.Mock)
+      .mockRejectedValueOnce(pendingExecutionsApiError(3, ['exec-a', 'exec-b', 'exec-c']))
+      .mockResolvedValueOnce(undefined);
+    (api.cancelPurchase as jest.Mock).mockResolvedValue(undefined);
+
+    await loadAccountsForProvider('aws');
+    await clickDeleteOnFirstAccount();
+    // Flush several microtasks so all sequential awaits in the handler resolve.
+    for (let i = 0; i < 10; i++) {
+      await new Promise(r => setTimeout(r, 0));
+    }
+
+    // cancelPurchase called once per execution id, in order.
+    expect(api.cancelPurchase).toHaveBeenCalledTimes(3);
+    expect((api.cancelPurchase as jest.Mock).mock.calls[0][0]).toBe('exec-a');
+    expect((api.cancelPurchase as jest.Mock).mock.calls[1][0]).toBe('exec-b');
+    expect((api.cancelPurchase as jest.Mock).mock.calls[2][0]).toBe('exec-c');
+
+    // deleteAccount called twice (initial 409 + retry after cancels).
+    expect(api.deleteAccount).toHaveBeenCalledTimes(2);
+
+    // Success toast surfaced.
+    expect(mockShowToast).toHaveBeenCalled();
+    const successCalls = mockShowToast.mock.calls.filter(c => {
+      const opts = c[0] as { kind?: string };
+      return opts.kind === 'success';
+    });
+    expect(successCalls.length).toBe(1);
+  });
+
+  test('partial cancel failure leaves account in place and surfaces error toast', async () => {
+    (api.listAccounts as jest.Mock).mockResolvedValue([
+      { id: 'acc-1', name: 'Prod', external_id: '111111111111', enabled: true, provider: 'aws' },
+    ]);
+    mockConfirmDialog.mockResolvedValueOnce(true).mockResolvedValueOnce(true);
+    (api.deleteAccount as jest.Mock).mockRejectedValueOnce(
+      pendingExecutionsApiError(2, ['exec-1', 'exec-2']),
+    );
+    (api.cancelPurchase as jest.Mock)
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('cancel failed'));
+
+    await loadAccountsForProvider('aws');
+    await clickDeleteOnFirstAccount();
+    for (let i = 0; i < 10; i++) {
+      await new Promise(r => setTimeout(r, 0));
+    }
+
+    // Second cancelPurchase rejected — deleteAccount must NOT retry.
+    expect(api.deleteAccount).toHaveBeenCalledTimes(1);
+    // Error toast surfaced (kind: 'error').
+    const errorCalls = mockShowToast.mock.calls.filter(c => {
+      const opts = c[0] as { kind?: string; message?: string };
+      return opts.kind === 'error';
+    });
+    expect(errorCalls.length).toBeGreaterThan(0);
+    const lastErrorMsg = (errorCalls[errorCalls.length - 1]![0] as { message: string }).message;
+    expect(lastErrorMsg).toContain('1 failed');
+    expect(lastErrorMsg).toContain('Account NOT deleted');
+  });
+
+  test('non-409 error path keeps original behaviour (no second dialog)', async () => {
+    (api.listAccounts as jest.Mock).mockResolvedValue([
+      { id: 'acc-1', name: 'Prod', external_id: '111111111111', enabled: true, provider: 'aws' },
+    ]);
+    mockConfirmDialog.mockResolvedValueOnce(true);
+    (api.deleteAccount as jest.Mock).mockRejectedValueOnce(new Error('boom'));
+
+    await loadAccountsForProvider('aws');
+    await clickDeleteOnFirstAccount();
+    for (let i = 0; i < 5; i++) {
+      await new Promise(r => setTimeout(r, 0));
+    }
+
+    expect(mockConfirmDialog).toHaveBeenCalledTimes(1);
+    expect(api.cancelPurchase).not.toHaveBeenCalled();
+    const errorCalls = mockShowToast.mock.calls.filter(c => {
+      const opts = c[0] as { kind?: string };
+      return opts.kind === 'error';
+    });
+    expect(errorCalls.length).toBeGreaterThan(0);
   });
 });

--- a/frontend/src/settings.ts
+++ b/frontend/src/settings.ts
@@ -1212,6 +1212,17 @@ export async function loadOverridesPanel(accountId: string, panel: HTMLElement, 
 }
 
 /**
+ * Re-entrancy guard for the deleteAccount + handlePendingExecutions409
+ * flow. A double-click on the Delete button (or a click during the
+ * cancel-loop-then-retry-delete sequence) used to be able to start two
+ * concurrent deletes for the same account, racing on the backend
+ * preflight + cancel + delete sequence. Module-scoped so guards apply
+ * across both helpers; keyed on account ID so different accounts can
+ * still be deleted in parallel.
+ */
+const inflightDeletes = new Set<string>();
+
+/**
  * Delete an account after confirmation.
  *
  * Issue #606 — when the backend preflight detects pending purchase
@@ -1225,6 +1236,10 @@ export async function loadOverridesPanel(accountId: string, panel: HTMLElement, 
  * cancelling and silently moving on.
  */
 async function deleteAccount(accountId: string, provider: AccountProvider, _container: HTMLElement): Promise<void> {
+  if (inflightDeletes.has(accountId)) {
+    showToast({ message: 'Delete already in progress for this account.', kind: 'info' });
+    return;
+  }
   const ok = await confirmDialog({
     title: 'Delete account?',
     body: 'Delete this account? This also removes its credentials and service overrides. This action cannot be undone.',
@@ -1232,19 +1247,24 @@ async function deleteAccount(accountId: string, provider: AccountProvider, _cont
     destructive: true,
   });
   if (!ok) return;
+  inflightDeletes.add(accountId);
   try {
-    await api.deleteAccount(accountId);
-    await loadAccountsForProvider(provider);
-    return;
-  } catch (err) {
-    const apiErr = err as Error & { status?: number; details?: Record<string, unknown> };
-    if (apiErr.status === 409 && apiErr.details?.['reason'] === 'pending_executions') {
-      await handlePendingExecutions409(accountId, provider, apiErr);
+    try {
+      await api.deleteAccount(accountId);
+      await loadAccountsForProvider(provider);
       return;
+    } catch (err) {
+      const apiErr = err as Error & { status?: number; details?: Record<string, unknown> };
+      if (apiErr.status === 409 && apiErr.details?.['reason'] === 'pending_executions') {
+        await handlePendingExecutions409(accountId, provider, apiErr);
+        return;
+      }
+      console.error('Failed to delete account:', err);
+      showToast({ message: `Failed to delete account: ${(err as Error).message}`, kind: 'error' });
+      void loadAccountsForProvider(provider);
     }
-    console.error('Failed to delete account:', err);
-    showToast({ message: `Failed to delete account: ${(err as Error).message}`, kind: 'error' });
-    void loadAccountsForProvider(provider);
+  } finally {
+    inflightDeletes.delete(accountId);
   }
 }
 
@@ -1260,10 +1280,45 @@ async function handlePendingExecutions409(
   provider: AccountProvider,
   apiErr: Error & { status?: number; details?: Record<string, unknown> },
 ): Promise<void> {
+  // Defense-in-depth re-entrancy guard. deleteAccount already adds to the
+  // set before calling us, in which case `ownsLock` stays false and the
+  // outer try/finally owns cleanup. A direct external caller (e.g. tests
+  // or a future caller invoking this helper standalone) gets a fresh
+  // lock + a finally that releases it.
+  let ownsLock = false;
+  if (!inflightDeletes.has(accountId)) {
+    inflightDeletes.add(accountId);
+    ownsLock = true;
+  }
+  try {
+    await handlePendingExecutions409Inner(accountId, provider, apiErr);
+  } finally {
+    if (ownsLock) inflightDeletes.delete(accountId);
+  }
+}
+
+async function handlePendingExecutions409Inner(
+  accountId: string,
+  provider: AccountProvider,
+  apiErr: Error & { status?: number; details?: Record<string, unknown> },
+): Promise<void> {
   const rawCount = apiErr.details?.['pending_count'];
   const pendingCount = typeof rawCount === 'number' ? rawCount : Number(rawCount) || 0;
   const rawIDs = apiErr.details?.['pending_execution_ids'];
   const pendingIDs = Array.isArray(rawIDs) ? (rawIDs as unknown[]).filter((x): x is string => typeof x === 'string') : [];
+
+  // No IDs to cancel (the server's list-call errored — see the Go-side
+  // PendingListErr_StillReturns409 path). Skip the "Cancel All N Pending"
+  // confirm entirely, since we can't enumerate cancellations, and point
+  // the operator at the History page instead.
+  if (pendingIDs.length === 0) {
+    showToast({
+      message: `Cannot auto-cancel: pending purchase IDs unavailable. Cancel them from the History page and try again.`,
+      kind: 'error',
+      timeout: null,
+    });
+    return;
+  }
 
   const proceed = await confirmDialog({
     title: 'Pending purchases must be cancelled',
@@ -1275,18 +1330,6 @@ async function handlePendingExecutions409(
     // Operator cancelled the second dialog. Refresh to keep the list in
     // sync; the account is unchanged.
     void loadAccountsForProvider(provider);
-    return;
-  }
-
-  if (pendingIDs.length === 0) {
-    // Backend reported a count but the list was unavailable (e.g. the
-    // list call errored on the server). The operator should cancel
-    // pending purchases via the History page instead.
-    showToast({
-      message: `Cannot auto-cancel: pending purchase IDs unavailable. Cancel them from the History page and try again.`,
-      kind: 'error',
-      timeout: null,
-    });
     return;
   }
 

--- a/frontend/src/settings.ts
+++ b/frontend/src/settings.ts
@@ -1212,7 +1212,17 @@ export async function loadOverridesPanel(accountId: string, panel: HTMLElement, 
 }
 
 /**
- * Delete an account after confirmation
+ * Delete an account after confirmation.
+ *
+ * Issue #606 — when the backend preflight detects pending purchase
+ * executions still referencing this account, it returns a 409 with
+ * `pending_count` + `pending_execution_ids` in `error.details`. The
+ * handler offers the operator a second confirmation: "Cancel All N
+ * Pending + Delete" which cancels each pending execution sequentially
+ * and then retries the delete. On any per-execution cancel failure we
+ * surface a toast with the count of failures and stop short of the
+ * delete so the operator can investigate manually instead of partially
+ * cancelling and silently moving on.
  */
 async function deleteAccount(accountId: string, provider: AccountProvider, _container: HTMLElement): Promise<void> {
   const ok = await confirmDialog({
@@ -1225,9 +1235,96 @@ async function deleteAccount(accountId: string, provider: AccountProvider, _cont
   try {
     await api.deleteAccount(accountId);
     await loadAccountsForProvider(provider);
+    return;
   } catch (err) {
+    const apiErr = err as Error & { status?: number; details?: Record<string, unknown> };
+    if (apiErr.status === 409 && apiErr.details?.['reason'] === 'pending_executions') {
+      await handlePendingExecutions409(accountId, provider, apiErr);
+      return;
+    }
     console.error('Failed to delete account:', err);
     showToast({ message: `Failed to delete account: ${(err as Error).message}`, kind: 'error' });
+    void loadAccountsForProvider(provider);
+  }
+}
+
+/**
+ * Issue #606 — 409 handler for the deleteAccount path. Surfaces a second
+ * confirmation dialog with the pending-count and, on confirm, walks the
+ * `pending_execution_ids` list cancelling each one before retrying the
+ * delete. Exported (lower-case) helper so the test file can exercise it
+ * without standing up the full settings page chrome.
+ */
+async function handlePendingExecutions409(
+  accountId: string,
+  provider: AccountProvider,
+  apiErr: Error & { status?: number; details?: Record<string, unknown> },
+): Promise<void> {
+  const rawCount = apiErr.details?.['pending_count'];
+  const pendingCount = typeof rawCount === 'number' ? rawCount : Number(rawCount) || 0;
+  const rawIDs = apiErr.details?.['pending_execution_ids'];
+  const pendingIDs = Array.isArray(rawIDs) ? (rawIDs as unknown[]).filter((x): x is string => typeof x === 'string') : [];
+
+  const proceed = await confirmDialog({
+    title: 'Pending purchases must be cancelled',
+    body: `This account has ${pendingCount} pending purchase${pendingCount === 1 ? '' : 's'}. They must be cancelled before the account can be deleted. Cancel all pending purchases and then delete the account?`,
+    confirmLabel: `Cancel All ${pendingCount} Pending + Delete`,
+    destructive: true,
+  });
+  if (!proceed) {
+    // Operator cancelled the second dialog. Refresh to keep the list in
+    // sync; the account is unchanged.
+    void loadAccountsForProvider(provider);
+    return;
+  }
+
+  if (pendingIDs.length === 0) {
+    // Backend reported a count but the list was unavailable (e.g. the
+    // list call errored on the server). The operator should cancel
+    // pending purchases via the History page instead.
+    showToast({
+      message: `Cannot auto-cancel: pending purchase IDs unavailable. Cancel them from the History page and try again.`,
+      kind: 'error',
+      timeout: null,
+    });
+    return;
+  }
+
+  const failures: { id: string; err: Error }[] = [];
+  for (const execID of pendingIDs) {
+    try {
+      await api.cancelPurchase(execID);
+    } catch (cancelErr) {
+      failures.push({ id: execID, err: cancelErr as Error });
+    }
+  }
+
+  if (failures.length > 0) {
+    console.error('Failed to cancel some pending executions:', failures);
+    showToast({
+      message: `Cancelled ${pendingIDs.length - failures.length} of ${pendingIDs.length} purchases; ${failures.length} failed. Account NOT deleted — review History and retry.`,
+      kind: 'error',
+      timeout: null,
+    });
+    void loadAccountsForProvider(provider);
+    return;
+  }
+
+  // All cancels succeeded — retry the delete.
+  try {
+    await api.deleteAccount(accountId);
+    showToast({
+      message: `Cancelled ${pendingIDs.length} pending purchase${pendingIDs.length === 1 ? '' : 's'} and deleted the account.`,
+      kind: 'success',
+    });
+  } catch (retryErr) {
+    console.error('Failed to delete account after cancelling pending purchases:', retryErr);
+    showToast({
+      message: `Cancelled ${pendingIDs.length} purchase${pendingIDs.length === 1 ? '' : 's'} but the account delete still failed: ${(retryErr as Error).message}`,
+      kind: 'error',
+      timeout: null,
+    });
+  } finally {
     void loadAccountsForProvider(provider);
   }
 }

--- a/internal/analytics/collector_test.go
+++ b/internal/analytics/collector_test.go
@@ -196,6 +196,14 @@ func (m *mockConfigStore) CleanupOldExecutions(ctx context.Context, retentionDay
 	return 0, nil
 }
 
+func (m *mockConfigStore) CountPendingExecutionsForAccount(ctx context.Context, accountID string) (int, error) {
+	return 0, nil
+}
+
+func (m *mockConfigStore) ListPendingExecutionIDsForAccount(ctx context.Context, accountID string) ([]string, error) {
+	return nil, nil
+}
+
 func (m *mockConfigStore) TransitionExecutionStatus(ctx context.Context, executionID string, fromStatuses []string, toStatus string) (*config.PurchaseExecution, error) {
 	return nil, nil
 }

--- a/internal/api/handler_accounts.go
+++ b/internal/api/handler_accounts.go
@@ -517,6 +517,13 @@ func (h *Handler) updateAccount(ctx context.Context, httpReq *events.LambdaFunct
 }
 
 // deleteAccount handles DELETE /api/accounts/:id.
+//
+// Preflights the delete against pending/notified purchase_executions
+// (issue #606). Migration 000053 also enforces ON DELETE RESTRICT at the
+// DB level so a race that slips past the preflight still can't orphan a
+// pending execution — but the preflight gives the frontend a structured
+// 409 (with the count + execution_ids) so it can offer a Cancel-All-Then-
+// Delete affordance instead of surfacing a raw FK-violation 500.
 func (h *Handler) deleteAccount(ctx context.Context, req *events.LambdaFunctionURLRequest, id string) (any, error) {
 	if err := validateUUID(id); err != nil {
 		return nil, err
@@ -531,6 +538,36 @@ func (h *Handler) deleteAccount(ctx context.Context, req *events.LambdaFunctionU
 	// for both "doesn't exist" and "out of scope" to avoid existence leakage.
 	if _, err := h.requireAccountAccess(ctx, session, id); err != nil {
 		return nil, err
+	}
+
+	// Preflight: refuse the delete if pending/notified executions still
+	// reference this account. The frontend uses the pending_count + the
+	// pending_execution_ids list to drive the Cancel-All-Then-Delete UX.
+	pendingCount, err := h.config.CountPendingExecutionsForAccount(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("accounts: %w", err)
+	}
+	if pendingCount > 0 {
+		execIDs, listErr := h.config.ListPendingExecutionIDsForAccount(ctx, id)
+		if listErr != nil {
+			// Count succeeded but list failed — still surface the 409 so the
+			// operator gets a clear "cancel them first" message instead of
+			// the raw FK error from the eventual DB delete. The list payload
+			// is omitted; the frontend falls back to a generic message.
+			return nil, NewClientErrorWithDetails(409,
+				fmt.Sprintf("cannot delete account: %d pending purchase(s) must be cancelled first", pendingCount),
+				map[string]any{
+					"pending_count": pendingCount,
+					"reason":        "pending_executions",
+				})
+		}
+		return nil, NewClientErrorWithDetails(409,
+			fmt.Sprintf("cannot delete account: %d pending purchase(s) must be cancelled first", pendingCount),
+			map[string]any{
+				"pending_count":         pendingCount,
+				"pending_execution_ids": execIDs,
+				"reason":                "pending_executions",
+			})
 	}
 
 	if err := h.config.DeleteCloudAccount(ctx, id); err != nil {

--- a/internal/api/handler_accounts.go
+++ b/internal/api/handler_accounts.go
@@ -21,6 +21,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
 )
 
 // CloudAccountRequest is the request body for create/update account endpoints.
@@ -571,6 +572,21 @@ func (h *Handler) deleteAccount(ctx context.Context, req *events.LambdaFunctionU
 	}
 
 	if err := h.config.DeleteCloudAccount(ctx, id); err != nil {
+		// Race: the preflight count was 0 but a pending execution row was
+		// inserted concurrently before we issued the DELETE. Migration 000053
+		// enforces ON DELETE RESTRICT, so Postgres raises SQLSTATE 23503
+		// (foreign_key_violation). Map this to the same structured 409 the
+		// preflight branch returns so the frontend's Cancel-All-Then-Delete
+		// affordance still kicks in — minus the count/ids, which we can't
+		// supply without re-querying (and the operator can just retry).
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23503" {
+			return nil, NewClientErrorWithDetails(409,
+				"cannot delete account: pending purchase(s) must be cancelled first",
+				map[string]any{
+					"reason": "pending_executions",
+				})
+		}
 		return nil, fmt.Errorf("accounts: %w", err)
 	}
 

--- a/internal/api/handler_accounts_test.go
+++ b/internal/api/handler_accounts_test.go
@@ -268,6 +268,108 @@ func TestDeleteAccount_Success(t *testing.T) {
 	assert.Nil(t, result)
 }
 
+// TestDeleteAccount_PendingExecutions_Returns409 asserts the issue #606
+// preflight: when at least one purchase_executions row in status
+// pending/notified still references this account, the handler returns a
+// 409 ClientError with the count + execution_ids in the details payload,
+// and never issues the DELETE FROM cloud_accounts that would either
+// trigger migration 000053's RESTRICT (an opaque 500) or — pre-migration —
+// silently orphan the executions.
+func TestDeleteAccount_PendingExecutions_Returns409(t *testing.T) {
+	ctx := context.Background()
+	mockAuth := new(MockAuthService)
+	setupAdminAuth(ctx, mockAuth)
+
+	store := setupAdminMock(ctx)
+	store.CountPendingExecutionsForAccountFn = func(_ context.Context, _ string) (int, error) {
+		return 3, nil
+	}
+	pendingIDs := []string{"exec-1", "exec-2", "exec-3"}
+	store.ListPendingExecutionIDsForAccountFn = func(_ context.Context, _ string) ([]string, error) {
+		return pendingIDs, nil
+	}
+	deleteCalled := false
+	store.DeleteCloudAccountFn = func(_ context.Context, _ string) error {
+		deleteCalled = true
+		return nil
+	}
+	handler := &Handler{auth: mockAuth, config: store}
+
+	result, err := handler.deleteAccount(ctx, adminRequest(""), "11111111-1111-1111-1111-111111111111")
+	assert.Nil(t, result)
+	require.Error(t, err)
+	ce, ok := IsClientError(err)
+	require.True(t, ok, "expected ClientError, got %v", err)
+	assert.Equal(t, 409, ce.code, "expected 409 status code")
+	assert.Contains(t, ce.message, "3", "error message should reference the pending count")
+	assert.Contains(t, ce.message, "pending", "error message should mention pending purchases")
+	details := ce.Details()
+	require.NotNil(t, details)
+	assert.EqualValues(t, 3, details["pending_count"])
+	assert.Equal(t, "pending_executions", details["reason"])
+	assert.ElementsMatch(t, pendingIDs, details["pending_execution_ids"])
+	assert.False(t, deleteCalled, "DeleteCloudAccount must NOT be called when pending executions exist")
+}
+
+// TestDeleteAccount_PendingZero_DeletesNormally asserts the happy path:
+// CountPendingExecutionsForAccount returns 0 so the preflight is satisfied
+// and the underlying DeleteCloudAccount call runs to completion.
+func TestDeleteAccount_PendingZero_DeletesNormally(t *testing.T) {
+	ctx := context.Background()
+	mockAuth := new(MockAuthService)
+	setupAdminAuth(ctx, mockAuth)
+
+	store := setupAdminMock(ctx)
+	countCalled := false
+	store.CountPendingExecutionsForAccountFn = func(_ context.Context, _ string) (int, error) {
+		countCalled = true
+		return 0, nil
+	}
+	deleteCalled := false
+	store.DeleteCloudAccountFn = func(_ context.Context, _ string) error {
+		deleteCalled = true
+		return nil
+	}
+	handler := &Handler{auth: mockAuth, config: store}
+
+	result, err := handler.deleteAccount(ctx, adminRequest(""), "11111111-1111-1111-1111-111111111111")
+	require.NoError(t, err)
+	assert.Nil(t, result)
+	assert.True(t, countCalled, "preflight must run before delete")
+	assert.True(t, deleteCalled, "delete should proceed when no pending executions")
+}
+
+// TestDeleteAccount_PendingListErr_StillReturns409 asserts that a failure
+// listing execution_ids doesn't downgrade the 409 to a 500 — the operator
+// still gets the structured count and the explicit "cancel first" ask,
+// just without the per-execution id payload.
+func TestDeleteAccount_PendingListErr_StillReturns409(t *testing.T) {
+	ctx := context.Background()
+	mockAuth := new(MockAuthService)
+	setupAdminAuth(ctx, mockAuth)
+
+	store := setupAdminMock(ctx)
+	store.CountPendingExecutionsForAccountFn = func(_ context.Context, _ string) (int, error) {
+		return 5, nil
+	}
+	store.ListPendingExecutionIDsForAccountFn = func(_ context.Context, _ string) ([]string, error) {
+		return nil, errors.New("transient list failure")
+	}
+	handler := &Handler{auth: mockAuth, config: store}
+
+	_, err := handler.deleteAccount(ctx, adminRequest(""), "11111111-1111-1111-1111-111111111111")
+	require.Error(t, err)
+	ce, ok := IsClientError(err)
+	require.True(t, ok)
+	assert.Equal(t, 409, ce.code)
+	details := ce.Details()
+	require.NotNil(t, details)
+	assert.EqualValues(t, 5, details["pending_count"])
+	// pending_execution_ids should be absent on the list-failure fallback path.
+	_, hasIDs := details["pending_execution_ids"]
+	assert.False(t, hasIDs, "pending_execution_ids must be omitted when list call failed")
+}
+
 // TestDeleteAccount_NotFound asserts that deleteAccount returns 404 and never
 // invokes DeleteCloudAccount when the account does not exist. Locks down the
 // existence check added in 031b958cf so a refactor cannot regress the 404 path.

--- a/internal/api/handler_accounts_test.go
+++ b/internal/api/handler_accounts_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -368,6 +369,66 @@ func TestDeleteAccount_PendingListErr_StillReturns409(t *testing.T) {
 	// pending_execution_ids should be absent on the list-failure fallback path.
 	_, hasIDs := details["pending_execution_ids"]
 	assert.False(t, hasIDs, "pending_execution_ids must be omitted when list call failed")
+}
+
+// TestDeleteAccount_FKViolationRace_Returns409 asserts that when the
+// preflight count is 0 but DeleteCloudAccount fails with SQLSTATE 23503
+// (foreign_key_violation — migration 000053 enforces RESTRICT and a
+// pending row was inserted concurrently), the handler maps the raw error
+// to the structured 409 shape the frontend understands, rather than
+// surfacing a 500 from the wrapped fmt.Errorf branch. Issue #606 race
+// regression guard.
+func TestDeleteAccount_FKViolationRace_Returns409(t *testing.T) {
+	ctx := context.Background()
+	mockAuth := new(MockAuthService)
+	setupAdminAuth(ctx, mockAuth)
+
+	store := setupAdminMock(ctx)
+	// Preflight count is 0 (no pending rows at preflight time).
+	store.CountPendingExecutionsForAccountFn = func(_ context.Context, _ string) (int, error) {
+		return 0, nil
+	}
+	// But the DELETE itself fails with FK violation (a row was inserted
+	// after the preflight check — exactly the race the migration guards).
+	store.DeleteCloudAccountFn = func(_ context.Context, _ string) error {
+		return &pgconn.PgError{
+			Code:    "23503",
+			Message: "update or delete on table \"cloud_accounts\" violates foreign key constraint",
+		}
+	}
+	handler := &Handler{auth: mockAuth, config: store}
+
+	_, err := handler.deleteAccount(ctx, adminRequest(""), "11111111-1111-1111-1111-111111111111")
+	require.Error(t, err)
+	ce, ok := IsClientError(err)
+	require.True(t, ok, "expected ClientError (409), got %T: %v", err, err)
+	assert.Equal(t, 409, ce.code)
+	details := ce.Details()
+	require.NotNil(t, details)
+	assert.Equal(t, "pending_executions", details["reason"])
+}
+
+// TestDeleteAccount_NonFKError_StillReturns500 asserts that errors which
+// are NOT FK violations continue to bubble up as wrapped errors (500),
+// so we don't accidentally swallow real failures as 409s.
+func TestDeleteAccount_NonFKError_StillReturns500(t *testing.T) {
+	ctx := context.Background()
+	mockAuth := new(MockAuthService)
+	setupAdminAuth(ctx, mockAuth)
+
+	store := setupAdminMock(ctx)
+	store.CountPendingExecutionsForAccountFn = func(_ context.Context, _ string) (int, error) {
+		return 0, nil
+	}
+	store.DeleteCloudAccountFn = func(_ context.Context, _ string) error {
+		return errors.New("connection refused")
+	}
+	handler := &Handler{auth: mockAuth, config: store}
+
+	_, err := handler.deleteAccount(ctx, adminRequest(""), "11111111-1111-1111-1111-111111111111")
+	require.Error(t, err)
+	_, ok := IsClientError(err)
+	assert.False(t, ok, "non-FK errors must NOT be classified as ClientError; got %v", err)
 }
 
 // TestDeleteAccount_NotFound asserts that deleteAccount returns 404 and never

--- a/internal/api/mocks_test.go
+++ b/internal/api/mocks_test.go
@@ -42,6 +42,16 @@ type MockConfigStore struct {
 	// not) reached — e.g. confirming invalid-combo rejections short-circuit
 	// before the store write.
 	SaveAccountServiceOverrideFn func(ctx context.Context, override *config.AccountServiceOverride) error
+	// CountPendingExecutionsForAccountFn overrides CountPendingExecutionsForAccount.
+	// Used by the deleteAccount preflight tests (issue #606) to seed a
+	// pending-execution count without standing up a real Postgres mock —
+	// see TestDeleteAccount_PendingExecutions_Returns409.
+	CountPendingExecutionsForAccountFn func(ctx context.Context, accountID string) (int, error)
+	// ListPendingExecutionIDsForAccountFn overrides ListPendingExecutionIDsForAccount.
+	// Currently unused at the api layer (the handler only needs the count),
+	// but exported so future tests covering Cancel-All-Then-Delete server-side
+	// helpers can wire it without re-extending this struct.
+	ListPendingExecutionIDsForAccountFn func(ctx context.Context, accountID string) ([]string, error)
 }
 
 func (m *MockConfigStore) GetGlobalConfig(ctx context.Context) (*config.GlobalConfig, error) {
@@ -195,6 +205,22 @@ func (m *MockConfigStore) GetExecutionByPlanAndDate(ctx context.Context, planID 
 func (m *MockConfigStore) CleanupOldExecutions(ctx context.Context, retentionDays int) (int64, error) {
 	args := m.Called(ctx, retentionDays)
 	return args.Get(0).(int64), args.Error(1)
+}
+
+func (m *MockConfigStore) CountPendingExecutionsForAccount(ctx context.Context, accountID string) (int, error) {
+	if m.CountPendingExecutionsForAccountFn != nil {
+		return m.CountPendingExecutionsForAccountFn(ctx, accountID)
+	}
+	// Default: zero pending, no error. Lets every existing test that doesn't
+	// care about the preflight continue compiling without explicit setup.
+	return 0, nil
+}
+
+func (m *MockConfigStore) ListPendingExecutionIDsForAccount(ctx context.Context, accountID string) ([]string, error) {
+	if m.ListPendingExecutionIDsForAccountFn != nil {
+		return m.ListPendingExecutionIDsForAccountFn(ctx, accountID)
+	}
+	return nil, nil
 }
 
 func (m *MockConfigStore) TransitionExecutionStatus(ctx context.Context, executionID string, fromStatuses []string, toStatus string) (*config.PurchaseExecution, error) {

--- a/internal/config/interfaces.go
+++ b/internal/config/interfaces.go
@@ -43,6 +43,20 @@ type StoreInterface interface {
 	GetExecutionsByStatuses(ctx context.Context, statuses []string, limit int) ([]PurchaseExecution, error)
 	GetExecutionByID(ctx context.Context, executionID string) (*PurchaseExecution, error)
 	GetExecutionByPlanAndDate(ctx context.Context, planID string, scheduledDate time.Time) (*PurchaseExecution, error)
+	// CountPendingExecutionsForAccount returns the number of purchase_executions
+	// in status 'pending' or 'notified' that reference the given cloud account.
+	// Used by the deleteAccount handler to preflight DB-level FK violations
+	// (migration 000053 tightened the FK to ON DELETE RESTRICT) and emit a
+	// 409 with a count so the frontend can offer Cancel-All-Then-Delete UX
+	// instead of surfacing a raw constraint error. See issue #606.
+	CountPendingExecutionsForAccount(ctx context.Context, accountID string) (int, error)
+	// ListPendingExecutionIDsForAccount returns the execution IDs of all
+	// pending / notified executions referencing this account, used by the
+	// frontend's Cancel-All-Then-Delete flow when the operator opts to
+	// cancel everything in one go after a 409. Capped at 1000 rows; if a
+	// single account has more pending executions than that, the cleanup
+	// is a one-off operator task rather than a button click anyway.
+	ListPendingExecutionIDsForAccount(ctx context.Context, accountID string) ([]string, error)
 	CleanupOldExecutions(ctx context.Context, retentionDays int) (int64, error)
 	TransitionExecutionStatus(ctx context.Context, executionID string, fromStatuses []string, toStatus string) (*PurchaseExecution, error)
 

--- a/internal/config/store_postgres.go
+++ b/internal/config/store_postgres.go
@@ -901,6 +901,55 @@ func (s *PostgresStore) GetExecutionByPlanAndDate(ctx context.Context, planID st
 	return &executions[0], nil
 }
 
+// CountPendingExecutionsForAccount returns the number of pending/notified
+// purchase executions still referencing this cloud account. The deleteAccount
+// handler calls this before issuing DELETE FROM cloud_accounts so it can
+// short-circuit with a 409 instead of letting migration 000053's ON DELETE
+// RESTRICT bubble up as an opaque FK-violation error. See issue #606.
+func (s *PostgresStore) CountPendingExecutionsForAccount(ctx context.Context, accountID string) (int, error) {
+	var n int
+	err := s.db.QueryRow(ctx, `
+		SELECT COUNT(*) FROM purchase_executions
+		WHERE cloud_account_id = $1
+		  AND status IN ('pending', 'notified')
+	`, accountID).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("failed to count pending executions for account: %w", err)
+	}
+	return n, nil
+}
+
+// ListPendingExecutionIDsForAccount returns the execution IDs that the
+// frontend's Cancel-All-Then-Delete flow needs to POST cancel for. Capped
+// at 1000 rows — a single account with more pending executions than that
+// is an unusual operator-cleanup task rather than a button-click flow.
+func (s *PostgresStore) ListPendingExecutionIDsForAccount(ctx context.Context, accountID string) ([]string, error) {
+	rows, err := s.db.Query(ctx, `
+		SELECT execution_id FROM purchase_executions
+		WHERE cloud_account_id = $1
+		  AND status IN ('pending', 'notified')
+		ORDER BY scheduled_date ASC
+		LIMIT 1000
+	`, accountID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list pending execution ids for account: %w", err)
+	}
+	defer rows.Close()
+
+	ids := make([]string, 0)
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("failed to scan pending execution id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate pending execution ids: %w", err)
+	}
+	return ids, nil
+}
+
 // queryExecutions is a helper to query and scan purchase executions
 func (s *PostgresStore) queryExecutions(ctx context.Context, query string, args ...any) ([]PurchaseExecution, error) {
 	rows, err := s.db.Query(ctx, query, args...)

--- a/internal/config/store_postgres_pgxmock_test.go
+++ b/internal/config/store_postgres_pgxmock_test.go
@@ -1327,6 +1327,69 @@ func TestPGXMock_SavePurchaseHistory_Success(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// ─── CountPendingExecutionsForAccount / ListPendingExecutionIDsForAccount ───
+// Regression coverage for the issue #606 deleteAccount preflight. The handler
+// uses these to convert what would otherwise be a raw ON DELETE RESTRICT
+// FK violation (post-migration 000053) into a structured 409 response.
+
+func TestPGXMock_CountPendingExecutionsForAccount_Success(t *testing.T) {
+	mock := newMock(t)
+	store := storeWith(mock)
+	ctx := context.Background()
+
+	rows := pgxmock.NewRows([]string{"count"}).AddRow(4)
+	mock.ExpectQuery("SELECT COUNT").WithArgs("acct-1").WillReturnRows(rows)
+
+	n, err := store.CountPendingExecutionsForAccount(ctx, "acct-1")
+	require.NoError(t, err)
+	assert.Equal(t, 4, n)
+}
+
+func TestPGXMock_CountPendingExecutionsForAccount_Zero(t *testing.T) {
+	mock := newMock(t)
+	store := storeWith(mock)
+	ctx := context.Background()
+
+	rows := pgxmock.NewRows([]string{"count"}).AddRow(0)
+	mock.ExpectQuery("SELECT COUNT").WithArgs("acct-1").WillReturnRows(rows)
+
+	n, err := store.CountPendingExecutionsForAccount(ctx, "acct-1")
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+}
+
+func TestPGXMock_ListPendingExecutionIDsForAccount_Success(t *testing.T) {
+	mock := newMock(t)
+	store := storeWith(mock)
+	ctx := context.Background()
+
+	rows := pgxmock.NewRows([]string{"execution_id"}).
+		AddRow("exec-1").
+		AddRow("exec-2")
+	mock.ExpectQuery("SELECT execution_id FROM purchase_executions").
+		WithArgs("acct-1").
+		WillReturnRows(rows)
+
+	ids, err := store.ListPendingExecutionIDsForAccount(ctx, "acct-1")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"exec-1", "exec-2"}, ids)
+}
+
+func TestPGXMock_ListPendingExecutionIDsForAccount_Empty(t *testing.T) {
+	mock := newMock(t)
+	store := storeWith(mock)
+	ctx := context.Background()
+
+	rows := pgxmock.NewRows([]string{"execution_id"})
+	mock.ExpectQuery("SELECT execution_id FROM purchase_executions").
+		WithArgs("acct-1").
+		WillReturnRows(rows)
+
+	ids, err := store.ListPendingExecutionIDsForAccount(ctx, "acct-1")
+	require.NoError(t, err)
+	assert.Empty(t, ids)
+}
+
 // ─── errNoRows helper ────────────────────────────────────────────────────────
 
 func errNoRows() error {

--- a/internal/config/store_postgres_pgxmock_test.go
+++ b/internal/config/store_postgres_pgxmock_test.go
@@ -1343,6 +1343,7 @@ func TestPGXMock_CountPendingExecutionsForAccount_Success(t *testing.T) {
 	n, err := store.CountPendingExecutionsForAccount(ctx, "acct-1")
 	require.NoError(t, err)
 	assert.Equal(t, 4, n)
+	require.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestPGXMock_CountPendingExecutionsForAccount_Zero(t *testing.T) {
@@ -1356,6 +1357,7 @@ func TestPGXMock_CountPendingExecutionsForAccount_Zero(t *testing.T) {
 	n, err := store.CountPendingExecutionsForAccount(ctx, "acct-1")
 	require.NoError(t, err)
 	assert.Equal(t, 0, n)
+	require.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestPGXMock_ListPendingExecutionIDsForAccount_Success(t *testing.T) {
@@ -1373,6 +1375,7 @@ func TestPGXMock_ListPendingExecutionIDsForAccount_Success(t *testing.T) {
 	ids, err := store.ListPendingExecutionIDsForAccount(ctx, "acct-1")
 	require.NoError(t, err)
 	assert.Equal(t, []string{"exec-1", "exec-2"}, ids)
+	require.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestPGXMock_ListPendingExecutionIDsForAccount_Empty(t *testing.T) {
@@ -1388,6 +1391,7 @@ func TestPGXMock_ListPendingExecutionIDsForAccount_Empty(t *testing.T) {
 	ids, err := store.ListPendingExecutionIDsForAccount(ctx, "acct-1")
 	require.NoError(t, err)
 	assert.Empty(t, ids)
+	require.NoError(t, mock.ExpectationsWereMet())
 }
 
 // ─── errNoRows helper ────────────────────────────────────────────────────────

--- a/internal/database/postgres/migrations/000053_executions_account_fk_restrict.down.sql
+++ b/internal/database/postgres/migrations/000053_executions_account_fk_restrict.down.sql
@@ -1,0 +1,16 @@
+-- 000053 rollback: revert purchase_executions.cloud_account_id FK to ON DELETE SET NULL
+--
+-- This restores the original migration-000011 behaviour. Note that operators
+-- rolling back should be aware they are re-introducing the silent-orphan
+-- behaviour described in issue #606; the cleanup script
+-- scripts/mark_orphan_executions_failed.sql will need to be re-run after any
+-- subsequent account deletes.
+
+ALTER TABLE purchase_executions
+    DROP CONSTRAINT IF EXISTS purchase_executions_cloud_account_id_fkey;
+
+ALTER TABLE purchase_executions
+    ADD CONSTRAINT purchase_executions_cloud_account_id_fkey
+    FOREIGN KEY (cloud_account_id)
+    REFERENCES cloud_accounts(id)
+    ON DELETE SET NULL;

--- a/internal/database/postgres/migrations/000053_executions_account_fk_restrict.up.sql
+++ b/internal/database/postgres/migrations/000053_executions_account_fk_restrict.up.sql
@@ -1,0 +1,30 @@
+-- 000053: tighten purchase_executions.cloud_account_id FK to ON DELETE RESTRICT (issue #606)
+--
+-- The original FK (migration 000011, line 132) was declared ON DELETE SET NULL.
+-- That choice silently invalidates every pending / notified execution that
+-- references the deleted cloud_account row:
+--
+--   1. The approve modal renders "(ambient)" because the frontend can't
+--      resolve the now-null account.
+--   2. The execution can never actually run for non-AWS providers: the
+--      executor's chained DefaultAzureCredential / GCP ADC chain has no
+--      registered account to dial, so the purchase fails with a credential
+--      error the user can't fix without re-registering the deleted account.
+--
+-- Recommendations rows on the same migration keep ON DELETE SET NULL because
+-- the next recommendation-collection cycle re-upserts them with the current
+-- account IDs (or evicts orphans). Executions are immutable snapshots and
+-- cannot self-heal, so the safer default is RESTRICT: block the DELETE at
+-- the DB level and force the operator to cancel pending purchases first.
+-- The handler in internal/api/handler_accounts.go also preflights this so
+-- the frontend can offer a Cancel-All-And-Delete affordance instead of
+-- surfacing a raw FK violation.
+
+ALTER TABLE purchase_executions
+    DROP CONSTRAINT IF EXISTS purchase_executions_cloud_account_id_fkey;
+
+ALTER TABLE purchase_executions
+    ADD CONSTRAINT purchase_executions_cloud_account_id_fkey
+    FOREIGN KEY (cloud_account_id)
+    REFERENCES cloud_accounts(id)
+    ON DELETE RESTRICT;

--- a/internal/database/postgres/migrations/000053_executions_account_fk_restrict_test.go
+++ b/internal/database/postgres/migrations/000053_executions_account_fk_restrict_test.go
@@ -1,0 +1,103 @@
+//go:build integration
+// +build integration
+
+package migrations_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/LeanerCloud/CUDly/internal/database/postgres/migrations"
+	"github.com/LeanerCloud/CUDly/internal/database/postgres/testhelpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMigration_ExecutionsAccountFKRestrict locks down migration 000053: the
+// purchase_executions.cloud_account_id FK must be ON DELETE RESTRICT after
+// the migration runs. Issue #606 — silent-orphan regression guard.
+func TestMigration_ExecutionsAccountFKRestrict(t *testing.T) {
+	ctx := context.Background()
+	migrationsPath := getMigrationsPath()
+
+	container, err := testhelpers.SetupPostgresContainer(ctx, t)
+	require.NoError(t, err)
+	defer container.Cleanup(ctx)
+	pool := container.DB.Pool()
+
+	require.NoError(t, migrations.RunMigrations(ctx, pool, migrationsPath, "", ""))
+
+	// Verify the FK is RESTRICT after the migration.
+	var deleteAction string
+	err = pool.QueryRow(ctx, `
+		SELECT confdeltype
+		FROM pg_constraint
+		WHERE conname = 'purchase_executions_cloud_account_id_fkey'
+	`).Scan(&deleteAction)
+	require.NoError(t, err)
+	assert.Equal(t, "r", deleteAction,
+		"expected confdeltype 'r' (RESTRICT) after 000053, got %q", deleteAction)
+
+	// Behavioural test: insert an account + a pending execution that
+	// references it, then attempt to delete the account. Postgres must
+	// raise a foreign-key-violation (SQLSTATE 23503).
+	_, err = pool.Exec(ctx, `
+		INSERT INTO cloud_accounts (id, name, provider, external_id)
+		VALUES ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'fk-test', 'aws', '999999999999')
+	`)
+	require.NoError(t, err)
+
+	_, err = pool.Exec(ctx, `
+		INSERT INTO purchase_executions
+		    (execution_id, status, step_number, scheduled_date, cloud_account_id)
+		VALUES
+		    ('exec-fk-test', 'pending', 1, NOW(), 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+	`)
+	require.NoError(t, err)
+
+	_, err = pool.Exec(ctx, `DELETE FROM cloud_accounts WHERE id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'`)
+	require.Error(t, err, "DELETE must fail with FK violation")
+	// pgx surfaces the SQLSTATE in the error string ("SQLSTATE 23503").
+	assert.True(t,
+		strings.Contains(err.Error(), "23503") || strings.Contains(err.Error(), "foreign key"),
+		"expected FK violation, got %v", err)
+
+	// Cancel the execution, then the delete should succeed.
+	_, err = pool.Exec(ctx, `
+		UPDATE purchase_executions
+		   SET status = 'cancelled'
+		 WHERE execution_id = 'exec-fk-test'
+	`)
+	require.NoError(t, err)
+
+	_, err = pool.Exec(ctx, `DELETE FROM cloud_accounts WHERE id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'`)
+	require.NoError(t, err, "DELETE should succeed once pending executions are cancelled")
+}
+
+// TestMigration_ExecutionsAccountFKRestrict_Rollback asserts that the
+// 000053 down migration restores the original SET NULL behaviour, so an
+// emergency rollback re-introduces the (documented) silent-orphan
+// behaviour rather than leaving the database in an indeterminate state.
+func TestMigration_ExecutionsAccountFKRestrict_Rollback(t *testing.T) {
+	ctx := context.Background()
+	migrationsPath := getMigrationsPath()
+
+	container, err := testhelpers.SetupPostgresContainer(ctx, t)
+	require.NoError(t, err)
+	defer container.Cleanup(ctx)
+	pool := container.DB.Pool()
+
+	require.NoError(t, migrations.RunMigrations(ctx, pool, migrationsPath, "", ""))
+	require.NoError(t, migrations.RollbackMigrations(ctx, pool, migrationsPath, 1))
+
+	var deleteAction string
+	err = pool.QueryRow(ctx, `
+		SELECT confdeltype
+		FROM pg_constraint
+		WHERE conname = 'purchase_executions_cloud_account_id_fkey'
+	`).Scan(&deleteAction)
+	require.NoError(t, err)
+	assert.Equal(t, "n", deleteAction,
+		"expected confdeltype 'n' (SET NULL) after rollback, got %q", deleteAction)
+}

--- a/internal/database/postgres/migrations/000053_executions_account_fk_restrict_test.go
+++ b/internal/database/postgres/migrations/000053_executions_account_fk_restrict_test.go
@@ -39,6 +39,20 @@ func TestMigration_ExecutionsAccountFKRestrict(t *testing.T) {
 	assert.Equal(t, "r", deleteAction,
 		"expected confdeltype 'r' (RESTRICT) after 000053, got %q", deleteAction)
 
+	// Negative-space guard: migration 000053 must only tighten the executions
+	// FK. The recommendations FK should stay ON DELETE SET NULL — orphaning a
+	// historical recommendation is fine (it's advisory data), unlike a pending
+	// execution (which represents money about to be spent).
+	var recsDeleteAction string
+	err = pool.QueryRow(ctx, `
+		SELECT confdeltype
+		FROM pg_constraint
+		WHERE conname = 'recommendations_cloud_account_id_fkey'
+	`).Scan(&recsDeleteAction)
+	require.NoError(t, err)
+	assert.Equal(t, "n", recsDeleteAction,
+		"recommendations FK must stay SET NULL after 000053, got %q", recsDeleteAction)
+
 	// Behavioural test: insert an account + a pending execution that
 	// references it, then attempt to delete the account. Postgres must
 	// raise a foreign-key-violation (SQLSTATE 23503).
@@ -100,4 +114,16 @@ func TestMigration_ExecutionsAccountFKRestrict_Rollback(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "n", deleteAction,
 		"expected confdeltype 'n' (SET NULL) after rollback, got %q", deleteAction)
+
+	// Negative-space guard: rolling back 000053 must not touch the
+	// recommendations FK — it has always been SET NULL and should stay so.
+	var recsDeleteAction string
+	err = pool.QueryRow(ctx, `
+		SELECT confdeltype
+		FROM pg_constraint
+		WHERE conname = 'recommendations_cloud_account_id_fkey'
+	`).Scan(&recsDeleteAction)
+	require.NoError(t, err)
+	assert.Equal(t, "n", recsDeleteAction,
+		"recommendations FK must stay SET NULL after rollback, got %q", recsDeleteAction)
 }

--- a/internal/mocks/stores.go
+++ b/internal/mocks/stores.go
@@ -144,6 +144,21 @@ func (m *MockConfigStore) GetExecutionByPlanAndDate(ctx context.Context, planID 
 	return args.Get(0).(*config.PurchaseExecution), args.Error(1)
 }
 
+// CountPendingExecutionsForAccount mocks the CountPendingExecutionsForAccount operation
+func (m *MockConfigStore) CountPendingExecutionsForAccount(ctx context.Context, accountID string) (int, error) {
+	args := m.Called(ctx, accountID)
+	return args.Int(0), args.Error(1)
+}
+
+// ListPendingExecutionIDsForAccount mocks the ListPendingExecutionIDsForAccount operation
+func (m *MockConfigStore) ListPendingExecutionIDsForAccount(ctx context.Context, accountID string) ([]string, error) {
+	args := m.Called(ctx, accountID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]string), args.Error(1)
+}
+
 // SavePurchaseHistory mocks the SavePurchaseHistory operation
 func (m *MockConfigStore) SavePurchaseHistory(ctx context.Context, record *config.PurchaseHistoryRecord) error {
 	args := m.Called(ctx, record)

--- a/internal/purchase/mocks_test.go
+++ b/internal/purchase/mocks_test.go
@@ -286,6 +286,19 @@ func (m *MockConfigStore) CleanupOldExecutions(ctx context.Context, retentionDay
 	return args.Get(0).(int64), args.Error(1)
 }
 
+func (m *MockConfigStore) CountPendingExecutionsForAccount(ctx context.Context, accountID string) (int, error) {
+	args := m.Called(ctx, accountID)
+	return args.Int(0), args.Error(1)
+}
+
+func (m *MockConfigStore) ListPendingExecutionIDsForAccount(ctx context.Context, accountID string) ([]string, error) {
+	args := m.Called(ctx, accountID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]string), args.Error(1)
+}
+
 func (m *MockConfigStore) TransitionExecutionStatus(ctx context.Context, executionID string, fromStatuses []string, toStatus string) (*config.PurchaseExecution, error) {
 	args := m.Called(ctx, executionID, fromStatuses, toStatus)
 	if args.Get(0) == nil {

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -179,6 +179,19 @@ func (m *MockConfigStore) CleanupOldExecutions(ctx context.Context, retentionDay
 	return args.Get(0).(int64), args.Error(1)
 }
 
+func (m *MockConfigStore) CountPendingExecutionsForAccount(ctx context.Context, accountID string) (int, error) {
+	args := m.Called(ctx, accountID)
+	return args.Int(0), args.Error(1)
+}
+
+func (m *MockConfigStore) ListPendingExecutionIDsForAccount(ctx context.Context, accountID string) ([]string, error) {
+	args := m.Called(ctx, accountID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]string), args.Error(1)
+}
+
 func (m *MockConfigStore) TransitionExecutionStatus(ctx context.Context, executionID string, fromStatuses []string, toStatus string) (*config.PurchaseExecution, error) {
 	args := m.Called(ctx, executionID, fromStatuses, toStatus)
 	if args.Get(0) == nil {

--- a/internal/server/test_helpers_test.go
+++ b/internal/server/test_helpers_test.go
@@ -95,6 +95,14 @@ func (m *mockConfigStoreForHealth) CleanupOldExecutions(ctx context.Context, ret
 	return 0, nil
 }
 
+func (m *mockConfigStoreForHealth) CountPendingExecutionsForAccount(ctx context.Context, accountID string) (int, error) {
+	return 0, nil
+}
+
+func (m *mockConfigStoreForHealth) ListPendingExecutionIDsForAccount(ctx context.Context, accountID string) ([]string, error) {
+	return nil, nil
+}
+
 func (m *mockConfigStoreForHealth) TransitionExecutionStatus(ctx context.Context, executionID string, fromStatuses []string, toStatus string) (*config.PurchaseExecution, error) {
 	return nil, nil
 }

--- a/scripts/mark_orphan_executions_failed.sql
+++ b/scripts/mark_orphan_executions_failed.sql
@@ -30,20 +30,18 @@ FROM purchase_executions
 WHERE cloud_account_id IS NULL
   AND status IN ('pending', 'notified');
 
-UPDATE purchase_executions
-   SET status = 'failed',
-       error  = COALESCE(
-                  NULLIF(error, ''),
-                  'account deleted, cannot execute (issue #606 cleanup)'
-                )
- WHERE cloud_account_id IS NULL
-   AND status IN ('pending', 'notified');
-
--- Confirm the row count for the operator.
-SELECT COUNT(*) AS rows_updated
-FROM purchase_executions
-WHERE cloud_account_id IS NULL
-  AND status = 'failed'
-  AND error = 'account deleted, cannot execute (issue #606 cleanup)';
+-- Unconditionally set the canonical error message — pending/notified rows
+-- shouldn't carry meaningful prior errors (the executor only sets error on
+-- terminal status transitions), and the RETURNING clause below gives us an
+-- accurate row count without a separate filter that could drift.
+WITH updated AS (
+    UPDATE purchase_executions
+       SET status = 'failed',
+           error  = 'account deleted, cannot execute (issue #606 cleanup)'
+     WHERE cloud_account_id IS NULL
+       AND status IN ('pending', 'notified')
+    RETURNING execution_id
+)
+SELECT COUNT(*) AS rows_updated FROM updated;
 
 COMMIT;

--- a/scripts/mark_orphan_executions_failed.sql
+++ b/scripts/mark_orphan_executions_failed.sql
@@ -1,0 +1,49 @@
+-- mark_orphan_executions_failed.sql
+--
+-- One-shot cleanup for issue #606: before migration 000053 tightened the
+-- purchase_executions.cloud_account_id FK to ON DELETE RESTRICT, deleting a
+-- cloud account silently set cloud_account_id = NULL on every pending /
+-- notified execution that referenced it. Those rows can never execute
+-- (the executor has no account to dial credentials against) yet still
+-- show as "pending" in the dashboard.
+--
+-- Run this script ONCE per deployment after migration 000053 lands to
+-- mark the existing orphan rows as failed so operators stop seeing them
+-- in the approve queue. The migration itself does NOT do this — it's a
+-- one-time data cleanup, not a schema change, so it lives here.
+--
+--   psql "$DATABASE_URL" -f scripts/mark_orphan_executions_failed.sql
+--
+-- Idempotent: re-running is a no-op because all affected rows will be
+-- 'failed' after the first run. Wrapped in a transaction so a syntax
+-- error or partial failure rolls back cleanly.
+
+BEGIN;
+
+-- Show the rows we're about to update so the operator can sanity-check.
+SELECT execution_id,
+       status,
+       scheduled_date,
+       plan_id,
+       'will mark failed' AS action
+FROM purchase_executions
+WHERE cloud_account_id IS NULL
+  AND status IN ('pending', 'notified');
+
+UPDATE purchase_executions
+   SET status = 'failed',
+       error  = COALESCE(
+                  NULLIF(error, ''),
+                  'account deleted, cannot execute (issue #606 cleanup)'
+                )
+ WHERE cloud_account_id IS NULL
+   AND status IN ('pending', 'notified');
+
+-- Confirm the row count for the operator.
+SELECT COUNT(*) AS rows_updated
+FROM purchase_executions
+WHERE cloud_account_id IS NULL
+  AND status = 'failed'
+  AND error = 'account deleted, cannot execute (issue #606 cleanup)';
+
+COMMIT;


### PR DESCRIPTION
## Summary
- Tighten `purchase_executions.cloud_account_id` FK to `ON DELETE RESTRICT` (migration 000053) so the DB blocks an account delete that would orphan a pending purchase. Recommendations rows keep `SET NULL` — they self-heal on the next collection cycle.
- Preflight in `deleteCloudAccount` handler: count pending/notified executions for the target account and, if > 0, return a 409 `ClientError` with `pending_count` + `pending_execution_ids` in the details payload (so the frontend can branch without parsing the human message).
- Frontend `settings.ts` handles the 409 with a second confirm dialog ("Cancel All N Pending + Delete"). On confirm it walks the execution-ID list cancelling each one before retrying the delete; partial cancel failure aborts the retry so the operator can investigate via the History page.
- One-shot SQL cleanup script `scripts/mark_orphan_executions_failed.sql` marks existing orphan rows (`cloud_account_id IS NULL AND status IN ('pending', 'notified')`) as `failed`. Operators run it once after the migration lands; idempotent.

Closes #606.

## Test plan
- [x] DB (pgxmock): `TestPGXMock_CountPendingExecutionsForAccount_*` + `TestPGXMock_ListPendingExecutionIDsForAccount_*` — covers the new store methods.
- [x] DB (integration, `+build integration`): `TestMigration_ExecutionsAccountFKRestrict` runs the migration, asserts `confdeltype = 'r'`, then attempts a `DELETE FROM cloud_accounts` while a pending execution references it (must raise SQLSTATE 23503), then verifies the delete succeeds after cancelling the execution. Companion `_Rollback` test asserts the down migration restores `SET NULL`.
- [x] Handler: `TestDeleteAccount_PendingExecutions_Returns409` (3 pending → 409 + structured details, `DeleteCloudAccount` not called), `TestDeleteAccount_PendingZero_DeletesNormally` (happy path), `TestDeleteAccount_PendingListErr_StillReturns409` (list call fails → 409 with degraded payload, no 500).
- [x] Frontend: 4 new tests in `settings-accounts.test.ts` — second confirm dialog renders with correct count + label, Cancel-All-Then-Delete posts cancel per execution then retries delete, partial cancel failure aborts retry + surfaces error toast, non-409 errors keep original behaviour.
- [x] `go test ./...` — 4607 passed, 0 new failures (2 pre-existing failures on `TestPGXMock_GetExecutionByID_*` reproduce on the unmodified base branch).
- [x] `go vet ./...` clean. `tsc --noEmit` clean. All 1906 frontend tests pass.
- [ ] Operator follow-up after merge: run `psql "$DATABASE_URL" -f scripts/mark_orphan_executions_failed.sql` once to clean up any pre-existing orphan rows. Script is idempotent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added account deletion workflow that detects pending purchases and requires their cancellation before proceeding with deletion.
  * Users now receive a confirmation dialog showing the count of pending purchases to be cancelled.

* **Bug Fixes**
  * Improved validation when deleting accounts with linked pending purchases to prevent data integrity issues.

* **Database**
  * Updated foreign key constraint enforcement for purchase executions to prevent orphaned records.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/614?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->