### PR TITLE
test(purchase): stub RecoverStrandedApprovals late-completion mock to fix panic

### DIFF
--- a/internal/purchase/manager_test.go
+++ b/internal/purchase/manager_test.go
@@ -414,6 +414,12 @@ func TestManager_RecoverStrandedApprovals_LateCompletionNotClobbered(t *testing.
 		Return([]config.PurchaseExecution{stranded}, nil)
 	mockStore.On("TransitionExecutionStatus", ctx, "exec-raced", []string{"approved"}, "failed").
 		Return(nil, errors.New("execution exec-raced cannot transition from \"completed\" to \"failed\""))
+	// When TransitionExecutionStatus fails the manager calls GetExecutionByID to
+	// distinguish a race (row already left "approved") from a real store error.
+	// Returning a "completed" row causes RecoverStrandedApprovals to skip the
+	// execution, which is the behaviour this test asserts.
+	mockStore.On("GetExecutionByID", ctx, "exec-raced").
+		Return(&config.PurchaseExecution{ExecutionID: "exec-raced", Status: "completed"}, nil)
 
 	manager := &Manager{config: mockStore, dashboardURL: "https://dashboard.example.com"}
 


### PR DESCRIPTION
Closes #657. Stubs the GetExecutionByID call in the RecoverStrandedApprovals race-disambiguation path so the late-completion-not-clobbered test no longer panics on an unstubbed mock. Full internal/purchase suite green with -race (144 pass).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for purchase execution recovery scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/663?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->