### PR TITLE
feat(frontend/history): inline column filters via shared lib (refs #166)

### DIFF
--- a/frontend/src/__tests__/allowed-accounts.test.ts
+++ b/frontend/src/__tests__/allowed-accounts.test.ts
@@ -73,6 +73,12 @@ jest.mock('../state', () => ({
   getAmortizeUpfront: jest.fn().mockReturnValue(false),
   setAmortizeUpfront: jest.fn(),
   subscribeAmortizeUpfront: jest.fn().mockReturnValue(() => {}),
+  getPurchaseHistoryColumnFilters: jest.fn().mockReturnValue({}),
+  setPurchaseHistoryColumnFilter: jest.fn(),
+  clearAllPurchaseHistoryColumnFilters: jest.fn(),
+  getApprovalQueueColumnFilters: jest.fn().mockReturnValue({}),
+  setApprovalQueueColumnFilter: jest.fn(),
+  clearAllApprovalQueueColumnFilters: jest.fn(),
 }));
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/__tests__/approval-queue-column-filters.test.ts
+++ b/frontend/src/__tests__/approval-queue-column-filters.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Approval Queue column-filter regression suite (issue #166).
+ *
+ * Covers the inline per-column filters wired onto the Approval Queue
+ * table headers. Filterable columns: Provider, Account, Service, Term,
+ * Payment, Created by (categorical), Count, Monthly Cost, Upfront Cost,
+ * Monthly Savings (numeric). Status is excluded by design — the queue
+ * scope is already pending|notified.
+ *
+ * Tested matrix:
+ *   1. Numeric expr filter narrows by predicate (monthly_cost >= N).
+ *   2. Categorical set filter narrows by membership (payment in set).
+ *   3. Multiple filters AND together across columns.
+ *   4. Invalid numeric expression is skipped (no exception, no narrowing).
+ *   5. NaN-as-missing contract: monthly_cost == null produces NaN, which
+ *      fails every numeric predicate (not coincidentally matches "= 0").
+ *   6. Clearing returns a fresh clone of the input.
+ */
+
+import { applyApprovalQueueColumnFilters } from '../history';
+import type { HistoryPurchase } from '../types';
+import type { ApprovalQueueColumnFilters } from '../state';
+
+jest.mock('../api', () => ({}));
+jest.mock('../navigation', () => ({ switchTab: jest.fn() }));
+jest.mock('../utils', () => ({
+  formatCurrency: jest.fn((v) => `$${v ?? 0}`),
+  formatDate: jest.fn((v) => v),
+  formatTerm: jest.fn((y) => `${y} Year${y === 1 ? '' : 's'}`),
+  escapeHtml: jest.fn((s) => s ?? ''),
+}));
+jest.mock('../state', () => ({
+  subscribeProvider: jest.fn().mockReturnValue(() => {}),
+  subscribeAccount: jest.fn().mockReturnValue(() => {}),
+}));
+jest.mock('../confirmDialog', () => ({ confirmDialog: jest.fn() }));
+jest.mock('../approval-details', () => ({ buildApprovalDetailsBody: jest.fn() }));
+jest.mock('../toast', () => ({ showToast: jest.fn() }));
+jest.mock('../lib/skeleton', () => ({ showSkeletonRows: jest.fn(), teardownSkeleton: jest.fn() }));
+jest.mock('../recommendations', () => ({ getAccountName: jest.fn((id: string) => id) }));
+
+function mkRow(overrides: Partial<HistoryPurchase>): HistoryPurchase {
+  return {
+    purchase_id: 'p',
+    timestamp: '2024-01-01T00:00:00Z',
+    provider: 'aws',
+    service: 'ec2',
+    resource_type: 'reserved-instance',
+    region: 'us-east-1',
+    count: 1,
+    term: 1,
+    payment: 'all_upfront',
+    upfront_cost: 100,
+    monthly_cost: 50,
+    estimated_savings: 30,
+    account_id: 'acct-1',
+    created_by_user_email: 'alice@example.com',
+    status: 'pending',
+    ...overrides,
+  };
+}
+
+const rows: HistoryPurchase[] = [
+  mkRow({ purchase_id: 'a', provider: 'aws',   account_id: 'acct-1', payment: 'all_upfront',     monthly_cost: 50,   estimated_savings: 30,  created_by_user_email: 'alice@example.com' }),
+  mkRow({ purchase_id: 'b', provider: 'aws',   account_id: 'acct-2', payment: 'no_upfront',      monthly_cost: 200,  estimated_savings: 100, created_by_user_email: 'bob@example.com' }),
+  mkRow({ purchase_id: 'c', provider: 'azure', account_id: 'acct-2', payment: 'partial_upfront', monthly_cost: null as unknown as number | undefined, estimated_savings: 60, created_by_user_email: 'alice@example.com' }),
+  mkRow({ purchase_id: 'd', provider: 'gcp',   account_id: 'acct-3', payment: 'all_upfront',     monthly_cost: 500,  estimated_savings: 250, created_by_user_email: 'carol@example.com' }),
+];
+
+describe('applyApprovalQueueColumnFilters', () => {
+  test('numeric expr: monthly_cost >= 200 narrows to expensive rows', () => {
+    const filters: ApprovalQueueColumnFilters = {
+      monthly_cost: { kind: 'expr', expr: '>=200' },
+    };
+    const out = applyApprovalQueueColumnFilters(rows, filters);
+    expect(out.map((r) => r.purchase_id)).toEqual(['b', 'd']);
+  });
+
+  test('categorical set: payment in {all_upfront} narrows to those rows', () => {
+    const filters: ApprovalQueueColumnFilters = {
+      payment: { kind: 'set', values: ['all_upfront'] },
+    };
+    const out = applyApprovalQueueColumnFilters(rows, filters);
+    expect(out.map((r) => r.purchase_id)).toEqual(['a', 'd']);
+  });
+
+  test('multiple filters AND together (provider=aws + created_by=alice)', () => {
+    const filters: ApprovalQueueColumnFilters = {
+      provider: { kind: 'set', values: ['aws'] },
+      created_by: { kind: 'set', values: ['alice@example.com'] },
+    };
+    const out = applyApprovalQueueColumnFilters(rows, filters);
+    expect(out.map((r) => r.purchase_id)).toEqual(['a']);
+  });
+
+  test('invalid numeric expression is skipped (filter is a no-op)', () => {
+    const filters: ApprovalQueueColumnFilters = {
+      savings: { kind: 'expr', expr: 'not-a-num' },
+    };
+    const out = applyApprovalQueueColumnFilters(rows, filters);
+    expect(out).toHaveLength(rows.length);
+  });
+
+  test('null monthly_cost fails every numeric predicate (NaN contract)', () => {
+    // Row c has monthly_cost: null. A "= 0" predicate must NOT match it,
+    // and a ">0" predicate must NOT match it either.
+    const eqZero: ApprovalQueueColumnFilters = {
+      monthly_cost: { kind: 'expr', expr: '0' },
+    };
+    expect(applyApprovalQueueColumnFilters(rows, eqZero).map((r) => r.purchase_id))
+      .not.toContain('c');
+
+    const gtZero: ApprovalQueueColumnFilters = {
+      monthly_cost: { kind: 'expr', expr: '>0' },
+    };
+    expect(applyApprovalQueueColumnFilters(rows, gtZero).map((r) => r.purchase_id))
+      .not.toContain('c');
+  });
+
+  test('clearing filters via empty record returns a fresh clone', () => {
+    const out = applyApprovalQueueColumnFilters(rows, {});
+    expect(out).toEqual(rows);
+    expect(out).not.toBe(rows);
+  });
+});

--- a/frontend/src/__tests__/history-approval-queue.test.ts
+++ b/frontend/src/__tests__/history-approval-queue.test.ts
@@ -63,6 +63,12 @@ jest.mock('../state', () => ({
   getAmortizeUpfront: jest.fn().mockReturnValue(false),
   setAmortizeUpfront: jest.fn(),
   subscribeAmortizeUpfront: jest.fn().mockReturnValue(() => {}),
+  getPurchaseHistoryColumnFilters: jest.fn().mockReturnValue({}),
+  setPurchaseHistoryColumnFilter: jest.fn(),
+  clearAllPurchaseHistoryColumnFilters: jest.fn(),
+  getApprovalQueueColumnFilters: jest.fn().mockReturnValue({}),
+  setApprovalQueueColumnFilter: jest.fn(),
+  clearAllApprovalQueueColumnFilters: jest.fn(),
 }));
 
 jest.mock('../recommendations', () => ({

--- a/frontend/src/__tests__/history-approve-button.test.ts
+++ b/frontend/src/__tests__/history-approve-button.test.ts
@@ -64,6 +64,12 @@ jest.mock('../state', () => ({
   getAmortizeUpfront: jest.fn().mockReturnValue(false),
   setAmortizeUpfront: jest.fn(),
   subscribeAmortizeUpfront: jest.fn().mockReturnValue(() => {}),
+  getPurchaseHistoryColumnFilters: jest.fn().mockReturnValue({}),
+  setPurchaseHistoryColumnFilter: jest.fn(),
+  clearAllPurchaseHistoryColumnFilters: jest.fn(),
+  getApprovalQueueColumnFilters: jest.fn().mockReturnValue({}),
+  setApprovalQueueColumnFilter: jest.fn(),
+  clearAllApprovalQueueColumnFilters: jest.fn(),
 }));
 
 import * as api from '../api';

--- a/frontend/src/__tests__/history-cancel-button.test.ts
+++ b/frontend/src/__tests__/history-cancel-button.test.ts
@@ -61,6 +61,12 @@ jest.mock('../state', () => ({
   getAmortizeUpfront: jest.fn().mockReturnValue(false),
   setAmortizeUpfront: jest.fn(),
   subscribeAmortizeUpfront: jest.fn().mockReturnValue(() => {}),
+  getPurchaseHistoryColumnFilters: jest.fn().mockReturnValue({}),
+  setPurchaseHistoryColumnFilter: jest.fn(),
+  clearAllPurchaseHistoryColumnFilters: jest.fn(),
+  getApprovalQueueColumnFilters: jest.fn().mockReturnValue({}),
+  setApprovalQueueColumnFilter: jest.fn(),
+  clearAllApprovalQueueColumnFilters: jest.fn(),
 }));
 
 import * as api from '../api';

--- a/frontend/src/__tests__/history-cancel-permissions.test.ts
+++ b/frontend/src/__tests__/history-cancel-permissions.test.ts
@@ -60,6 +60,12 @@ jest.mock('../state', () => ({
   getAmortizeUpfront: jest.fn().mockReturnValue(false),
   setAmortizeUpfront: jest.fn(),
   subscribeAmortizeUpfront: jest.fn().mockReturnValue(() => {}),
+  getPurchaseHistoryColumnFilters: jest.fn().mockReturnValue({}),
+  setPurchaseHistoryColumnFilter: jest.fn(),
+  clearAllPurchaseHistoryColumnFilters: jest.fn(),
+  getApprovalQueueColumnFilters: jest.fn().mockReturnValue({}),
+  setApprovalQueueColumnFilter: jest.fn(),
+  clearAllApprovalQueueColumnFilters: jest.fn(),
 }));
 
 // Mock permissions so we can inject arbitrary permission sets, including

--- a/frontend/src/__tests__/history-column-filters.test.ts
+++ b/frontend/src/__tests__/history-column-filters.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Purchase History column-filter regression suite (issue #166).
+ *
+ * Covers the inline per-column filters wired onto the Purchase History
+ * table headers. The existing Status chip-row remains the canonical
+ * filter for status — these tests exercise the new column-filter slice
+ * (provider/service/type/region/term + count/upfront_cost/savings).
+ *
+ * Tested matrix:
+ *   1. Numeric expr filter narrows by predicate (savings > N).
+ *   2. Categorical set filter narrows by membership (provider in set).
+ *   3. Multiple filters AND together across columns.
+ *   4. Invalid numeric expression is skipped (no exception, no narrowing).
+ *   5. Clearing a filter via setPurchaseHistoryColumnFilter(col, null)
+ *      restores the full slice.
+ *   6. Term column treats absent vs zero correctly — categorical-empty
+ *      filtering.
+ */
+
+import { applyPurchaseHistoryColumnFilters } from '../history';
+import type { HistoryPurchase } from '../types';
+import type { PurchaseHistoryColumnFilters } from '../state';
+
+// history.ts pulls in api/state/navigation transitively; the column-filter
+// helper is pure (operates on the passed-in rows + filter record), but the
+// module import path still resolves those — stub them out so the test runs
+// without an apiBase / DOM context.
+jest.mock('../api', () => ({}));
+jest.mock('../navigation', () => ({ switchTab: jest.fn() }));
+jest.mock('../utils', () => ({
+  formatCurrency: jest.fn((v) => `$${v ?? 0}`),
+  formatDate: jest.fn((v) => v),
+  formatTerm: jest.fn((y) => `${y} Year${y === 1 ? '' : 's'}`),
+  escapeHtml: jest.fn((s) => s ?? ''),
+}));
+jest.mock('../state', () => ({
+  subscribeProvider: jest.fn().mockReturnValue(() => {}),
+  subscribeAccount: jest.fn().mockReturnValue(() => {}),
+}));
+jest.mock('../confirmDialog', () => ({ confirmDialog: jest.fn() }));
+jest.mock('../approval-details', () => ({ buildApprovalDetailsBody: jest.fn() }));
+jest.mock('../toast', () => ({ showToast: jest.fn() }));
+jest.mock('../lib/skeleton', () => ({ showSkeletonRows: jest.fn(), teardownSkeleton: jest.fn() }));
+jest.mock('../recommendations', () => ({ getAccountName: jest.fn((id: string) => id) }));
+
+function mkRow(overrides: Partial<HistoryPurchase>): HistoryPurchase {
+  return {
+    purchase_id: 'p',
+    timestamp: '2024-01-01T00:00:00Z',
+    provider: 'aws',
+    service: 'ec2',
+    resource_type: 'reserved-instance',
+    region: 'us-east-1',
+    count: 1,
+    term: 1,
+    upfront_cost: 100,
+    estimated_savings: 50,
+    ...overrides,
+  };
+}
+
+const rows: HistoryPurchase[] = [
+  mkRow({ purchase_id: 'a', provider: 'aws',   service: 'ec2',  region: 'us-east-1', count: 1, term: 1, upfront_cost: 100,  estimated_savings: 50 }),
+  mkRow({ purchase_id: 'b', provider: 'aws',   service: 'rds',  region: 'us-west-2', count: 3, term: 3, upfront_cost: 500,  estimated_savings: 200 }),
+  mkRow({ purchase_id: 'c', provider: 'azure', service: 'ec2',  region: 'eu-west-1', count: 5, term: 1, upfront_cost: 1000, estimated_savings: 400 }),
+  mkRow({ purchase_id: 'd', provider: 'gcp',   service: 'ec2',  region: 'us-east-1', count: 2, term: 1, upfront_cost: 250,  estimated_savings: 80  }),
+];
+
+describe('applyPurchaseHistoryColumnFilters', () => {
+  test('numeric expr: savings > 100 narrows to high-saving rows', () => {
+    const filters: PurchaseHistoryColumnFilters = {
+      savings: { kind: 'expr', expr: '>100' },
+    };
+    const out = applyPurchaseHistoryColumnFilters(rows, filters);
+    expect(out.map((r) => r.purchase_id)).toEqual(['b', 'c']);
+  });
+
+  test('categorical set: provider in {aws, gcp} excludes azure', () => {
+    const filters: PurchaseHistoryColumnFilters = {
+      provider: { kind: 'set', values: ['aws', 'gcp'] },
+    };
+    const out = applyPurchaseHistoryColumnFilters(rows, filters);
+    expect(out.map((r) => r.purchase_id)).toEqual(['a', 'b', 'd']);
+  });
+
+  test('multiple filters AND together (provider=aws + savings >= 100)', () => {
+    const filters: PurchaseHistoryColumnFilters = {
+      provider: { kind: 'set', values: ['aws'] },
+      savings: { kind: 'expr', expr: '>=100' },
+    };
+    const out = applyPurchaseHistoryColumnFilters(rows, filters);
+    expect(out.map((r) => r.purchase_id)).toEqual(['b']);
+  });
+
+  test('invalid numeric expression is skipped (filter is a no-op)', () => {
+    const filters: PurchaseHistoryColumnFilters = {
+      savings: { kind: 'expr', expr: '>>nope' },
+    };
+    const out = applyPurchaseHistoryColumnFilters(rows, filters);
+    // Parse failure → filter ignored; full slice passes.
+    expect(out).toHaveLength(rows.length);
+  });
+
+  test('clearing filters via empty record returns a fresh clone', () => {
+    const out = applyPurchaseHistoryColumnFilters(rows, {});
+    expect(out).toEqual(rows);
+    expect(out).not.toBe(rows);
+  });
+
+  test('term filter uses categorical-set semantics with stringified values', () => {
+    const filters: PurchaseHistoryColumnFilters = {
+      term: { kind: 'set', values: ['3'] },
+    };
+    const out = applyPurchaseHistoryColumnFilters(rows, filters);
+    expect(out.map((r) => r.purchase_id)).toEqual(['b']);
+  });
+});

--- a/frontend/src/__tests__/history-filter-popover-xss.test.ts
+++ b/frontend/src/__tests__/history-filter-popover-xss.test.ts
@@ -1,0 +1,63 @@
+/**
+ * XSS regression for renderHistoryFilterButton (issue #166 follow-up).
+ *
+ * renderHistoryFilterButton injects `column` and `label` into HTML attribute
+ * values (data-column, aria-label, title) via template literal. Any caller
+ * passing a user-controlled string without escaping would produce a stored-XSS
+ * vector. escapeHtmlAttr must be applied to both values before interpolation.
+ */
+
+import { renderHistoryFilterButton } from '../lib/history-filter-popover';
+
+// Use the real escapeHtmlAttr so DOM-based escaping is exercised, not a
+// pass-through stub.
+jest.mock('../lib/column-filters', () => ({
+  parseNumericFilter: jest.fn(),
+}));
+
+describe('renderHistoryFilterButton: attribute-injection XSS guard', () => {
+  // This payload attempts to break out of the aria-label attribute and inject
+  // a script element. In raw form it would produce:
+  //   aria-label=""><script>alert(1)</script><span x=""
+  const SCRIPT_PAYLOAD = '"><script>alert(1)</script><span x="';
+  // This payload injects an event handler attribute.
+  const EVENT_PAYLOAD = '" onmouseover="alert(1)" x="';
+
+  test('hostile label does not inject raw <script> tag into attribute context', () => {
+    const html = renderHistoryFilterButton('provider', SCRIPT_PAYLOAD, false);
+    // The raw < > and " chars must be entity-encoded; no unescaped angle brackets.
+    expect(html).not.toContain('"><script>');
+    expect(html).not.toContain('</script>');
+    // The encoded form is present (attribute value is escaped, not stripped).
+    expect(html).toContain('&lt;script&gt;');
+  });
+
+  test('hostile label does not inject event handler attribute', () => {
+    const html = renderHistoryFilterButton('provider', EVENT_PAYLOAD, false);
+    // The injected " must be encoded; no raw onmouseover= outside an attribute value.
+    expect(html).not.toContain('" onmouseover=');
+    // The encoded form must appear inside the attribute value.
+    expect(html).toContain('&quot; onmouseover=');
+  });
+
+  test('hostile column id does not inject raw markup into data-column', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const html = renderHistoryFilterButton(SCRIPT_PAYLOAD as any, 'Provider', false);
+    expect(html).not.toContain('><script>');
+    expect(html).not.toContain('</script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+
+  test('safe column and label pass through correctly', () => {
+    const html = renderHistoryFilterButton('provider', 'Provider', false);
+    expect(html).toContain('data-column="provider"');
+    expect(html).toContain('aria-label="Filter Provider"');
+    expect(html).toContain('class="history-column-filter-btn"');
+  });
+
+  test('active flag adds "active" class and updates aria-label', () => {
+    const html = renderHistoryFilterButton('savings', 'Monthly Savings', true);
+    expect(html).toContain('class="history-column-filter-btn active"');
+    expect(html).toContain('aria-label="Filter Monthly Savings - currently active"');
+  });
+});

--- a/frontend/src/__tests__/history-marketplace-sell-button.test.ts
+++ b/frontend/src/__tests__/history-marketplace-sell-button.test.ts
@@ -65,6 +65,12 @@ jest.mock('../state', () => ({
   getAmortizeUpfront: jest.fn().mockReturnValue(false),
   setAmortizeUpfront: jest.fn(),
   subscribeAmortizeUpfront: jest.fn().mockReturnValue(() => {}),
+  getPurchaseHistoryColumnFilters: jest.fn().mockReturnValue({}),
+  setPurchaseHistoryColumnFilter: jest.fn(),
+  clearAllPurchaseHistoryColumnFilters: jest.fn(),
+  getApprovalQueueColumnFilters: jest.fn().mockReturnValue({}),
+  setApprovalQueueColumnFilter: jest.fn(),
+  clearAllApprovalQueueColumnFilters: jest.fn(),
 }));
 
 import * as api from '../api';

--- a/frontend/src/__tests__/history-retry-button.test.ts
+++ b/frontend/src/__tests__/history-retry-button.test.ts
@@ -70,6 +70,12 @@ jest.mock('../state', () => ({
   getAmortizeUpfront: jest.fn().mockReturnValue(false),
   setAmortizeUpfront: jest.fn(),
   subscribeAmortizeUpfront: jest.fn().mockReturnValue(() => {}),
+  getPurchaseHistoryColumnFilters: jest.fn().mockReturnValue({}),
+  setPurchaseHistoryColumnFilter: jest.fn(),
+  clearAllPurchaseHistoryColumnFilters: jest.fn(),
+  getApprovalQueueColumnFilters: jest.fn().mockReturnValue({}),
+  setApprovalQueueColumnFilter: jest.fn(),
+  clearAllApprovalQueueColumnFilters: jest.fn(),
 }));
 
 import * as api from '../api';

--- a/frontend/src/__tests__/history-revoke-button.test.ts
+++ b/frontend/src/__tests__/history-revoke-button.test.ts
@@ -60,6 +60,12 @@ jest.mock('../state', () => ({
   getAmortizeUpfront: jest.fn().mockReturnValue(false),
   setAmortizeUpfront: jest.fn(),
   subscribeAmortizeUpfront: jest.fn().mockReturnValue(() => {}),
+  getPurchaseHistoryColumnFilters: jest.fn().mockReturnValue({}),
+  setPurchaseHistoryColumnFilter: jest.fn(),
+  clearAllPurchaseHistoryColumnFilters: jest.fn(),
+  getApprovalQueueColumnFilters: jest.fn().mockReturnValue({}),
+  setApprovalQueueColumnFilter: jest.fn(),
+  clearAllApprovalQueueColumnFilters: jest.fn(),
 }));
 
 import * as api from '../api';

--- a/frontend/src/__tests__/history.test.ts
+++ b/frontend/src/__tests__/history.test.ts
@@ -44,6 +44,14 @@ jest.mock('../state', () => ({
   getAmortizeUpfront: jest.fn().mockReturnValue(false),
   setAmortizeUpfront: jest.fn(),
   subscribeAmortizeUpfront: jest.fn().mockReturnValue(() => {}),
+  // History per-column filter accessors (issue #166): tests only exercise
+  // empty filter state, so each getter returns {} and each setter is a no-op.
+  getPurchaseHistoryColumnFilters: jest.fn().mockReturnValue({}),
+  setPurchaseHistoryColumnFilter: jest.fn(),
+  clearAllPurchaseHistoryColumnFilters: jest.fn(),
+  getApprovalQueueColumnFilters: jest.fn().mockReturnValue({}),
+  setApprovalQueueColumnFilter: jest.fn(),
+  clearAllApprovalQueueColumnFilters: jest.fn(),
 }));
 
 import * as api from '../api';

--- a/frontend/src/__tests__/xss-provider-class.test.ts
+++ b/frontend/src/__tests__/xss-provider-class.test.ts
@@ -46,6 +46,12 @@ jest.mock('../state', () => ({
   getAmortizeUpfront: jest.fn().mockReturnValue(false),
   setAmortizeUpfront: jest.fn(),
   subscribeAmortizeUpfront: jest.fn().mockReturnValue(() => {}),
+  getPurchaseHistoryColumnFilters: jest.fn().mockReturnValue({}),
+  setPurchaseHistoryColumnFilter: jest.fn(),
+  clearAllPurchaseHistoryColumnFilters: jest.fn(),
+  getApprovalQueueColumnFilters: jest.fn().mockReturnValue({}),
+  setApprovalQueueColumnFilter: jest.fn(),
+  clearAllApprovalQueueColumnFilters: jest.fn(),
 }));
 
 import * as api from '../api';

--- a/frontend/src/history.ts
+++ b/frontend/src/history.ts
@@ -14,6 +14,16 @@ import { getCurrentUser } from './state';
 import { canAccess } from './permissions';
 import { showSkeletonRows, teardownSkeleton } from './lib/skeleton';
 import { getAccountName } from './recommendations';
+import { applyColumnFilters } from './lib/column-filters';
+import {
+  openHistoryColumnPopover,
+  renderHistoryFilterButton,
+  closeOpenHistoryPopover,
+} from './lib/history-filter-popover';
+import type {
+  PurchaseHistoryColumnId,
+  ApprovalQueueColumnId,
+} from './state';
 
 const VALID_PROVIDERS: api.Provider[] = ['aws', 'azure', 'gcp'];
 
@@ -274,6 +284,12 @@ export async function loadHistory(): Promise<void> {
   // skeleton size.
   const queueEl = document.getElementById('purchases-approval-queue');
   if (queueEl) showSkeletonRows(queueEl, 3, 12);
+
+  // Close any open History column-filter popover before re-rendering so the
+  // popover doesn't sit anchored to a stale <th> button after the table is
+  // innerHTML-rewritten. The next render with active filters rebinds fresh
+  // triggers; the popover stays opt-in (user clicks again to re-open).
+  closeOpenHistoryPopover();
 
   try {
     // Provider/account filters live in state.ts now (mutated by topbar chips).
@@ -820,6 +836,149 @@ function renderActionCell(p: HistoryPurchase): string {
   return escapeHtml(p.plan_name || '-');
 }
 
+// ---------------------------------------------------------------------------
+// Per-column filter wiring for the Purchase History table.
+//
+// The Status chip-row above stays as-is — it's an enum-driven filter with no
+// natural fit for the generic set/expr column-filter shape, and the chip-row
+// is the more discoverable affordance for status anyway. Column filters here
+// cover the row attributes (provider/service/type/region/term/count/upfront/
+// savings) — Status is intentionally excluded.
+//
+// Numeric extractors round to 0 decimal places to match formatCurrency's
+// default (CURRENCY_DEFAULT_DIGITS), so a user typing the visible "$123"
+// matches the row that displays that exact value (issue #484 contract on
+// the recommendations table).
+// ---------------------------------------------------------------------------
+
+const PURCHASE_HISTORY_NUMERIC_COLUMNS: ReadonlySet<PurchaseHistoryColumnId> = new Set([
+  'count', 'upfront_cost', 'savings',
+]);
+
+function purchaseHistoryCategoricalCellValue(
+  p: HistoryPurchase,
+  col: PurchaseHistoryColumnId,
+): string {
+  switch (col) {
+    case 'provider':       return p.provider ?? '';
+    case 'service':        return p.service ?? '';
+    case 'resource_type':  return p.resource_type ?? '';
+    case 'region':         return p.region ?? '';
+    case 'term':           return p.term == null ? '' : String(p.term);
+    case 'count':
+    case 'upfront_cost':
+    case 'savings':        return '';
+  }
+}
+
+function purchaseHistoryNumericCellValue(
+  p: HistoryPurchase,
+  col: PurchaseHistoryColumnId,
+): number {
+  switch (col) {
+    case 'count':         return p.count ?? 0;
+    case 'upfront_cost':  return p.upfront_cost ?? 0;
+    case 'savings':       return p.estimated_savings ?? 0;
+    case 'provider':
+    case 'service':
+    case 'resource_type':
+    case 'region':
+    case 'term':          return Number.NaN;
+  }
+}
+
+// Round to display precision so typed values match the rendered cell value
+// (formatCurrency default of 0 fraction digits, formatTerm renders the
+// integer term unchanged).
+function roundForDisplay(n: number): number {
+  if (!Number.isFinite(n)) return n;
+  return Number(n.toFixed(0));
+}
+
+export function applyPurchaseHistoryColumnFilters(
+  purchases: readonly HistoryPurchase[],
+  filters: state.PurchaseHistoryColumnFilters,
+): HistoryPurchase[] {
+  return applyColumnFilters<HistoryPurchase, PurchaseHistoryColumnId>(
+    purchases,
+    filters,
+    {
+      categorical: purchaseHistoryCategoricalCellValue,
+      numeric: (p, col) => roundForDisplay(purchaseHistoryNumericCellValue(p, col)),
+    },
+  );
+}
+
+const PURCHASE_HISTORY_LABELS: Record<PurchaseHistoryColumnId, string> = {
+  provider: 'Provider',
+  service: 'Service',
+  resource_type: 'Type',
+  region: 'Region',
+  term: 'Term',
+  count: 'Count',
+  upfront_cost: 'Upfront Cost',
+  savings: 'Monthly Savings',
+};
+
+function purchaseHistoryDistinctValues(
+  purchases: readonly HistoryPurchase[],
+  column: PurchaseHistoryColumnId,
+): string[] {
+  const seen = new Set<string>();
+  for (const p of purchases) {
+    seen.add(purchaseHistoryCategoricalCellValue(p, column));
+  }
+  return Array.from(seen).sort((a, b) => {
+    if (a === '' && b !== '') return -1;
+    if (a !== '' && b === '') return 1;
+    return a.localeCompare(b);
+  });
+}
+
+function purchaseHistoryDisplayLabel(
+  column: PurchaseHistoryColumnId,
+  value: string,
+): string {
+  if (value === '') return '(empty)';
+  if (column === 'term') {
+    const n = Number(value);
+    return Number.isFinite(n) ? formatTerm(n) : value;
+  }
+  return value;
+}
+
+function wirePurchaseHistoryFilterButtons(
+  container: HTMLElement,
+  // The pre-column-filter slice — popover lists distinct values from
+  // every row that survived the status chip, NOT the further-narrowed
+  // visible slice (otherwise the popover would lose values the user just
+  // unchecked).
+  sourceRows: readonly HistoryPurchase[],
+): void {
+  container.querySelectorAll<HTMLButtonElement>('.history-column-filter-btn').forEach((btn) => {
+    const column = btn.dataset['column'] as PurchaseHistoryColumnId | undefined;
+    if (!column) return;
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const isNumeric = PURCHASE_HISTORY_NUMERIC_COLUMNS.has(column);
+      const filters = state.getPurchaseHistoryColumnFilters();
+      openHistoryColumnPopover<PurchaseHistoryColumnId>({
+        column,
+        anchor: btn,
+        currentFilter: filters[column],
+        headerLabel: PURCHASE_HISTORY_LABELS[column],
+        kind: isNumeric ? 'numeric' : 'categorical',
+        distinctValues: isNumeric ? undefined : purchaseHistoryDistinctValues(sourceRows, column),
+        displayLabel: (v) => purchaseHistoryDisplayLabel(column, v),
+        onCommit: (filter) => {
+          state.setPurchaseHistoryColumnFilter(column, filter);
+          renderHistoryList(lastPurchases);
+        },
+      });
+    });
+  });
+}
+
 function renderHistoryList(purchases: HistoryPurchase[]): void {
   const container = document.getElementById('history-list');
   if (!container) return;
@@ -872,7 +1031,7 @@ function renderHistoryList(purchases: HistoryPurchase[]): void {
     return;
   }
 
-  const visible = purchases.filter(p => {
+  const statusFiltered = purchases.filter(p => {
     if (activeStatusFilter === 'all') return true;
     const s = normalizeStatus(p).toLowerCase();
     if (activeStatusFilter === 'pending') return s === 'pending' || s === 'notified' || isInFlightStatus(s);
@@ -882,6 +1041,13 @@ function renderHistoryList(purchases: HistoryPurchase[]): void {
     if (activeStatusFilter === 'cancelled') return s === 'cancelled' || s === 'canceled';
     return s === activeStatusFilter;
   });
+
+  // Apply the per-column filters AFTER the status chip filter so the
+  // categorical popover lists only values present in the active status
+  // slice (e.g. filtering by "Failed" only shows providers/services that
+  // have failed rows).
+  const colFilters = state.getPurchaseHistoryColumnFilters();
+  const visible = applyPurchaseHistoryColumnFilters(statusFiltered, colFilters);
 
   const tableRows = visible.map(p => {
     const statusCell = (() => {
@@ -925,6 +1091,9 @@ function renderHistoryList(purchases: HistoryPurchase[]): void {
 
   const amortize = state.getAmortizeUpfront();
   const monthlyColHeader = amortize ? 'Monthly Cost (amortized)' : 'Monthly Cost';
+  const fbtn = (col: PurchaseHistoryColumnId): string => renderHistoryFilterButton(
+    col, PURCHASE_HISTORY_LABELS[col], colFilters[col] != null,
+  );
   const markup = `
     ${buildStatusChipRowHTML(purchases, activeStatusFilter)}
     <table>
@@ -932,15 +1101,15 @@ function renderHistoryList(purchases: HistoryPurchase[]): void {
         <tr>
           <th>Status</th>
           <th>Date</th>
-          <th>Provider</th>
-          <th>Service</th>
-          <th>Type</th>
-          <th>Region</th>
-          <th>Count</th>
-          <th>Term</th>
-          <th>Upfront Cost</th>
+          <th><span>Provider</span>${fbtn('provider')}</th>
+          <th><span>Service</span>${fbtn('service')}</th>
+          <th><span>Type</span>${fbtn('resource_type')}</th>
+          <th><span>Region</span>${fbtn('region')}</th>
+          <th><span>Count</span>${fbtn('count')}</th>
+          <th><span>Term</span>${fbtn('term')}</th>
+          <th><span>Upfront Cost</span>${fbtn('upfront_cost')}</th>
           <th>${escapeHtml(monthlyColHeader)}</th>
-          <th>Monthly Savings</th>
+          <th><span>Monthly Savings</span>${fbtn('savings')}</th>
           <th>Plan</th>
         </tr>
       </thead>
@@ -953,6 +1122,7 @@ function renderHistoryList(purchases: HistoryPurchase[]): void {
 
   // Mount the amortize checkbox into the controls area (idempotent).
   mountAmortizeCheckbox('history-controls', 'history-amortize-checkbox');
+  wirePurchaseHistoryFilterButtons(container, statusFiltered);
 
   container.querySelectorAll<HTMLButtonElement>('.status-chip[data-history-status]').forEach(btn => {
     btn.addEventListener('click', () => {

--- a/frontend/src/history.ts
+++ b/frontend/src/history.ts
@@ -1505,18 +1505,171 @@ function isPendingRow(p: HistoryPurchase): boolean {
 // from the history table (confirmDialog → API → toast → reload). The
 // reload re-renders both views from one fetch, which removes the
 // approved row from BOTH lists in one shot.
+// ---------------------------------------------------------------------------
+// Per-column filter wiring for the Approval Queue table.
+//
+// The queue scope is already narrow (pending|notified rows only); column
+// filters add inline narrowing on the queue's own columns. As with the
+// Purchase History wiring, Status is excluded because the queue's row set
+// is status-defined and the parent loadHistory loop is the authoritative
+// status source.
+//
+// Numeric extractors round to 0 decimal places (CURRENCY_DEFAULT_DIGITS)
+// so a "$X" filter targets the same value the cell renders.
+// ---------------------------------------------------------------------------
+
+const APPROVAL_QUEUE_NUMERIC_COLUMNS: ReadonlySet<ApprovalQueueColumnId> = new Set([
+  'count', 'monthly_cost', 'upfront_cost', 'savings',
+]);
+
+const APPROVAL_QUEUE_LABELS: Record<ApprovalQueueColumnId, string> = {
+  provider: 'Provider',
+  account: 'Account',
+  service: 'Service',
+  term: 'Term',
+  payment: 'Payment',
+  created_by: 'Created by',
+  count: 'Count',
+  monthly_cost: 'Monthly Cost',
+  upfront_cost: 'Upfront Cost',
+  savings: 'Monthly Savings',
+};
+
+function approvalQueueCategoricalCellValue(
+  p: HistoryPurchase,
+  col: ApprovalQueueColumnId,
+): string {
+  switch (col) {
+    case 'provider':    return p.provider ?? '';
+    case 'account':     return p.account_id ?? '';
+    case 'service':     return p.service ?? '';
+    case 'term':        return p.term == null ? '' : String(p.term);
+    case 'payment':     return p.payment ?? '';
+    case 'created_by':  return p.created_by_user_email ?? p.created_by_user_id ?? '';
+    case 'count':
+    case 'monthly_cost':
+    case 'upfront_cost':
+    case 'savings':     return '';
+  }
+}
+
+function approvalQueueNumericCellValue(
+  p: HistoryPurchase,
+  col: ApprovalQueueColumnId,
+): number {
+  switch (col) {
+    case 'count':        return p.count ?? 0;
+    // Return NaN for null monthly_cost so numeric predicates (e.g. "= 0")
+    // don't match rows where the provider didn't report a monthly cost.
+    case 'monthly_cost': return p.monthly_cost == null ? Number.NaN : p.monthly_cost;
+    case 'upfront_cost': return p.upfront_cost ?? 0;
+    case 'savings':      return p.estimated_savings ?? 0;
+    case 'provider':
+    case 'account':
+    case 'service':
+    case 'term':
+    case 'payment':
+    case 'created_by':   return Number.NaN;
+  }
+}
+
+export function applyApprovalQueueColumnFilters(
+  purchases: readonly HistoryPurchase[],
+  filters: state.ApprovalQueueColumnFilters,
+): HistoryPurchase[] {
+  return applyColumnFilters<HistoryPurchase, ApprovalQueueColumnId>(
+    purchases,
+    filters,
+    {
+      categorical: approvalQueueCategoricalCellValue,
+      numeric: (p, col) => roundForDisplay(approvalQueueNumericCellValue(p, col)),
+    },
+  );
+}
+
+function approvalQueueDistinctValues(
+  purchases: readonly HistoryPurchase[],
+  column: ApprovalQueueColumnId,
+): string[] {
+  const seen = new Set<string>();
+  for (const p of purchases) {
+    seen.add(approvalQueueCategoricalCellValue(p, column));
+  }
+  return Array.from(seen).sort((a, b) => {
+    if (a === '' && b !== '') return -1;
+    if (a !== '' && b === '') return 1;
+    return a.localeCompare(b);
+  });
+}
+
+function approvalQueueDisplayLabel(
+  column: ApprovalQueueColumnId,
+  value: string,
+): string {
+  if (value === '') return '(empty)';
+  if (column === 'term') {
+    const n = Number(value);
+    return Number.isFinite(n) ? formatTerm(n) : value;
+  }
+  if (column === 'account') {
+    // Account cells render via getAccountName() — mirror the same display.
+    return getAccountName(value);
+  }
+  return value;
+}
+
+function wireApprovalQueueFilterButtons(
+  container: HTMLElement,
+  // Source for the popover's distinct-values list — the pre-column-filter
+  // pending slice. Same reasoning as Purchase History: the popover must
+  // list every value that exists in the broader (un-narrowed) set so
+  // the user can re-check a value after unchecking it.
+  sourceRows: readonly HistoryPurchase[],
+): void {
+  container.querySelectorAll<HTMLButtonElement>('.history-column-filter-btn').forEach((btn) => {
+    const column = btn.dataset['column'] as ApprovalQueueColumnId | undefined;
+    if (!column) return;
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const isNumeric = APPROVAL_QUEUE_NUMERIC_COLUMNS.has(column);
+      const filters = state.getApprovalQueueColumnFilters();
+      openHistoryColumnPopover<ApprovalQueueColumnId>({
+        column,
+        anchor: btn,
+        currentFilter: filters[column],
+        headerLabel: APPROVAL_QUEUE_LABELS[column],
+        kind: isNumeric ? 'numeric' : 'categorical',
+        distinctValues: isNumeric ? undefined : approvalQueueDistinctValues(sourceRows, column),
+        displayLabel: (v) => approvalQueueDisplayLabel(column, v),
+        onCommit: (filter) => {
+          state.setApprovalQueueColumnFilter(column, filter);
+          renderApprovalQueue(lastPendingForQueue);
+        },
+      });
+    });
+  });
+}
+
+// Cache of the last pre-column-filter pending list so the popover-driven
+// re-render path can rebuild the table without re-fetching.
+let lastPendingForQueue: HistoryPurchase[] = [];
+
 export function renderApprovalQueue(purchases: HistoryPurchase[]): void {
   const container = document.getElementById('purchases-approval-queue');
   if (!container) return;
 
   const pending = (purchases || []).filter(isPendingRow);
+  lastPendingForQueue = pending;
 
   if (pending.length === 0) {
     container.innerHTML = '<p class="empty">No pending approvals.</p>';
     return;
   }
 
-  const rows = pending.map(p => {
+  const colFilters = state.getApprovalQueueColumnFilters();
+  const visible = applyApprovalQueueColumnFilters(pending, colFilters);
+
+  const rows = visible.map(p => {
     const actions = renderPendingActionButtons(p);
     const actionsCell = actions || '<span class="muted">-</span>';
     // Show email when resolved; fall back to UUID so the cancel-own gate still
@@ -1562,21 +1715,24 @@ export function renderApprovalQueue(purchases: HistoryPurchase[]): void {
   const monthlyColHeader = amortize ? 'Monthly Cost (amortized)' : 'Monthly Cost';
   // monthlyColHeader is a hardcoded constant string (no user data), so
   // interpolating it directly into the template is safe.
+  const fbtn = (col: ApprovalQueueColumnId): string => renderHistoryFilterButton(
+    col, APPROVAL_QUEUE_LABELS[col], colFilters[col] != null,
+  );
   container.innerHTML = `
     <table class="approval-queue-table">
       <thead>
         <tr>
           <th>Date</th>
-          <th>Account</th>
-          <th>Provider</th>
-          <th>Service</th>
-          <th>Count</th>
-          <th>Term</th>
-          <th>Payment</th>
-          <th>${monthlyColHeader}</th>
-          <th>Upfront Cost</th>
-          <th>Monthly Savings</th>
-          <th>Created by</th>
+          <th><span>Account</span>${fbtn('account')}</th>
+          <th><span>Provider</span>${fbtn('provider')}</th>
+          <th><span>Service</span>${fbtn('service')}</th>
+          <th><span>Count</span>${fbtn('count')}</th>
+          <th><span>Term</span>${fbtn('term')}</th>
+          <th><span>Payment</span>${fbtn('payment')}</th>
+          <th><span>${monthlyColHeader}</span>${fbtn('monthly_cost')}</th>
+          <th><span>Upfront Cost</span>${fbtn('upfront_cost')}</th>
+          <th><span>Monthly Savings</span>${fbtn('savings')}</th>
+          <th><span>Created by</span>${fbtn('created_by')}</th>
           <th>Actions</th>
         </tr>
       </thead>
@@ -1590,4 +1746,5 @@ export function renderApprovalQueue(purchases: HistoryPurchase[]): void {
   mountAmortizeCheckbox('purchases-approval-queue-section', 'approval-queue-amortize-checkbox');
 
   wireRowActionHandlers(container);
+  wireApprovalQueueFilterButtons(container, pending);
 }

--- a/frontend/src/lib/history-filter-popover.ts
+++ b/frontend/src/lib/history-filter-popover.ts
@@ -1,0 +1,355 @@
+/**
+ * Lightweight column-filter popover shared by the two History tables
+ * (Purchase History + Approval Queue) — issue #166 follow-up.
+ *
+ * Mirrors the visual shape of recommendations.ts's popover (so the same
+ * CSS in styles/components.css applies) but is intentionally simpler:
+ *   - One popover open at a time per `openColumnPopover` call.
+ *   - The caller owns the column-id enum, the filter state slice, and
+ *     the re-render callback; this module only renders the popover DOM,
+ *     wires inputs to commit, and manages anchor/global-listener teardown.
+ *   - No "All Savings Plans" group affordance (recs-specific).
+ *
+ * The popover is appended to `document.body` (portal pattern) so it
+ * survives the table's `innerHTML` rewrite on every commit; the next
+ * render is expected to rebind the trigger button by `[data-column=…]`.
+ */
+
+import {
+  parseNumericFilter,
+  type ColumnFilterKind,
+} from './column-filters';
+
+export interface PopoverConfig<TColumnId extends string> {
+  column: TColumnId;
+  anchor: HTMLElement;
+  // Current filter for this column (null = not narrowed).
+  currentFilter: ColumnFilterKind | undefined;
+  // Header label rendered inside the popover ("Filter <Label>").
+  headerLabel: string;
+  // 'numeric' → free-text expression input; 'categorical' → checkbox list.
+  kind: 'numeric' | 'categorical';
+  // Categorical only: distinct raw cell values (post-extract). Order is
+  // preserved as the caller provided it (caller controls sort).
+  distinctValues?: readonly string[];
+  // Categorical only: render-time label resolver (e.g. account_id → name).
+  displayLabel?: (value: string) => string;
+  // Commit callback: caller writes to state then re-renders the table.
+  // Passing `null` clears the filter (no narrowing applied).
+  onCommit: (filter: ColumnFilterKind | null) => void;
+}
+
+interface OpenPopoverHandle {
+  el: HTMLDivElement;
+  column: string;
+}
+
+let openPopover: OpenPopoverHandle | null = null;
+let outsideClickHandler: ((e: MouseEvent) => void) | null = null;
+let escKeyHandler: ((e: KeyboardEvent) => void) | null = null;
+let scrollCloseHandler: ((e: Event) => void) | null = null;
+let resizeHandler: (() => void) | null = null;
+let lastAnchorSelector: (() => HTMLElement | null) | null = null;
+
+function detachGlobalListeners(): void {
+  if (outsideClickHandler) document.removeEventListener('mousedown', outsideClickHandler);
+  if (escKeyHandler) document.removeEventListener('keydown', escKeyHandler);
+  if (scrollCloseHandler) {
+    window.removeEventListener(
+      'scroll',
+      scrollCloseHandler,
+      { capture: true } as EventListenerOptions,
+    );
+  }
+  if (resizeHandler) window.removeEventListener('resize', resizeHandler);
+  outsideClickHandler = null;
+  escKeyHandler = null;
+  scrollCloseHandler = null;
+  resizeHandler = null;
+}
+
+export function closeOpenHistoryPopover(restoreFocus = false): void {
+  if (!openPopover) return;
+  const { el, column } = openPopover;
+  el.remove();
+  openPopover = null;
+  detachGlobalListeners();
+  if (restoreFocus) {
+    const trigger = document.querySelector<HTMLElement>(
+      `.history-column-filter-btn[data-column="${CSS.escape(column)}"]`,
+    );
+    trigger?.focus();
+  }
+  lastAnchorSelector = null;
+}
+
+function positionPopover(popover: HTMLElement, anchor: HTMLElement): void {
+  const rect = anchor.getBoundingClientRect();
+  popover.style.display = 'block';
+  const popRect = popover.getBoundingClientRect();
+  const margin = 8;
+  let top = rect.bottom + 4;
+  if (top + popRect.height > window.innerHeight - margin) {
+    top = Math.max(margin, rect.top - popRect.height - 4);
+  }
+  let left = rect.left;
+  if (left + popRect.width > window.innerWidth - margin) {
+    left = Math.max(margin, window.innerWidth - margin - popRect.width);
+  }
+  popover.style.position = 'absolute';
+  popover.style.top = `${top + window.scrollY}px`;
+  popover.style.left = `${left + window.scrollX}px`;
+}
+
+function attachGlobalListeners(popover: HTMLElement): void {
+  outsideClickHandler = (e: MouseEvent): void => {
+    if (!openPopover) return;
+    const target = e.target as Node | null;
+    if (!target) return;
+    if (popover.contains(target)) return;
+    if (target instanceof Element && target.closest('.history-column-filter-btn')) return;
+    closeOpenHistoryPopover();
+  };
+  escKeyHandler = (e: KeyboardEvent): void => {
+    if (!openPopover) return;
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      closeOpenHistoryPopover(true);
+    }
+  };
+  scrollCloseHandler = (e: Event): void => {
+    if (!openPopover) return;
+    const target = e.target as Node | null;
+    if (target && popover.contains(target)) return;
+    closeOpenHistoryPopover();
+  };
+  resizeHandler = (): void => {
+    if (!openPopover) return;
+    const anchor = lastAnchorSelector?.();
+    if (!anchor) {
+      closeOpenHistoryPopover();
+      return;
+    }
+    positionPopover(popover, anchor);
+  };
+  document.addEventListener('mousedown', outsideClickHandler);
+  document.addEventListener('keydown', escKeyHandler);
+  window.addEventListener('scroll', scrollCloseHandler, { capture: true, passive: true });
+  window.addEventListener('resize', resizeHandler);
+}
+
+/**
+ * Open the popover anchored to `anchor`. Toggles closed if the same
+ * column is already open. Closes any previously-open popover (from
+ * either History table — only one is open at a time, even across
+ * the two tables, to avoid stacking dialogs).
+ */
+export function openHistoryColumnPopover<TColumnId extends string>(
+  config: PopoverConfig<TColumnId>,
+): void {
+  // Toggle / swap.
+  if (openPopover) {
+    const sameColumn = openPopover.column === config.column;
+    closeOpenHistoryPopover();
+    if (sameColumn) return;
+  }
+
+  const popover = document.createElement('div');
+  popover.className = 'column-filter-popover';
+  popover.setAttribute('role', 'dialog');
+  popover.setAttribute('aria-modal', 'false');
+
+  const headingId = `history-column-filter-heading-${String(config.column)}`;
+  popover.setAttribute('aria-labelledby', headingId);
+
+  const heading = document.createElement('h3');
+  heading.id = headingId;
+  heading.className = 'column-filter-heading';
+  heading.textContent = `Filter ${config.headerLabel}`;
+  popover.appendChild(heading);
+
+  let commitAllRef: ((target: boolean) => void) | null = null;
+  let inputRef: HTMLInputElement | null = null;
+  let errorRef: HTMLElement | null = null;
+
+  if (config.kind === 'numeric') {
+    const label = document.createElement('label');
+    label.className = 'column-filter-numeric-label';
+    label.textContent = 'Expression';
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.className = 'column-filter-numeric-input';
+    input.placeholder = 'e.g. >100, 50..200, 5';
+    const errorId = `history-column-filter-error-${String(config.column)}`;
+    input.setAttribute('aria-describedby', errorId);
+    label.appendChild(input);
+    popover.appendChild(label);
+
+    const errorEl = document.createElement('div');
+    errorEl.id = errorId;
+    errorEl.className = 'column-filter-error';
+    errorEl.setAttribute('role', 'status');
+    popover.appendChild(errorEl);
+
+    inputRef = input;
+    errorRef = errorEl;
+
+    const cur = config.currentFilter;
+    if (cur && cur.kind === 'expr') input.value = cur.expr;
+
+    const commit = (): void => {
+      const expr = input.value.trim();
+      if (expr === '') {
+        errorEl.textContent = '';
+        config.onCommit(null);
+        return;
+      }
+      const parsed = parseNumericFilter(expr);
+      if (!parsed.ok) {
+        errorEl.textContent = parsed.error;
+        return;
+      }
+      errorEl.textContent = '';
+      config.onCommit({ kind: 'expr', expr });
+    };
+    input.addEventListener('blur', commit);
+    input.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        commit();
+      }
+    });
+  } else {
+    const distinct = config.distinctValues ?? [];
+    const display = config.displayLabel ?? ((v: string): string => (v === '' ? '(empty)' : v));
+
+    const allLabel = document.createElement('label');
+    allLabel.className = 'column-filter-all';
+    const allBox = document.createElement('input');
+    allBox.type = 'checkbox';
+    allBox.dataset['role'] = 'all';
+    allLabel.appendChild(allBox);
+    const allText = document.createElement('span');
+    allText.textContent = '(All)';
+    allLabel.appendChild(allText);
+    popover.appendChild(allLabel);
+
+    const list = document.createElement('div');
+    list.className = 'column-filter-list';
+    const checkboxes = new Map<string, HTMLInputElement>();
+    for (const value of distinct) {
+      const itemLabel = document.createElement('label');
+      itemLabel.className = 'column-filter-item';
+      const cb = document.createElement('input');
+      cb.type = 'checkbox';
+      cb.dataset['value'] = value;
+      itemLabel.appendChild(cb);
+      const text = document.createElement('span');
+      text.textContent = display(value);
+      itemLabel.appendChild(text);
+      list.appendChild(itemLabel);
+      checkboxes.set(value, cb);
+    }
+    popover.appendChild(list);
+
+    // Resync checked state from current filter.
+    const cur = config.currentFilter;
+    if (cur == null) {
+      checkboxes.forEach((cb) => { cb.checked = true; });
+    } else if (cur.kind === 'set') {
+      const set = new Set(cur.values);
+      checkboxes.forEach((cb, v) => { cb.checked = set.has(v); });
+    }
+
+    const updateAllTriState = (): void => {
+      const total = checkboxes.size;
+      let checked = 0;
+      checkboxes.forEach((cb) => { if (cb.checked) checked++; });
+      allBox.indeterminate = checked > 0 && checked < total;
+      allBox.checked = checked === total && total > 0;
+    };
+    updateAllTriState();
+
+    const commit = (): void => {
+      const selected: string[] = [];
+      checkboxes.forEach((cb, value) => { if (cb.checked) selected.push(value); });
+      if (selected.length === checkboxes.size) {
+        config.onCommit(null);
+      } else {
+        config.onCommit({ kind: 'set', values: selected });
+      }
+      updateAllTriState();
+    };
+    const commitAll = (target: boolean): void => {
+      checkboxes.forEach((cb) => { cb.checked = target; });
+      if (target) {
+        config.onCommit(null);
+      } else {
+        config.onCommit({ kind: 'set', values: [] });
+      }
+      updateAllTriState();
+    };
+    commitAllRef = commitAll;
+
+    checkboxes.forEach((cb) => {
+      cb.addEventListener('change', commit);
+    });
+    allBox.addEventListener('change', () => {
+      commitAll(allBox.checked);
+    });
+  }
+
+  // Footer with Clear button.
+  const footer = document.createElement('div');
+  footer.className = 'column-filter-footer';
+  const clearBtn = document.createElement('button');
+  clearBtn.type = 'button';
+  clearBtn.className = 'column-filter-clear';
+  clearBtn.textContent = 'Clear';
+  clearBtn.addEventListener('click', () => {
+    if (config.kind === 'numeric') {
+      if (inputRef) inputRef.value = '';
+      if (errorRef) errorRef.textContent = '';
+      config.onCommit(null);
+    } else {
+      // Categorical Clear: explicit empty allow-list to distinguish from
+      // "no filter applied" (which would show every row). Mirrors the
+      // recommendations popover behaviour (issue #482 / #700).
+      commitAllRef?.(false);
+    }
+  });
+  footer.appendChild(clearBtn);
+  popover.appendChild(footer);
+
+  document.body.appendChild(popover);
+  config.anchor.setAttribute('aria-expanded', 'true');
+  positionPopover(popover, config.anchor);
+
+  openPopover = { el: popover, column: String(config.column) };
+  lastAnchorSelector = (): HTMLElement | null => document.querySelector<HTMLElement>(
+    `.history-column-filter-btn[data-column="${CSS.escape(String(config.column))}"]`,
+  );
+  attachGlobalListeners(popover);
+
+  // Focus first interactive control for keyboard users.
+  const firstFocusable = inputRef
+    ?? popover.querySelector<HTMLInputElement>('input[type="checkbox"]');
+  firstFocusable?.focus();
+}
+
+/**
+ * Render the filter-icon button placed inside a `<th>` cell. The caller
+ * binds the click handler against `.history-column-filter-btn` after the
+ * table is innerHTML-rewritten.
+ */
+export function renderHistoryFilterButton<TColumnId extends string>(
+  column: TColumnId,
+  label: string,
+  active: boolean,
+): string {
+  const cls = `history-column-filter-btn${active ? ' active' : ''}`;
+  const ariaLabel = active ? `Filter ${label} — currently active` : `Filter ${label}`;
+  // Use the same gear-style glyph (⛛) the recommendations popover
+  // uses so the two surfaces are visually identical to the user.
+  return `<button type="button" class="${cls}" data-column="${column}" aria-haspopup="dialog" aria-expanded="false" aria-label="${ariaLabel}" title="${ariaLabel}">⛛</button>`;
+}

--- a/frontend/src/lib/history-filter-popover.ts
+++ b/frontend/src/lib/history-filter-popover.ts
@@ -74,10 +74,12 @@ export function closeOpenHistoryPopover(restoreFocus = false): void {
   el.remove();
   openPopover = null;
   detachGlobalListeners();
+  const trigger = document.querySelector<HTMLElement>(
+    `.history-column-filter-btn[data-column="${CSS.escape(column)}"]`,
+  );
+  // Always clear the stale expanded state, regardless of focus restoration.
+  trigger?.setAttribute('aria-expanded', 'false');
   if (restoreFocus) {
-    const trigger = document.querySelector<HTMLElement>(
-      `.history-column-filter-btn[data-column="${CSS.escape(column)}"]`,
-    );
     trigger?.focus();
   }
   lastAnchorSelector = null;

--- a/frontend/src/lib/history-filter-popover.ts
+++ b/frontend/src/lib/history-filter-popover.ts
@@ -19,6 +19,7 @@ import {
   parseNumericFilter,
   type ColumnFilterKind,
 } from './column-filters';
+import { escapeHtmlAttr } from '../utils';
 
 export interface PopoverConfig<TColumnId extends string> {
   column: TColumnId;
@@ -350,8 +351,11 @@ export function renderHistoryFilterButton<TColumnId extends string>(
   active: boolean,
 ): string {
   const cls = `history-column-filter-btn${active ? ' active' : ''}`;
-  const ariaLabel = active ? `Filter ${label} — currently active` : `Filter ${label}`;
+  const ariaLabel = escapeHtmlAttr(
+    active ? `Filter ${label} - currently active` : `Filter ${label}`,
+  );
+  const safeColumn = escapeHtmlAttr(String(column));
   // Use the same gear-style glyph (⛛) the recommendations popover
   // uses so the two surfaces are visually identical to the user.
-  return `<button type="button" class="${cls}" data-column="${column}" aria-haspopup="dialog" aria-expanded="false" aria-label="${ariaLabel}" title="${ariaLabel}">⛛</button>`;
+  return `<button type="button" class="${cls}" data-column="${safeColumn}" aria-haspopup="dialog" aria-expanded="false" aria-label="${ariaLabel}" title="${ariaLabel}">⛛</button>`;
 }

--- a/frontend/src/state.ts
+++ b/frontend/src/state.ts
@@ -335,6 +335,93 @@ export function clearAllActiveRiColumnFilters(): void {
 }
 
 // ---------------------------------------------------------------------------
+// History per-column filters (issue #166 follow-up).
+//
+// The History page renders two tables: Purchase History (completed-and-final
+// rows) and Approval Queue (pending/in-flight rows). Their column shapes
+// overlap only partially (Account / Payment / Monthly Cost / Created By
+// appear only on the queue; Resource Type / Region appear only on Purchase
+// History), so each table gets its own closed column-id enum and its own
+// in-memory filter slice. Both reuse `applyColumnFilters` from
+// lib/column-filters.ts via the same `kind: 'set' | 'expr'` shape used by
+// the recommendations table -- no new lib-level abstractions needed.
+//
+// In-memory only on this iteration; persistence (localStorage) is a
+// follow-up tracked under the same umbrella as the recommendations
+// equivalent.
+// ---------------------------------------------------------------------------
+
+export type PurchaseHistoryColumnId =
+  | 'provider' | 'service' | 'resource_type' | 'region' | 'term'
+  | 'count' | 'upfront_cost' | 'savings';
+
+export type ApprovalQueueColumnId =
+  | 'provider' | 'account' | 'service' | 'term' | 'payment' | 'created_by'
+  | 'count' | 'monthly_cost' | 'upfront_cost' | 'savings';
+
+export type HistoryColumnFilter =
+  | { kind: 'set'; values: string[] }
+  | { kind: 'expr'; expr: string };
+
+export type PurchaseHistoryColumnFilters = Partial<
+  Record<PurchaseHistoryColumnId, HistoryColumnFilter>
+>;
+export type ApprovalQueueColumnFilters = Partial<
+  Record<ApprovalQueueColumnId, HistoryColumnFilter>
+>;
+
+let purchaseHistoryColumnFilters: PurchaseHistoryColumnFilters = {};
+let approvalQueueColumnFilters: ApprovalQueueColumnFilters = {};
+
+export function getPurchaseHistoryColumnFilters(): PurchaseHistoryColumnFilters {
+  return { ...purchaseHistoryColumnFilters };
+}
+
+export function setPurchaseHistoryColumnFilter(
+  column: PurchaseHistoryColumnId,
+  filter: HistoryColumnFilter | null,
+): void {
+  if (filter === null) {
+    const next = { ...purchaseHistoryColumnFilters };
+    delete next[column];
+    purchaseHistoryColumnFilters = next;
+    return;
+  }
+  purchaseHistoryColumnFilters = {
+    ...purchaseHistoryColumnFilters,
+    [column]: filter,
+  };
+}
+
+export function clearAllPurchaseHistoryColumnFilters(): void {
+  purchaseHistoryColumnFilters = {};
+}
+
+export function getApprovalQueueColumnFilters(): ApprovalQueueColumnFilters {
+  return { ...approvalQueueColumnFilters };
+}
+
+export function setApprovalQueueColumnFilter(
+  column: ApprovalQueueColumnId,
+  filter: HistoryColumnFilter | null,
+): void {
+  if (filter === null) {
+    const next = { ...approvalQueueColumnFilters };
+    delete next[column];
+    approvalQueueColumnFilters = next;
+    return;
+  }
+  approvalQueueColumnFilters = {
+    ...approvalQueueColumnFilters,
+    [column]: filter,
+  };
+}
+
+export function clearAllApprovalQueueColumnFilters(): void {
+  approvalQueueColumnFilters = {};
+}
+
+// ---------------------------------------------------------------------------
 // Per-column visibility state (issue #318).
 // A column id in this set is HIDDEN; an absent id is visible (default visible).
 // In-memory only; the localStorage layer lives in recommendations.ts alongside


### PR DESCRIPTION
## Summary

Wires the History page to the shared `frontend/src/lib/column-filters.ts` extracted by merged PR #570. Adds inline per-column filter buttons to **both** History tables (Purchase History + Approval Queue) using the same `applyColumnFilters<TRow, TColumnId>` shape that recommendations.ts already uses.

- New state slices: `PurchaseHistoryColumnId` + `ApprovalQueueColumnId`, each with its own in-memory filter record, get/set/clear accessors. Two separate enums because the queue uses Account/Payment/Monthly Cost/Created By while Purchase History uses Resource Type/Region — overlap is too narrow to share a single column-id type without ugly unions.
- New `frontend/src/lib/history-filter-popover.ts` — small reusable popover helper shared by the two tables; reuses the existing `.column-filter-popover` CSS so the visual matches recommendations.
- Filterable columns:
  - **Purchase History**: Provider, Service, Type, Region, Term (categorical) + Count, Upfront Cost, Monthly Savings (numeric).
  - **Approval Queue**: Provider, Account, Service, Term, Payment, Created by (categorical) + Count, Monthly Cost, Upfront Cost, Monthly Savings (numeric).
- Status is intentionally excluded — the existing status chip-row stays as the canonical status filter on Purchase History; the Approval Queue scope is status-defined.
- Numeric extractors apply `roundForDisplay(_, 0)` so a typed `$X` matches the rendered cell (matches the issue #484 contract on recommendations).
- `monthly_cost` returns `NaN` for null (`= 0` and `> 0` filters don't coincidentally match unreported rows).

## Sibling PRs

Part of the issue #166 follow-up trio:
- This PR: History tables.
- Sibling: Plans table.
- Sibling: RI Exchange table.

Each PR touches only its own state slice, so all three rebase cleanly against feat/multicloud-web-frontend.

## Test plan

- [x] `npm test -- history` — all history-related suites green.
- [x] `npm test -- approval-queue` — new regression suite passes.
- [x] `npm test -- column-filters` — shared lib regression unchanged.
- [x] `npx tsc --noEmit` — clean.
- [x] Full `npm test` — 67 suites / 2154 tests / 1 skipped — all green.

Refs #166.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Column filtering added to Purchase History table supporting numeric expressions and categorical selections
* Column filtering added to Approval Queue table with interactive popover-based filter UI
* New filter buttons in table headers enabling quick application and clearing of active filters

**Tests**
* Added regression test suites for column filter functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->