### PR TITLE
fix(iac/aws-lambda): preserve Function URL via moved block (followup to #574)

### DIFF
--- a/terraform/modules/compute/aws/lambda/main.tf
+++ b/terraform/modules/compute/aws/lambda/main.tf
@@ -114,6 +114,18 @@ resource "aws_lambda_function" "main" {
 # Lambda Function URL (for HTTP access)
 # ==============================================
 
+# moved: aws_lambda_function_url.main lost its `count` in PR #574 (drop
+# of dead-knob lambda_enable_function_url). The existing deployment's
+# state holds the resource at index [0]; this block tells terraform
+# to update the state index in-place instead of destroying the
+# existing Function URL and creating a fresh one with a different
+# host (which would break the dashboard until origins/DASHBOARD_URL
+# are re-propagated everywhere).
+moved {
+  from = aws_lambda_function_url.main[0]
+  to   = aws_lambda_function_url.main
+}
+
 resource "aws_lambda_function_url" "main" {
   function_name      = aws_lambda_function.main.function_name
   authorization_type = var.function_url_auth_type


### PR DESCRIPTION
## Summary

Adds a `moved` block to preserve `aws_lambda_function_url.main` across the `count` removal from #574.

## Why this is urgent

PR #574 merged commit `601318f49` removed `count = var.enable_function_url ? 1 : 0` from `aws_lambda_function_url.main`. The terraform address changed from `aws_lambda_function_url.main[0]` to bare `aws_lambda_function_url.main`. Existing state still holds the resource at `[0]`. Without a `moved` block, the NEXT `terraform apply` would:

- DESTROY the existing Function URL (current dev: `https://33pz7pombdqwu3bdlxp4lqxyra0bsriy.lambda-url.us-east-1.on.aws`)
- CREATE a new Function URL with a brand-new random host

Cascading break:
- `lambda_allowed_origins` in `github-dev.tfvars` pins the old host -> CORS rejects the new URL until tfvars is updated AND re-applied
- `DASHBOARD_URL` env var pins the old host -> invite/reset emails carry dead links
- Frontend bundles that bake the URL point to nothing
- Any external integration on the URL host breaks

## Fix

One-line `moved` block in `terraform/modules/compute/aws/lambda/main.tf`:

```hcl
moved {
  from = aws_lambda_function_url.main[0]
  to   = aws_lambda_function_url.main
}
```

Terraform treats this as a state-index update, NOT a destroy/create. URL host preserved across apply.

## Test plan
- [ ] terraform validate clean on both module + env layer
- [ ] terraform fmt clean
- [ ] No semantic change to deployed resources; ONLY a state-address rename

## Land BEFORE next deploy

Once this merges, the next `terraform apply` is safe. If a deploy happens between #574 merging and this PR landing, the dashboard breaks. Worth fast-tracking.
