### PR TITLE
fix(purchases): keep in-flight and audit-gap purchases visible in History (closes #621)

### DIFF
--- a/frontend/src/__tests__/history.test.ts
+++ b/frontend/src/__tests__/history.test.ts
@@ -270,6 +270,31 @@ describe('History Module', () => {
       expect(list?.innerHTML).toContain('Failed to load history');
     });
 
+    // Issue #621: an approved/running/paused execution is in-flight — its
+    // synchronous AWS purchase may have been interrupted (Lambda timeout /
+    // crash). It MUST render as "In Progress", never the green "Completed"
+    // badge, or the user could think the purchase finished and re-approve it
+    // (double-spend). Pre-fix these statuses fell through to the Completed
+    // default in statusBadgeHTML.
+    test('renders approved/running/paused as In Progress, not Completed', async () => {
+      (api.getHistory as jest.Mock).mockResolvedValue({
+        summary: {},
+        purchases: [
+          { purchase_id: 'appr-1', status: 'approved', provider: 'aws', region: 'us-east-1' },
+          { purchase_id: 'run-1', status: 'running', provider: 'aws', region: 'us-east-1' },
+          { purchase_id: 'paus-1', status: 'paused', provider: 'aws', region: 'us-east-1' },
+        ],
+      });
+
+      await loadHistory();
+
+      const list = document.getElementById('history-list');
+      const html = list?.innerHTML || '';
+      const inProgressBadges = (html.match(/In Progress/g) || []).length;
+      expect(inProgressBadges).toBe(3);
+      expect(html).not.toContain('>Completed<');
+    });
+
     test('handles empty provider filter', async () => {
       (api.getHistory as jest.Mock).mockResolvedValue({
         summary: {},

--- a/frontend/src/history.ts
+++ b/frontend/src/history.ts
@@ -27,6 +27,16 @@ function normalizeStatus(p: HistoryPurchase): string {
   return p.status || 'completed';
 }
 
+// isInFlight reports whether a status is an approved-but-not-yet-finalised
+// execution (issue #621): the synchronous AWS purchase is mid-execution or got
+// interrupted (Lambda timeout / crash). These rows MUST NOT render as the green
+// "Completed" badge — doing so would tell the user a purchase finished when it
+// may not have, tempting a re-approval / double-spend. They are grouped under
+// the "Pending" filter chip (not "Completed") for the same reason.
+function isInFlightStatus(s: string): boolean {
+  return s === 'approved' || s === 'running' || s === 'paused';
+}
+
 // readDeepLinkExecutionID returns the value of the ?execution=<id>
 // query parameter inside the current location hash, or '' when
 // absent. The app uses hash routing ("#history"), so the "query" piece
@@ -259,6 +269,12 @@ function statusBadgeHTML(status: string): string {
     case 'pending':
     case 'notified':
       return '<span class="badge badge-warning">Pending</span>';
+    case 'approved':
+    case 'running':
+    case 'paused':
+      // In-flight (issue #621): not finished — never show the green Completed
+      // badge for these, or the user may think the purchase is done.
+      return '<span class="badge badge-warning">In Progress</span>';
     case 'cancelled':
       return '<span class="badge badge-muted">Cancelled</span>';
     case 'failed':
@@ -281,7 +297,7 @@ function buildStatusChipRowHTML(purchases: HistoryPurchase[], active: StatusFilt
   };
   for (const p of purchases) {
     const s = normalizeStatus(p).toLowerCase();
-    if (s === 'pending' || s === 'notified') counts.pending++;
+    if (s === 'pending' || s === 'notified' || isInFlightStatus(s)) counts.pending++;
     else if (s === 'cancelled') counts.cancelled++;
     else if (s === 'failed') counts.failed++;
     else if (s === 'expired') counts.expired++;
@@ -538,7 +554,7 @@ function renderHistoryList(purchases: HistoryPurchase[]): void {
   // empty "Cancelled" slice after reloading with a fresh query.
   if (activeStatusFilter !== 'all' && !purchases.some(p => {
     const s = normalizeStatus(p).toLowerCase();
-    if (activeStatusFilter === 'pending') return s === 'pending' || s === 'notified';
+    if (activeStatusFilter === 'pending') return s === 'pending' || s === 'notified' || isInFlightStatus(s);
     if (activeStatusFilter === 'completed') return s === 'completed' || !p.status;
     return s === activeStatusFilter;
   })) {
@@ -553,7 +569,7 @@ function renderHistoryList(purchases: HistoryPurchase[]): void {
   const visible = purchases.filter(p => {
     if (activeStatusFilter === 'all') return true;
     const s = normalizeStatus(p).toLowerCase();
-    if (activeStatusFilter === 'pending') return s === 'pending' || s === 'notified';
+    if (activeStatusFilter === 'pending') return s === 'pending' || s === 'notified' || isInFlightStatus(s);
     if (activeStatusFilter === 'completed') return s === 'completed' || !p.status;
     return s === activeStatusFilter;
   });

--- a/internal/api/handler_history.go
+++ b/internal/api/handler_history.go
@@ -63,18 +63,26 @@ func (h *Handler) getHistory(ctx context.Context, req *events.LambdaFunctionURLR
 }
 
 // historyExecutionStatuses enumerates the PurchaseExecution statuses the
-// History view shows alongside completed purchases. "approved" and
-// "completed" are excluded because approval now executes synchronously
-// (issue #372): an Approve click drives the row through "approved" inside
-// a single HTTP request and lands on either "completed" (already in
-// purchase_history) or "failed" (which is in this list). Listing
-// "approved" would either duplicate a completed row or surface a ghost
-// row that no longer exists from the user's perspective. The remaining
-// states (pending, notified, failed, expired, cancelled) are terminal or
-// in-flight states the user needs audit-trail visibility into: a
-// cancelled purchase that simply vanishes is worse UX than a cancelled
-// row with a clear badge.
-var historyExecutionStatuses = []string{"pending", "notified", "failed", "expired", "cancelled"}
+// History view loads alongside completed purchases. Issue #372 assumed
+// approval executes synchronously (approved -> completed/failed inside one
+// HTTP request) and so excluded "approved"; issue #621 showed that
+// assumption breaks under interruption: a Lambda timeout or a crash mid-
+// execution leaves the row stuck in "approved"/"running"/"paused", in
+// neither purchase_history nor this list, and it silently vanishes — the
+// worst failure mode for a financial action (the user can't tell whether
+// the purchase fired and may re-approve). So we now load those in-flight
+// states too, rendered with a clear "in progress" badge rather than as a
+// (misleading) completed row.
+//
+// "completed" is also loaded, but fetchExecutionsAsHistory synthesises a
+// row for it ONLY when the execution carries a non-empty Error — the
+// audit-gap case where the purchase succeeded but its purchase_history
+// write failed (issue #621 secondary path). A normal completed execution
+// has Error=="" and is skipped here so it surfaces exactly once via its
+// purchase_history rows (no duplicate). The execution row's PurchaseID is
+// the ExecutionID while a purchase_history row's is the CommitmentID, so
+// the keys never collide even when both happen to render.
+var historyExecutionStatuses = []string{"pending", "notified", "approved", "running", "paused", "completed", "failed", "expired", "cancelled"}
 
 // approvalExpiryWindow is how long a pending approval stays actionable
 // before the History view flips it to "expired". Aligns with the
@@ -105,6 +113,14 @@ func (h *Handler) fetchExecutionsAsHistory(ctx context.Context) []config.Purchas
 	approver := h.resolvePendingApproverEmail(ctx)
 	out := make([]config.PurchaseHistoryRecord, 0, len(executions))
 	for _, exec := range executions {
+		// Dedup: a normal completed execution is already represented by its
+		// purchase_history rows. Skip it here so it shows exactly once. Only
+		// completed executions carrying an audit-gap Error (history write
+		// failed after a successful purchase, issue #621) are synthesised —
+		// those have no purchase_history row to collide with.
+		if exec.Status == "completed" && exec.Error == "" {
+			continue
+		}
 		exec = h.expireIfStale(ctx, exec)
 		out = append(out, executionToHistoryRow(exec, approver))
 	}
@@ -207,8 +223,26 @@ func annotateHistoryRowByStatus(row *config.PurchaseHistoryRecord, exec config.P
 		row.StatusDescription = "approval link expired (not approved within 7 days)"
 	case "cancelled":
 		annotateCancelled(row, exec, approver)
-	case "approved", "completed":
+	case "approved", "running":
+		// In-flight (issue #621): approved/running rows are NOT terminal —
+		// the synchronous AWS purchase is mid-execution or got interrupted
+		// (Lambda timeout / crash). Resolve who approved (so the user knows
+		// who to ask) and overlay an "in progress" note so the UI never
+		// renders this as a finished purchase.
 		annotateApproved(row, exec, approver)
+		row.StatusDescription = "approved — purchase in progress"
+	case "paused":
+		row.Approver = approver
+		row.StatusDescription = "purchase paused — resume or cancel from the plan"
+	case "completed":
+		// Only audit-gap completed executions reach here (fetchExecutionsAsHistory
+		// skips clean completed rows). exec.Error carries why the history write
+		// failed after a successful purchase — surface it so the purchase is
+		// visible despite the missing purchase_history row (issue #621).
+		annotateApproved(row, exec, approver)
+		if exec.Error != "" {
+			row.StatusDescription = "purchase completed but its history record could not be saved: " + exec.Error
+		}
 	}
 }
 
@@ -318,13 +352,19 @@ func summarizePurchaseHistory(purchases []config.PurchaseHistoryRecord) HistoryS
 	summary := HistorySummary{TotalPurchases: len(purchases)}
 	for _, p := range purchases {
 		// Non-completed rows count toward TotalPurchases and their specific
-		// bucket (pending / failed / expired) but are excluded from the
-		// dollar totals — the money hasn't been committed for any of those
-		// states. "completed" and unset (legacy DB rows that pre-date the
-		// status field) both count as completed.
+		// bucket (pending / in-progress / failed / expired) but are excluded
+		// from the dollar totals — the money hasn't been committed for any of
+		// those states. "completed" and unset (legacy DB rows that pre-date
+		// the status field) both count as completed.
 		switch p.Status {
 		case "pending", "notified":
 			summary.TotalPending++
+			continue
+		case "approved", "running", "paused":
+			// In-flight (issue #621). Not yet confirmed final — keep out of the
+			// committed dollar totals so an interrupted approval can't inflate
+			// reported spend/savings.
+			summary.TotalInProgress++
 			continue
 		case "failed":
 			summary.TotalFailed++
@@ -334,6 +374,19 @@ func summarizePurchaseHistory(purchases []config.PurchaseHistoryRecord) HistoryS
 			continue
 		}
 		summary.TotalCompleted++
+		// Audit-gap completed rows (issue #621) are synthesised execution rows
+		// whose purchase_history write failed; they uniquely carry a
+		// StatusDescription (real purchase_history rows never set it). Count
+		// them as completed (the money WAS committed and they must stay
+		// visible) but exclude their execution-level dollars: a partially-saved
+		// multi-rec execution can have BOTH some purchase_history rows AND this
+		// synthesised row, and adding the full execution total here would
+		// double-count the recs that did save. The dollars are surfaced via the
+		// individual purchase_history rows that succeeded; the synthesised row
+		// is the audit flag, not a money source.
+		if p.StatusDescription != "" {
+			continue
+		}
 		summary.TotalUpfront += p.UpfrontCost
 		summary.TotalMonthlySavings += p.EstimatedSavings
 	}

--- a/internal/api/handler_history.go
+++ b/internal/api/handler_history.go
@@ -238,7 +238,11 @@ func annotateHistoryRowByStatus(row *config.PurchaseHistoryRecord, exec config.P
 		// Only audit-gap completed executions reach here (fetchExecutionsAsHistory
 		// skips clean completed rows). exec.Error carries why the history write
 		// failed after a successful purchase — surface it so the purchase is
-		// visible despite the missing purchase_history row (issue #621).
+		// visible despite the missing purchase_history row (issue #621). Flag the
+		// row so the dollar accounting excludes its execution-level total without
+		// relying on StatusDescription being set (which annotateApproved may also
+		// populate).
+		row.IsAuditGap = true
 		annotateApproved(row, exec, approver)
 		if exec.Error != "" {
 			row.StatusDescription = "purchase completed but its history record could not be saved: " + exec.Error
@@ -375,16 +379,17 @@ func summarizePurchaseHistory(purchases []config.PurchaseHistoryRecord) HistoryS
 		}
 		summary.TotalCompleted++
 		// Audit-gap completed rows (issue #621) are synthesised execution rows
-		// whose purchase_history write failed; they uniquely carry a
-		// StatusDescription (real purchase_history rows never set it). Count
-		// them as completed (the money WAS committed and they must stay
-		// visible) but exclude their execution-level dollars: a partially-saved
-		// multi-rec execution can have BOTH some purchase_history rows AND this
-		// synthesised row, and adding the full execution total here would
-		// double-count the recs that did save. The dollars are surfaced via the
-		// individual purchase_history rows that succeeded; the synthesised row
-		// is the audit flag, not a money source.
-		if p.StatusDescription != "" {
+		// whose purchase_history write failed. Count them as completed (the
+		// money WAS committed and they must stay visible) but exclude their
+		// execution-level dollars: a partially-saved multi-rec execution can
+		// have BOTH some purchase_history rows AND this synthesised row, and
+		// adding the full execution total here would double-count the recs that
+		// did save. The dollars are surfaced via the individual purchase_history
+		// rows that succeeded; the synthesised row is the audit flag, not a
+		// money source. IsAuditGap is the explicit marker: real purchase_history
+		// rows loaded from the DB always leave it false, so a future change that
+		// annotates completed DB rows can't silently drop them from the totals.
+		if p.IsAuditGap {
 			continue
 		}
 		summary.TotalUpfront += p.UpfrontCost

--- a/internal/api/handler_history_test.go
+++ b/internal/api/handler_history_test.go
@@ -453,6 +453,7 @@ func TestHandler_getHistory_AuditGapCompletedVisible(t *testing.T) {
 	assert.Equal(t, "gap-1", row.PurchaseID)
 	assert.Equal(t, "completed", row.Status)
 	assert.Contains(t, row.StatusDescription, "history record could not be saved", "the audit gap must be surfaced to the user")
+	assert.True(t, row.IsAuditGap, "synthesised audit-gap row must carry the explicit IsAuditGap marker")
 	assert.Equal(t, 1, resp.Summary.TotalCompleted, "money was committed, so it counts as completed")
 	// Double-count guard: the synthesised audit-gap row is an audit flag, not a
 	// money source. A partially-saved multi-rec execution can have BOTH some
@@ -461,6 +462,49 @@ func TestHandler_getHistory_AuditGapCompletedVisible(t *testing.T) {
 	// purchase_history rows that actually saved).
 	assert.Equal(t, 0.0, resp.Summary.TotalUpfront, "audit-gap row must not contribute execution-level dollars (double-count risk)")
 	assert.Equal(t, 0.0, resp.Summary.TotalMonthlySavings)
+}
+
+// TestHandler_getHistory_CompletedDBRowWithDescriptionStillCounts guards the
+// financial invariant that dollar exclusion keys off the explicit IsAuditGap
+// marker, NOT off StatusDescription being set. A real purchase_history row
+// loaded from the DB always has IsAuditGap=false, so even if some future code
+// path annotates it with a StatusDescription, its committed dollars must still
+// flow into the totals; undercounting committed spend is as wrong as
+// double-counting it (issue #621).
+func TestHandler_getHistory_CompletedDBRowWithDescriptionStillCounts(t *testing.T) {
+	ctx := context.Background()
+	mockStore := new(MockConfigStore)
+
+	// A genuine completed purchase_history row that happens to carry a
+	// human-readable StatusDescription (IsAuditGap stays false, as it is for
+	// every DB-loaded row). Its dollars are committed and must be counted.
+	completed := []config.PurchaseHistoryRecord{
+		{
+			AccountID:         "acc-1",
+			PurchaseID:        "ri-commitment-1",
+			Status:            "completed",
+			StatusDescription: "approved by ops@example.com",
+			UpfrontCost:       700.0,
+			EstimatedSavings:  70.0,
+		},
+	}
+	mockStore.On("GetAllPurchaseHistory", ctx, 100).Return(completed, nil)
+	mockStore.On("GetExecutionsByStatuses", ctx, mock.Anything, mock.Anything).Return([]config.PurchaseExecution{}, nil)
+	approver := "ops@example.com"
+	mockStore.On("GetGlobalConfig", ctx).Return(&config.GlobalConfig{NotificationEmail: &approver}, nil)
+
+	mockAuth, req := adminHistoryReq(ctx)
+	handler := &Handler{auth: mockAuth, config: mockStore}
+
+	result, err := handler.getHistory(ctx, req, map[string]string{})
+	require.NoError(t, err)
+	resp := result.(HistoryResponse)
+
+	require.Len(t, resp.Purchases, 1)
+	assert.False(t, resp.Purchases[0].IsAuditGap, "DB-loaded completed rows are never audit gaps")
+	assert.Equal(t, 1, resp.Summary.TotalCompleted)
+	assert.Equal(t, 700.0, resp.Summary.TotalUpfront, "a completed DB row with a StatusDescription must still count its committed dollars")
+	assert.Equal(t, 70.0, resp.Summary.TotalMonthlySavings)
 }
 
 // TestHandler_getHistory_CompletedExecutionNotDuplicated guards the dedup path.
@@ -475,7 +519,12 @@ func TestHandler_getHistory_CompletedExecutionNotDuplicated(t *testing.T) {
 	completed := []config.PurchaseHistoryRecord{
 		{AccountID: "acc-1", PurchaseID: "ri-commitment-1", UpfrontCost: 400.0, EstimatedSavings: 40.0},
 	}
-	// Same logical purchase, now also returned as a clean completed execution.
+	// A clean completed execution exists alongside a purchase_history row. The
+	// execution (exec-clean-1) and the purchase_history row (ri-commitment-1)
+	// are separate records with different IDs; the test does not assert they
+	// match. It asserts that ALL clean completed executions are skipped (not
+	// synthesised) because they are assumed already represented by their
+	// purchase_history rows, so the surviving row is the purchase_history one.
 	cleanCompletedExec := []config.PurchaseExecution{
 		{
 			ExecutionID:     "exec-clean-1",

--- a/internal/api/handler_history_test.go
+++ b/internal/api/handler_history_test.go
@@ -350,3 +350,155 @@ func TestHandler_getHistory_PermissionDenied(t *testing.T) {
 	mockStore.AssertNotCalled(t, "GetPurchaseHistory")
 	mockStore.AssertNotCalled(t, "GetAllPurchaseHistory")
 }
+
+// TestHandler_getHistory_IncludesInFlightApprovals is the issue #621 primary-
+// path regression guard. An execution stuck in "approved" (Lambda timeout /
+// crash mid-execute) and one in "running" must BOTH appear in the History
+// list, rendered with their real status and counted as in-progress — never
+// silently dropped, never folded into the committed dollar totals. Pre-fix
+// the statuses list excluded approved/running so these rows vanished.
+func TestHandler_getHistory_IncludesInFlightApprovals(t *testing.T) {
+	ctx := context.Background()
+	mockStore := new(MockConfigStore)
+
+	completed := []config.PurchaseHistoryRecord{
+		{AccountID: "acc-1", PurchaseID: "done-1", UpfrontCost: 500.0, EstimatedSavings: 50.0},
+	}
+	approver := "ops@example.com"
+	inFlight := []config.PurchaseExecution{
+		{
+			ExecutionID:      "appr-1",
+			Status:           "approved",
+			ScheduledDate:    time.Now(),
+			TotalUpfrontCost: 999.0,
+			EstimatedSavings: 99.0,
+			ApprovedBy:       &approver,
+			Recommendations:  []config.RecommendationRecord{{Provider: "aws", Service: "ec2", Region: "us-east-1"}},
+		},
+		{
+			ExecutionID:      "run-1",
+			Status:           "running",
+			ScheduledDate:    time.Now(),
+			TotalUpfrontCost: 777.0,
+			EstimatedSavings: 77.0,
+			Recommendations:  []config.RecommendationRecord{{Provider: "aws", Service: "rds", Region: "us-east-1"}},
+		},
+	}
+
+	mockStore.On("GetAllPurchaseHistory", ctx, 100).Return(completed, nil)
+	mockStore.On("GetExecutionsByStatuses", ctx, mock.Anything, mock.Anything).Return(inFlight, nil)
+	mockStore.On("GetGlobalConfig", ctx).Return(&config.GlobalConfig{NotificationEmail: &approver}, nil)
+
+	mockAuth, req := adminHistoryReq(ctx)
+	handler := &Handler{auth: mockAuth, config: mockStore}
+
+	result, err := handler.getHistory(ctx, req, map[string]string{})
+	require.NoError(t, err)
+	resp := result.(HistoryResponse)
+
+	byID := map[string]config.PurchaseHistoryRecord{}
+	for _, p := range resp.Purchases {
+		byID[p.PurchaseID] = p
+	}
+	apprRow, ok := byID["appr-1"]
+	require.True(t, ok, "approved (stuck) execution must stay visible in History (issue #621)")
+	assert.Equal(t, "approved", apprRow.Status)
+	assert.Contains(t, apprRow.StatusDescription, "in progress", "approved row must render as in-progress, not as completed")
+	runRow, ok := byID["run-1"]
+	require.True(t, ok, "running execution must stay visible in History")
+	assert.Equal(t, "running", runRow.Status)
+
+	assert.Equal(t, 3, resp.Summary.TotalPurchases)
+	assert.Equal(t, 1, resp.Summary.TotalCompleted)
+	assert.Equal(t, 2, resp.Summary.TotalInProgress, "approved+running must count as in-progress")
+	assert.Equal(t, 500.0, resp.Summary.TotalUpfront, "in-flight spend must not inflate committed totals")
+	assert.Equal(t, 50.0, resp.Summary.TotalMonthlySavings)
+}
+
+// TestHandler_getHistory_AuditGapCompletedVisible is the issue #621 secondary-
+// path regression guard. A "completed" execution whose purchase_history write
+// failed (carries a non-empty Error) MUST surface in the History list — the
+// purchase happened, the money was committed, and silently dropping it is the
+// worst failure mode for a financial action. It is rendered completed (the
+// purchase succeeded) with a StatusDescription that surfaces the audit gap.
+func TestHandler_getHistory_AuditGapCompletedVisible(t *testing.T) {
+	ctx := context.Background()
+	mockStore := new(MockConfigStore)
+
+	auditGap := []config.PurchaseExecution{
+		{
+			ExecutionID:      "gap-1",
+			Status:           "completed",
+			Error:            "commitment ri-abc purchased but its history record failed to save: insert failed",
+			ScheduledDate:    time.Now(),
+			TotalUpfrontCost: 300.0,
+			EstimatedSavings: 30.0,
+			Recommendations:  []config.RecommendationRecord{{Provider: "aws", Service: "ec2", Region: "us-east-1"}},
+		},
+	}
+	approver := "ops@example.com"
+	mockStore.On("GetAllPurchaseHistory", ctx, 100).Return([]config.PurchaseHistoryRecord{}, nil)
+	mockStore.On("GetExecutionsByStatuses", ctx, mock.Anything, mock.Anything).Return(auditGap, nil)
+	mockStore.On("GetGlobalConfig", ctx).Return(&config.GlobalConfig{NotificationEmail: &approver}, nil)
+
+	mockAuth, req := adminHistoryReq(ctx)
+	handler := &Handler{auth: mockAuth, config: mockStore}
+
+	result, err := handler.getHistory(ctx, req, map[string]string{})
+	require.NoError(t, err)
+	resp := result.(HistoryResponse)
+
+	require.Len(t, resp.Purchases, 1, "audit-gap completed execution must not be silently dropped (issue #621)")
+	row := resp.Purchases[0]
+	assert.Equal(t, "gap-1", row.PurchaseID)
+	assert.Equal(t, "completed", row.Status)
+	assert.Contains(t, row.StatusDescription, "history record could not be saved", "the audit gap must be surfaced to the user")
+	assert.Equal(t, 1, resp.Summary.TotalCompleted, "money was committed, so it counts as completed")
+	// Double-count guard: the synthesised audit-gap row is an audit flag, not a
+	// money source. A partially-saved multi-rec execution can have BOTH some
+	// purchase_history rows AND this synthesised row, so its execution-level
+	// dollars must NOT be added to the committed totals (those come from the
+	// purchase_history rows that actually saved).
+	assert.Equal(t, 0.0, resp.Summary.TotalUpfront, "audit-gap row must not contribute execution-level dollars (double-count risk)")
+	assert.Equal(t, 0.0, resp.Summary.TotalMonthlySavings)
+}
+
+// TestHandler_getHistory_CompletedExecutionNotDuplicated guards the dedup path.
+// The store loads "completed" executions now (so audit-gap rows can surface),
+// but a NORMAL completed execution (Error=="") is already represented by its
+// purchase_history rows and must NOT be synthesised a second time. The History
+// list must contain exactly one row for that purchase.
+func TestHandler_getHistory_CompletedExecutionNotDuplicated(t *testing.T) {
+	ctx := context.Background()
+	mockStore := new(MockConfigStore)
+
+	completed := []config.PurchaseHistoryRecord{
+		{AccountID: "acc-1", PurchaseID: "ri-commitment-1", UpfrontCost: 400.0, EstimatedSavings: 40.0},
+	}
+	// Same logical purchase, now also returned as a clean completed execution.
+	cleanCompletedExec := []config.PurchaseExecution{
+		{
+			ExecutionID:     "exec-clean-1",
+			Status:          "completed",
+			Error:           "",
+			ScheduledDate:   time.Now(),
+			Recommendations: []config.RecommendationRecord{{Provider: "aws", Service: "ec2", Region: "us-east-1"}},
+		},
+	}
+	approver := "ops@example.com"
+	mockStore.On("GetAllPurchaseHistory", ctx, 100).Return(completed, nil)
+	mockStore.On("GetExecutionsByStatuses", ctx, mock.Anything, mock.Anything).Return(cleanCompletedExec, nil)
+	mockStore.On("GetGlobalConfig", ctx).Return(&config.GlobalConfig{NotificationEmail: &approver}, nil)
+
+	mockAuth, req := adminHistoryReq(ctx)
+	handler := &Handler{auth: mockAuth, config: mockStore}
+
+	result, err := handler.getHistory(ctx, req, map[string]string{})
+	require.NoError(t, err)
+	resp := result.(HistoryResponse)
+
+	require.Len(t, resp.Purchases, 1, "a clean completed execution must not duplicate its purchase_history row")
+	assert.Equal(t, "ri-commitment-1", resp.Purchases[0].PurchaseID, "the surviving row is the purchase_history row")
+	assert.Equal(t, 1, resp.Summary.TotalCompleted)
+	assert.Equal(t, 400.0, resp.Summary.TotalUpfront)
+}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -732,9 +732,15 @@ type HistoryResponse struct {
 // non-completed states have committed money yet, so folding them in would
 // inflate "what I have spent".
 type HistorySummary struct {
-	TotalPurchases      int     `json:"total_purchases"`
-	TotalCompleted      int     `json:"total_completed"`
-	TotalPending        int     `json:"total_pending"`
+	TotalPurchases int `json:"total_purchases"`
+	TotalCompleted int `json:"total_completed"`
+	TotalPending   int `json:"total_pending"`
+	// TotalInProgress counts executions that have been approved but whose
+	// synchronous purchase has not finalised (status approved/running/paused).
+	// Tracked separately from pending and excluded from the dollar totals so an
+	// interrupted approval (issue #621) stays visible without inflating
+	// committed spend/savings.
+	TotalInProgress     int     `json:"total_in_progress"`
 	TotalFailed         int     `json:"total_failed"`
 	TotalExpired        int     `json:"total_expired"`
 	TotalUpfront        float64 `json:"total_upfront"`

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -480,6 +480,18 @@ type PurchaseHistoryRecord struct {
 	// empty otherwise. Excluded from DB persistence (computed at read
 	// time so updates to the persistent-failure map land instantly).
 	OpsHint string `json:"ops_hint,omitempty" dynamodbav:"-"`
+	// IsAuditGap marks a synthesised "completed" row whose purchase_history
+	// write failed after a successful purchase (issue #621). Such a row is
+	// reconstructed from the execution so the purchase stays visible, but its
+	// execution-level dollars are excluded from the committed totals: a
+	// partially-saved multi-rec execution can have BOTH some real
+	// purchase_history rows AND this synthesised row, so adding the full
+	// execution total would double-count the recs that did save. The dollars
+	// are surfaced via the individual purchase_history rows that succeeded;
+	// this row is the audit flag, not a money source. Real purchase_history
+	// rows loaded from the DB always leave this false. Excluded from DB
+	// persistence (set only at read time on synthesised rows).
+	IsAuditGap bool `json:"is_audit_gap,omitempty" dynamodbav:"-"`
 }
 
 // RIExchangeRecord represents a record in the ri_exchange_history table

--- a/internal/purchase/execution.go
+++ b/internal/purchase/execution.go
@@ -358,9 +358,33 @@ func (m *Manager) aggregatePurchaseOutcomes(ctx context.Context, exec *config.Pu
 		exec.Recommendations[i].PurchaseID = v.purchase.CommitmentID
 		totalSavings += rec.Savings
 		totalUpfront += rec.UpfrontCost
-		m.savePurchaseHistory(ctx, exec, plan, rec, v.purchase, accountID)
+		if histErr := m.savePurchaseHistory(ctx, exec, plan, rec, v.purchase, accountID); histErr != nil {
+			// The purchase SUCCEEDED but its purchase_history row failed to
+			// persist. Do NOT add this to purchaseErrors — that would flip the
+			// execution to "failed" and tempt the user to re-approve a purchase
+			// that already fired (the exact double-spend trap issue #621 warns
+			// about). Instead stamp an audit-gap marker on the execution so it
+			// stays "completed" but visible in the History view despite the
+			// missing purchase_history row.
+			recordHistoryAuditGap(exec, v.purchase.CommitmentID, histErr)
+		}
 	}
 	return totalSavings, totalUpfront, purchaseErrors
+}
+
+// recordHistoryAuditGap stamps exec.Error with a note that a successful
+// purchase's history record could not be saved (issue #621). The execution
+// keeps a successful status; the marker is what makes the row visible in the
+// History view (which synthesises completed executions that carry an Error).
+// Appends rather than overwrites so multiple failed history writes within one
+// execution are all recorded.
+func recordHistoryAuditGap(exec *config.PurchaseExecution, commitmentID string, histErr error) {
+	note := fmt.Sprintf("commitment %s purchased but its history record failed to save: %v", commitmentID, histErr)
+	if exec.Error == "" {
+		exec.Error = note
+	} else {
+		exec.Error += "; " + note
+	}
 }
 
 // normalizePurchaseSource canonicalizes exec.Source for downstream tag
@@ -425,7 +449,12 @@ func singleCloudAccountIDFromRecs(recs []config.RecommendationRecord) *string {
 	return found
 }
 
-func (m *Manager) savePurchaseHistory(ctx context.Context, exec *config.PurchaseExecution, plan *config.PurchasePlan, rec config.RecommendationRecord, result common.PurchaseResult, accountID string) {
+// savePurchaseHistory persists one purchase_history row for a successful
+// commitment. It returns the store error (rather than only logging it) so the
+// caller can record an audit gap on the execution: a swallowed failure here
+// used to leave the execution silently "completed" with no purchase_history
+// row, making the purchase invisible in the History view (issue #621).
+func (m *Manager) savePurchaseHistory(ctx context.Context, exec *config.PurchaseExecution, plan *config.PurchasePlan, rec config.RecommendationRecord, result common.PurchaseResult, accountID string) error {
 	historyRecord := &config.PurchaseHistoryRecord{
 		AccountID:        accountID,
 		PurchaseID:       result.CommitmentID,
@@ -448,7 +477,9 @@ func (m *Manager) savePurchaseHistory(ctx context.Context, exec *config.Purchase
 	}
 	if err := m.config.SavePurchaseHistory(ctx, historyRecord); err != nil {
 		logging.Errorf("Failed to save history: %v", err)
+		return err
 	}
+	return nil
 }
 
 func (m *Manager) sendPurchaseNotification(ctx context.Context, exec *config.PurchaseExecution, plan *config.PurchasePlan, totalSavings, totalUpfront float64) error {

--- a/internal/purchase/execution_test.go
+++ b/internal/purchase/execution_test.go
@@ -1175,3 +1175,65 @@ func TestSingleCloudAccountIDFromRecs(t *testing.T) {
 		})
 	}
 }
+
+// TestManager_ExecuteAndFinalize_HistorySaveFailure_StaysVisible is the issue
+// #621 secondary-path regression guard. When the AWS purchase SUCCEEDS but the
+// purchase_history insert fails, the execution must NOT be silently marked a
+// clean "completed" with no trace: it stays "completed" (the money WAS
+// committed, so flagging it failed would tempt a double-spend re-approval) but
+// carries an audit-gap Error so the History view can surface it. Pre-fix,
+// savePurchaseHistory swallowed the error and the purchase vanished from the UI.
+func TestManager_ExecuteAndFinalize_HistorySaveFailure_StaysVisible(t *testing.T) {
+	ctx := context.Background()
+	mockStore := new(MockConfigStore)
+	mockEmail := new(MockEmailSender)
+	mockSTS := new(MockSTSClient)
+	mockFactory := new(MockProviderFactory)
+	mockProviderInst := new(MockProvider)
+	mockServiceClient := new(MockServiceClient)
+
+	// Direct purchase (no plan) → single-account path, no updatePlanProgress.
+	exec := &config.PurchaseExecution{
+		ExecutionID: "exec-auditgap",
+		PlanID:      "",
+		StepNumber:  1,
+		Recommendations: []config.RecommendationRecord{
+			{Provider: "aws", Service: "ec2", ResourceType: "m5.large", Region: "us-east-1", Count: 1, UpfrontCost: 500.0, Selected: true},
+		},
+	}
+
+	saveErr := errors.New("insert failed: monthly_cost violates not-null constraint")
+	mockStore.On("SavePurchaseHistory", ctx, mock.AnythingOfType("*config.PurchaseHistoryRecord")).Return(saveErr)
+	// The execution record itself must still be persisted (with the audit marker).
+	mockStore.On("SavePurchaseExecution", ctx, mock.AnythingOfType("*config.PurchaseExecution")).Return(nil)
+	mockEmail.On("SendPurchaseConfirmation", ctx, mock.AnythingOfType("email.NotificationData")).Return(nil)
+	mockSTS.On("GetCallerIdentity", ctx, mock.AnythingOfType("*sts.GetCallerIdentityInput")).Return(&sts.GetCallerIdentityOutput{
+		Account: aws.String("123456789012"),
+	}, nil)
+	mockFactory.On("CreateAndValidateProvider", ctx, "aws", mock.Anything).Return(mockProviderInst, nil)
+	mockProviderInst.On("GetServiceClient", ctx, common.ServiceEC2, "us-east-1").Return(mockServiceClient, nil)
+	mockServiceClient.On("PurchaseCommitment", ctx, mock.AnythingOfType("common.Recommendation"), mock.AnythingOfType("common.PurchaseOptions")).Return(common.PurchaseResult{
+		Success:      true,
+		CommitmentID: "ri-auditgap",
+	}, nil)
+
+	manager := &Manager{
+		config:          mockStore,
+		email:           mockEmail,
+		stsClient:       mockSTS,
+		providerFactory: mockFactory,
+		dashboardURL:    "https://dashboard.example.com",
+	}
+
+	// executeAndFinalize must NOT return an error: the purchase succeeded.
+	err := manager.executeAndFinalize(ctx, exec)
+	require.NoError(t, err, "a failed history write must not surface as a purchase failure (re-approval / double-spend risk)")
+
+	assert.Equal(t, "completed", exec.Status, "purchase succeeded, so the execution stays completed")
+	assert.NotEmpty(t, exec.Error, "history-save failure must be recorded so the row stays visible in History (issue #621)")
+	assert.Contains(t, exec.Error, "ri-auditgap")
+	assert.Contains(t, exec.Error, "history record failed to save")
+
+	mockStore.AssertExpectations(t)
+	mockFactory.AssertExpectations(t)
+}


### PR DESCRIPTION
## Summary

Fixes the P0 where an approved AWS purchase silently vanishes from Purchase History (#621).

**Root cause:** the History list only showed `purchase_history` rows + `purchase_executions` in `{pending, notified, failed, expired, cancelled}`, excluding `approved`/`running`/`paused`. `ApproveAndExecute` persists `approved` *before* running the slow synchronous purchase and only flips to `completed`/`failed` *after*. A Lambda timeout or crash mid-execution leaves the row stuck in an excluded status (in neither table the UI reads) so it disappears. Secondary path: `savePurchaseHistory` swallowed `SavePurchaseHistory` errors, so a successful purchase whose history write failed was also invisible.

## Fixes

1. **Visibility** — widened `historyExecutionStatuses` to include `approved`/`running`/`paused`; they render as "In Progress" (backend `StatusDescription` + frontend badge), never the green "Completed" default that would invite a re-approval. Added a `TotalInProgress` summary counter, excluded from dollar totals.
2. **Dedup** — clean completed executions (`Error==""`) are skipped in `fetchExecutionsAsHistory`, so a completed purchase appears exactly once via `purchase_history`. Execution `PurchaseID` (=ExecutionID) and commitment `PurchaseID` (=CommitmentID) never collide.
3. **No invisible completed** — `savePurchaseHistory` now returns its error; on a successful purchase whose history write fails, `recordHistoryAuditGap` stamps the execution `Error` (status stays `completed`, not `failed`, to avoid re-purchase) and the row is synthesized so it stays visible.
4. **No double-count** — audit-gap synthesized rows are counted as completed but excluded from `TotalUpfront`/`TotalMonthlySavings`, so a partially-saved multi-rec execution can't double-count the recs that did save.

## Test plan

- [x] `go test ./internal/api/... ./internal/purchase/...` (1311 pass); frontend `history`+`xss` 19/19; `tsc --noEmit`, `go vet`, `gofmt`, `gocyclo` clean
- [x] New tests verified fail-on-regression: in-flight visibility + TotalInProgress; audit-gap visible + no dollar double-count; clean completed not duplicated; SavePurchaseHistory-failure keeps execution visible; frontend renders in-flight as "In Progress" not "Completed"

Closes #621.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * History now correctly shows "In Progress" badges for in-flight executions and avoids duplicating completed entries; completed items created only as audit-gap markers no longer inflate committed totals.
  * Completed purchases remain visible even when their history record failed to save.

* **New Features**
  * Added a separate "In Progress" counter and updated filters so in-flight executions are counted and shown with appropriate status in the History view.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/623?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->