### PR TITLE
fix(purchases): add execution-tagged logging to executeSinglePurchase (refs #667)

### DIFF
--- a/internal/purchase/execution.go
+++ b/internal/purchase/execution.go
@@ -372,14 +372,26 @@ type recPurchaseOutcome struct {
 }
 
 func (m *Manager) processPurchaseRecommendations(ctx context.Context, exec *config.PurchaseExecution, plan *config.PurchasePlan, accountID string, provCfg *provider.ProviderConfig) (float64, float64, []string) {
-	opts := common.PurchaseOptions{Source: m.normalizePurchaseSource(exec)}
+	// ExecutionID is carried into PurchaseOptions so executeSinglePurchase
+	// can tag every per-rec log line with the owning exec UUID. Without
+	// this, CloudWatch filtering by exec ID returns zero hits and a stuck
+	// or failed execution (e.g. issue #667's context-deadline timeout)
+	// can't be correlated to the cloud SDK call that produced it.
+	opts := common.PurchaseOptions{
+		Source:      m.normalizePurchaseSource(exec),
+		ExecutionID: exec.ExecutionID,
+	}
 
 	// Build the list of selected indices once so the fan-out closure only
 	// has to look up rec[i] (no second pass over the full slice).
 	selected := selectedIndices(exec.Recommendations)
 	if len(selected) == 0 {
+		logging.Infof("purchase[%s]: no selected recommendations, nothing to execute (account=%s plan=%q)",
+			exec.ExecutionID, accountID, plan.Name)
 		return 0, 0, nil
 	}
+	logging.Infof("purchase[%s]: dispatching %d recommendation(s) for account=%s plan=%q",
+		exec.ExecutionID, len(selected), accountID, plan.Name)
 
 	// Each rec runs in its own goroutine so a multi-rec execution that
 	// spans providers (AWS RI + Azure reservation + GCP CUD) or services
@@ -639,20 +651,39 @@ func (m *Manager) buildPurchaseConfirmationData(exec *config.PurchaseExecution, 
 // opts carries execution-level metadata (the source surface) that providers stamp
 // onto the commitment they create.
 func (m *Manager) executeSinglePurchase(ctx context.Context, rec config.RecommendationRecord, provCfg *provider.ProviderConfig, opts common.PurchaseOptions) (common.PurchaseResult, error) {
+	// Per-purchase Info logs tagged with the owning execution ID so a
+	// CloudWatch filter on the execution UUID surfaces every step of the
+	// purchase attempt — provider construction, service-client lookup,
+	// details decode, the cloud SDK call, and the result. Issue #667
+	// surfaced that the prior flow had ZERO observable signal between the
+	// approve handler and the final aggregated error toast; a timed-out
+	// SDK call left no trace in CloudWatch beyond the wrapped error.
+	logging.Infof("purchase[%s]: starting rec %s/%s/%s/%s (count=%d term=%dyr payment=%s)",
+		opts.ExecutionID, rec.Provider, rec.Service, rec.Region, rec.ResourceType, rec.Count, rec.Term, rec.Payment)
+
 	// Create the provider
+	t0 := time.Now()
 	cloudProvider, err := m.providerFactory.CreateAndValidateProvider(ctx, rec.Provider, provCfg)
 	if err != nil {
+		logging.Errorf("purchase[%s]: provider construction failed for %s after %s: %v",
+			opts.ExecutionID, rec.Provider, time.Since(t0), err)
 		return common.PurchaseResult{}, fmt.Errorf("failed to create %s provider: %w", rec.Provider, err)
 	}
+	logging.Infof("purchase[%s]: provider %s constructed in %s", opts.ExecutionID, rec.Provider, time.Since(t0))
 
 	// Map service string to ServiceType
 	serviceType := m.mapServiceType(rec.Service)
 
 	// Get the service client for this region
+	t0 = time.Now()
 	serviceClient, err := cloudProvider.GetServiceClient(ctx, serviceType, rec.Region)
 	if err != nil {
+		logging.Errorf("purchase[%s]: service client lookup failed for %s/%s in %s after %s: %v",
+			opts.ExecutionID, rec.Provider, serviceType, rec.Region, time.Since(t0), err)
 		return common.PurchaseResult{}, fmt.Errorf("failed to get service client: %w", err)
 	}
+	logging.Infof("purchase[%s]: service client %s/%s/%s ready in %s",
+		opts.ExecutionID, rec.Provider, serviceType, rec.Region, time.Since(t0))
 
 	// Build the recommendation in common format
 	recommendation := common.Recommendation{
@@ -684,27 +715,49 @@ func (m *Manager) executeSinglePurchase(ctx context.Context, rec config.Recommen
 	// legacy non-default-engine rec as the default engine.
 	details, detailsErr := common.DecodeServiceDetailsFor(rec.Service, rec.Details)
 	if detailsErr != nil {
+		logging.Errorf("purchase[%s]: decode service details failed for %s rec %s: %v",
+			opts.ExecutionID, rec.Service, rec.ResourceType, detailsErr)
 		return common.PurchaseResult{}, fmt.Errorf("decode service details for %s rec %s: %w", rec.Service, rec.ResourceType, detailsErr)
 	}
 	if details != nil {
 		applyEngineFallback(details, rec.Engine)
 		recommendation.Details = details
 	}
+	// One log line capturing the details shape that's about to drive
+	// findOfferingID. detailsAbsent=true is the legacy-row fallback
+	// (issue #453) and a strong indicator that filters will fall back
+	// to defaults — surface it so a "no offerings found" failure is
+	// linkable to a stale rec rather than a transient AWS issue.
+	logging.Infof("purchase[%s]: details ready for %s/%s (detailsAbsent=%v engine=%q idempotencyToken=%q)",
+		opts.ExecutionID, rec.Provider, rec.Service, len(rec.Details) == 0, rec.Engine, opts.IdempotencyToken)
 
-	// Execute the purchase
+	// Execute the purchase. This is the call that hits the cloud SDK
+	// (and ultimately the AWS / Azure / GCP API). Time it explicitly so
+	// CloudWatch shows whether a failure came from the SDK call itself
+	// (which the AWS SDK retries up to 3× × 30s by default) versus
+	// something earlier in the flow — issue #667.
+	tCall := time.Now()
 	result, err := serviceClient.PurchaseCommitment(ctx, recommendation, opts)
+	elapsed := time.Since(tCall)
 	if err != nil {
+		logging.Errorf("purchase[%s]: %s/%s/%s/%s PurchaseCommitment failed after %s: %v",
+			opts.ExecutionID, rec.Provider, rec.Service, rec.Region, rec.ResourceType, elapsed, err)
 		return result, fmt.Errorf("purchase failed: %w", err)
 	}
 
 	if !result.Success {
 		if result.Error != nil {
+			logging.Errorf("purchase[%s]: %s/%s/%s/%s PurchaseCommitment returned Success=false after %s: %v",
+				opts.ExecutionID, rec.Provider, rec.Service, rec.Region, rec.ResourceType, elapsed, result.Error)
 			return result, result.Error
 		}
+		logging.Errorf("purchase[%s]: %s/%s/%s/%s PurchaseCommitment returned Success=false after %s (no error detail)",
+			opts.ExecutionID, rec.Provider, rec.Service, rec.Region, rec.ResourceType, elapsed)
 		return result, fmt.Errorf("purchase was not successful")
 	}
 
-	logging.Infof("Successfully purchased %s: %s", rec.ResourceType, result.CommitmentID)
+	logging.Infof("purchase[%s]: %s/%s/%s/%s PurchaseCommitment succeeded in %s (commitmentID=%s, cost=%.2f)",
+		opts.ExecutionID, rec.Provider, rec.Service, rec.Region, rec.ResourceType, elapsed, result.CommitmentID, result.Cost)
 	return result, nil
 }
 

--- a/internal/purchase/execution_test.go
+++ b/internal/purchase/execution_test.go
@@ -136,6 +136,7 @@ func TestManager_ExecutePurchase_WebSourcePropagates(t *testing.T) {
 		common.PurchaseOptions{
 			Source:           common.PurchaseSourceWeb,
 			IdempotencyToken: common.DeriveIdempotencyToken("exec-web", 0),
+			ExecutionID:      "exec-web",
 		},
 	).Return(common.PurchaseResult{Success: true, CommitmentID: "ri-web"}, nil)
 
@@ -191,6 +192,7 @@ func TestManager_ExecutePurchase_InvalidSourceFallsBackUntagged(t *testing.T) {
 		common.PurchaseOptions{
 			Source:           "",
 			IdempotencyToken: common.DeriveIdempotencyToken("exec-bad", 0),
+			ExecutionID:      "exec-bad",
 		},
 	).Return(common.PurchaseResult{Success: true, CommitmentID: "ri-bad"}, nil)
 

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -286,6 +286,12 @@ type PurchaseOptions struct {
 	// purchase path, which has no owning execution, leaves it empty and keeps
 	// its prior non-idempotent behaviour).
 	IdempotencyToken string
+	// ExecutionID, when non-empty, is the purchase_executions row UUID that
+	// owns this purchase attempt. Carried so the purchase-execution flow can
+	// emit log lines tagged with the execution ID for correlation with the
+	// CloudWatch / DB execution row (issue #667). The CLI purchase path has
+	// no owning execution and leaves it empty.
+	ExecutionID string
 }
 
 // NormalizeSource lowercases s and returns it when it matches an allowed


### PR DESCRIPTION
## Summary

The purchase-execution flow had **zero Info-level observability** between the approve handler and the final aggregated error toast. QA reported a `context deadline exceeded` on EC2 `DescribeReservedInstancesOfferings` (issue #667) and CloudWatch had **no log lines** to confirm which rec ran, what details were used, or how long the SDK call took. The only existing log was a single `Purchasing:` Info line from the fan-out closure.

This PR adds execution-tagged logging at every critical step in `executeSinglePurchase` + `processPurchaseRecommendations` so a CloudWatch filter on the execution UUID surfaces the full per-rec trace.

## What changed

- **`pkg/common/types.go`** — added `ExecutionID string` to `PurchaseOptions` with doc comment explaining the propagation contract.
- **`internal/purchase/execution.go`**:
  - `processPurchaseRecommendations` populates `opts.ExecutionID = exec.ExecutionID` and logs `dispatching N recommendation(s)` at entry.
  - `executeSinglePurchase` now logs:
    - `starting rec <prov>/<svc>/<region>/<sku> (count=N term=Tyr payment=P)`
    - `provider <prov> constructed in <ms>` (or Error on failure)
    - `service client <prov>/<svc>/<region> ready in <ms>` (or Error)
    - `details ready for <prov>/<svc> (detailsAbsent=<bool> engine=<e> idempotencyToken=<tok>)` — the `detailsAbsent` flag is the diagnostic for legacy-row code path from issue #453
    - `<rec-tuple> PurchaseCommitment succeeded in <ms> (commitmentID=<id>, cost=<n>)` on success
    - `<rec-tuple> PurchaseCommitment failed after <ms>: <err>` on error (so a slow SDK call shows the elapsed wall clock)
- **`internal/purchase/execution_test.go`** — updated two tests (`TestManager_ExecutePurchase_WebSourcePropagates`, `TestManager_ExecutePurchase_InvalidSourceFallsBackUntagged`) to include `ExecutionID` in the expected `PurchaseOptions` literal.

## Why it matters

Diagnosing #667 (and similar future failures) currently requires guessing at where in the flow the SDK retry storm consumed the Lambda budget. With this PR, a single CloudWatch query filters the entire purchase timeline by exec ID:

```
filter @message like /purchase\[<exec-id>\]/
| sort @timestamp asc
```

Operators see: provider/service-client construction time, whether `detailsAbsent=true` (signal that legacy fallback fired), and the exact elapsed time the cloud SDK call took before erroring. A 60s+ elapsed on `PurchaseCommitment failed` confirms #667's retry-storm diagnosis; sub-second timings rule it out.

## Test plan

- [x] `go test ./internal/purchase/... -count=1 -short` — 161/161 pass
- [x] `go build ./...` — clean
- [ ] Sanity log capture from one happy-path and one failure-path test confirming the new lines appear
- [ ] Post-merge: re-deploy + re-run QA's failing scenario; verify CloudWatch now shows the per-rec trace tagged with the new exec ID

## Cross-references

- Refs #667 (the timeout that surfaced this logging gap)
- Refs #632 (the related status-stranding bug — separate fix scope)
- Doesn't close any single issue; this is a diagnostic-quality improvement that unblocks debugging the next purchase failure


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced logging for purchase operations with improved execution tracking and correlation.
  * Added detailed timing information around provider construction, service client lookup, and purchase commitment processing.
  * Improved error logging to include commitmentID and cost on successful purchases, and elapsed time on failures.
  * Added logging when no recommendations are selected during purchase processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/668?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->