### PR TITLE
test(azure/savings-plans): cover unsupported payment option in GetOfferingDetails

### DIFF
--- a/providers/azure/services/savingsplans/client_test.go
+++ b/providers/azure/services/savingsplans/client_test.go
@@ -389,6 +389,19 @@ func TestGetOfferingDetails_BadTerm(t *testing.T) {
 	assert.Contains(t, err.Error(), "unsupported savings plan term")
 }
 
+func TestGetOfferingDetails_BadPaymentOption(t *testing.T) {
+	c := NewClient(nil, "sub", "eastus")
+	rec := common.Recommendation{
+		Term:          "1yr",
+		PaymentOption: "Quarterly",
+		Details:       &common.SavingsPlanDetails{PlanType: "Compute", HourlyCommitment: 1.0},
+	}
+
+	_, err := c.GetOfferingDetails(context.Background(), rec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported payment option")
+}
+
 func TestGetOfferingDetails_WrongDetails(t *testing.T) {
 	c := NewClient(nil, "sub", "eastus")
 	rec := common.Recommendation{Term: "1yr", Details: nil}


### PR DESCRIPTION
Adds the regression test CodeRabbit requested on PR #592 (already merged). #592 fixed the payment-option switch to return an error on an unrecognized option rather than silently falling back to no-upfront, but the guarding test was missing. This adds TestGetOfferingDetails_BadPaymentOption asserting an unsupported option (Quarterly) returns an 'unsupported payment option' error and does not fall back. savingsplans suite 35/35 green.