### PR TITLE
fix(ux/history): map in-progress purchase row from rec fields (closes #631)

### DIFF
--- a/internal/api/handler_history.go
+++ b/internal/api/handler_history.go
@@ -188,17 +188,14 @@ func executionToHistoryRow(exec config.PurchaseExecution, approver string) confi
 		PurchaseID:       exec.ExecutionID,
 		Timestamp:        exec.ScheduledDate,
 		Provider:         collapseRecommendationProvider(exec.Recommendations),
-		Region:           "multiple",
-		ResourceType:     fmt.Sprintf("%d commitment(s)", len(exec.Recommendations)),
 		Count:            len(exec.Recommendations),
-		UpfrontCost:      exec.TotalUpfrontCost,
-		EstimatedSavings: exec.EstimatedSavings,
 		PlanID:           exec.PlanID,
 		Status:           exec.Status,
 		CreatedByUserID:  createdBy,
 		RetryExecutionID: retryExecID,
 		RetryAttemptN:    exec.RetryAttemptN,
 	}
+	projectRecommendationFields(&row, exec)
 	// Compute ops_hint at read time (issue #47, Q3) so updates to the
 	// persistent-failure map land instantly without a re-collect. Only
 	// failed rows can carry a hint — the resolver returns "" for empty
@@ -282,6 +279,79 @@ func annotateApproved(row *config.PurchaseHistoryRecord, exec config.PurchaseExe
 	if approver != "" {
 		row.Approver = approver
 	}
+}
+
+// projectRecommendationFields fills the row's resource/cost/term columns from
+// the execution's recommendations so an in-progress (approved/running/paused)
+// or audit-gap row renders with the SAME shape the completed purchase_history
+// row would (issue #631). The completed row carries per-commitment service /
+// resource_type / region / term / monthly_cost / upfront / savings; the
+// synthetic execution row must too, or a single valid 1yr t4g.nano RI shows up
+// as "0 Years / multiple / $0" because Term/MonthlyCost/ResourceType were never
+// mapped.
+//
+//   - Single-rec execution (the common single-RI case in #631): project that
+//     rec's fields verbatim — exactly what the completed row stores per
+//     commitment. Costs come from the rec itself (UpfrontCost / MonthlyCost /
+//     Savings), matching how purchase_history persists per-commitment dollars.
+//   - Multi-rec execution: keep the aggregate display — "N commitment(s)" /
+//     "multiple" region, term collapsed to the shared value (0 when recs
+//     disagree), and execution-level cost totals. A single row cannot honestly
+//     show one resource type or term for a heterogeneous basket.
+func projectRecommendationFields(row *config.PurchaseHistoryRecord, exec config.PurchaseExecution) {
+	recs := exec.Recommendations
+	if len(recs) == 1 {
+		r := recs[0]
+		row.Service = r.Service
+		row.ResourceType = r.ResourceType
+		row.Region = r.Region
+		row.Term = r.Term
+		row.UpfrontCost = r.UpfrontCost
+		row.EstimatedSavings = r.Savings
+		if r.MonthlyCost != nil {
+			row.MonthlyCost = *r.MonthlyCost
+		}
+		return
+	}
+	row.Region = "multiple"
+	row.ResourceType = fmt.Sprintf("%d commitment(s)", len(recs))
+	row.Service = collapseRecommendationService(recs)
+	row.Term = collapseRecommendationTerm(recs)
+	row.UpfrontCost = exec.TotalUpfrontCost
+	row.EstimatedSavings = exec.EstimatedSavings
+}
+
+// collapseRecommendationService returns the single service shared by every
+// recommendation in a multi-rec execution, or "multiple" when they differ (or
+// the slice is empty).
+func collapseRecommendationService(recs []config.RecommendationRecord) string {
+	if len(recs) == 0 {
+		return "multiple"
+	}
+	s := recs[0].Service
+	for _, r := range recs[1:] {
+		if r.Service != s {
+			return "multiple"
+		}
+	}
+	return s
+}
+
+// collapseRecommendationTerm returns the term shared by every recommendation in
+// a multi-rec execution, or 0 when they differ (or the slice is empty). 0
+// renders as "" in the UI rather than a misleading single term for a basket
+// that spans 1yr and 3yr commitments.
+func collapseRecommendationTerm(recs []config.RecommendationRecord) int {
+	if len(recs) == 0 {
+		return 0
+	}
+	t := recs[0].Term
+	for _, r := range recs[1:] {
+		if r.Term != t {
+			return 0
+		}
+	}
+	return t
 }
 
 // collapseRecommendationProvider returns the single provider shared by every

--- a/internal/api/handler_history_test.go
+++ b/internal/api/handler_history_test.go
@@ -415,6 +415,76 @@ func TestHandler_getHistory_IncludesInFlightApprovals(t *testing.T) {
 	assert.Equal(t, 50.0, resp.Summary.TotalMonthlySavings)
 }
 
+// TestHandler_getHistory_InProgressRowMapsRecFields is the issue #631
+// regression guard. A single-rec in-progress (approved/running/paused)
+// execution must project the recommendation's real service / resource_type /
+// region / term / count / costs onto its synthetic History row — the SAME
+// shape a completed purchase_history row carries. Before the fix the row left
+// Term=0 ("0 Years"), ResourceType="N commitment(s)" (rendered "multiple"-ish
+// and never the real type), and pulled costs from the execution aggregate, so
+// a valid 1yr t4g.nano RI rendered as "0 Years / 1 commitment(s) / $0" — the
+// user could not tell what they had approved on a financial action.
+func TestHandler_getHistory_InProgressRowMapsRecFields(t *testing.T) {
+	monthly := 2.117
+	rec := config.RecommendationRecord{
+		Provider:     "aws",
+		Service:      "ec2",
+		Region:       "eu-west-1",
+		ResourceType: "t4g.nano",
+		Term:         1,
+		Payment:      "no-upfront",
+		Count:        1,
+		UpfrontCost:  0,
+		MonthlyCost:  &monthly,
+		Savings:      1.2333,
+	}
+
+	for _, status := range []string{"approved", "running", "paused"} {
+		t.Run(status, func(t *testing.T) {
+			ctx := context.Background()
+			mockStore := new(MockConfigStore)
+
+			inProgress := []config.PurchaseExecution{
+				{
+					ExecutionID:   "ip-1",
+					Status:        status,
+					ScheduledDate: time.Now(),
+					// Execution aggregates intentionally differ from the rec so
+					// the test proves the row is sourced from the rec, not these.
+					TotalUpfrontCost: 12345.0,
+					EstimatedSavings: 99.0,
+					Recommendations:  []config.RecommendationRecord{rec},
+				},
+			}
+			approver := "ops@example.com"
+			mockStore.On("GetAllPurchaseHistory", ctx, 100).Return([]config.PurchaseHistoryRecord{}, nil)
+			mockStore.On("GetExecutionsByStatuses", ctx, mock.Anything, mock.Anything).Return(inProgress, nil)
+			mockStore.On("GetGlobalConfig", ctx).Return(&config.GlobalConfig{NotificationEmail: &approver}, nil)
+
+			mockAuth, req := adminHistoryReq(ctx)
+			handler := &Handler{auth: mockAuth, config: mockStore}
+
+			result, err := handler.getHistory(ctx, req, map[string]string{})
+			require.NoError(t, err)
+			resp := result.(HistoryResponse)
+			require.Len(t, resp.Purchases, 1)
+			row := resp.Purchases[0]
+
+			assert.Equal(t, status, row.Status)
+			assert.Equal(t, "ec2", row.Service, "service must come from the rec, not be left blank")
+			assert.Equal(t, "t4g.nano", row.ResourceType, "resource type must be the rec's, not 'N commitment(s)'/multiple")
+			assert.Equal(t, "eu-west-1", row.Region, "region must be the rec's, not 'multiple'")
+			assert.Equal(t, 1, row.Term, "term must be the rec's 1yr, not 0 ('0 Years')")
+			assert.Equal(t, 1, row.Count)
+			assert.Equal(t, 0.0, row.UpfrontCost, "upfront must come from the rec")
+			assert.Equal(t, 1.2333, row.EstimatedSavings, "savings must come from the rec")
+			assert.Equal(t, 2.117, row.MonthlyCost, "monthly cost must come from the rec")
+			assert.NotEmpty(t, row.StatusDescription,
+				"in-progress rows must carry a human-readable status description, not render as a finished purchase")
+		})
+	}
+}
+
 // TestHandler_getHistory_AuditGapCompletedVisible is the issue #621 secondary-
 // path regression guard. A "completed" execution whose purchase_history write
 // failed (carries a non-empty Error) MUST surface in the History list — the


### PR DESCRIPTION
## Summary

The synthetic in-progress History rows added by PR #623 (#621 fix) for `approved`/`running`/`paused` executions left `term`, `resource_type`, and cost unmapped: `executionToHistoryRow` hardcoded `Region:"multiple"` / `ResourceType:"N commitment(s)"`, pulled costs from execution-level aggregates, and never set `Term`/`Service`/`MonthlyCost`. So a valid single 1-year t4g.nano RI (term=1, monthly=2.117, savings=1.2333) rendered as `0 Years`, `multiple`, `$0`/`$1`. The data was correct; only the projection was wrong.

## Fix

`projectRecommendationFields` projects a single-rec execution's real `service`/`resource_type`/`region`/`term`/`upfront_cost`/`monthly_cost`/`savings` onto the row, matching the completed `purchase_history` row shape. Multi-rec executions keep the existing aggregate display ("N commitment(s)" / "multiple" / exec totals) via small collapse helpers mirroring the existing `collapseRecommendationProvider`. No frontend change needed (it already renders these fields).

## Test plan

- [x] `TestHandler_getHistory_InProgressRowMapsRecFields` (approved/running/paused subtests) asserts the row shows term=1, resource_type=t4g.nano, region, service, and the rec's costs
- [x] Fail-on-regression confirmed: with the buggy mapping restored, all 4 cases fail; with the fix, all 1180 api tests pass; gofmt + go vet clean

Closes #631.
