### PR TITLE
fix(home/stats): drop /mo suffix from Period Savings total (revert #763 auto-fix)

### DIFF
--- a/frontend/src/__tests__/savings-history.test.ts
+++ b/frontend/src/__tests__/savings-history.test.ts
@@ -65,6 +65,7 @@ describe('Savings History Module', () => {
         <p class="help-text">Data will be collected hourly once you have active purchases.</p>
       </div>
       <div id="savings-stats">
+        <h4 id="period-savings-label">Period Savings</h4>
         <span id="period-savings">$0</span>
         <h4 id="avg-savings-label">Avg Monthly Savings</h4>
         <span id="avg-hourly-savings">$0/mo</span>
@@ -1278,21 +1279,24 @@ describe('Savings History Module', () => {
     test('period savings (cumulative total) also converts with unit toggle', async () => {
       (getSavingsAnalytics as jest.Mock).mockResolvedValue(mockData);
 
-      // Monthly
+      // Monthly: value is clean dollar total; label reflects view mode
       await loadSavingsHistory();
       const periodElMonthly = document.getElementById('period-savings');
       expect(periodElMonthly?.textContent).toBe('$730.00');
+      expect(document.getElementById('period-savings-label')?.textContent).toContain('monthly');
 
-      // Hourly: 730 / 730 = 1.00
+      // Hourly: 730 / 730 = 1.00; label updates to 'hourly'
       const unitSelect = document.getElementById('savings-unit') as HTMLSelectElement;
       unitSelect.value = 'hourly';
       await loadSavingsHistory();
       expect(document.getElementById('period-savings')?.textContent).toBe('$1.00');
+      expect(document.getElementById('period-savings-label')?.textContent).toContain('hourly');
 
-      // Yearly: 730 * 12 = 8760 -> $8.76K
+      // Yearly: 730 * 12 = 8760 -> $8.76K; label updates to 'yearly'
       unitSelect.value = 'yearly';
       await loadSavingsHistory();
       expect(document.getElementById('period-savings')?.textContent).toBe('$8.76K');
+      expect(document.getElementById('period-savings-label')?.textContent).toContain('yearly');
     });
 
     test('chart tooltip uses selected unit suffix for period savings dataset', async () => {

--- a/frontend/src/__tests__/savings-history.test.ts
+++ b/frontend/src/__tests__/savings-history.test.ts
@@ -67,6 +67,7 @@ describe('Savings History Module', () => {
       <div id="savings-stats">
         <h4 id="period-savings-label">Period Savings</h4>
         <span id="period-savings">$0</span>
+        <p id="period-savings-unit">shown in monthly equivalents</p>
         <h4 id="avg-savings-label">Avg Monthly Savings</h4>
         <span id="avg-hourly-savings">$0/mo</span>
         <span id="peak-savings">$0/mo</span>
@@ -1279,24 +1280,24 @@ describe('Savings History Module', () => {
     test('period savings (cumulative total) also converts with unit toggle', async () => {
       (getSavingsAnalytics as jest.Mock).mockResolvedValue(mockData);
 
-      // Monthly: value is clean dollar total; label reflects view mode
+      // Monthly: value is clean dollar total; sub-line reflects view mode
       await loadSavingsHistory();
       const periodElMonthly = document.getElementById('period-savings');
       expect(periodElMonthly?.textContent).toBe('$730.00');
-      expect(document.getElementById('period-savings-label')?.textContent).toContain('monthly');
+      expect(document.getElementById('period-savings-unit')?.textContent).toContain('monthly');
 
-      // Hourly: 730 / 730 = 1.00; label updates to 'hourly'
+      // Hourly: 730 / 730 = 1.00; sub-line updates to 'hourly'
       const unitSelect = document.getElementById('savings-unit') as HTMLSelectElement;
       unitSelect.value = 'hourly';
       await loadSavingsHistory();
       expect(document.getElementById('period-savings')?.textContent).toBe('$1.00');
-      expect(document.getElementById('period-savings-label')?.textContent).toContain('hourly');
+      expect(document.getElementById('period-savings-unit')?.textContent).toContain('hourly');
 
-      // Yearly: 730 * 12 = 8760 -> $8.76K; label updates to 'yearly'
+      // Yearly: 730 * 12 = 8760 -> $8.76K; sub-line updates to 'yearly'
       unitSelect.value = 'yearly';
       await loadSavingsHistory();
       expect(document.getElementById('period-savings')?.textContent).toBe('$8.76K');
-      expect(document.getElementById('period-savings-label')?.textContent).toContain('yearly');
+      expect(document.getElementById('period-savings-unit')?.textContent).toContain('yearly');
     });
 
     test('chart tooltip uses selected unit suffix for period savings dataset', async () => {

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -175,7 +175,7 @@
                     <!-- Savings Stats Cards -->
                     <div id="savings-stats" class="stats-grid">
                         <div class="stat-card">
-                            <h4>Period Savings</h4>
+                            <h4 id="period-savings-label">Period Savings</h4>
                             <p id="period-savings" class="stat-value">$0.00</p>
                         </div>
                         <div class="stat-card">

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -177,6 +177,7 @@
                         <div class="stat-card">
                             <h4 id="period-savings-label">Period Savings</h4>
                             <p id="period-savings" class="stat-value">$0.00</p>
+                            <p class="stat-unit-context" id="period-savings-unit">shown in monthly equivalents</p>
                         </div>
                         <div class="stat-card">
                             <h4 id="avg-savings-label">Avg Monthly Savings</h4>

--- a/frontend/src/modules/savings-history.ts
+++ b/frontend/src/modules/savings-history.ts
@@ -248,6 +248,12 @@ function getPeriodDates(period: string): { start: Date; end: Date; interval: 'ho
  */
 function renderSavingsStats(data: SavingsAnalyticsResponse): void {
     const periodSavingsEl = document.getElementById('period-savings');
+    // The unit indicator belongs on the label, not appended to the value.
+    // Period Savings is a cumulative dollar total over the selected date range,
+    // not a per-unit rate -- appending /mo, /hr, /yr would misrepresent it as
+    // a rate.  The label "Period Savings (monthly)" shows which view mode is
+    // active without implying a rate.
+    const periodSavingsLabelEl = document.getElementById('period-savings-label');
     const avgSavingsEl = document.getElementById('avg-hourly-savings');
     const peakSavingsEl = document.getElementById('peak-savings');
     const avgLabelEl = document.getElementById('avg-savings-label');
@@ -290,6 +296,9 @@ function renderSavingsStats(data: SavingsAnalyticsResponse): void {
         // Period Savings is the cumulative total over the selected date range
         // (no per-unit rate suffix -- it is already a dollar total).
         periodSavingsEl.textContent = formatCurrency(displayTotal);
+    }
+    if (periodSavingsLabelEl) {
+        periodSavingsLabelEl.textContent = `Period Savings (${adjective.toLowerCase()})`;
     }
     if (avgLabelEl) {
         avgLabelEl.textContent = `Avg ${adjective} Savings`;

--- a/frontend/src/modules/savings-history.ts
+++ b/frontend/src/modules/savings-history.ts
@@ -248,12 +248,13 @@ function getPeriodDates(period: string): { start: Date; end: Date; interval: 'ho
  */
 function renderSavingsStats(data: SavingsAnalyticsResponse): void {
     const periodSavingsEl = document.getElementById('period-savings');
-    // The unit indicator belongs on the label, not appended to the value.
+    // The unit indicator belongs below the value, not inside the label.
     // Period Savings is a cumulative dollar total over the selected date range,
-    // not a per-unit rate -- appending /mo, /hr, /yr would misrepresent it as
-    // a rate.  The label "Period Savings (monthly)" shows which view mode is
-    // active without implying a rate.
+    // not a per-unit rate -- the label stays plain ("Period Savings") and the
+    // sub-line (#period-savings-unit) shows which view mode is active without
+    // implying a rate.
     const periodSavingsLabelEl = document.getElementById('period-savings-label');
+    const periodSavingsUnitEl = document.getElementById('period-savings-unit');
     const avgSavingsEl = document.getElementById('avg-hourly-savings');
     const peakSavingsEl = document.getElementById('peak-savings');
     const avgLabelEl = document.getElementById('avg-savings-label');
@@ -298,7 +299,10 @@ function renderSavingsStats(data: SavingsAnalyticsResponse): void {
         periodSavingsEl.textContent = formatCurrency(displayTotal);
     }
     if (periodSavingsLabelEl) {
-        periodSavingsLabelEl.textContent = `Period Savings (${adjective.toLowerCase()})`;
+        periodSavingsLabelEl.textContent = 'Period Savings';
+    }
+    if (periodSavingsUnitEl) {
+        periodSavingsUnitEl.textContent = `shown in ${adjective.toLowerCase()} equivalents`;
     }
     if (avgLabelEl) {
         avgLabelEl.textContent = `Avg ${adjective} Savings`;

--- a/frontend/src/modules/savings-history.ts
+++ b/frontend/src/modules/savings-history.ts
@@ -289,7 +289,7 @@ function renderSavingsStats(data: SavingsAnalyticsResponse): void {
     if (periodSavingsEl) {
         // Period Savings is the cumulative total over the selected date range
         // (no per-unit rate suffix -- it is already a dollar total).
-        periodSavingsEl.textContent = formatCurrency(displayTotal) + ' ' + suffix;
+        periodSavingsEl.textContent = formatCurrency(displayTotal);
     }
     if (avgLabelEl) {
         avgLabelEl.textContent = `Avg ${adjective} Savings`;

--- a/frontend/src/styles/charts.css
+++ b/frontend/src/styles/charts.css
@@ -61,3 +61,9 @@
     font-weight: var(--cudly-fw-bold);
     color: var(--cudly-primary);
 }
+
+.stat-unit-context {
+    font-size: 0.85rem;
+    color: var(--cudly-text-muted);
+    margin-top: 0.25rem;
+}


### PR DESCRIPTION
## Problem

PR #763 ("CodeRabbit auto-fixes") appended `' ' + suffix` (e.g. `/mo`) to
`periodSavingsEl.textContent`. That is semantically wrong: **Period Savings
is a cumulative dollar total over the selected date range, not a per-unit
rate.** Displaying `$500.00 /mo` implies a monthly rate, not a total.
Four tests failed as a result.

**Update:** moved unit indicator below the value for cleaner semantic separation.

## Fix

Move the unit indicator from the **label** to a small sub-line **below** the value:

- Label stays plain: `Period Savings`
- Value stays clean: `$500.00`
- New sub-line (`#period-savings-unit`): `shown in monthly equivalents` / `shown in hourly equivalents` / `shown in yearly equivalents`

This separates the three concerns cleanly: label = what, value = number,
sub-line = how it is displayed. The sub-line uses the new `.stat-unit-context`
CSS class (small, muted text) consistent with the project's `--cudly-text-muted`
token already used throughout stat cards.

## Changes

- `frontend/src/index.html`: added `<p class="stat-unit-context" id="period-savings-unit">shown in monthly equivalents</p>` below `#period-savings`. Restored `#period-savings-label` to plain `Period Savings`.
- `frontend/src/modules/savings-history.ts`: in `renderSavingsStats`,
  set `#period-savings-label` to the constant `'Period Savings'` and drive
  `#period-savings-unit` with `shown in ${adjective.toLowerCase()} equivalents`.
  Updated inline comment to reflect new "below the value" placement.
- `frontend/src/styles/charts.css`: added `.stat-unit-context` rule
  (`font-size: 0.85rem`, `color: var(--cudly-text-muted)`, `margin-top: 0.25rem`).
- `frontend/src/__tests__/savings-history.test.ts`: added
  `<p id="period-savings-unit">` to the DOM fixture; updated the three
  unit-toggle assertions to query `#period-savings-unit` instead of
  `#period-savings-label`.

## Tests

79 tests pass. The originally-failing value assertions (`toBe('$500.00')` etc.)
are unchanged.
