### PR TITLE
fix(purchases): don't leak raw persistence error into audit-gap status (refs #623)

### DIFF
--- a/internal/purchase/execution.go
+++ b/internal/purchase/execution.go
@@ -379,7 +379,11 @@ func (m *Manager) aggregatePurchaseOutcomes(ctx context.Context, exec *config.Pu
 // Appends rather than overwrites so multiple failed history writes within one
 // execution are all recorded.
 func recordHistoryAuditGap(exec *config.PurchaseExecution, commitmentID string, histErr error) {
-	note := fmt.Sprintf("commitment %s purchased but its history record failed to save: %v", commitmentID, histErr)
+	// histErr is a raw persistence error: log it server-side for diagnosis but
+	// keep it out of exec.Error, which is surfaced to clients via the history
+	// status_description. Only a generic, user-safe note reaches the UI.
+	logging.Errorf("history audit gap for commitment %s: %v", commitmentID, histErr)
+	note := fmt.Sprintf("commitment %s purchased but its history record failed to save", commitmentID)
 	if exec.Error == "" {
 		exec.Error = note
 	} else {

--- a/internal/purchase/execution_test.go
+++ b/internal/purchase/execution_test.go
@@ -1233,6 +1233,12 @@ func TestManager_ExecuteAndFinalize_HistorySaveFailure_StaysVisible(t *testing.T
 	assert.NotEmpty(t, exec.Error, "history-save failure must be recorded so the row stays visible in History (issue #621)")
 	assert.Contains(t, exec.Error, "ri-auditgap")
 	assert.Contains(t, exec.Error, "history record failed to save")
+	// The raw persistence error must NOT leak into exec.Error, which is
+	// surfaced to clients via the history status_description (CR on #623).
+	assert.NotContains(t, exec.Error, "insert failed",
+		"raw persistence error text must not reach the user-facing exec.Error")
+	assert.NotContains(t, exec.Error, "not-null constraint",
+		"raw persistence error text must not reach the user-facing exec.Error")
 
 	mockStore.AssertExpectations(t)
 	mockFactory.AssertExpectations(t)


### PR DESCRIPTION
## Summary

Follow-up to a CodeRabbit review comment on #623 that landed right at merge time, so it couldn't be folded into that PR.

`recordHistoryAuditGap` (added in #623) embedded the raw `SavePurchaseHistory` error (`histErr`) verbatim into `exec.Error`. That field is surfaced to clients via the history `status_description`, so an internal storage error (e.g. SQL constraint text like `monthly_cost violates not-null constraint`) leaked to the UI.

## Fix

- Log `histErr` server-side via `logging.Errorf` for diagnosis.
- Store only a generic, user-safe note in `exec.Error` ("commitment X purchased but its history record failed to save") with no raw error interpolation.
- Extend the existing audit-gap regression test (`TestManager_ExecuteAndFinalize_HistorySaveFailure_StaysVisible`) with `NotContains` assertions on the raw error text, so it fails-on-regression if the leak is reintroduced.

The #621 invariants are preserved: a history-write failure still keeps the completed purchase visible (the note is still recorded), the execution still stays `completed` (not `failed`), and dollar totals are unaffected.

## Test plan

- [x] `go test ./internal/purchase/ -run TestManager_ExecuteAndFinalize_HistorySaveFailure_StaysVisible` passes; the new `NotContains` assertions fail against the pre-fix code
- [x] `gofmt` / `go vet` clean

Refs #623.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refined error messaging for purchase history failures to exclude internal technical details from user-facing notifications while preserving essential context information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/628?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->