### PR TITLE
ci(pre-commit): auth tflint via GITHUB_TOKEN + retry transient flakes (closes #564)

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,7 +13,13 @@ jobs:
   pre-commit:
     name: Run pre-commit hooks
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # 35 minutes accommodates the 3-attempt retry wrapper on the
+    # `Run pre-commit` step below (3 attempts * 10 min per-attempt
+    # timeout + 2 * 90 s retry waits = 33 min worst case) plus a
+    # small margin for setup/install steps. Without the bump, the
+    # job-level cap killed any retry attempt before it could start,
+    # making the retry policy ineffective (CR finding on #697).
+    timeout-minutes: 35
     steps:
       - name: Checkout code
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -199,7 +205,7 @@ jobs:
           SKIP: terraform_validate
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          timeout_minutes: 15
+          timeout_minutes: 10
           max_attempts: 3
           retry_wait_seconds: 90
           command: pre-commit run --all-files

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -180,6 +180,26 @@ jobs:
         # run and catch the syntax/style issues that terraform_validate
         # would catch; the deeper schema validation runs in
         # `terraform plan` during deploy workflows.
+        #
+        # GITHUB_TOKEN is passed so terraform_tflint's `tflint --init`
+        # step authenticates against the GitHub API (5000/hr per-token)
+        # when it downloads ruleset plugin releases. Without the token,
+        # tflint goes anonymous and hits the 60/hr per-IP limit shared
+        # across every workflow on the runner's NAT IP, which trips
+        # intermittently when PRs land in the same hour (issue #564).
+        #
+        # nick-fields/retry wraps the run with up to 3 attempts and a
+        # 90-second wait so transient flakes (GitHub Releases blips,
+        # tflint plugin download timeouts, etc.) do not require a
+        # manual rerun. The GITHUB_TOKEN fix above is the primary fix;
+        # the retry wrapper is the cheap defense-in-depth for the
+        # residual flakes that token alone cannot eliminate.
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         env:
           SKIP: terraform_validate
-        run: pre-commit run --all-files
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          retry_wait_seconds: 90
+          command: pre-commit run --all-files


### PR DESCRIPTION
## Summary

Fixes the recurring `Run pre-commit` CI failure (issue #564) caused by `terraform_tflint`'s `tflint --init` hitting the GitHub Releases API anonymously. Two-part fix:

1. **Expose `secrets.GITHUB_TOKEN`** to the `Run pre-commit` step. `tflint --init` reads `GITHUB_TOKEN` natively; with it set the rate limit jumps from 60/hr per shared runner IP to 5000/hr per workflow-run token. Eliminates the rate-limit failure class entirely.

2. **Wrap with `nick-fields/retry@v3.0.2`** (SHA-pinned at `ce71cc2ab81d554ebbe88c79ab5975992d79ba08` per project policy `feedback_sha_pin_current_major.md`): 3 attempts with 90s wait, 15-minute timeout. Defense-in-depth for the residual transient flakes (GitHub Releases availability blips, plugin download timeouts) that the token cannot fix.

Most recent observation of this failure: PR #696's [pre-commit job](https://github.com/LeanerCloud/CUDly/actions/runs/26411029351). The actual code in that PR was clean; only this CI-infra hook tripped.

## Diff

`.github/workflows/pre-commit.yml` (+21/-1):

- Added `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to the step's `env:` block.
- Changed the step from `run:` to `uses: nick-fields/retry@<SHA> # v3.0.2` with `command:` carrying the previous shell line.
- Comment block explains both the token fix (issue #564 root cause) and the retry wrapper (defense in depth).

## Test plan

- [x] Local YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] CI's own `Run pre-commit` job for this PR is the first end-to-end test (this commit is intentionally tiny and self-validating)
- [ ] Three consecutive CI runs across PRs in the same hour all pass without a tflint rate-limit failure (post-merge observation; acceptance criterion from #564)

## Cross-references

- Closes #564
- Triggered by the PR #696 failure mode
- Memory entries applied: `feedback_sha_pin_current_major.md` (SHA-pinned action), `feedback_ci_tool_version_pin.md` (tflint version is already pinned elsewhere in the workflow)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved reliability of pre-commit checks in CI by adding retry attempts and increasing step timeouts.
  * Extended overall workflow timeout to allow longer runs and accommodate retries.
  * Set authentication for hook downloads to ensure terraform/tflint-related hooks can fetch resources while preserving an existing skip for terraform validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/697?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->