### PR TITLE
fix(test): settings-purchasing-grace.test.ts failure on feat (closes #514)

### DIFF
--- a/frontend/src/__tests__/settings-purchasing-grace.test.ts
+++ b/frontend/src/__tests__/settings-purchasing-grace.test.ts
@@ -9,6 +9,14 @@
  *   - Out-of-range input (< 0, > 30, non-integer) is rejected with a
  *     targeted toast instead of silently succeeding or being clamped.
  *   - Reset-to-defaults restores every input to 7.
+ *
+ * History: PR #478 aggregated per-provider validation errors into a single
+ * toast (one call listing every failing provider in input order rather than
+ * bailing on the first). The assertions here were originally written for the
+ * per-provider wording ("AWS grace period: Must be...") and updated in
+ * PR #548 to match the aggregated format ("Grace period must be a whole
+ * number between 0 and 30 days (AWS)."). Issue #514 tracked the pre-existing
+ * CI failure caused by the mismatch; PR #548 resolved it.
  */
 
 import { loadGlobalSettings, saveGlobalSettings, resetSettings, setupSettingsHandlers } from '../settings';


### PR DESCRIPTION
## Summary

- **Failing assertion** (line 305 of `settings-purchasing-grace.test.ts` before the fix): `expect(toastArg.message).toBe('AWS grace period: Must be a whole number between 0 and 30')` -- the test expected the old per-provider toast wording.
- **Root cause**: PR #478 changed `saveGlobalSettings` to aggregate all failing grace-period providers into a single toast (`Grace period must be a whole number between 0 and 30 days (AWS).`). Commit `1c92887be` (PR #471 follow-up) added the inline-validation tests but carried the stale per-provider assertion from the pre-#478 design.
- **Fix shape (test-side)**: PR #548 (`508704a79`) already updated the assertions to match the aggregated format. The fix is test-side: the production code (`saveGlobalSettings`) is correct and emits the aggregated message as designed by #478.
- This PR adds an 8-line history comment to the test file header so future readers understand why the expected message format is aggregated and where the mismatch was introduced/resolved.

## Test counts

17 passed, 0 failed (`npx jest src/__tests__/settings-purchasing-grace.test.ts`). `npx tsc --noEmit` clean.

Closes #514
