### PR TITLE
fix(execution): recover from panics inside FanOutWithConcurrency goroutines (closes #669)

### DIFF
--- a/internal/execution/fanout.go
+++ b/internal/execution/fanout.go
@@ -3,9 +3,13 @@ package execution
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"runtime"
 	"strconv"
 	"sync"
+
+	"github.com/LeanerCloud/CUDly/pkg/logging"
 )
 
 // ConcurrencyFromEnv reads the CUDLY_MAX_ACCOUNT_PARALLELISM env var and
@@ -69,6 +73,25 @@ func FanOutWithConcurrency[T any](
 		go func(idx int, accountID string) {
 			defer wg.Done()
 			defer func() { <-sem }() // release slot
+			// recover() guard so a panic inside fn (nil deref, type
+			// assertion failure, slice OOB, etc.) doesn't crash the
+			// whole Lambda process and strand the purchase execution
+			// at 'approved' with no way to debug post-mortem (issue
+			// #669). Surface the panic as an Err on the result slot
+			// so the parent aggregator records it on the execution
+			// row exactly like a regular fn-returned error, and log
+			// the goroutine stack at Error level for diagnosis.
+			defer func() {
+				if r := recover(); r != nil {
+					buf := make([]byte, 4096)
+					n := runtime.Stack(buf, false)
+					logging.Errorf("fan-out goroutine panic (account=%s): %v\n%s", accountID, r, buf[:n])
+					results[idx] = Result[T]{
+						AccountID: accountID,
+						Err:       fmt.Errorf("panic during fan-out (account=%s): %v", accountID, r),
+					}
+				}
+			}()
 			val, err := fn(ctx, accountID)
 			results[idx] = Result[T]{AccountID: accountID, Value: val, Err: err}
 		}(i, id)

--- a/internal/execution/fanout_test.go
+++ b/internal/execution/fanout_test.go
@@ -81,3 +81,37 @@ func TestPartition(t *testing.T) {
 	require.Len(t, failures, 1)
 	assert.Equal(t, "b", failures[0].AccountID)
 }
+
+// TestFanOut_PanicInFn asserts that a panic inside the per-item function is
+// caught by the goroutine's deferred recover, converted to an Err on that
+// item's result slot, and does NOT propagate up and crash the whole process
+// (which would strand the surrounding purchase execution at 'approved' and
+// terminate the Lambda invocation abnormally — see #669).
+func TestFanOut_PanicInFn(t *testing.T) {
+	ids := []string{"a", "panic-me", "c"}
+	results := FanOut(context.Background(), ids, func(ctx context.Context, id string) (string, error) {
+		if id == "panic-me" {
+			panic("synthetic panic for test")
+		}
+		return "ok:" + id, nil
+	})
+
+	require.Len(t, results, 3)
+	// Map by AccountID since FanOut order is non-deterministic.
+	byID := make(map[string]Result[string], len(results))
+	for _, r := range results {
+		byID[r.AccountID] = r
+	}
+
+	// Non-panicking items still succeed.
+	assert.NoError(t, byID["a"].Err)
+	assert.Equal(t, "ok:a", byID["a"].Value)
+	assert.NoError(t, byID["c"].Err)
+	assert.Equal(t, "ok:c", byID["c"].Value)
+
+	// The panicking item is surfaced as an Err containing the panic value.
+	require.Error(t, byID["panic-me"].Err)
+	assert.Contains(t, byID["panic-me"].Err.Error(), "panic during fan-out")
+	assert.Contains(t, byID["panic-me"].Err.Error(), "synthetic panic for test")
+	assert.Contains(t, byID["panic-me"].Err.Error(), "panic-me")
+}


### PR DESCRIPTION
## Summary

Defence-in-depth for `internal/execution/FanOutWithConcurrency`. Before this change, any panic inside `fn` (nil deref, type assertion failure, slice OOB in a future refactor) propagated up the unrecovered goroutine and crashed the entire Lambda process. Consequences:

- Purchase execution row stays at `approved` with no transition to `failed` (the aggregator that would record the failure never runs).
- Lambda invocation terminates abnormally; CloudWatch may not flush the final log lines.
- User sees a generic Lambda invocation error rather than the actual panic detail.

The fan-out helper now installs a deferred `recover()` in every goroutine that:
1. Converts the panic into a structured `Err` on the per-item `Result` slot.
2. Logs the goroutine stack at Error level for post-mortem.
3. Lets the parent aggregator process the failure exactly like a normal `fn`-returned error.

## Why now?

Current call sites in `internal/purchase/execution.go` (per-account `executeForAccount` + per-rec `processPurchaseRecommendations`) have no obvious panic source today, so this is cheap insurance, not a bug fix. But the failure mode is catastrophic (whole-Lambda crash + stranded execution at `approved`), and the cost is ~10 lines with zero perf impact. Found during the concurrency-audit pass on #667 + #632; filed as #669.

## What changed

- `internal/execution/fanout.go`: added a deferred `recover()` inside the goroutine launched by `FanOutWithConcurrency`. Captures the panic value + stack via `runtime.Stack`, logs at Error, and writes a structured error to `results[idx]`.
- `internal/execution/fanout_test.go`: new test `TestFanOut_PanicInFn` panics from `fn` for one of three items, asserts the panicking item carries an `Err` containing the panic value AND that the other two items still succeed — i.e. one goroutine's panic doesn't cascade across the fan-out.

## Test plan

- [x] `go test ./internal/execution/... ./internal/purchase/... -count=1 -short` — 174/174 pass
- [x] `go build ./...` — clean
- [ ] Optional post-merge: induce a deliberate panic in a test executeSinglePurchase to verify end-to-end that the execution row transitions to `failed` (not `approved`) with the panic visible in `exec.Error`

## Cross-references

- Closes #669
- Refs #632 (status stranding when sync execute fails — recover() reduces one cause of this)
- Refs #667 (the context-deadline timeout that prompted the concurrency audit; this PR is from that same audit, not the fix for #667 itself)
- Original commit was pushed onto `fix/purchases-add-execution-logging` (PR #668) after that PR had already merged with only the logging commit — this PR is the orphaned recover() commit landed cleanly on its own branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced concurrent processing to gracefully handle failures; individual operations that encounter issues now return errors instead of causing unexpected terminations, ensuring more robust batch processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/670?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->