### PR TITLE
fix(config): accept provider-canonical payment options in plan validator

### DIFF
--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -10,8 +10,44 @@ import (
 // ValidProviders lists all supported cloud providers
 var ValidProviders = []string{"aws", "azure", "gcp"}
 
-// ValidPaymentOptions lists all supported payment options
+// ValidPaymentOptions lists the AWS-canonical payment options. Kept for
+// backwards compatibility; prefer ValidPaymentOptionsByProvider for
+// provider-aware validation.
 var ValidPaymentOptions = []string{"no-upfront", "partial-upfront", "all-upfront"}
+
+// ValidPaymentOptionsByProvider maps each provider to the payment option
+// tokens it accepts. Azure and GCP reservations use "upfront" (all-upfront
+// billing) and "monthly" (no-upfront / spread billing). AWS RIs/SPs use the
+// three classic tiers. See providers/{azure,gcp}/services/*/client.go for
+// the case statements that consume these values.
+var ValidPaymentOptionsByProvider = map[string][]string{
+	"aws":   {"no-upfront", "partial-upfront", "all-upfront"},
+	"azure": {"all-upfront", "no-upfront", "upfront", "monthly"},
+	"gcp":   {"all-upfront", "no-upfront", "upfront", "monthly"},
+}
+
+// validPaymentOptionsUnion is the union of all provider payment option sets,
+// used for global-config default validation where no provider context is
+// available. Accepts any token that is valid for at least one provider.
+var validPaymentOptionsUnion = func() []string {
+	seen := map[string]bool{}
+	var all []string
+	for _, opts := range ValidPaymentOptionsByProvider {
+		for _, o := range opts {
+			if !seen[o] {
+				seen[o] = true
+				all = append(all, o)
+			}
+		}
+	}
+	return all
+}()
+
+// validPaymentOptionsFor returns the provider-canonical payment option slice
+// for the given provider (lowercase). Returns nil when the provider is unknown.
+func validPaymentOptionsFor(provider string) []string {
+	return ValidPaymentOptionsByProvider[provider]
+}
 
 // ValidRampScheduleTypes lists all supported ramp schedule types
 var ValidRampScheduleTypes = []string{"immediate", "weekly", "monthly", "custom"}
@@ -142,10 +178,12 @@ func validateGlobalTerm(term int) error {
 	return nil
 }
 
-// validatePaymentOption validates that the payment option is valid if set
+// validatePaymentOption validates that the payment option is in the union of
+// all provider sets. Used by GlobalConfig.Validate where no provider context
+// is available; any token valid for at least one provider is accepted.
 func validatePaymentOption(payment string) error {
 	if payment != "" && !isValidPaymentOption(payment) {
-		return fmt.Errorf("invalid payment option: %s (valid: %s)", payment, strings.Join(ValidPaymentOptions, ", "))
+		return fmt.Errorf("invalid payment option: %s (valid: %s)", payment, strings.Join(validPaymentOptionsUnion, ", "))
 	}
 	return nil
 }
@@ -200,10 +238,23 @@ func (c *ServiceConfig) validateTerm() error {
 }
 
 func (c *ServiceConfig) validatePayment() error {
-	if c.Payment != "" && !isValidPaymentOption(c.Payment) {
-		return fmt.Errorf("invalid payment option: %s (valid: %s)", c.Payment, strings.Join(ValidPaymentOptions, ", "))
+	if c.Payment == "" {
+		return nil
 	}
-	return nil
+	// Provider-canonical validation: each provider accepts only its own token
+	// set. A cross-provider token (e.g. "all-upfront" on an Azure service) is
+	// rejected even though that token is valid somewhere else.
+	opts := validPaymentOptionsFor(c.Provider)
+	if opts == nil {
+		// Provider was already validated; unknown provider here is a bug.
+		return fmt.Errorf("internal error: no payment options defined for provider %q", c.Provider)
+	}
+	for _, v := range opts {
+		if c.Payment == v {
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid payment option: %s (valid for %s: %s)", c.Payment, c.Provider, strings.Join(opts, ", "))
 }
 
 func (c *ServiceConfig) validateConfigCoverage() error {
@@ -297,7 +348,7 @@ func isValidProvider(p string) bool {
 }
 
 func isValidPaymentOption(p string) bool {
-	for _, valid := range ValidPaymentOptions {
+	for _, valid := range validPaymentOptionsUnion {
 		if p == valid {
 			return true
 		}

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -347,6 +347,8 @@ func isValidProvider(p string) bool {
 	return false
 }
 
+// isValidPaymentOption reports whether p is a valid payment option for any
+// provider. It checks against the union of all provider payment option sets.
 func isValidPaymentOption(p string) bool {
 	for _, valid := range validPaymentOptionsUnion {
 		if p == valid {

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -44,16 +44,24 @@ var ValidPaymentOptions = []string{"no-upfront", "partial-upfront", "all-upfront
 //     recommendations are not currently emitted — GetRecommendations returns
 //     []; the canonical set follows the only path that emits today.)
 //
-//   - GCP  : {upfront, monthly}
-//     CUD purchase model has only one-time upfront vs monthly recurring. See:
-//     providers/gcp/services/computeengine/client.go:587-591
-//     providers/gcp/services/cloudsql/client.go:288-292
-//     providers/gcp/services/cloudstorage/client.go:297-301
-//     providers/gcp/services/memorystore/client.go:245-249
+//   - GCP  : {monthly}
+//     GCP CUDs are inherently monthly-billed across the term — the GCP CUD
+//     purchase API only takes a Plan (TWELVE_MONTH / THIRTY_SIX_MONTH), not a
+//     payment-option discriminator (see
+//     providers/gcp/services/computeengine/client.go:350-373 where
+//     buildCommitmentRequests sets Plan from rec.Term and never reads
+//     PaymentOption). The per-service pricing switches at
+//     providers/gcp/services/computeengine/client.go:587-591,
+//     providers/gcp/services/cloudsql/client.go:288-292,
+//     providers/gcp/services/cloudstorage/client.go:297-301,
+//     providers/gcp/services/memorystore/client.go:245-249 alias "upfront"
+//     and "all-upfront" only for compatibility with downstream code that
+//     expects a payment-option token; semantically GCP exposes one billing
+//     plan and the validator surfaces that explicitly.
 var ValidPaymentOptionsByProvider = map[string][]string{
 	"aws":   {"no-upfront", "partial-upfront", "all-upfront"},
 	"azure": {"upfront", "monthly"},
-	"gcp":   {"upfront", "monthly"},
+	"gcp":   {"monthly"},
 }
 
 // validPaymentOptionsUnion is the union of all provider payment option sets,
@@ -88,21 +96,30 @@ func validPaymentOptionsFor(provider string) []string {
 // persisted and later validated against the provider-canonical set.
 //
 // Returns (canonical, true) when raw is already canonical for the provider
-// or has an unambiguous canonical mapping. Returns ("", false) only for
-// unknown providers — every known cross-provider AWS-style token maps to a
-// canonical value:
+// or has an unambiguous canonical mapping. Returns ("", false) for unknown
+// providers and (raw, false) for tokens that have no canonical mapping on
+// the given provider (e.g. an Azure/GCP-style "upfront" on AWS) — callers
+// can use ok=false to surface the unmapped token at the next validator
+// boundary. Per-provider mapping:
 //
 //   - AWS  : passthrough (AWS already speaks the three-tier set).
 //   - Azure: all-upfront → upfront, no-upfront → monthly,
-//     partial-upfront → upfront (no semantic equivalent — coerce to nearest
+//     partial-upfront → upfront (no semantic equivalent — coerce to the
 //     all-upfront tier rather than drop the rec; caller may log).
-//   - GCP  : all-upfront → upfront, no-upfront → monthly,
-//     partial-upfront → upfront (same rationale as Azure).
+//   - GCP  : all-upfront → monthly, no-upfront → monthly,
+//     partial-upfront → monthly, upfront → monthly (GCP CUDs are
+//     inherently monthly-billed — every non-monthly token collapses to the
+//     one billing plan GCP actually models). The collapse from "upfront" to
+//     "monthly" is what makes the existing
+//     providers/gcp/services/computeengine/client.go:804 stamp safe: the
+//     scheduler.convertRecommendations boundary coerces it once before
+//     persistence so the rec carries the canonical token downstream.
 //
-// The partial-upfront coercion is deliberate: dropping the rec would be a
-// silent data loss for the user, while coercing to the all-upfront tier
-// preserves the rec at the closest billing model the provider offers. The
-// caller is expected to log a warning so an operator notices the input bug.
+// The partial-upfront coercion is deliberate on both Azure and GCP: dropping
+// the rec would be a silent data loss for the user, while coercing to the
+// closest billing model the provider offers preserves the rec. The caller is
+// expected to log a warning when raw != canonical so an operator notices the
+// upstream input bug.
 //
 // Empty raw passes through as ("", true) — callers that distinguish "unset"
 // from "invalid" can check the returned bool only when raw is non-empty.
@@ -119,24 +136,45 @@ func NormalizePaymentOption(provider, raw string) (string, bool) {
 			return raw, true
 		}
 	}
-	// Cross-provider AWS-style tokens that have a canonical equivalent in
-	// the Azure/GCP two-tier model.
-	if provider == "azure" || provider == "gcp" {
-		switch raw {
-		case "all-upfront":
-			return "upfront", true
-		case "no-upfront":
-			return "monthly", true
-		case "partial-upfront":
-			// No semantic equivalent — coerce to the all-upfront tier so the
-			// rec survives validation; caller should WARN-log the substitution
-			// so an operator can fix the upstream stamping bug.
-			return "upfront", true
-		}
+	// Cross-provider tokens that have a canonical equivalent in the target
+	// provider's billing model. Each provider's mapping is delegated to a
+	// helper to keep cyclomatic complexity below the project limit.
+	if canon, ok := crossProviderPaymentAlias(provider, raw); ok {
+		return canon, true
 	}
 	// Anything else (including Azure/GCP-style tokens on AWS) is left as-is
 	// and will surface as a validation error at the next boundary.
 	return raw, false
+}
+
+// crossProviderPaymentAlias maps an AWS-style (or Azure-style on GCP) token
+// onto the target provider's canonical token. Returns (canonical, true) when
+// a mapping exists, ("", false) when none does. Split out of
+// NormalizePaymentOption purely to keep that function under the project's
+// gocyclo limit; the policy lives here.
+func crossProviderPaymentAlias(provider, raw string) (string, bool) {
+	switch provider {
+	case "azure":
+		// Azure reservations model both billing plans; coerce AWS-style tokens
+		// to the Azure-canonical spelling. partial-upfront has no Azure
+		// equivalent — coerce to the all-upfront tier so the rec survives
+		// validation rather than dropping silently (caller WARN-logs).
+		switch raw {
+		case "all-upfront", "partial-upfront":
+			return "upfront", true
+		case "no-upfront":
+			return "monthly", true
+		}
+	case "gcp":
+		// GCP commitments are monthly-only — every non-monthly token (AWS-style
+		// or the legacy "upfront" some GCP code paths still stamp) collapses
+		// to "monthly", the one billing plan GCP semantically models.
+		switch raw {
+		case "all-upfront", "no-upfront", "partial-upfront", "upfront":
+			return "monthly", true
+		}
+	}
+	return "", false
 }
 
 // ValidRampScheduleTypes lists all supported ramp schedule types

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -79,6 +79,66 @@ func validPaymentOptionsFor(provider string) []string {
 	return ValidPaymentOptionsByProvider[provider]
 }
 
+// NormalizePaymentOption maps a raw payment-option token onto the canonical
+// token the given provider semantically models (see ValidPaymentOptionsByProvider).
+// It exists so the recommendation-emission boundary (see
+// internal/scheduler/scheduler.go:convertRecommendations) can defensively
+// canonicalize any AWS-style token that a code path or a globally-default
+// payment-option setting might stamp onto a non-AWS rec, before the rec is
+// persisted and later validated against the provider-canonical set.
+//
+// Returns (canonical, true) when raw is already canonical for the provider
+// or has an unambiguous canonical mapping. Returns ("", false) only for
+// unknown providers — every known cross-provider AWS-style token maps to a
+// canonical value:
+//
+//   - AWS  : passthrough (AWS already speaks the three-tier set).
+//   - Azure: all-upfront → upfront, no-upfront → monthly,
+//     partial-upfront → upfront (no semantic equivalent — coerce to nearest
+//     all-upfront tier rather than drop the rec; caller may log).
+//   - GCP  : all-upfront → upfront, no-upfront → monthly,
+//     partial-upfront → upfront (same rationale as Azure).
+//
+// The partial-upfront coercion is deliberate: dropping the rec would be a
+// silent data loss for the user, while coercing to the all-upfront tier
+// preserves the rec at the closest billing model the provider offers. The
+// caller is expected to log a warning so an operator notices the input bug.
+//
+// Empty raw passes through as ("", true) — callers that distinguish "unset"
+// from "invalid" can check the returned bool only when raw is non-empty.
+func NormalizePaymentOption(provider, raw string) (string, bool) {
+	if _, known := ValidPaymentOptionsByProvider[provider]; !known {
+		return "", false
+	}
+	if raw == "" {
+		return "", true
+	}
+	// Already canonical for this provider: passthrough.
+	for _, v := range ValidPaymentOptionsByProvider[provider] {
+		if raw == v {
+			return raw, true
+		}
+	}
+	// Cross-provider AWS-style tokens that have a canonical equivalent in
+	// the Azure/GCP two-tier model.
+	if provider == "azure" || provider == "gcp" {
+		switch raw {
+		case "all-upfront":
+			return "upfront", true
+		case "no-upfront":
+			return "monthly", true
+		case "partial-upfront":
+			// No semantic equivalent — coerce to the all-upfront tier so the
+			// rec survives validation; caller should WARN-log the substitution
+			// so an operator can fix the upstream stamping bug.
+			return "upfront", true
+		}
+	}
+	// Anything else (including Azure/GCP-style tokens on AWS) is left as-is
+	// and will surface as a validation error at the next boundary.
+	return raw, false
+}
+
 // ValidRampScheduleTypes lists all supported ramp schedule types
 var ValidRampScheduleTypes = []string{"immediate", "weekly", "monthly", "custom"}
 

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -16,14 +16,44 @@ var ValidProviders = []string{"aws", "azure", "gcp"}
 var ValidPaymentOptions = []string{"no-upfront", "partial-upfront", "all-upfront"}
 
 // ValidPaymentOptionsByProvider maps each provider to the payment option
-// tokens it accepts. Azure and GCP reservations use "upfront" (all-upfront
-// billing) and "monthly" (no-upfront / spread billing). AWS RIs/SPs use the
-// three classic tiers. See providers/{azure,gcp}/services/*/client.go for
-// the case statements that consume these values.
+// tokens it accepts. The sets are tightened to the canonical tokens each
+// provider actually models semantically; AWS-style aliases the service
+// clients also accept (for legacy frontend compat) are deliberately not
+// surfaced here — config-layer validation rejects them so input bugs aren't
+// hidden behind silent alias coercion in the service-client switches.
+// Callers that need to translate legacy/cross-provider tokens into the
+// canonical form should use NormalizePaymentOption at the emission boundary
+// (see internal/scheduler/scheduler.go:convertRecommendations).
+//
+// Canonical sets, verified against the per-service purchase/pricing switches:
+//
+//   - AWS  : {no-upfront, partial-upfront, all-upfront}
+//     Three distinct billing tiers exposed by RI/SP offering APIs.
+//
+//   - Azure: {upfront, monthly}
+//     Reservation purchases only model two billing plans. See:
+//     providers/azure/services/compute/client.go:493-497
+//     providers/azure/services/cache/client.go:375-379
+//     providers/azure/services/cosmosdb/client.go:368-372
+//     providers/azure/services/database/client.go:376-380
+//     providers/azure/services/search/client.go:349-353
+//     providers/azure/services/synapse/client.go:354-358
+//     providers/azure/services/managedredis/client.go:345-349
+//     (The savingsplans switch at providers/azure/services/savingsplans/
+//     client.go:418-429 mirrors AWS's three-tier set, but Azure savings-plan
+//     recommendations are not currently emitted — GetRecommendations returns
+//     []; the canonical set follows the only path that emits today.)
+//
+//   - GCP  : {upfront, monthly}
+//     CUD purchase model has only one-time upfront vs monthly recurring. See:
+//     providers/gcp/services/computeengine/client.go:587-591
+//     providers/gcp/services/cloudsql/client.go:288-292
+//     providers/gcp/services/cloudstorage/client.go:297-301
+//     providers/gcp/services/memorystore/client.go:245-249
 var ValidPaymentOptionsByProvider = map[string][]string{
 	"aws":   {"no-upfront", "partial-upfront", "all-upfront"},
-	"azure": {"all-upfront", "no-upfront", "upfront", "monthly"},
-	"gcp":   {"all-upfront", "no-upfront", "upfront", "monthly"},
+	"azure": {"upfront", "monthly"},
+	"gcp":   {"upfront", "monthly"},
 }
 
 // validPaymentOptionsUnion is the union of all provider payment option sets,

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -4,6 +4,7 @@ package config
 import (
 	"fmt"
 	"net/mail"
+	"sort"
 	"strings"
 )
 
@@ -67,6 +68,8 @@ var ValidPaymentOptionsByProvider = map[string][]string{
 // validPaymentOptionsUnion is the union of all provider payment option sets,
 // used for global-config default validation where no provider context is
 // available. Accepts any token that is valid for at least one provider.
+// The slice is sorted so that validation error messages are deterministic
+// across runs (map iteration order in Go is non-deterministic).
 var validPaymentOptionsUnion = func() []string {
 	seen := map[string]bool{}
 	var all []string
@@ -78,6 +81,7 @@ var validPaymentOptionsUnion = func() []string {
 			}
 		}
 	}
+	sort.Strings(all)
 	return all
 }()
 

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -17,48 +17,29 @@ var ValidProviders = []string{"aws", "azure", "gcp"}
 var ValidPaymentOptions = []string{"no-upfront", "partial-upfront", "all-upfront"}
 
 // ValidPaymentOptionsByProvider maps each provider to the payment option
-// tokens it accepts. The sets are tightened to the canonical tokens each
-// provider actually models semantically; AWS-style aliases the service
-// clients also accept (for legacy frontend compat) are deliberately not
-// surfaced here — config-layer validation rejects them so input bugs aren't
-// hidden behind silent alias coercion in the service-client switches.
-// Callers that need to translate legacy/cross-provider tokens into the
-// canonical form should use NormalizePaymentOption at the emission boundary
-// (see internal/scheduler/scheduler.go:convertRecommendations).
+// tokens it accepts. Each provider's set is the canonical set verified
+// against the provider's service-client switch statements:
 //
-// Canonical sets, verified against the per-service purchase/pricing switches:
+//   - aws:   {no-upfront, partial-upfront, all-upfront}: the three RI/SP
+//     billing tiers exposed by AWS APIs.
 //
-//   - AWS  : {no-upfront, partial-upfront, all-upfront}
-//     Three distinct billing tiers exposed by RI/SP offering APIs.
+//   - azure: {upfront, monthly}: verified against the 7 Azure service-client
+//     switches in providers/azure/services/{compute,cache,cosmosdb,database,
+//     search,synapse,managedredis}/client.go. (The savingsplans client mirrors
+//     AWS's three-tier set, but Azure savings-plan recs are not currently
+//     emitted; GetRecommendations returns []. The canonical set follows the
+//     only path that emits today.)
 //
-//   - Azure: {upfront, monthly}
-//     Reservation purchases only model two billing plans. See:
-//     providers/azure/services/compute/client.go:493-497
-//     providers/azure/services/cache/client.go:375-379
-//     providers/azure/services/cosmosdb/client.go:368-372
-//     providers/azure/services/database/client.go:376-380
-//     providers/azure/services/search/client.go:349-353
-//     providers/azure/services/synapse/client.go:354-358
-//     providers/azure/services/managedredis/client.go:345-349
-//     (The savingsplans switch at providers/azure/services/savingsplans/
-//     client.go:418-429 mirrors AWS's three-tier set, but Azure savings-plan
-//     recommendations are not currently emitted — GetRecommendations returns
-//     []; the canonical set follows the only path that emits today.)
+//   - gcp:   {monthly}: GCP CUDs are billed monthly across the commitment
+//     term; there is no upfront billing tier. See
+//     providers/gcp/services/computeengine/client.go:buildCommitmentRequests
+//     which takes only a Plan (TWELVE_MONTH/THIRTY_SIX_MONTH) and never reads
+//     PaymentOption.
 //
-//   - GCP  : {monthly}
-//     GCP CUDs are inherently monthly-billed across the term — the GCP CUD
-//     purchase API only takes a Plan (TWELVE_MONTH / THIRTY_SIX_MONTH), not a
-//     payment-option discriminator (see
-//     providers/gcp/services/computeengine/client.go:350-373 where
-//     buildCommitmentRequests sets Plan from rec.Term and never reads
-//     PaymentOption). The per-service pricing switches at
-//     providers/gcp/services/computeengine/client.go:587-591,
-//     providers/gcp/services/cloudsql/client.go:288-292,
-//     providers/gcp/services/cloudstorage/client.go:297-301,
-//     providers/gcp/services/memorystore/client.go:245-249 alias "upfront"
-//     and "all-upfront" only for compatibility with downstream code that
-//     expects a payment-option token; semantically GCP exposes one billing
-//     plan and the validator surfaces that explicitly.
+// Cross-provider tokens are rejected loudly by the validator. Legacy AWS-style
+// tokens emitted by older code paths are canonicalized via NormalizePaymentOption
+// at the rec-emission boundary BEFORE reaching this validator (see
+// internal/scheduler/scheduler.go:convertRecommendations).
 var ValidPaymentOptionsByProvider = map[string][]string{
 	"aws":   {"no-upfront", "partial-upfront", "all-upfront"},
 	"azure": {"upfront", "monthly"},

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -855,6 +855,28 @@ func TestIsValidPaymentOption(t *testing.T) {
 	assert.False(t, isValidPaymentOption(""))
 }
 
+func TestValidPaymentOptionsUnionDeterministic(t *testing.T) {
+	// validPaymentOptionsUnion must be sorted so that validation error messages
+	// that include the list of valid options are reproducible across runs.
+	// Map iteration in Go is non-deterministic; without an explicit sort the
+	// slice order can vary, making test assertions on error strings brittle.
+	expected := []string{"all-upfront", "monthly", "no-upfront", "partial-upfront", "upfront"}
+	assert.Equal(t, expected, validPaymentOptionsUnion,
+		"validPaymentOptionsUnion must be in sorted order for deterministic error messages")
+
+	// Double-check: building the union a second time (simulating another init
+	// call) must produce the same sorted result. We verify by sorting a fresh
+	// copy of the current value and confirming it is byte-equal.
+	sorted := make([]string, len(validPaymentOptionsUnion))
+	copy(sorted, validPaymentOptionsUnion)
+	// sorted is already sorted by construction; assert the slice is in order.
+	for i := 1; i < len(sorted); i++ {
+		assert.LessOrEqual(t, sorted[i-1], sorted[i],
+			"validPaymentOptionsUnion[%d] %q must be <= validPaymentOptionsUnion[%d] %q",
+			i-1, sorted[i-1], i, sorted[i])
+	}
+}
+
 func TestNormalizePaymentOption(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -390,13 +390,24 @@ func TestServiceConfig_Validate(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "azure all-upfront is valid",
+			name: "azure all-upfront is rejected (aws-only token)",
 			config: ServiceConfig{
 				Provider: "azure",
 				Service:  "vm",
 				Payment:  "all-upfront",
 			},
-			wantErr: false,
+			wantErr: true,
+			errMsg:  "invalid payment option",
+		},
+		{
+			name: "azure no-upfront is rejected (aws-only token)",
+			config: ServiceConfig{
+				Provider: "azure",
+				Service:  "vm",
+				Payment:  "no-upfront",
+			},
+			wantErr: true,
+			errMsg:  "invalid payment option",
 		},
 		{
 			name: "azure partial-upfront is rejected (aws-only token)",
@@ -407,6 +418,16 @@ func TestServiceConfig_Validate(t *testing.T) {
 			},
 			wantErr: true,
 			errMsg:  "invalid payment option",
+		},
+		{
+			name: "azure error message includes canonical set",
+			config: ServiceConfig{
+				Provider: "azure",
+				Service:  "vm",
+				Payment:  "all-upfront",
+			},
+			wantErr: true,
+			errMsg:  "valid for azure: upfront, monthly",
 		},
 		{
 			name: "gcp upfront is valid",
@@ -435,6 +456,36 @@ func TestServiceConfig_Validate(t *testing.T) {
 			},
 			wantErr: true,
 			errMsg:  "invalid payment option",
+		},
+		{
+			name: "gcp all-upfront is rejected (aws-only token)",
+			config: ServiceConfig{
+				Provider: "gcp",
+				Service:  "computeengine",
+				Payment:  "all-upfront",
+			},
+			wantErr: true,
+			errMsg:  "invalid payment option",
+		},
+		{
+			name: "gcp no-upfront is rejected (aws-only token)",
+			config: ServiceConfig{
+				Provider: "gcp",
+				Service:  "computeengine",
+				Payment:  "no-upfront",
+			},
+			wantErr: true,
+			errMsg:  "invalid payment option",
+		},
+		{
+			name: "gcp error message includes canonical set",
+			config: ServiceConfig{
+				Provider: "gcp",
+				Service:  "computeengine",
+				Payment:  "no-upfront",
+			},
+			wantErr: true,
+			errMsg:  "valid for gcp: upfront, monthly",
 		},
 		{
 			name: "coverage too low",

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -72,6 +72,23 @@ func TestGlobalConfig_Validate(t *testing.T) {
 			wantErr: true,
 			errMsg:  "invalid payment option",
 		},
+		// Issue #698: GlobalConfig accepts union of all provider payment tokens
+		{
+			name: "global config accepts azure/gcp upfront token",
+			config: GlobalConfig{
+				DefaultTerm:    3,
+				DefaultPayment: "upfront",
+			},
+			wantErr: false,
+		},
+		{
+			name: "global config accepts azure/gcp monthly token",
+			config: GlobalConfig{
+				DefaultTerm:    3,
+				DefaultPayment: "monthly",
+			},
+			wantErr: false,
+		},
 		{
 			name: "coverage too low",
 			config: GlobalConfig{
@@ -330,6 +347,91 @@ func TestServiceConfig_Validate(t *testing.T) {
 				Provider: "gcp",
 				Service:  "compute",
 				Payment:  "invalid-payment",
+			},
+			wantErr: true,
+			errMsg:  "invalid payment option",
+		},
+		// Issue #698: provider-canonical payment validation
+		{
+			name: "aws all-upfront is valid",
+			config: ServiceConfig{
+				Provider: "aws",
+				Service:  "ec2",
+				Payment:  "all-upfront",
+			},
+			wantErr: false,
+		},
+		{
+			name: "aws monthly is rejected",
+			config: ServiceConfig{
+				Provider: "aws",
+				Service:  "ec2",
+				Payment:  "monthly",
+			},
+			wantErr: true,
+			errMsg:  "invalid payment option",
+		},
+		{
+			name: "azure upfront is valid",
+			config: ServiceConfig{
+				Provider: "azure",
+				Service:  "vm",
+				Payment:  "upfront",
+			},
+			wantErr: false,
+		},
+		{
+			name: "azure monthly is valid",
+			config: ServiceConfig{
+				Provider: "azure",
+				Service:  "vm",
+				Payment:  "monthly",
+			},
+			wantErr: false,
+		},
+		{
+			name: "azure all-upfront is valid",
+			config: ServiceConfig{
+				Provider: "azure",
+				Service:  "vm",
+				Payment:  "all-upfront",
+			},
+			wantErr: false,
+		},
+		{
+			name: "azure partial-upfront is rejected (aws-only token)",
+			config: ServiceConfig{
+				Provider: "azure",
+				Service:  "vm",
+				Payment:  "partial-upfront",
+			},
+			wantErr: true,
+			errMsg:  "invalid payment option",
+		},
+		{
+			name: "gcp upfront is valid",
+			config: ServiceConfig{
+				Provider: "gcp",
+				Service:  "computeengine",
+				Payment:  "upfront",
+			},
+			wantErr: false,
+		},
+		{
+			name: "gcp monthly is valid",
+			config: ServiceConfig{
+				Provider: "gcp",
+				Service:  "computeengine",
+				Payment:  "monthly",
+			},
+			wantErr: false,
+		},
+		{
+			name: "gcp partial-upfront is rejected (aws-only token)",
+			config: ServiceConfig{
+				Provider: "gcp",
+				Service:  "computeengine",
+				Payment:  "partial-upfront",
 			},
 			wantErr: true,
 			errMsg:  "invalid payment option",
@@ -689,9 +791,14 @@ func TestIsValidProvider(t *testing.T) {
 }
 
 func TestIsValidPaymentOption(t *testing.T) {
+	// AWS tokens
 	assert.True(t, isValidPaymentOption("no-upfront"))
 	assert.True(t, isValidPaymentOption("partial-upfront"))
 	assert.True(t, isValidPaymentOption("all-upfront"))
+	// Azure/GCP tokens (union set)
+	assert.True(t, isValidPaymentOption("upfront"))
+	assert.True(t, isValidPaymentOption("monthly"))
+	// Unknown tokens rejected
 	assert.False(t, isValidPaymentOption("invalid"))
 	assert.False(t, isValidPaymentOption(""))
 }

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -430,15 +430,6 @@ func TestServiceConfig_Validate(t *testing.T) {
 			errMsg:  "valid for azure: upfront, monthly",
 		},
 		{
-			name: "gcp upfront is valid",
-			config: ServiceConfig{
-				Provider: "gcp",
-				Service:  "computeengine",
-				Payment:  "upfront",
-			},
-			wantErr: false,
-		},
-		{
 			name: "gcp monthly is valid",
 			config: ServiceConfig{
 				Provider: "gcp",
@@ -446,6 +437,16 @@ func TestServiceConfig_Validate(t *testing.T) {
 				Payment:  "monthly",
 			},
 			wantErr: false,
+		},
+		{
+			name: "gcp upfront is rejected (gcp is monthly-only)",
+			config: ServiceConfig{
+				Provider: "gcp",
+				Service:  "computeengine",
+				Payment:  "upfront",
+			},
+			wantErr: true,
+			errMsg:  "invalid payment option",
 		},
 		{
 			name: "gcp partial-upfront is rejected (aws-only token)",
@@ -485,7 +486,7 @@ func TestServiceConfig_Validate(t *testing.T) {
 				Payment:  "no-upfront",
 			},
 			wantErr: true,
-			errMsg:  "valid for gcp: upfront, monthly",
+			errMsg:  "valid for gcp: monthly",
 		},
 		{
 			name: "coverage too low",
@@ -879,13 +880,14 @@ func TestNormalizePaymentOption(t *testing.T) {
 		{"azure no-upfront → monthly", "azure", "no-upfront", "monthly", true},
 		{"azure partial-upfront → upfront (nearest)", "azure", "partial-upfront", "upfront", true},
 
-		// GCP: canonical passthrough.
-		{"gcp upfront passthrough", "gcp", "upfront", "upfront", true},
+		// GCP: canonical passthrough (monthly-only — every non-monthly token
+		// collapses to monthly because GCP CUDs only model one billing plan).
 		{"gcp monthly passthrough", "gcp", "monthly", "monthly", true},
-		// GCP: AWS-style aliases coerced to canonical.
-		{"gcp all-upfront → upfront", "gcp", "all-upfront", "upfront", true},
+		{"gcp upfront → monthly (gcp is monthly-only)", "gcp", "upfront", "monthly", true},
+		// GCP: AWS-style aliases coerced to the one canonical token.
+		{"gcp all-upfront → monthly", "gcp", "all-upfront", "monthly", true},
 		{"gcp no-upfront → monthly", "gcp", "no-upfront", "monthly", true},
-		{"gcp partial-upfront → upfront (nearest)", "gcp", "partial-upfront", "upfront", true},
+		{"gcp partial-upfront → monthly", "gcp", "partial-upfront", "monthly", true},
 
 		// Empty raw: passthrough on any known provider.
 		{"empty raw on aws", "aws", "", "", true},

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -854,6 +854,63 @@ func TestIsValidPaymentOption(t *testing.T) {
 	assert.False(t, isValidPaymentOption(""))
 }
 
+func TestNormalizePaymentOption(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		raw      string
+		want     string
+		ok       bool
+	}{
+		// AWS: passthrough for every canonical token.
+		{"aws no-upfront passthrough", "aws", "no-upfront", "no-upfront", true},
+		{"aws partial-upfront passthrough", "aws", "partial-upfront", "partial-upfront", true},
+		{"aws all-upfront passthrough", "aws", "all-upfront", "all-upfront", true},
+		// AWS: Azure/GCP-style tokens are left as-is and flagged for the
+		// next validator boundary to surface.
+		{"aws upfront left as-is", "aws", "upfront", "upfront", false},
+		{"aws monthly left as-is", "aws", "monthly", "monthly", false},
+
+		// Azure: canonical passthrough.
+		{"azure upfront passthrough", "azure", "upfront", "upfront", true},
+		{"azure monthly passthrough", "azure", "monthly", "monthly", true},
+		// Azure: AWS-style aliases coerced to canonical.
+		{"azure all-upfront → upfront", "azure", "all-upfront", "upfront", true},
+		{"azure no-upfront → monthly", "azure", "no-upfront", "monthly", true},
+		{"azure partial-upfront → upfront (nearest)", "azure", "partial-upfront", "upfront", true},
+
+		// GCP: canonical passthrough.
+		{"gcp upfront passthrough", "gcp", "upfront", "upfront", true},
+		{"gcp monthly passthrough", "gcp", "monthly", "monthly", true},
+		// GCP: AWS-style aliases coerced to canonical.
+		{"gcp all-upfront → upfront", "gcp", "all-upfront", "upfront", true},
+		{"gcp no-upfront → monthly", "gcp", "no-upfront", "monthly", true},
+		{"gcp partial-upfront → upfront (nearest)", "gcp", "partial-upfront", "upfront", true},
+
+		// Empty raw: passthrough on any known provider.
+		{"empty raw on aws", "aws", "", "", true},
+		{"empty raw on azure", "azure", "", "", true},
+		{"empty raw on gcp", "gcp", "", "", true},
+
+		// Unknown provider: ok=false, no canonicalization.
+		{"unknown provider", "ibm", "all-upfront", "", false},
+		{"empty provider", "", "monthly", "", false},
+
+		// Garbage tokens on known providers: left as-is, ok=false.
+		{"azure garbage", "azure", "ohai", "ohai", false},
+		{"gcp garbage", "gcp", "ohai", "ohai", false},
+		{"aws garbage", "aws", "ohai", "ohai", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := NormalizePaymentOption(tt.provider, tt.raw)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.ok, ok)
+		})
+	}
+}
+
 func TestIsValidRampScheduleType(t *testing.T) {
 	assert.True(t, isValidRampScheduleType("immediate"))
 	assert.True(t, isValidRampScheduleType("weekly"))

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -1102,6 +1102,26 @@ func (s *Scheduler) convertRecommendations(recs []common.Recommendation, provide
 		engine := extractEngine(rec.Details)
 		detailsBlob := marshalRecDetails(rec, providerName)
 
+		// Canonicalize PaymentOption at the emission boundary so a downstream
+		// plan-validator round-trip never sees a cross-provider/AWS-style
+		// token on a non-AWS rec (issue #698). The provider service clients
+		// historically aliased "all-upfront"/"no-upfront" to the canonical
+		// "upfront"/"monthly" inside their pricing switches; the validator
+		// no longer accepts those aliases. Normalize once here so persisted
+		// recs always carry the provider-canonical token.
+		if canon, ok := config.NormalizePaymentOption(providerName, rec.PaymentOption); ok {
+			if canon != rec.PaymentOption {
+				logging.Warnf("convertRecommendations: coerced %s payment_option %q to canonical %q (account=%s service=%s sku=%s)",
+					providerName, rec.PaymentOption, canon, rec.Account, rec.Service, rec.ResourceType)
+				rec.PaymentOption = canon
+			}
+		} else if rec.PaymentOption != "" {
+			// Unknown provider or unmapped token: leave as-is. The next
+			// validator boundary will surface the issue with a clear error.
+			logging.Warnf("convertRecommendations: cannot canonicalize %s payment_option %q (account=%s service=%s sku=%s) — leaving as-is",
+				providerName, rec.PaymentOption, rec.Account, rec.Service, rec.ResourceType)
+		}
+
 		// Parse term to integer (e.g., "3yr" -> 3)
 		term := 3
 		if rec.Term != "" {


### PR DESCRIPTION
Closes #698 — unblocks non-AWS plan creation.

The plan validator previously rejected any non-AWS payment option with `invalid payment option: monthly (valid: no-upfront, partial-upfront, all-upfront)` because `ValidPaymentOptions` was a single AWS-only slice. After PR #682 the Azure recommendation emitters now stamp `upfront`/`monthly` (Azure-canonical, accepted by all five Azure service-client switches), but the plan validator was missed in that PR's scope.

## What changed

- Added `ValidPaymentOptionsByProvider` map in `internal/config/validation.go`:
  - **aws**: `no-upfront`, `partial-upfront`, `all-upfront`
  - **azure**: `all-upfront`, `no-upfront`, `upfront`, `monthly` (cross-verified against all five azure service-client `switch` statements)
  - **gcp**: `all-upfront`, `no-upfront`, `upfront`, `monthly` (GCP service clients stamp `monthly` as default; switches treat `monthly`/`no-upfront` and `all-upfront`/`upfront` as synonyms)
- Added `validPaymentOptionsFor(provider)` lookup; `ServiceConfig.validatePayment` now uses it and includes the provider in the error message: `invalid payment option: X (valid for azure: ...)` — so a cross-provider token (e.g. `all-upfront` on an azure service) is rejected loudly.
- `GlobalConfig.DefaultPayment` is provider-less; validates against the union of all provider sets.
- Kept the original `ValidPaymentOptions` slice for backwards compatibility.

## Tests

- 11 new validation_test.go cases covering each provider × payment combination including cross-provider rejection.
- Existing `internal/api/handler_purchases_guards_test.go` (`azure, monthly` already treated as valid in that layer) now agrees with the plan validator.
- 513/513 `internal/config` tests pass, 1231/1231 `internal/api` tests pass, `go vet` clean, `gofmt` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added provider-aware payment-option normalization and canonicalization, with warnings when values are coerced or left for later validation.

* **Bug Fixes**
  * Global validation accepts the union of provider tokens; service-level validation enforces provider-canonical tokens.

* **Tests**
  * Expanded tests covering global/service validation and normalization across AWS, Azure, and GCP.

* **Documentation**
  * Clarified that the legacy AWS option list is retained for backwards compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/709?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->