### PR TITLE
fix(purchase): map service slugs to provider-neutral types so Azure purchases work (P0)

### DIFF
--- a/internal/purchase/coverage_extra_test.go
+++ b/internal/purchase/coverage_extra_test.go
@@ -12,8 +12,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Tests for mapServiceType to hit all branches
-
+// Tests for mapServiceType to hit all branches.
+//
+// As of the Azure-purchase regression fix, mapServiceType returns the
+// provider-neutral canonical types so both AWS and Azure providers can
+// resolve them in GetServiceClient. The legacy AWS aliases (ServiceEC2,
+// ServiceRDS, ServiceElastiCache, ServiceOpenSearch, ServiceRedshift)
+// are no longer produced by this function; the AWS provider still
+// accepts them as input via its case-list union for backward
+// compatibility with persisted rec.Service strings.
 func TestMapServiceType_AllBranches(t *testing.T) {
 	m := &Manager{}
 
@@ -21,16 +28,16 @@ func TestMapServiceType_AllBranches(t *testing.T) {
 		input    string
 		expected common.ServiceType
 	}{
-		{"ec2", common.ServiceEC2},
-		{"compute", common.ServiceEC2},
-		{"rds", common.ServiceRDS},
-		{"relational-db", common.ServiceRDS},
-		{"elasticache", common.ServiceElastiCache},
-		{"cache", common.ServiceElastiCache},
-		{"opensearch", common.ServiceOpenSearch},
-		{"search", common.ServiceOpenSearch},
-		{"redshift", common.ServiceRedshift},
-		{"data-warehouse", common.ServiceRedshift},
+		{"ec2", common.ServiceCompute},
+		{"compute", common.ServiceCompute},
+		{"rds", common.ServiceRelationalDB},
+		{"relational-db", common.ServiceRelationalDB},
+		{"elasticache", common.ServiceCache},
+		{"cache", common.ServiceCache},
+		{"opensearch", common.ServiceSearch},
+		{"search", common.ServiceSearch},
+		{"redshift", common.ServiceDataWarehouse},
+		{"data-warehouse", common.ServiceDataWarehouse},
 		{"memorydb", common.ServiceMemoryDB},
 		{"savingsplans", common.ServiceSavingsPlans},
 		// Issue #85: the legacy hyphenated form is still accepted as a
@@ -49,6 +56,38 @@ func TestMapServiceType_AllBranches(t *testing.T) {
 			got := m.mapServiceType(tc.input)
 			assert.Equal(t, tc.expected, got)
 		})
+	}
+}
+
+// TestMapServiceType_AzureCanonicalTypesResolveOnAzureProvider is the
+// regression test for the Azure purchase failure traced to execution
+// 757c9a6e-b22a-4a81-bf04-b11043cbf658 ("unsupported service: ec2"):
+// the previous mapping returned AWS-specific ServiceEC2 for both "ec2"
+// and "compute", which broke every Azure VM purchase because the Azure
+// provider's GetServiceClient switch only accepts ServiceCompute.
+// Pinning the canonical-type contract here keeps a future refactor
+// from re-introducing the bug.
+func TestMapServiceType_AzureCanonicalTypesResolveOnAzureProvider(t *testing.T) {
+	m := &Manager{}
+
+	// "compute" is the slug Azure's collector writes for VM
+	// recommendations (providers/azure/recommendations.go:
+	// convertAdvisorRecommendation maps Microsoft.Compute ->
+	// common.ServiceCompute). The mapping must round-trip to a value
+	// the Azure provider can dispatch.
+	azureInputs := []string{"compute", "relational-db", "cache", "search", "data-warehouse"}
+	awsAliases := []common.ServiceType{
+		common.ServiceEC2,
+		common.ServiceRDS,
+		common.ServiceElastiCache,
+		common.ServiceOpenSearch,
+		common.ServiceRedshift,
+	}
+	for _, slug := range azureInputs {
+		got := m.mapServiceType(slug)
+		for _, alias := range awsAliases {
+			assert.NotEqual(t, alias, got, "slug %q must not map to AWS-specific %s", slug, alias)
+		}
 	}
 }
 
@@ -575,7 +614,7 @@ func TestManager_ExecuteSinglePurchase_ServiceClientError(t *testing.T) {
 
 	mockStore.On("GetPurchasePlan", ctx, "plan-svc-err").Return(plan, nil)
 	mockFactory.On("CreateAndValidateProvider", ctx, "aws", mock.Anything).Return(mockProvider, nil)
-	mockProvider.On("GetServiceClient", ctx, common.ServiceRDS, "eu-west-1").Return(nil, errors.New("service client error"))
+	mockProvider.On("GetServiceClient", ctx, common.ServiceRelationalDB, "eu-west-1").Return(nil, errors.New("service client error"))
 	mockSTS.On("GetCallerIdentity", ctx, mock.Anything).Return(nil, errors.New("sts error"))
 
 	manager := &Manager{
@@ -624,7 +663,7 @@ func TestManager_ExecuteSinglePurchase_PurchaseNotSuccessful(t *testing.T) {
 
 	mockStore.On("GetPurchasePlan", ctx, "plan-not-success").Return(plan, nil)
 	mockFactory.On("CreateAndValidateProvider", ctx, "aws", mock.Anything).Return(mockProvider, nil)
-	mockProvider.On("GetServiceClient", ctx, common.ServiceElastiCache, "ap-southeast-1").Return(mockServiceClient, nil)
+	mockProvider.On("GetServiceClient", ctx, common.ServiceCache, "ap-southeast-1").Return(mockServiceClient, nil)
 	mockServiceClient.On("PurchaseCommitment", ctx, mock.AnythingOfType("common.Recommendation"), mock.AnythingOfType("common.PurchaseOptions")).Return(
 		common.PurchaseResult{Success: false}, nil,
 	)
@@ -677,7 +716,7 @@ func TestManager_ExecuteSinglePurchase_PurchaseNotSuccessful_WithError(t *testin
 	specificErr := errors.New("capacity limit exceeded")
 	mockStore.On("GetPurchasePlan", ctx, "plan-err-result").Return(plan, nil)
 	mockFactory.On("CreateAndValidateProvider", ctx, "aws", mock.Anything).Return(mockProvider, nil)
-	mockProvider.On("GetServiceClient", ctx, common.ServiceOpenSearch, "us-west-2").Return(mockServiceClient, nil)
+	mockProvider.On("GetServiceClient", ctx, common.ServiceSearch, "us-west-2").Return(mockServiceClient, nil)
 	mockServiceClient.On("PurchaseCommitment", ctx, mock.AnythingOfType("common.Recommendation"), mock.AnythingOfType("common.PurchaseOptions")).Return(
 		common.PurchaseResult{Success: false, Error: specificErr}, nil,
 	)
@@ -733,7 +772,7 @@ func TestManager_ExecuteSinglePurchase_WithEngine(t *testing.T) {
 	mockStore.On("SavePurchaseHistory", ctx, mock.AnythingOfType("*config.PurchaseHistoryRecord")).Return(nil)
 	mockEmail.On("SendPurchaseConfirmation", ctx, mock.AnythingOfType("email.NotificationData")).Return(nil)
 	mockFactory.On("CreateAndValidateProvider", ctx, "aws", mock.Anything).Return(mockProvider, nil)
-	mockProvider.On("GetServiceClient", ctx, common.ServiceRDS, "us-east-1").Return(mockServiceClient, nil)
+	mockProvider.On("GetServiceClient", ctx, common.ServiceRelationalDB, "us-east-1").Return(mockServiceClient, nil)
 	mockServiceClient.On("PurchaseCommitment", ctx, mock.AnythingOfType("common.Recommendation"), mock.AnythingOfType("common.PurchaseOptions")).Return(
 		common.PurchaseResult{Success: true, CommitmentID: "ri-engine-001"}, nil,
 	)
@@ -790,7 +829,7 @@ func TestManager_SavePurchaseHistory_Error(t *testing.T) {
 	mockStore.On("SavePurchaseHistory", ctx, mock.AnythingOfType("*config.PurchaseHistoryRecord")).Return(errors.New("history write error"))
 	mockEmail.On("SendPurchaseConfirmation", ctx, mock.AnythingOfType("email.NotificationData")).Return(nil)
 	mockFactory.On("CreateAndValidateProvider", ctx, "aws", mock.Anything).Return(mockProvider, nil)
-	mockProvider.On("GetServiceClient", ctx, common.ServiceEC2, "us-east-1").Return(mockServiceClient, nil)
+	mockProvider.On("GetServiceClient", ctx, common.ServiceCompute, "us-east-1").Return(mockServiceClient, nil)
 	mockServiceClient.On("PurchaseCommitment", ctx, mock.AnythingOfType("common.Recommendation"), mock.AnythingOfType("common.PurchaseOptions")).Return(
 		common.PurchaseResult{Success: true, CommitmentID: "ri-hist-001"}, nil,
 	)
@@ -847,7 +886,7 @@ func TestManager_ExecuteSinglePurchase_DetailsByService(t *testing.T) {
 		{
 			name:        "ec2_windows",
 			service:     "ec2",
-			serviceType: common.ServiceEC2,
+			serviceType: common.ServiceCompute,
 			region:      "us-east-1",
 			resource:    "t4g.nano",
 			details:     &common.ComputeDetails{InstanceType: "t4g.nano", Platform: "Windows", Tenancy: "dedicated", Scope: "Region"},
@@ -866,7 +905,7 @@ func TestManager_ExecuteSinglePurchase_DetailsByService(t *testing.T) {
 		{
 			name:        "rds_postgres",
 			service:     "rds",
-			serviceType: common.ServiceRDS,
+			serviceType: common.ServiceRelationalDB,
 			region:      "us-east-1",
 			resource:    "db.r5.large",
 			engine:      "postgres",
@@ -883,7 +922,7 @@ func TestManager_ExecuteSinglePurchase_DetailsByService(t *testing.T) {
 		{
 			name:        "elasticache_redis",
 			service:     "elasticache",
-			serviceType: common.ServiceElastiCache,
+			serviceType: common.ServiceCache,
 			region:      "us-east-1",
 			resource:    "cache.r5.large",
 			engine:      "redis",
@@ -899,7 +938,7 @@ func TestManager_ExecuteSinglePurchase_DetailsByService(t *testing.T) {
 		{
 			name:        "opensearch",
 			service:     "opensearch",
-			serviceType: common.ServiceOpenSearch,
+			serviceType: common.ServiceSearch,
 			region:      "us-west-2",
 			resource:    "r5.large.search",
 			details:     &common.SearchDetails{InstanceType: "r5.large.search"},
@@ -913,7 +952,7 @@ func TestManager_ExecuteSinglePurchase_DetailsByService(t *testing.T) {
 		{
 			name:        "redshift",
 			service:     "redshift",
-			serviceType: common.ServiceRedshift,
+			serviceType: common.ServiceDataWarehouse,
 			region:      "us-east-1",
 			resource:    "ra3.xlplus",
 			details:     &common.DataWarehouseDetails{NodeType: "ra3.xlplus", NumberOfNodes: 2, ClusterType: "multi-node"},
@@ -1081,7 +1120,7 @@ func TestManager_ExecuteSinglePurchase_LegacyEmptyDetails(t *testing.T) {
 		{
 			name:        "legacy_ec2",
 			service:     "ec2",
-			serviceType: common.ServiceEC2,
+			serviceType: common.ServiceCompute,
 			region:      "us-east-1",
 			resource:    "t4g.nano",
 			assertDetails: func(t *testing.T, d common.ServiceDetails) {
@@ -1097,7 +1136,7 @@ func TestManager_ExecuteSinglePurchase_LegacyEmptyDetails(t *testing.T) {
 		{
 			name:        "legacy_rds_postgres",
 			service:     "rds",
-			serviceType: common.ServiceRDS,
+			serviceType: common.ServiceRelationalDB,
 			region:      "us-east-1",
 			resource:    "db.r5.large",
 			engine:      "postgres",
@@ -1115,7 +1154,7 @@ func TestManager_ExecuteSinglePurchase_LegacyEmptyDetails(t *testing.T) {
 		{
 			name:        "legacy_elasticache_redis",
 			service:     "elasticache",
-			serviceType: common.ServiceElastiCache,
+			serviceType: common.ServiceCache,
 			region:      "us-east-1",
 			resource:    "cache.r5.large",
 			engine:      "redis",

--- a/internal/purchase/execution.go
+++ b/internal/purchase/execution.go
@@ -558,22 +558,36 @@ func (m *Manager) executeSinglePurchase(ctx context.Context, rec config.Recommen
 	return result, nil
 }
 
-// mapServiceType maps a service string to common.ServiceType
+// mapServiceType maps a service string to common.ServiceType.
+//
+// Returns the provider-neutral canonical types (ServiceCompute,
+// ServiceRelationalDB, ServiceCache, ServiceSearch, ServiceDataWarehouse)
+// rather than the legacy AWS-specific aliases (ServiceEC2, ServiceRDS,
+// ServiceElastiCache, ServiceOpenSearch, ServiceRedshift). Both the AWS
+// and Azure provider switches accept the canonical types; only the AWS
+// switch accepts the legacy aliases (see providers/aws/provider.go +
+// providers/azure/provider.go). Returning the AWS alias here caused
+// every Azure VM purchase to fail at provider.GetServiceClient with
+// "unsupported service: ec2" because rec.Service="compute" on an Azure
+// rec was mapped to ServiceEC2 and the Azure provider's switch only
+// accepts ServiceCompute.
+//
+// ServiceMemoryDB stays as-is because Azure has no MemoryDB equivalent.
 func (m *Manager) mapServiceType(service string) common.ServiceType {
 	if svc, ok := mapSavingsPlansSlug(service); ok {
 		return svc
 	}
 	switch service {
 	case "ec2", "compute":
-		return common.ServiceEC2
+		return common.ServiceCompute
 	case "rds", "relational-db":
-		return common.ServiceRDS
+		return common.ServiceRelationalDB
 	case "elasticache", "cache":
-		return common.ServiceElastiCache
+		return common.ServiceCache
 	case "opensearch", "search":
-		return common.ServiceOpenSearch
+		return common.ServiceSearch
 	case "redshift", "data-warehouse":
-		return common.ServiceRedshift
+		return common.ServiceDataWarehouse
 	case "memorydb":
 		return common.ServiceMemoryDB
 	default:

--- a/internal/purchase/execution_test.go
+++ b/internal/purchase/execution_test.go
@@ -68,7 +68,7 @@ func TestManager_ExecutePurchase(t *testing.T) {
 
 	// Mock provider factory to return a mock provider
 	mockFactory.On("CreateAndValidateProvider", ctx, "aws", mock.Anything).Return(mockProviderInst, nil)
-	mockProviderInst.On("GetServiceClient", ctx, common.ServiceEC2, "us-east-1").Return(mockServiceClient, nil)
+	mockProviderInst.On("GetServiceClient", ctx, common.ServiceCompute, "us-east-1").Return(mockServiceClient, nil)
 	mockServiceClient.On("PurchaseCommitment", ctx, mock.AnythingOfType("common.Recommendation"), mock.AnythingOfType("common.PurchaseOptions")).Return(common.PurchaseResult{
 		Success:      true,
 		CommitmentID: "ri-12345",
@@ -128,7 +128,7 @@ func TestManager_ExecutePurchase_WebSourcePropagates(t *testing.T) {
 		Account: aws.String("123456789012"),
 	}, nil)
 	mockFactory.On("CreateAndValidateProvider", ctx, "aws", mock.Anything).Return(mockProviderInst, nil)
-	mockProviderInst.On("GetServiceClient", ctx, common.ServiceEC2, "us-east-1").Return(mockServiceClient, nil)
+	mockProviderInst.On("GetServiceClient", ctx, common.ServiceCompute, "us-east-1").Return(mockServiceClient, nil)
 	mockServiceClient.On("PurchaseCommitment", ctx,
 		mock.AnythingOfType("common.Recommendation"),
 		common.PurchaseOptions{Source: common.PurchaseSourceWeb},
@@ -178,7 +178,7 @@ func TestManager_ExecutePurchase_InvalidSourceFallsBackUntagged(t *testing.T) {
 		Account: aws.String("123456789012"),
 	}, nil)
 	mockFactory.On("CreateAndValidateProvider", ctx, "aws", mock.Anything).Return(mockProviderInst, nil)
-	mockProviderInst.On("GetServiceClient", ctx, common.ServiceEC2, "us-east-1").Return(mockServiceClient, nil)
+	mockProviderInst.On("GetServiceClient", ctx, common.ServiceCompute, "us-east-1").Return(mockServiceClient, nil)
 	// Expect EMPTY source, not "cudly-evil" — NormalizeSource must have wiped it.
 	mockServiceClient.On("PurchaseCommitment", ctx,
 		mock.AnythingOfType("common.Recommendation"),
@@ -518,7 +518,7 @@ func TestManager_ExecutePurchase_MultiAccount(t *testing.T) {
 	mockEmail.On("SendPurchaseConfirmation", ctx, mock.AnythingOfType("email.NotificationData")).Return(nil).Times(2)
 
 	mockFactory.On("CreateAndValidateProvider", ctx, "aws", mock.Anything).Return(mockProvider, nil)
-	mockProvider.On("GetServiceClient", ctx, common.ServiceEC2, "us-east-1").Return(mockServiceClient, nil)
+	mockProvider.On("GetServiceClient", ctx, common.ServiceCompute, "us-east-1").Return(mockServiceClient, nil)
 	mockServiceClient.On("PurchaseCommitment", ctx, mock.AnythingOfType("common.Recommendation"), mock.AnythingOfType("common.PurchaseOptions")).Return(common.PurchaseResult{
 		Success: true, CommitmentID: "ri-99999",
 	}, nil)
@@ -746,7 +746,7 @@ func TestExecuteMultiAccount_PartialFailure_IsolatesAccounts(t *testing.T) {
 	// Only account-V reaches the provider; account-I fails at credential resolution.
 	// Use .Once() so testify fails if the factory is called for account-I as well.
 	mockFactory.On("CreateAndValidateProvider", ctx, "aws", mock.Anything).Return(mockProviderInst, nil).Once()
-	mockProviderInst.On("GetServiceClient", ctx, common.ServiceEC2, "us-east-1").Return(mockServiceClient, nil).Once()
+	mockProviderInst.On("GetServiceClient", ctx, common.ServiceCompute, "us-east-1").Return(mockServiceClient, nil).Once()
 	mockServiceClient.On("PurchaseCommitment", ctx,
 		mock.AnythingOfType("common.Recommendation"),
 		mock.AnythingOfType("common.PurchaseOptions"),
@@ -911,7 +911,7 @@ func TestExecuteMultiAccount_RunsAccountsInParallel(t *testing.T) {
 	}
 
 	mockFactory.On("CreateAndValidateProvider", ctx, "aws", mock.Anything).Return(mockProviderInst, nil).Twice()
-	mockProviderInst.On("GetServiceClient", ctx, common.ServiceEC2, "us-east-1").Return(mockServiceClient, nil).Twice()
+	mockProviderInst.On("GetServiceClient", ctx, common.ServiceCompute, "us-east-1").Return(mockServiceClient, nil).Twice()
 
 	// Each PurchaseCommitment call blocks for perCallDelay. Under serial
 	// execution the total elapsed time would exceed serialBoundary; under
@@ -1033,7 +1033,7 @@ func TestExecutePurchase_SingleAccount_AzureUsesResolvedCreds(t *testing.T) {
 			return cfg != nil && cfg.ProviderOverride != nil
 		}),
 	).Return(mockProviderInst, nil)
-	mockProviderInst.On("GetServiceClient", ctx, common.ServiceEC2, "eastus").Return(mockServiceClient, nil)
+	mockProviderInst.On("GetServiceClient", ctx, common.ServiceCompute, "eastus").Return(mockServiceClient, nil)
 	mockServiceClient.On("PurchaseCommitment", ctx,
 		mock.AnythingOfType("common.Recommendation"),
 		mock.AnythingOfType("common.PurchaseOptions"),

--- a/internal/purchase/manager_test.go
+++ b/internal/purchase/manager_test.go
@@ -216,7 +216,7 @@ func TestManager_ProcessScheduledPurchases_DuePurchase(t *testing.T) {
 	mockServiceClient := new(MockServiceClient)
 
 	mockFactory.On("CreateAndValidateProvider", ctx, "", mock.Anything).Return(mockProvider, nil)
-	mockProvider.On("GetServiceClient", ctx, common.ServiceEC2, "us-east-1").Return(mockServiceClient, nil)
+	mockProvider.On("GetServiceClient", ctx, common.ServiceCompute, "us-east-1").Return(mockServiceClient, nil)
 	mockServiceClient.On("PurchaseCommitment", ctx, mock.AnythingOfType("common.Recommendation"), mock.AnythingOfType("common.PurchaseOptions")).Return(common.PurchaseResult{
 		Success:      true,
 		CommitmentID: "ri-12345",


### PR DESCRIPTION
## Summary

Every Azure VM purchase failed in production with `"unsupported service: ec2"` (most recent: execution `757c9a6e-b22a-4a81-bf04-b11043cbf658`). Re-approving was blocked because the row was `status=failed`.

## Root cause

`Manager.mapServiceType` in `internal/purchase/execution.go` returned AWS-specific service-type aliases for synonym slugs. Azure's collector writes `rec.Service = "compute"` for Microsoft.Compute VM recs; mapServiceType converted that to `ServiceEC2` (= `"ec2"`); `provider.GetServiceClient` then routed it to the Azure provider, whose switch only accepts the canonical `ServiceCompute`. The default arm returned `"unsupported service: ec2"`. AWS purchases worked by accident because the AWS switch accepts both the canonical and the legacy alias.

## Fix

Return provider-neutral canonical types so both providers' `GetServiceClient` switches can dispatch:

| Input slug | Before | After |
|---|---|---|
| `ec2`, `compute` | `ServiceEC2` | `ServiceCompute` |
| `rds`, `relational-db` | `ServiceRDS` | `ServiceRelationalDB` |
| `elasticache`, `cache` | `ServiceElastiCache` | `ServiceCache` |
| `opensearch`, `search` | `ServiceOpenSearch` | `ServiceSearch` |
| `redshift`, `data-warehouse` | `ServiceRedshift` | `ServiceDataWarehouse` |
| `memorydb` | `ServiceMemoryDB` (unchanged) | (unchanged) |

`ServiceMemoryDB` stays as-is because Azure has no MemoryDB equivalent.

## Test plan

- [x] `go test ./internal/purchase/...` — 136 tests pass.
- New regression test `TestMapServiceType_AzureCanonicalTypesResolveOnAzureProvider` pins that every Azure-collector slug maps to a non-AWS-specific type.
- Existing GetServiceClient mock expectations updated to use the canonical types (AWS provider accepts both, so AWS-targeted tests stay semantically equivalent).
- [ ] Manual verification after deploy: trigger an Azure VM purchase from the dashboard, confirm the execution lands on `completed` instead of `failed`.

## Stranded executions

Rows like `757c9a6e-b22a-4a81-bf04-b11043cbf658` already at `status=failed` won't be auto-rescued. Operator action: either DB nudge `status='pending'` to re-trigger the existing Approve flow, or use the existing `/retry` endpoint.

## Pre-existing failures

Two unrelated failures in `internal/config/store_postgres_pgxmock_test.go` (column-count mismatch in `TestPGXMock_GetExecutionByID_*`) predate this change and were confirmed pre-existing during the #614 work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression test ensuring Azure service type resolution works correctly.
  * Updated test expectations across multiple suites to use canonical service types.

* **Refactor**
  * Improved internal service type handling to use provider-neutral mappings, enhancing multi-cloud provider support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/629?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->