### PR TITLE
fix(approvals): populate Account/Payment/MonthlyCost on Approval queue rows (refs #704)

### DIFF
--- a/internal/api/handler_history.go
+++ b/internal/api/handler_history.go
@@ -665,10 +665,15 @@ func parseHistoryDateBounds(startStr, endStr string) (time.Time, time.Time, erro
 //     multi-rec basket that spans providers (e.g. aws+azure) matches any of
 //     them — dropping such an execution because its collapsed display label
 //     is "multiple" would hide real activity the user owns.
-//   - Account: matches when the execution's CloudAccountID is one of the
-//     filtered IDs. Executions with a NULL CloudAccountID are excluded once
-//     account_ids is non-empty, mirroring the SQL semantics on
-//     purchase_history.cloud_account_id (issue #211).
+//   - Account: matches when the execution's effective account ID is one of the
+//     filtered IDs. The effective account ID is exec.CloudAccountID when set;
+//     otherwise collapseRecommendationAccount(exec.Recommendations) provides
+//     the fallback, matching the same logic used in executionToHistoryRow.
+//     Web-initiated bulk purchases never set exec.CloudAccountID — only the
+//     per-rec field is populated — so without this fallback an account-filtered
+//     approval queue would silently drop all pending web purchases (issue #704).
+//     An execution whose effective account ID is "" (nil exec field AND recs
+//     disagree or have no account) is excluded once account_ids is non-empty.
 //   - Date: matches when ScheduledDate is within [Start, End]. Inclusive
 //     both sides; End is the end-of-day for YYYY-MM-DD inputs.
 func (f historyFilters) matchesExecution(exec config.PurchaseExecution) bool {
@@ -682,10 +687,18 @@ func (f historyFilters) matchesExecution(exec config.PurchaseExecution) bool {
 		// LegacyAccountID is intentionally NOT folded here because it is a
 		// different (VARCHAR(20)) cloud-provider account number that the
 		// fast path applies on the SQL side.
-		if exec.CloudAccountID == nil {
-			return false
+		//
+		// Use the same two-level account resolution as executionToHistoryRow:
+		// exec.CloudAccountID first, then the rec-level fallback. This ensures
+		// web bulk-purchase executions (exec.CloudAccountID == nil) are not
+		// silently dropped when the caller filters by account.
+		var accountID string
+		if exec.CloudAccountID != nil {
+			accountID = *exec.CloudAccountID
+		} else {
+			accountID = collapseRecommendationAccount(exec.Recommendations)
 		}
-		if !stringInSlice(*exec.CloudAccountID, f.AccountIDs) {
+		if accountID == "" || !stringInSlice(accountID, f.AccountIDs) {
 			return false
 		}
 	}

--- a/internal/api/handler_history_test.go
+++ b/internal/api/handler_history_test.go
@@ -747,7 +747,7 @@ func TestHandler_getHistory_FilterParams(t *testing.T) {
 		}
 		assert.True(t, ids["exec-in-A"], "execution in account A must survive the filter")
 		assert.False(t, ids["exec-in-C"], "execution in unrelated account C must be filtered out")
-		assert.False(t, ids["exec-nil-account"], "execution with NULL CloudAccountID must be excluded once account_ids is non-empty")
+		assert.False(t, ids["exec-nil-account"], "execution with NULL exec.CloudAccountID AND no rec-level CloudAccountID must still be excluded (effective account is empty)")
 	})
 
 	t.Run("legacy singular account_id is ignored when combined with new filters", func(t *testing.T) {
@@ -1244,7 +1244,63 @@ func TestHandler_getHistory_ApprovalQueueColumnsPopulated(t *testing.T) {
 		require.Len(t, resp.Purchases, 1)
 		row := resp.Purchases[0]
 
-		assert.Empty(t, row.Payment, "Payment must collapse to empty when recs disagree — the dash fallback is more honest than a single arbitrary value (#733)")
+		assert.Empty(t, row.Payment, "Payment must collapse to empty when recs disagree - the dash fallback is more honest than a single arbitrary value (#733)")
+	})
+
+	t.Run("account_ids filter matches pending row via rec-level fallback when exec.CloudAccountID is nil", func(t *testing.T) {
+		// Regression: matchesExecution previously rejected executions with a nil
+		// exec.CloudAccountID even when the rec carried the matching UUID. Web
+		// bulk-purchase flows only populate the per-rec CloudAccountID, so an
+		// account-filtered approval queue would silently drop all web-initiated
+		// pending rows. The fix makes matchesExecution apply the same two-level
+		// fallback as executionToHistoryRow (issue #704, CR #738).
+		ctx := context.Background()
+		mockStore := new(MockConfigStore)
+		t.Cleanup(func() { mockStore.AssertExpectations(t) })
+
+		recAccountID := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+		monthly := 9.0
+		pending := []config.PurchaseExecution{
+			{
+				ExecutionID:   "pend-nil-exec-account",
+				Status:        "pending",
+				ScheduledDate: time.Now(),
+				// exec.CloudAccountID intentionally nil - mirrors web bulk-purchase
+				// flow. The rec carries the canonical account UUID.
+				Recommendations: []config.RecommendationRecord{
+					{
+						Provider:       "aws",
+						Service:        "ec2",
+						Region:         "us-east-1",
+						ResourceType:   "m5.large",
+						Term:           1,
+						Payment:        "no-upfront",
+						Count:          1,
+						UpfrontCost:    0.0,
+						MonthlyCost:    &monthly,
+						CloudAccountID: &recAccountID,
+					},
+				},
+			},
+		}
+		mockStore.On("GetExecutionsByStatuses", ctx, mock.Anything, mock.Anything).Return(pending, nil)
+		// account_ids is set, so fetchPurchaseHistory routes to GetPurchaseHistoryFiltered
+		// (not GetAllPurchaseHistory). No DB rows needed; we only care about the
+		// execution path.
+		mockStore.On("GetPurchaseHistoryFiltered", ctx, "", []string{recAccountID}, (*time.Time)(nil), (*time.Time)(nil), 100).
+			Return([]config.PurchaseHistoryRecord{}, nil)
+		mockStore.On("GetGlobalConfig", ctx).Return(&config.GlobalConfig{NotificationEmail: &approverEmail}, nil)
+
+		mockAuth, req := adminHistoryReq(ctx)
+		handler := &Handler{auth: mockAuth, config: mockStore}
+
+		result, err := handler.getHistory(ctx, req, map[string]string{"account_ids": recAccountID})
+		require.NoError(t, err)
+		resp := result.(HistoryResponse)
+		require.Len(t, resp.Purchases, 1, "pending row must survive the account_ids filter via rec-level CloudAccountID fallback")
+		row := resp.Purchases[0]
+
+		assert.Equal(t, recAccountID, row.AccountID, "AccountID must be resolved from the rec when exec.CloudAccountID is nil (#704)")
 	})
 }
 


### PR DESCRIPTION
## Summary

Fixes #704 follow-up (PR #713 added the columns but data wasn't populated; verification on QA row 274 still failed with all cells showing `-`).

Root cause: `executionToHistoryRow` and `projectRecommendationFields` in `internal/api/handler_history.go` never wrote `Account` or `Payment` onto Approval queue rows for web-initiated bulk purchases. `buildPendingExecution` sets account IDs at the per-recommendation level only, never on the execution. Similarly, `r.Payment` was never copied onto `row.Payment` in either the single-rec or multi-rec branch. Frontend accessors were already wired correctly; they just had nothing to read.

## Changes

1. `executionToHistoryRow`: fall back to `collapseRecommendationAccount(exec.Recommendations)` when `exec.CloudAccountID` is nil.
2. `projectRecommendationFields` single-rec branch: copy `r.Payment` to `row.Payment`.
3. `projectRecommendationFields` multi-rec branch: `row.Payment = collapseRecommendationPayment(recs)` and `row.MonthlyCost = sumRecommendationMonthlyCost(recs)`.
4. New helpers: `collapseRecommendationPayment`, `collapseRecommendationAccount`, `sumRecommendationMonthlyCost`.

## Test plan

- [x] `TestHandler_getHistory_ApprovalQueueColumnsPopulated` covers 3 shapes (single-rec, multi-rec uniform payment, multi-rec heterogeneous payment)
- [x] `TestHandler_getHistory_InProgressRowMapsRecFields` extended with Payment assertion
- [x] New frontend test asserts Account/Term/Payment/Monthly Cost cells render real values, not `-`
- [x] Backend `internal/api`: 1277 pass
- [x] Frontend: 1989 pass, 1 skipped (63 suites)
- [x] `go vet` clean
- [ ] Manual verification: open Approval queue with web-initiated bulk Azure purchase; columns should now populate

Closes #733 referenced in commit; verifies QA row 274.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account filtering accuracy in history requests by using effective account ID resolution, ensuring correct handling of edge cases where account information is incomplete.

* **Tests**
  * Enhanced test coverage for account filtering scenarios with various account configuration states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/738?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->