### PR TITLE
feat(purchases): idempotent commitment creation (ClientToken/dedupe) (closes #636)

### DIFF
--- a/internal/purchase/execution.go
+++ b/internal/purchase/execution.go
@@ -310,7 +310,15 @@ func (m *Manager) processPurchaseRecommendations(ctx context.Context, exec *conf
 			}
 			rec := exec.Recommendations[i]
 			logging.Infof("Purchasing: %dx %s in %s (%s/%s)", rec.Count, rec.ResourceType, rec.Region, rec.Provider, rec.Service)
-			purchaseResult, err := m.executeSinglePurchase(ctx, rec, provCfg, opts)
+			// Derive a deterministic per-rec idempotency token from the
+			// execution ID and this rec's index so a re-drive of a stranded
+			// execution (issue #636) reuses the identical token and the
+			// commitment is never created twice. opts is a value, so this
+			// per-rec copy is safe under the parallel fan-out (no shared
+			// mutation across goroutines).
+			recOpts := opts
+			recOpts.IdempotencyToken = common.DeriveIdempotencyToken(exec.ExecutionID, i)
+			purchaseResult, err := m.executeSinglePurchase(ctx, rec, provCfg, recOpts)
 			return recPurchaseOutcome{index: i, purchase: purchaseResult, err: err}, nil
 		}, getMaxAccountParallelism())
 

--- a/internal/purchase/execution_test.go
+++ b/internal/purchase/execution_test.go
@@ -129,9 +129,14 @@ func TestManager_ExecutePurchase_WebSourcePropagates(t *testing.T) {
 	}, nil)
 	mockFactory.On("CreateAndValidateProvider", ctx, "aws", mock.Anything).Return(mockProviderInst, nil)
 	mockProviderInst.On("GetServiceClient", ctx, common.ServiceEC2, "us-east-1").Return(mockServiceClient, nil)
+	// The deterministic idempotency token (issue #636) is derived per-rec from
+	// the execution ID and the rec's index, so the web path now also carries it.
 	mockServiceClient.On("PurchaseCommitment", ctx,
 		mock.AnythingOfType("common.Recommendation"),
-		common.PurchaseOptions{Source: common.PurchaseSourceWeb},
+		common.PurchaseOptions{
+			Source:           common.PurchaseSourceWeb,
+			IdempotencyToken: common.DeriveIdempotencyToken("exec-web", 0),
+		},
 	).Return(common.PurchaseResult{Success: true, CommitmentID: "ri-web"}, nil)
 
 	manager := &Manager{
@@ -180,9 +185,13 @@ func TestManager_ExecutePurchase_InvalidSourceFallsBackUntagged(t *testing.T) {
 	mockFactory.On("CreateAndValidateProvider", ctx, "aws", mock.Anything).Return(mockProviderInst, nil)
 	mockProviderInst.On("GetServiceClient", ctx, common.ServiceEC2, "us-east-1").Return(mockServiceClient, nil)
 	// Expect EMPTY source, not "cudly-evil" — NormalizeSource must have wiped it.
+	// The idempotency token (issue #636) is still derived regardless of source.
 	mockServiceClient.On("PurchaseCommitment", ctx,
 		mock.AnythingOfType("common.Recommendation"),
-		common.PurchaseOptions{Source: ""},
+		common.PurchaseOptions{
+			Source:           "",
+			IdempotencyToken: common.DeriveIdempotencyToken("exec-bad", 0),
+		},
 	).Return(common.PurchaseResult{Success: true, CommitmentID: "ri-bad"}, nil)
 
 	manager := &Manager{

--- a/pkg/common/tokens.go
+++ b/pkg/common/tokens.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 )
@@ -21,4 +22,22 @@ func GenerateApprovalToken() (string, error) {
 		return "", fmt.Errorf("generate approval token: %w", err)
 	}
 	return hex.EncodeToString(b), nil
+}
+
+// DeriveIdempotencyToken returns a deterministic token for a single purchase
+// recommendation, derived from the owning execution's ID and the recommendation's
+// index within that execution. The same (executionID, recIndex) pair always
+// yields the same token, so a re-driven purchase of a stranded execution (issue
+// #636) reuses the identical token: AWS Savings Plans dedupe on it natively via
+// CreateSavingsPlanInput.ClientToken, and the EC2 RI client uses it as a dedupe
+// tag (IdempotencyTagKey). The output is a 64-char hex SHA-256 digest, which fits
+// the AWS ClientToken 64-character limit exactly.
+//
+// Unlike GenerateApprovalToken this is intentionally NOT random: idempotency
+// requires the token be reproducible from durable inputs (execution_id + index),
+// which both survive a strand-and-re-drive. It is not a credential, so the lack
+// of unpredictability is by design.
+func DeriveIdempotencyToken(executionID string, recIndex int) string {
+	sum := sha256.Sum256([]byte(fmt.Sprintf("%s:%d", executionID, recIndex)))
+	return hex.EncodeToString(sum[:])
 }

--- a/pkg/common/tokens_test.go
+++ b/pkg/common/tokens_test.go
@@ -36,3 +36,31 @@ func TestGenerateApprovalToken_NotZeroPrefix(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEqual(t, "0000000000000000000000000000000000000000000000000000000000000000", tok)
 }
+
+func TestDeriveIdempotencyToken_StableAcrossReDrive(t *testing.T) {
+	// The core idempotency guarantee (issue #636): re-deriving the token for
+	// the SAME execution + rec index must yield the IDENTICAL value, so a
+	// re-driven purchase reuses it and AWS / the EC2 dedupe guard collapse it
+	// onto the original commitment instead of creating a second one.
+	first := DeriveIdempotencyToken("exec-abc-123", 2)
+	second := DeriveIdempotencyToken("exec-abc-123", 2)
+	assert.Equal(t, first, second, "re-drive of same execution/rec must produce the same token")
+}
+
+func TestDeriveIdempotencyToken_DiffersByExecutionAndIndex(t *testing.T) {
+	// Different recs within an execution, and the same rec index across
+	// executions, must NOT collide, or one purchase would suppress another.
+	base := DeriveIdempotencyToken("exec-abc-123", 0)
+	assert.NotEqual(t, base, DeriveIdempotencyToken("exec-abc-123", 1), "different rec index must differ")
+	assert.NotEqual(t, base, DeriveIdempotencyToken("exec-xyz-999", 0), "different execution must differ")
+}
+
+func TestDeriveIdempotencyToken_FitsClientTokenLimit(t *testing.T) {
+	// AWS ClientToken (and the SP ClientToken) cap at 64 chars; a SHA-256 hex
+	// digest is exactly 64, so the token can be used verbatim without truncation.
+	tok := DeriveIdempotencyToken("exec-abc-123", 7)
+	assert.Len(t, tok, 64)
+	raw, err := hex.DecodeString(tok)
+	require.NoError(t, err)
+	assert.Len(t, raw, 32)
+}

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -248,6 +248,14 @@ const (
 // so customers and CUDly itself can attribute commitments back to the tool.
 const PurchaseTagKey = "purchase-automation"
 
+// IdempotencyTagKey is the tag key under which the deterministic per-rec
+// idempotency token (see DeriveIdempotencyToken) is stamped on commitments that
+// the cloud API cannot dedupe natively. EC2 Reserved Instances have no
+// ClientToken on PurchaseReservedInstancesOffering, so the EC2 client checks for
+// an already-tagged RI before purchasing and tags the freshly-bought RI with
+// this key afterwards, making a re-driven purchase idempotent (issue #636).
+const IdempotencyTagKey = "cudly-idempotency-token"
+
 // PurchaseOptions carries per-execution metadata threaded through
 // ServiceClient.PurchaseCommitment. Source is the CUDly surface that triggered
 // the purchase (CLI vs web); every provider stamps it onto the commitment it
@@ -260,6 +268,15 @@ type PurchaseOptions struct {
 	// carry a descriptive, account/engine/region-aware name instead of a
 	// generic auto-generated one. Providers sanitize it to their ID rules.
 	ReservationID string
+	// IdempotencyToken, when non-empty, is a deterministic token (see
+	// DeriveIdempotencyToken) that makes commitment creation idempotent across
+	// re-drives of the same execution (issue #636). Savings Plans pass it as
+	// the native CreateSavingsPlan ClientToken; EC2 RIs (which have no native
+	// token) check for an existing RI tagged with it before purchasing and tag
+	// the new RI with it afterwards. Empty means no idempotency guard (the CLI
+	// purchase path, which has no owning execution, leaves it empty and keeps
+	// its prior non-idempotent behaviour).
+	IdempotencyToken string
 }
 
 // NormalizeSource lowercases s and returns it when it matches an allowed

--- a/providers/aws/services/ec2/client.go
+++ b/providers/aws/services/ec2/client.go
@@ -112,6 +112,31 @@ func (c *Client) PurchaseCommitment(ctx context.Context, rec common.Recommendati
 		Timestamp:      time.Now(),
 	}
 
+	// Idempotency dedupe guard (issue #636). EC2's
+	// PurchaseReservedInstancesOfferingInput has no ClientToken, so the API
+	// cannot dedupe a repeated purchase server-side. Instead, when an
+	// idempotency token is supplied, look for an RI already tagged with it
+	// before buying: if one exists, this is a re-drive of a purchase that
+	// already succeeded, so short-circuit and return the existing RI rather
+	// than buying a second one.
+	if opts.IdempotencyToken != "" {
+		existingID, found, lookupErr := c.findRIByIdempotencyToken(ctx, opts.IdempotencyToken)
+		if lookupErr != nil {
+			// A failed lookup must NOT fall through to a purchase: doing so
+			// would defeat the guard and risk a double-buy on a re-drive. Fail
+			// loudly so the recovery sweep treats it as not-yet-purchased and
+			// retries the whole guarded path, rather than silently buying.
+			result.Error = fmt.Errorf("idempotency lookup failed before EC2 RI purchase (refusing to purchase to avoid a possible double-buy): %w", lookupErr)
+			return result, result.Error
+		}
+		if found {
+			log.Printf("EC2 RI for idempotency token %s already exists (%s); skipping purchase (issue #636 re-drive)", opts.IdempotencyToken, existingID)
+			result.Success = true
+			result.CommitmentID = existingID
+			return result, nil
+		}
+	}
+
 	// Find the offering ID
 	offeringID, err := c.findOfferingID(ctx, rec)
 	if err != nil {
@@ -146,11 +171,51 @@ func (c *Client) PurchaseCommitment(ctx context.Context, rec common.Recommendati
 	// purchase: the RI is already bought, and failing here would leave the
 	// customer with a paid-for-but-untagged commitment and no way to retry
 	// without double-purchasing.
-	if err := c.tagReservedInstance(ctx, result.CommitmentID, rec, opts.Source); err != nil {
+	//
+	// The idempotency-token tag (issue #636) rides this same CreateTags call.
+	// It is load-bearing for the dedupe guard above: if this write fails the
+	// guard degrades for that one RI (a re-drive would not find the tag and
+	// could double-buy). That residual window is backstopped by the recovery
+	// sweep's safe-fail + operator-confirm Retry (PR #635), since EC2 offers no
+	// atomic alternative. The cosmetic tags and the idempotency tag share one
+	// call so they cannot drift apart.
+	if err := c.tagReservedInstance(ctx, result.CommitmentID, rec, opts.Source, opts.IdempotencyToken); err != nil {
 		log.Printf("WARNING: failed to tag EC2 RI %s after purchase (commitment is bought; tag missing): %v", result.CommitmentID, err)
 	}
 
 	return result, nil
+}
+
+// findRIByIdempotencyToken looks for an active or payment-pending Reserved
+// Instance tagged with the given idempotency token (issue #636). It returns the
+// RI ID and true when exactly such an RI exists, so a re-driven purchase can
+// short-circuit instead of buying a second commitment. Retired/cancelled RIs are
+// excluded (they carry the same state filter as GetExistingCommitments) so a
+// returned or expired commitment does not suppress a legitimate fresh purchase.
+func (c *Client) findRIByIdempotencyToken(ctx context.Context, token string) (string, bool, error) {
+	input := &ec2.DescribeReservedInstancesInput{
+		Filters: []types.Filter{
+			{
+				Name:   aws.String("tag:" + common.IdempotencyTagKey),
+				Values: []string{token},
+			},
+			{
+				Name:   aws.String("state"),
+				Values: []string{"active", "payment-pending"},
+			},
+		},
+	}
+
+	response, err := c.client.DescribeReservedInstances(ctx, input)
+	if err != nil {
+		return "", false, fmt.Errorf("failed to describe reserved instances for idempotency check: %w", err)
+	}
+	for _, ri := range response.ReservedInstances {
+		if ri.ReservedInstancesId != nil {
+			return aws.ToString(ri.ReservedInstancesId), true, nil
+		}
+	}
+	return "", false, nil
 }
 
 // tagReservedInstance applies the standard CUDly tag set (including the
@@ -160,7 +225,7 @@ func (c *Client) PurchaseCommitment(ctx context.Context, rec common.Recommendati
 // Retries up to 4 attempts (1s/2s/4s backoff) on InvalidReservationID.NotFound,
 // since AWS sometimes needs a couple of seconds before the RI ID is visible
 // to CreateTags. Non-NotFound errors short-circuit immediately.
-func (c *Client) tagReservedInstance(ctx context.Context, riID string, rec common.Recommendation, source string) error {
+func (c *Client) tagReservedInstance(ctx context.Context, riID string, rec common.Recommendation, source, idempotencyToken string) error {
 	tags := []types.Tag{
 		{Key: aws.String("Purpose"), Value: aws.String("Reserved Instance Purchase")},
 		{Key: aws.String("ResourceType"), Value: aws.String(rec.ResourceType)},
@@ -172,6 +237,15 @@ func (c *Client) tagReservedInstance(ctx context.Context, riID string, rec commo
 		tags = append(tags, types.Tag{
 			Key:   aws.String(common.PurchaseTagKey),
 			Value: aws.String(source),
+		})
+	}
+	// The idempotency tag is what findRIByIdempotencyToken matches on for the
+	// dedupe guard (issue #636); it must be written for a re-drive to recognise
+	// this RI as already-purchased.
+	if idempotencyToken != "" {
+		tags = append(tags, types.Tag{
+			Key:   aws.String(common.IdempotencyTagKey),
+			Value: aws.String(idempotencyToken),
 		})
 	}
 

--- a/providers/aws/services/savingsplans/client.go
+++ b/providers/aws/services/savingsplans/client.go
@@ -194,6 +194,16 @@ func (c *Client) PurchaseCommitment(ctx context.Context, rec common.Recommendati
 		Tags:                  buildSavingsPlanTags(opts.Source),
 	}
 
+	// Native server-side idempotency (issue #636): a repeated CreateSavingsPlan
+	// with the same ClientToken returns the original Savings Plan instead of
+	// creating a second one, so re-driving a stranded execution can never
+	// double-purchase. The token is deterministic across re-drives (derived from
+	// execution_id + rec index). Left unset for the CLI path, which carries no
+	// owning execution and keeps its prior non-idempotent behaviour.
+	if opts.IdempotencyToken != "" {
+		input.ClientToken = aws.String(opts.IdempotencyToken)
+	}
+
 	response, err := c.client.CreateSavingsPlan(ctx, input)
 	if err != nil {
 		result.Error = fmt.Errorf("failed to purchase Savings Plan: %w", err)

--- a/providers/aws/services/savingsplans/client_test.go
+++ b/providers/aws/services/savingsplans/client_test.go
@@ -394,6 +394,86 @@ func TestClient_PurchaseCommitment(t *testing.T) {
 	mockSP.AssertExpectations(t)
 }
 
+// TestClient_PurchaseCommitment_SetsClientTokenForIdempotency asserts that an
+// idempotency token supplied via PurchaseOptions is passed verbatim as the
+// CreateSavingsPlan ClientToken (issue #636). AWS dedupes on this token, so a
+// re-driven purchase with the same token returns the original Savings Plan
+// instead of creating a second one. The test captures the input and confirms
+// the same token would be sent again on a re-drive.
+func TestClient_PurchaseCommitment_SetsClientTokenForIdempotency(t *testing.T) {
+	mockSP := &MockSavingsPlansClient{}
+	client := &Client{client: mockSP, region: "us-east-1"}
+
+	rec := common.Recommendation{
+		Service:       common.ServiceSavingsPlans,
+		ResourceType:  "Compute",
+		Count:         1,
+		PaymentOption: "all-upfront",
+		Term:          "1yr",
+		Details:       &common.SavingsPlanDetails{PlanType: "Compute", HourlyCommitment: 10.0},
+	}
+
+	mockSP.On("DescribeSavingsPlansOfferings", mock.Anything, mock.Anything).
+		Return(&savingsplans.DescribeSavingsPlansOfferingsOutput{
+			SearchResults: []types.SavingsPlanOffering{{OfferingId: aws.String("offering-123")}},
+		}, nil)
+
+	var captured *savingsplans.CreateSavingsPlanInput
+	mockSP.On("CreateSavingsPlan", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			captured = args.Get(1).(*savingsplans.CreateSavingsPlanInput)
+		}).
+		Return(&savingsplans.CreateSavingsPlanOutput{SavingsPlanId: aws.String("sp-789")}, nil)
+
+	token := common.DeriveIdempotencyToken("exec-sp-1", 0)
+	result, err := client.PurchaseCommitment(context.Background(), rec, common.PurchaseOptions{IdempotencyToken: token})
+
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+	require.NotNil(t, captured)
+	require.NotNil(t, captured.ClientToken, "CreateSavingsPlan must carry a ClientToken for idempotency")
+	assert.Equal(t, token, *captured.ClientToken)
+	// A re-drive of the same execution/rec derives the identical token, so AWS
+	// would dedupe the second CreateSavingsPlan onto the first.
+	assert.Equal(t, *captured.ClientToken, common.DeriveIdempotencyToken("exec-sp-1", 0))
+	mockSP.AssertExpectations(t)
+}
+
+// TestClient_PurchaseCommitment_NoClientTokenWhenUnset confirms the CLI path
+// (no owning execution, empty token) leaves ClientToken nil and keeps its prior
+// non-idempotent behaviour unchanged.
+func TestClient_PurchaseCommitment_NoClientTokenWhenUnset(t *testing.T) {
+	mockSP := &MockSavingsPlansClient{}
+	client := &Client{client: mockSP, region: "us-east-1"}
+
+	rec := common.Recommendation{
+		Service:       common.ServiceSavingsPlans,
+		ResourceType:  "Compute",
+		Count:         1,
+		PaymentOption: "all-upfront",
+		Term:          "1yr",
+		Details:       &common.SavingsPlanDetails{PlanType: "Compute", HourlyCommitment: 10.0},
+	}
+
+	mockSP.On("DescribeSavingsPlansOfferings", mock.Anything, mock.Anything).
+		Return(&savingsplans.DescribeSavingsPlansOfferingsOutput{
+			SearchResults: []types.SavingsPlanOffering{{OfferingId: aws.String("offering-123")}},
+		}, nil)
+
+	var captured *savingsplans.CreateSavingsPlanInput
+	mockSP.On("CreateSavingsPlan", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			captured = args.Get(1).(*savingsplans.CreateSavingsPlanInput)
+		}).
+		Return(&savingsplans.CreateSavingsPlanOutput{SavingsPlanId: aws.String("sp-789")}, nil)
+
+	_, err := client.PurchaseCommitment(context.Background(), rec, common.PurchaseOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, captured)
+	assert.Nil(t, captured.ClientToken, "no idempotency token supplied -> ClientToken stays nil")
+	mockSP.AssertExpectations(t)
+}
+
 func TestClient_PurchaseCommitment_InvalidDetails(t *testing.T) {
 	client := &Client{region: "us-east-1"}
 


### PR DESCRIPTION
## Summary

Adds idempotent commitment creation so a re-driven purchase can never double-buy (#636) — the prerequisite for eventually auto-re-driving stranded approvals (#635's recovery sweep currently safe-fails).

A deterministic per-rec token `DeriveIdempotencyToken(executionID, recIndex)` is threaded through `PurchaseOptions.IdempotencyToken` and the execution fan-out, so a re-drive of the same execution/rec produces the identical token.

## Per-provider double-buy guarantee

- **Savings Plans — race-free, native.** `CreateSavingsPlan.ClientToken` is AWS's documented native idempotency identifier (the SDK auto-injects a UUID when nil; confirmed in savingsplans v1.31.0). Passing our deterministic token means a re-drive sends the identical token and AWS dedupes server-side atomically. (Note: this corrects the premise in #636's body / #632 that SP has no native idempotency — it does, and we use it rather than a weaker lookup guard.)
- **EC2 RI — sound, one irreducible window.** No `ClientToken` exists for `PurchaseReservedInstancesOffering`. The guard queries `DescribeReservedInstances` filtered by `tag:cudly-idempotency-token` + state `active|payment-pending` (matching `GetExistingCommitments`) before buying, short-circuits if found, fails-loud (refuses to buy) on lookup error, and tags after purchase. The only residual double-buy window is purchase-succeeds-then-tag-write-fails, which is irreducible given EC2's API and stays backstopped by #635's safe-fail.

## Scope

Closes #636 (both EC2 + SP idempotency primitives). The `RecoverStrandedApprovals` re-drive flip is **not** done here — it remains the explicitly-deferred follow-up now that idempotency is safe.

## Test plan

- [x] 371 tests pass (pkg/common 130, aws ec2+sp 100, internal/purchase 141)
- [x] Asserts the same token on re-drive; SP native-ClientToken passthrough; EC2 tag-guard short-circuit + fail-loud-on-lookup-error
- [x] go vet + gofmt + gosec (new token const) clean

Closes #636.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented purchase deduplication for cloud commitments. Each recommendation now receives a unique idempotency token to prevent duplicate purchases when operations are retried for EC2 Reserved Instances and Savings Plans.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/638?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->