### PR TITLE
fix(gcp/purchases): make CloudSQL/Storage/Memorystore commitments advisory-only (closes #640)

### DIFF
--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -3,10 +3,19 @@ package common
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 )
+
+// ErrCommitmentPurchaseNotSupported is returned by ServiceClient.PurchaseCommitment
+// implementations for services that have no programmatic committed-use / commitment
+// purchase API. Their recommendations are advisory only: callers must surface them
+// for human action rather than auto-purchasing. Returning this sentinel (instead of
+// silently provisioning a billable resource) guarantees a "purchase" never creates
+// infrastructure. Callers can detect it with errors.Is(err, ErrCommitmentPurchaseNotSupported).
+var ErrCommitmentPurchaseNotSupported = errors.New("commitment purchase not supported for this service")
 
 // ProviderType identifies the cloud provider
 type ProviderType string

--- a/providers/gcp/services/cloudsql/client.go
+++ b/providers/gcp/services/cloudsql/client.go
@@ -233,61 +233,25 @@ func (c *CloudSQLClient) GetExistingCommitments(ctx context.Context) ([]common.C
 	return commitments, nil
 }
 
-// PurchaseCommitment purchases a Cloud SQL commitment
+// PurchaseCommitment is intentionally a no-op for Cloud SQL: GCP exposes no
+// programmatic API to buy a Cloud SQL committed-use discount. CUD purchases are
+// spend-based and bought via the Cloud Billing console / Cloud Commerce
+// Consumer Procurement API, not via sqladmin.Instances.Insert. The previous
+// implementation created a brand-new billable SQL instance (the legacy
+// PricingPlan "PACKAGE" is a per-instance billing mode, not a commitment), so a
+// "purchase" silently spun up a new database that kept billing. Cloud SQL
+// recommendations are therefore advisory only; this returns a clear
+// not-supported error and never calls any resource-creation API (issue #640).
 func (c *CloudSQLClient) PurchaseCommitment(ctx context.Context, rec common.Recommendation, opts common.PurchaseOptions) (common.PurchaseResult, error) {
-	result := common.PurchaseResult{
+	return common.PurchaseResult{
 		Recommendation: rec,
 		DryRun:         false,
 		Success:        false,
 		Timestamp:      time.Now(),
-	}
-
-	// Use injected service if available (for testing)
-	var svc SQLAdminService
-	if c.sqlAdminService != nil {
-		svc = c.sqlAdminService
-	} else {
-		service, err := sqladmin.NewService(ctx, c.clientOpts...)
-		if err != nil {
-			result.Error = fmt.Errorf("failed to create SQL admin service: %w", err)
-			return result, result.Error
-		}
-		svc = &realSQLAdminService{service: service}
-	}
-
-	// Create a new Cloud SQL instance with commitment pricing
-	instanceName := fmt.Sprintf("sql-committed-%d", time.Now().Unix())
-
-	instance := &sqladmin.DatabaseInstance{
-		Name:            instanceName,
-		Region:          c.region,
-		DatabaseVersion: "MYSQL_8_0", // Default to MySQL 8.0
-		Settings: &sqladmin.Settings{
-			Tier:        rec.ResourceType,
-			PricingPlan: "PACKAGE", // This indicates a commitment
-		},
-	}
-	if opts.Source != "" {
-		instance.Settings.UserLabels = map[string]string{common.PurchaseTagKey: opts.Source}
-	}
-
-	op, err := svc.InsertInstance(c.projectID, instance)
-	if err != nil {
-		result.Error = fmt.Errorf("failed to create SQL instance with commitment: %w", err)
-		return result, result.Error
-	}
-
-	// Wait for operation to complete (in production, you'd poll this)
-	if op.Status != "DONE" {
-		result.Error = fmt.Errorf("instance creation in progress: %s", op.Status)
-		return result, result.Error
-	}
-
-	result.Success = true
-	result.CommitmentID = instanceName
-	result.Cost = rec.CommitmentCost
-
-	return result, nil
+		Error: fmt.Errorf("%w: GCP Cloud SQL committed-use discounts are spend-based and "+
+			"must be purchased via the Cloud Billing console or Cloud Commerce Consumer "+
+			"Procurement API; this recommendation is advisory only", common.ErrCommitmentPurchaseNotSupported),
+	}, fmt.Errorf("%w: Cloud SQL", common.ErrCommitmentPurchaseNotSupported)
 }
 
 // ValidateOffering validates that a Cloud SQL tier exists

--- a/providers/gcp/services/cloudsql/client_test.go
+++ b/providers/gcp/services/cloudsql/client_test.go
@@ -18,10 +18,11 @@ import (
 
 // MockSQLAdminService mocks the SQLAdminService interface
 type MockSQLAdminService struct {
-	instances *sqladmin.InstancesListResponse
-	tiers     *sqladmin.TiersListResponse
-	operation *sqladmin.Operation
-	err       error
+	instances    *sqladmin.InstancesListResponse
+	tiers        *sqladmin.TiersListResponse
+	operation    *sqladmin.Operation
+	err          error
+	insertCalled bool
 }
 
 func (m *MockSQLAdminService) ListInstances(projectID string) (*sqladmin.InstancesListResponse, error) {
@@ -32,6 +33,7 @@ func (m *MockSQLAdminService) ListInstances(projectID string) (*sqladmin.Instanc
 }
 
 func (m *MockSQLAdminService) InsertInstance(projectID string, instance *sqladmin.DatabaseInstance) (*sqladmin.Operation, error) {
+	m.insertCalled = true
 	if m.err != nil {
 		return nil, m.err
 	}
@@ -453,14 +455,18 @@ func TestCloudSQLClient_ValidateOffering_Invalid(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid Cloud SQL tier")
 }
 
-func TestCloudSQLClient_PurchaseCommitment_WithMock(t *testing.T) {
+// TestCloudSQLClient_PurchaseCommitment_NotSupported is the regression test for
+// issue #640: Cloud SQL CUDs are spend-based and have no programmatic purchase API,
+// so PurchaseCommitment must return ErrCommitmentPurchaseNotSupported and MUST NOT
+// call any resource-creation API (it previously created a new billable SQL instance).
+func TestCloudSQLClient_PurchaseCommitment_NotSupported(t *testing.T) {
 	ctx := context.Background()
 	client, _ := NewClient(ctx, "test-project", "us-central1")
 
 	mockService := &MockSQLAdminService{
-		operation: &sqladmin.Operation{
-			Status: "DONE",
-		},
+		// If PurchaseCommitment ever calls InsertInstance, this would report a
+		// completed operation; the assertions below ensure it is never invoked.
+		operation: &sqladmin.Operation{Status: "DONE"},
 	}
 	client.SetSQLAdminService(mockService)
 
@@ -470,50 +476,14 @@ func TestCloudSQLClient_PurchaseCommitment_WithMock(t *testing.T) {
 	}
 
 	result, err := client.PurchaseCommitment(ctx, rec, common.PurchaseOptions{})
-	require.NoError(t, err)
-	assert.True(t, result.Success)
-	assert.NotEmpty(t, result.CommitmentID)
-	assert.Equal(t, 1000.0, result.Cost)
-}
 
-func TestCloudSQLClient_PurchaseCommitment_InProgress(t *testing.T) {
-	ctx := context.Background()
-	client, _ := NewClient(ctx, "test-project", "us-central1")
-
-	mockService := &MockSQLAdminService{
-		operation: &sqladmin.Operation{
-			Status: "RUNNING",
-		},
-	}
-	client.SetSQLAdminService(mockService)
-
-	rec := common.Recommendation{
-		ResourceType: "db-n1-standard-1",
-	}
-
-	result, err := client.PurchaseCommitment(ctx, rec, common.PurchaseOptions{})
-	assert.Error(t, err)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, common.ErrCommitmentPurchaseNotSupported)
 	assert.False(t, result.Success)
-	assert.Contains(t, err.Error(), "instance creation in progress")
-}
-
-func TestCloudSQLClient_PurchaseCommitment_Error(t *testing.T) {
-	ctx := context.Background()
-	client, _ := NewClient(ctx, "test-project", "us-central1")
-
-	mockService := &MockSQLAdminService{
-		err: errors.New("API error"),
-	}
-	client.SetSQLAdminService(mockService)
-
-	rec := common.Recommendation{
-		ResourceType: "db-n1-standard-1",
-	}
-
-	result, err := client.PurchaseCommitment(ctx, rec, common.PurchaseOptions{})
-	assert.Error(t, err)
-	assert.False(t, result.Success)
-	assert.Contains(t, err.Error(), "failed to create SQL instance")
+	assert.Empty(t, result.CommitmentID)
+	assert.ErrorIs(t, result.Error, common.ErrCommitmentPurchaseNotSupported)
+	// The critical guarantee: a "purchase" must never create infrastructure.
+	assert.False(t, mockService.insertCalled, "PurchaseCommitment must not call InsertInstance")
 }
 
 func TestCloudSQLClient_GetOfferingDetails_WithMock(t *testing.T) {

--- a/providers/gcp/services/cloudstorage/client.go
+++ b/providers/gcp/services/cloudstorage/client.go
@@ -245,52 +245,22 @@ func (c *CloudStorageClient) GetExistingCommitments(ctx context.Context) ([]comm
 	return commitments, nil
 }
 
-// PurchaseCommitment purchases a Cloud Storage commitment
+// PurchaseCommitment is intentionally a no-op for Cloud Storage: GCP has no CUD
+// or commitment purchase API for GCS at all. The previous implementation created
+// a brand-new empty bucket, which is not a commitment and incurs ongoing cost, so
+// a "purchase" silently provisioned billable infrastructure. Cloud Storage
+// recommendations are therefore advisory only; this returns a clear not-supported
+// error and never calls any resource-creation API (issue #640).
 func (c *CloudStorageClient) PurchaseCommitment(ctx context.Context, rec common.Recommendation, opts common.PurchaseOptions) (common.PurchaseResult, error) {
-	result := common.PurchaseResult{
+	return common.PurchaseResult{
 		Recommendation: rec,
 		DryRun:         false,
 		Success:        false,
 		Timestamp:      time.Now(),
-	}
-
-	// Use injected service if available (for testing)
-	var svc StorageService
-	if c.storageService != nil {
-		svc = c.storageService
-	} else {
-		client, err := storage.NewClient(ctx, c.clientOpts...)
-		if err != nil {
-			result.Error = fmt.Errorf("failed to create storage client: %w", err)
-			return result, result.Error
-		}
-		svc = &realStorageService{client: client}
-	}
-	defer svc.Close()
-
-	// Create a new Cloud Storage bucket with committed storage class
-	bucketName := fmt.Sprintf("storage-committed-%d", time.Now().Unix())
-
-	bucket := svc.Bucket(bucketName)
-	attrs := &storage.BucketAttrs{
-		Location:     c.region,
-		StorageClass: rec.ResourceType,
-	}
-	if opts.Source != "" {
-		attrs.Labels = map[string]string{common.PurchaseTagKey: opts.Source}
-	}
-
-	err := bucket.Create(ctx, c.projectID, attrs)
-	if err != nil {
-		result.Error = fmt.Errorf("failed to create storage bucket with commitment: %w", err)
-		return result, result.Error
-	}
-
-	result.Success = true
-	result.CommitmentID = bucketName
-	result.Cost = rec.CommitmentCost
-
-	return result, nil
+		Error: fmt.Errorf("%w: GCP Cloud Storage offers no committed-use discount or "+
+			"commitment purchase API; this recommendation is advisory only",
+			common.ErrCommitmentPurchaseNotSupported),
+	}, fmt.Errorf("%w: Cloud Storage", common.ErrCommitmentPurchaseNotSupported)
 }
 
 // ValidateOffering validates that a storage class exists

--- a/providers/gcp/services/cloudstorage/client_test.go
+++ b/providers/gcp/services/cloudstorage/client_test.go
@@ -18,10 +18,11 @@ import (
 
 // MockStorageService mocks the StorageService interface
 type MockStorageService struct {
-	buckets    []*storage.BucketAttrs
-	listErr    error
-	bucketName string
-	createErr  error
+	buckets      []*storage.BucketAttrs
+	listErr      error
+	bucketName   string
+	createErr    error
+	createCalled *bool
 }
 
 func (m *MockStorageService) Buckets(ctx context.Context, projectID string) BucketIterator {
@@ -30,7 +31,7 @@ func (m *MockStorageService) Buckets(ctx context.Context, projectID string) Buck
 
 func (m *MockStorageService) Bucket(name string) BucketHandle {
 	m.bucketName = name
-	return &MockBucketHandle{createErr: m.createErr}
+	return &MockBucketHandle{createErr: m.createErr, createCalled: m.createCalled}
 }
 
 func (m *MockStorageService) Close() error {
@@ -58,10 +59,14 @@ func (m *MockBucketIterator) Next() (*storage.BucketAttrs, error) {
 
 // MockBucketHandle mocks the BucketHandle interface
 type MockBucketHandle struct {
-	createErr error
+	createErr    error
+	createCalled *bool
 }
 
 func (m *MockBucketHandle) Create(ctx context.Context, projectID string, attrs *storage.BucketAttrs) error {
+	if m.createCalled != nil {
+		*m.createCalled = true
+	}
 	return m.createErr
 }
 
@@ -361,13 +366,16 @@ func TestCloudStorageClient_GetExistingCommitments_Empty(t *testing.T) {
 	assert.Empty(t, commitments)
 }
 
-func TestCloudStorageClient_PurchaseCommitment_WithMock(t *testing.T) {
+// TestCloudStorageClient_PurchaseCommitment_NotSupported is the regression test for
+// issue #640: Cloud Storage has no CUD or commitment purchase API, so
+// PurchaseCommitment must return ErrCommitmentPurchaseNotSupported and MUST NOT call
+// any resource-creation API (it previously created a new empty billable bucket).
+func TestCloudStorageClient_PurchaseCommitment_NotSupported(t *testing.T) {
 	ctx := context.Background()
 	client, _ := NewClient(ctx, "test-project", "us-central1")
 
-	mockService := &MockStorageService{
-		createErr: nil,
-	}
+	createCalled := false
+	mockService := &MockStorageService{createCalled: &createCalled}
 	client.SetStorageService(mockService)
 
 	rec := common.Recommendation{
@@ -376,29 +384,14 @@ func TestCloudStorageClient_PurchaseCommitment_WithMock(t *testing.T) {
 	}
 
 	result, err := client.PurchaseCommitment(ctx, rec, common.PurchaseOptions{})
-	require.NoError(t, err)
-	assert.True(t, result.Success)
-	assert.NotEmpty(t, result.CommitmentID)
-	assert.Equal(t, 100.0, result.Cost)
-}
 
-func TestCloudStorageClient_PurchaseCommitment_Error(t *testing.T) {
-	ctx := context.Background()
-	client, _ := NewClient(ctx, "test-project", "us-central1")
-
-	mockService := &MockStorageService{
-		createErr: errors.New("bucket creation failed"),
-	}
-	client.SetStorageService(mockService)
-
-	rec := common.Recommendation{
-		ResourceType: "STANDARD",
-	}
-
-	result, err := client.PurchaseCommitment(ctx, rec, common.PurchaseOptions{})
-	assert.Error(t, err)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, common.ErrCommitmentPurchaseNotSupported)
 	assert.False(t, result.Success)
-	assert.Contains(t, err.Error(), "failed to create storage bucket")
+	assert.Empty(t, result.CommitmentID)
+	assert.ErrorIs(t, result.Error, common.ErrCommitmentPurchaseNotSupported)
+	// The critical guarantee: a "purchase" must never create infrastructure.
+	assert.False(t, createCalled, "PurchaseCommitment must not call bucket Create")
 }
 
 func TestCloudStorageClient_GetRecommendations_WithMock(t *testing.T) {

--- a/providers/gcp/services/memorystore/client.go
+++ b/providers/gcp/services/memorystore/client.go
@@ -189,65 +189,26 @@ func (c *MemorystoreClient) GetExistingCommitments(ctx context.Context) ([]commo
 	return nil, nil
 }
 
-// PurchaseCommitment purchases a Memorystore Redis commitment
+// PurchaseCommitment is intentionally a no-op for Memorystore: GCP exposes no
+// standalone committed-use discount purchase API for Memorystore. Memorystore is
+// covered by spend-based CUDs bought via the Cloud Billing console / Cloud
+// Commerce Consumer Procurement API, not by creating an instance. The previous
+// implementation created a brand-new billable Redis instance (a reserved IP range
+// is networking config, not a commitment), so a "purchase" silently spun up a new
+// Redis instance that kept billing. Memorystore recommendations are therefore
+// advisory only; this returns a clear not-supported error and never calls any
+// resource-creation API (issue #640).
 func (c *MemorystoreClient) PurchaseCommitment(ctx context.Context, rec common.Recommendation, opts common.PurchaseOptions) (common.PurchaseResult, error) {
-	result := common.PurchaseResult{
+	return common.PurchaseResult{
 		Recommendation: rec,
 		DryRun:         false,
 		Success:        false,
 		Timestamp:      time.Now(),
-	}
-
-	redisSvc := c.redisService
-	if redisSvc == nil {
-		client, err := redis.NewCloudRedisClient(ctx, c.clientOpts...)
-		if err != nil {
-			result.Error = fmt.Errorf("failed to create redis client: %w", err)
-			return result, result.Error
-		}
-		redisSvc = &realRedisService{client: client}
-	}
-	defer redisSvc.Close()
-
-	// Create a new Memorystore Redis instance with committed pricing
-	instanceName := fmt.Sprintf("redis-committed-%d", time.Now().Unix())
-	parent := fmt.Sprintf("projects/%s/locations/%s", c.projectID, c.region)
-
-	instance := &redispb.Instance{
-		Name:         fmt.Sprintf("%s/instances/%s", parent, instanceName),
-		Tier:         redispb.Instance_STANDARD_HA,
-		MemorySizeGb: 1, // Minimum size
-		// Setting reserved IP range indicates committed use
-		ReservedIpRange: "10.0.0.0/29",
-	}
-	if opts.Source != "" {
-		instance.Labels = map[string]string{common.PurchaseTagKey: opts.Source}
-	}
-
-	insertReq := &redispb.CreateInstanceRequest{
-		Parent:     parent,
-		InstanceId: instanceName,
-		Instance:   instance,
-	}
-
-	op, err := redisSvc.CreateInstance(ctx, insertReq)
-	if err != nil {
-		result.Error = fmt.Errorf("failed to create redis instance with commitment: %w", err)
-		return result, result.Error
-	}
-
-	// Wait for operation to complete
-	_, err = op.Wait(ctx)
-	if err != nil {
-		result.Error = fmt.Errorf("instance creation failed: %w", err)
-		return result, result.Error
-	}
-
-	result.Success = true
-	result.CommitmentID = instanceName
-	result.Cost = rec.CommitmentCost
-
-	return result, nil
+		Error: fmt.Errorf("%w: GCP Memorystore has no standalone committed-use discount "+
+			"purchase API (spend-based CUDs are bought via the Cloud Billing console or "+
+			"Cloud Commerce Consumer Procurement API); this recommendation is advisory only",
+			common.ErrCommitmentPurchaseNotSupported),
+	}, fmt.Errorf("%w: Memorystore", common.ErrCommitmentPurchaseNotSupported)
 }
 
 // ValidateOffering validates that a Redis tier exists

--- a/providers/gcp/services/memorystore/client_test.go
+++ b/providers/gcp/services/memorystore/client_test.go
@@ -24,6 +24,7 @@ type MockRedisService struct {
 	instancesErr error
 	createResult CreateInstanceOperation
 	createErr    error
+	createCalled bool
 	closeCalled  bool
 }
 
@@ -32,6 +33,7 @@ func (m *MockRedisService) ListInstances(ctx context.Context, req *redispb.ListI
 }
 
 func (m *MockRedisService) CreateInstance(ctx context.Context, req *redispb.CreateInstanceRequest) (CreateInstanceOperation, error) {
+	m.createCalled = true
 	if m.createErr != nil {
 		return nil, m.createErr
 	}
@@ -372,73 +374,35 @@ func TestMemorystoreClient_GetExistingCommitments_WithMockService(t *testing.T) 
 	}
 }
 
-func TestMemorystoreClient_PurchaseCommitment_WithMockService(t *testing.T) {
-	tests := []struct {
-		name        string
-		createErr   error
-		waitErr     error
-		wantSuccess bool
-		errContains string
-	}{
-		{
-			name:        "successful purchase",
-			createErr:   nil,
-			waitErr:     nil,
-			wantSuccess: true,
-		},
-		{
-			name:        "create instance fails",
-			createErr:   errors.New("create failed"),
-			waitErr:     nil,
-			wantSuccess: false,
-			errContains: "failed to create redis instance",
-		},
-		{
-			name:        "wait operation fails",
-			createErr:   nil,
-			waitErr:     errors.New("operation failed"),
-			wantSuccess: false,
-			errContains: "instance creation failed",
-		},
+// TestMemorystoreClient_PurchaseCommitment_NotSupported is the regression test for
+// issue #640: Memorystore has no standalone CUD purchase API, so PurchaseCommitment
+// must return ErrCommitmentPurchaseNotSupported and MUST NOT call any
+// resource-creation API (it previously created a new billable Redis instance).
+func TestMemorystoreClient_PurchaseCommitment_NotSupported(t *testing.T) {
+	ctx := context.Background()
+	client, _ := NewClient(ctx, "test-project", "us-central1")
+
+	mockService := &MockRedisService{
+		// If PurchaseCommitment ever calls CreateInstance, this would return a
+		// successful op; the assertions below ensure it is never invoked.
+		createResult: &MockCreateInstanceOperation{instance: &redispb.Instance{Name: "test-instance"}},
+	}
+	client.SetRedisService(mockService)
+
+	rec := common.Recommendation{
+		ResourceType:   "STANDARD_HA",
+		CommitmentCost: 100.0,
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
-			client, _ := NewClient(ctx, "test-project", "us-central1")
+	result, err := client.PurchaseCommitment(ctx, rec, common.PurchaseOptions{})
 
-			mockOp := &MockCreateInstanceOperation{
-				instance: &redispb.Instance{Name: "test-instance"},
-				err:      tt.waitErr,
-			}
-
-			mockService := &MockRedisService{
-				createResult: mockOp,
-				createErr:    tt.createErr,
-			}
-			client.SetRedisService(mockService)
-
-			rec := common.Recommendation{
-				ResourceType:   "STANDARD_HA",
-				CommitmentCost: 100.0,
-			}
-
-			result, err := client.PurchaseCommitment(ctx, rec, common.PurchaseOptions{})
-
-			if tt.wantSuccess {
-				require.NoError(t, err)
-				assert.True(t, result.Success)
-				assert.NotEmpty(t, result.CommitmentID)
-				assert.Equal(t, 100.0, result.Cost)
-			} else {
-				require.Error(t, err)
-				assert.False(t, result.Success)
-				assert.Contains(t, err.Error(), tt.errContains)
-			}
-
-			assert.True(t, mockService.closeCalled)
-		})
-	}
+	require.Error(t, err)
+	assert.ErrorIs(t, err, common.ErrCommitmentPurchaseNotSupported)
+	assert.False(t, result.Success)
+	assert.Empty(t, result.CommitmentID)
+	assert.ErrorIs(t, result.Error, common.ErrCommitmentPurchaseNotSupported)
+	// The critical guarantee: a "purchase" must never create infrastructure.
+	assert.False(t, mockService.createCalled, "PurchaseCommitment must not call CreateInstance")
 }
 
 func TestMemorystoreClient_GetOfferingDetails_WithMockService(t *testing.T) {


### PR DESCRIPTION
## Summary

All three GCP `PurchaseCommitment` implementations provisioned NEW billable infrastructure instead of buying a committed-use discount (#640) — Cloud SQL created a new DB, Cloud Storage a new bucket, Memorystore a new Redis instance.

None of these services has a safe programmatic commitment-purchase API: Cloud SQL & Memorystore CUDs are spend-based (Cloud Billing console / Cloud Commerce Consumer Procurement API), and GCS has no CUD API at all. So this makes all three advisory-only.

## Fix

- Added shared sentinel `common.ErrCommitmentPurchaseNotSupported` (`pkg/common/types.go`).
- Cloud SQL / Cloud Storage / Memorystore `PurchaseCommitment` now return the sentinel and no longer call `InsertInstance` / bucket `Create` / `CreateInstance`. The executor (`internal/purchase/execution.go:589`) returns the error immediately, so no success path / no infra is reached.

## Test plan

- [x] 3 regression tests (one per service) assert the sentinel is returned (`errors.Is`), `Success=false`, empty `CommitmentID`, and the creation API is NEVER called
- [x] pkg/common 130/130, cloudstorage 36/36 pass; GCP module builds + vets clean

Closes #640.

Note: two pre-existing base-branch test failures were observed (`cloudsql/TestCloudSQLClient_ValidateOffering_NoCredentials` env-dependent ADC; `memorystore/.../GetExistingCommitments_WithMockService`) — both fail identically on unmodified base, out of scope here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected commitment purchase behavior for GCP services (Cloud SQL, Cloud Storage, Memorystore) to properly report unsupported operations with clear error messages instead of attempting invalid resource creation.

* **Tests**
  * Added regression tests to validate proper error handling for unsupported commitment purchases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/649?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->