### PR TITLE
fix(cli): purchase-output corrections (savings label, no-upfront warning, descriptive RI IDs)

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -504,7 +504,8 @@ func ApplyInstanceLimit(recs []common.Recommendation, maxInstances int32) []comm
 }
 
 // ConfirmPurchase asks the user for confirmation before proceeding.
-// totalSavings is the estimated annual savings from the purchase (not the purchase cost).
+// totalSavings is the estimated monthly savings from the purchase (not the purchase cost),
+// matching the EstimatedSavings column and the "Estimated monthly savings" summary.
 // Returns false without prompting if stdin is not a TTY and skipConfirmation is false.
 func ConfirmPurchase(totalInstances int, totalSavings float64, skipConfirmation bool) bool {
 	if skipConfirmation {
@@ -516,7 +517,7 @@ func ConfirmPurchase(totalInstances int, totalSavings float64, skipConfirmation 
 		return false
 	}
 
-	fmt.Printf("\n⚠️  About to purchase %d instances with estimated annual savings: $%.2f\n", totalInstances, totalSavings)
+	fmt.Printf("\n⚠️  About to purchase %d instances with estimated monthly savings: $%.2f\n", totalInstances, totalSavings)
 	fmt.Print("Do you want to proceed? (yes/no): ")
 
 	reader := bufio.NewReader(os.Stdin)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -283,6 +283,34 @@ func effectiveSizingPct(cfg Config) float64 {
 	return cfg.Coverage
 }
 
+// extractEngineLabel returns the engine or platform string from the polymorphic
+// Details field, handling both value and pointer forms. The live parser and the
+// CSV loader store pointers (*DatabaseDetails is required by findOfferingID),
+// while some test callers construct values directly.
+func extractEngineLabel(details interface{}) string {
+	switch d := details.(type) {
+	case common.DatabaseDetails:
+		return d.Engine
+	case *common.DatabaseDetails:
+		if d != nil {
+			return d.Engine
+		}
+	case common.CacheDetails:
+		return d.Engine
+	case *common.CacheDetails:
+		if d != nil {
+			return d.Engine
+		}
+	case common.ComputeDetails:
+		return d.Platform
+	case *common.ComputeDetails:
+		if d != nil {
+			return d.Platform
+		}
+	}
+	return ""
+}
+
 // generatePurchaseID creates a descriptive purchase ID with UUID for uniqueness.
 // sizingPct is the percentage that actually drove the sizing decision (see
 // effectiveSizingPct); it appears in the ID as e.g. "80pct" purely for human
@@ -299,20 +327,11 @@ func generatePurchaseID(rec common.Recommendation, region string, _ int, isDryRu
 	service := strings.ToLower(string(rec.Service))
 	instanceType := strings.ReplaceAll(rec.ResourceType, ".", "-")
 
-	// Extract engine information from service details
-	engine := ""
-	switch details := rec.Details.(type) {
-	case common.DatabaseDetails:
-		engine = strings.ToLower(details.Engine)
-		engine = strings.ReplaceAll(engine, " ", "-")
-		engine = strings.ReplaceAll(engine, "_", "-")
-	case common.CacheDetails:
-		engine = strings.ToLower(details.Engine)
-	case common.ComputeDetails:
-		engine = strings.ToLower(details.Platform)
-		engine = strings.ReplaceAll(engine, " ", "-")
-		engine = strings.ReplaceAll(engine, "/", "-")
-	}
+	raw := extractEngineLabel(rec.Details)
+	engine := strings.ToLower(raw)
+	engine = strings.ReplaceAll(engine, " ", "-")
+	engine = strings.ReplaceAll(engine, "_", "-")
+	engine = strings.ReplaceAll(engine, "/", "-")
 
 	// Add account name if available
 	accountName := sanitizeAccountName(rec.AccountName)

--- a/cmd/multi_service_helpers.go
+++ b/cmd/multi_service_helpers.go
@@ -230,14 +230,18 @@ func createCancelledResults(recs []common.Recommendation, region string, cfg Con
 // executePurchase executes an actual RI purchase
 func executePurchase(ctx context.Context, rec common.Recommendation, region string, index int, serviceClient provider.ServiceClient, cfg Config) common.PurchaseResult {
 	AppLogger.Printf("    ⚠️  ACTUAL PURCHASE: About to buy %d instances of %s\n", rec.Count, rec.ResourceType)
-	opts := common.PurchaseOptions{Source: common.PurchaseSourceCLI}
+	// Compute the descriptive commitment ID up front and hand it to the
+	// provider so the purchased commitment is named descriptively at AWS
+	// (e.g. RDS ReservedDBInstanceId), not just in our local report.
+	commitmentID := generatePurchaseID(rec, region, index, false, effectiveSizingPct(cfg))
+	opts := common.PurchaseOptions{Source: common.PurchaseSourceCLI, ReservationID: commitmentID}
 	result, err := serviceClient.PurchaseCommitment(ctx, rec, opts)
 	if err != nil {
 		result.Success = false
 		result.Error = err
 	}
 	if result.CommitmentID == "" {
-		result.CommitmentID = generatePurchaseID(rec, region, index, false, effectiveSizingPct(cfg))
+		result.CommitmentID = commitmentID
 	}
 	return result
 }

--- a/cmd/multi_service_helpers_test.go
+++ b/cmd/multi_service_helpers_test.go
@@ -367,13 +367,22 @@ func TestExecutePurchase(t *testing.T) {
 		Error:          nil,
 		Timestamp:      time.Now(),
 	}
-	mockClient.On("PurchaseCommitment", ctx, rec, common.PurchaseOptions{Source: common.PurchaseSourceCLI}).Return(expectedResult, nil)
+	var capturedOpts common.PurchaseOptions
+	mockClient.On("PurchaseCommitment", ctx, rec, mock.MatchedBy(func(o common.PurchaseOptions) bool {
+		capturedOpts = o
+		return o.Source == common.PurchaseSourceCLI
+	})).Return(expectedResult, nil)
 
 	result := executePurchase(ctx, rec, "eu-west-1", 5, mockClient, toolCfg)
 
 	assert.True(t, result.Success)
 	assert.Equal(t, "test-purchase-id-123", result.CommitmentID)
 	assert.Nil(t, result.Error)
+
+	// #617: executePurchase hands the provider a descriptive reservation ID
+	// (account/service/region/size aware) rather than leaving it generic.
+	assert.NotEmpty(t, capturedOpts.ReservationID)
+	assert.Contains(t, capturedOpts.ReservationID, "t3-medium")
 
 	mockClient.AssertExpectations(t)
 }

--- a/cmd/multi_service_test.go
+++ b/cmd/multi_service_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/LeanerCloud/CUDly/pkg/common"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestRunToolMultiService_Validation(t *testing.T) {
@@ -1218,7 +1219,7 @@ func TestProcessPurchaseLoopPurchaseFailure(t *testing.T) {
 		Error:          fmt.Errorf("API error: quota exceeded"),
 		Timestamp:      time.Now(),
 	}
-	mockClient.On("PurchaseCommitment", ctx, recs[0], common.PurchaseOptions{Source: common.PurchaseSourceCLI}).Return(failureResult, nil)
+	mockClient.On("PurchaseCommitment", ctx, recs[0], mock.MatchedBy(func(o common.PurchaseOptions) bool { return o.Source == common.PurchaseSourceCLI })).Return(failureResult, nil)
 
 	t.Setenv("DISABLE_PURCHASE_DELAY", "true")
 
@@ -1260,7 +1261,7 @@ func TestProcessPurchaseLoopUserCancellation(t *testing.T) {
 			CommitmentID:   "test-id",
 			Timestamp:      time.Now(),
 		}
-		mockClient.On("PurchaseCommitment", ctx, rec, common.PurchaseOptions{Source: common.PurchaseSourceCLI}).Return(result, nil)
+		mockClient.On("PurchaseCommitment", ctx, rec, mock.MatchedBy(func(o common.PurchaseOptions) bool { return o.Source == common.PurchaseSourceCLI })).Return(result, nil)
 	}
 
 	t.Setenv("DISABLE_PURCHASE_DELAY", "true")
@@ -1309,7 +1310,7 @@ func TestProcessServicePurchasesUserCancellation(t *testing.T) {
 		CommitmentID:   "cache-purchase-123",
 		Timestamp:      time.Now(),
 	}
-	mockClient.On("PurchaseCommitment", ctx, recs[0], common.PurchaseOptions{Source: common.PurchaseSourceCLI}).Return(result, nil)
+	mockClient.On("PurchaseCommitment", ctx, recs[0], mock.MatchedBy(func(o common.PurchaseOptions) bool { return o.Source == common.PurchaseSourceCLI })).Return(result, nil)
 
 	t.Setenv("DISABLE_PURCHASE_DELAY", "true")
 
@@ -1380,7 +1381,7 @@ func TestExecutePurchaseWithEmptyPurchaseID(t *testing.T) {
 		Error:          nil,
 		Timestamp:      time.Now(),
 	}
-	mockClient.On("PurchaseCommitment", ctx, rec, common.PurchaseOptions{Source: common.PurchaseSourceCLI}).Return(expectedResult, nil)
+	mockClient.On("PurchaseCommitment", ctx, rec, mock.MatchedBy(func(o common.PurchaseOptions) bool { return o.Source == common.PurchaseSourceCLI })).Return(expectedResult, nil)
 
 	// Logger output disabled for testing
 
@@ -1453,7 +1454,7 @@ func TestProcessPurchaseLoopActualPurchase(t *testing.T) {
 			Error:          nil,
 			Timestamp:      time.Now(),
 		}
-		mockClient.On("PurchaseCommitment", ctx, rec, common.PurchaseOptions{Source: common.PurchaseSourceCLI}).Return(result, nil)
+		mockClient.On("PurchaseCommitment", ctx, rec, mock.MatchedBy(func(o common.PurchaseOptions) bool { return o.Source == common.PurchaseSourceCLI })).Return(result, nil)
 	}
 
 	// Logger output disabled for testing
@@ -1497,7 +1498,7 @@ func TestProcessPurchaseLoopWithConfirmation(t *testing.T) {
 		Error:          nil,
 		Timestamp:      time.Now(),
 	}
-	mockClient.On("PurchaseCommitment", ctx, recs[0], common.PurchaseOptions{Source: common.PurchaseSourceCLI}).Return(result, nil)
+	mockClient.On("PurchaseCommitment", ctx, recs[0], mock.MatchedBy(func(o common.PurchaseOptions) bool { return o.Source == common.PurchaseSourceCLI })).Return(result, nil)
 
 	// Logger output disabled for testing
 

--- a/cmd/validators.go
+++ b/cmd/validators.go
@@ -110,6 +110,13 @@ func validatePaymentAndTerm() error {
 
 // warnRDS3YearNoUpfront warns if RDS service is selected with 3-year no-upfront
 func warnRDS3YearNoUpfront() error {
+	// In CSV-input mode the payment option comes from each row, not the
+	// --payment flag (which keeps its no-upfront default), so this flag-based
+	// check would fire a false alarm on a CSV full of partial-upfront rows.
+	if toolCfg.CSVInput != "" {
+		return nil
+	}
+
 	if toolCfg.PaymentOption != "no-upfront" || toolCfg.TermYears != 3 {
 		return nil
 	}

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -255,6 +255,11 @@ const PurchaseTagKey = "purchase-automation"
 // encoded in the commitment description).
 type PurchaseOptions struct {
 	Source string
+	// ReservationID, when set, is used as the provider-side commitment
+	// identifier (e.g. RDS ReservedDBInstanceId) so purchased commitments
+	// carry a descriptive, account/engine/region-aware name instead of a
+	// generic auto-generated one. Providers sanitize it to their ID rules.
+	ReservationID string
 }
 
 // NormalizeSource lowercases s and returns it when it matches an allowed

--- a/providers/aws/services/rds/client.go
+++ b/providers/aws/services/rds/client.go
@@ -139,8 +139,15 @@ func (c *Client) PurchaseCommitment(ctx context.Context, rec common.Recommendati
 		return result, result.Error
 	}
 
-	// Generate reservation ID (letters, digits, hyphens only; no leading/trailing/double hyphen)
-	reservationID := common.SanitizeReservationID(fmt.Sprintf("rds-%s-%d", rec.ResourceType, time.Now().Unix()), "rds-reserved-")
+	// Reservation ID (letters, digits, hyphens only; no leading/trailing/double
+	// hyphen). Prefer the caller-supplied descriptive ID (account/engine/region/
+	// size aware) so the reservation is identifiable in the console and billing;
+	// fall back to a generic one when the caller didn't supply it.
+	rawID := opts.ReservationID
+	if rawID == "" {
+		rawID = fmt.Sprintf("rds-%s-%d", rec.ResourceType, time.Now().Unix())
+	}
+	reservationID := common.SanitizeReservationID(rawID, "rds-reserved-")
 
 	// Create the purchase request
 	input := &rds.PurchaseReservedDBInstancesOfferingInput{


### PR DESCRIPTION
## Summary

Three correctness fixes for the purchase flow output:

- **#615 - Monthly savings label**: The `ConfirmPurchase` prompt said "estimated annual savings" but `EstimatedSavings` is a monthly value (from Cost Explorer's coverage API). Updated the doc comment and the printed line to say "monthly", consistent with the summary line and CSV column.

- **#616 - Skip 3yr no-upfront warning in CSV mode**: `warnRDS3YearNoUpfront` was firing a false alarm when `--input-csv` was used, because the `--payment` flag keeps its `no-upfront` default even though each CSV row carries its own payment option. Added an early return when `CSVInput != ""` so the warning only fires in interactive/flag-driven mode.

- **#617 - Descriptive RDS reservation IDs**: Reserved DB instances were being named with a generic `rds-<type>-<unix-timestamp>` ID. Now `executePurchase` computes a descriptive ID (account/engine/region/size/coverage-aware) up front and threads it through `PurchaseOptions.ReservationID` into `PurchaseCommitment`, so the reservation is identifiable in the AWS console and billing exports. `generatePurchaseID` was also fixed to handle pointer `Details` types (`*DatabaseDetails`, `*CacheDetails`, `*ComputeDetails`) that the live parser produces, preventing the engine segment from silently dropping out of real purchases.

Closes #615, Closes #616, Closes #617

**Out of scope**: multi-account execution is tracked separately and intentionally not addressed here.

## Verification

- `go build ./...` - clean
- `go vet github.com/LeanerCloud/CUDly/cmd github.com/LeanerCloud/CUDly/providers/aws/services/rds` - no issues
- `go test github.com/LeanerCloud/CUDly/cmd github.com/LeanerCloud/CUDly/providers/aws/services/rds github.com/LeanerCloud/CUDly/pkg/common` - 889 passed
- Pre-commit hooks (gofmt, go vet, gocyclo, go-sec, trivy) - all passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect RDS 3-year no-upfront warning appearing when running with CSV input where payment options are provided per row.

* **Improvements**
  * Updated purchase confirmation messaging to reference estimated monthly savings instead of annual savings for improved clarity.
  * Reserved database instances now receive descriptive names at purchase time instead of generic auto-generated names.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/618?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->