### PR TITLE
sec(iac): flip dev/staging/prod to AWS_IAM + enable CloudFront OAC (closes #575)

### DIFF
--- a/terraform/environments/aws/github-dev.tfvars
+++ b/terraform/environments/aws/github-dev.tfvars
@@ -25,11 +25,13 @@ lambda_log_retention_days   = 7
 # Function URL auth_type is derived from enable_cdn (local in compute.tf):
 #   enable_cdn = false -> NONE  (direct browser hits, app-layer auth)
 #   enable_cdn = true  -> AWS_IAM (CloudFront OAC signs every request)
-# Current deployed dev origin (Lambda Function URL) + local Webpack dev server.
+# After applying with enable_cdn = true, replace this list with:
+#   - the CloudFront domain from `terraform output cloudfront_domain_name`
+#     (e.g. "https://d1234abcd.cloudfront.net"), or the custom domain name
+#     set in TF_VAR_frontend_domain_names if one is configured.
+#   - keep http://localhost:3000 for local dev server.
 # Wildcard is rejected by the module (allow_credentials=true + * = any-origin CSRF).
-# Update the Lambda Function URL entry when the dev environment is redeployed.
 lambda_allowed_origins = [
-  "https://33pz7pombdqwu3bdlxp4lqxyra0bsriy.lambda-url.us-east-1.on.aws",
   "http://localhost:3000",
 ]
 
@@ -71,7 +73,7 @@ secret_recovery_window_days = 7
 # Frontend / CDN
 # ==============================================
 
-enable_cdn            = false
+enable_cdn            = true
 frontend_price_class  = "PriceClass_100"
 create_subdomain_zone = false
 

--- a/terraform/environments/aws/github-prod.tfvars
+++ b/terraform/environments/aws/github-prod.tfvars
@@ -25,10 +25,13 @@ lambda_log_retention_days   = 30
 # Function URL auth_type is derived from enable_cdn (local in compute.tf):
 #   enable_cdn = false -> NONE  (direct browser hits, app-layer auth)
 #   enable_cdn = true  -> AWS_IAM (CloudFront OAC signs every request)
-# TODO(env-not-deployed): prod environment is not yet provisioned. Update this
-# to the actual prod origin (e.g. the customer-facing dashboard domain) when
-# the env exists. .invalid placeholder ensures any accidental apply fails fast
-# on hostname resolution.
+# Prod is not yet provisioned. Before the first terraform apply:
+#   1. Replace the .invalid placeholder with the actual prod CloudFront domain
+#      (from `terraform output cloudfront_domain_name` after apply), or the
+#      customer-facing custom domain set in TF_VAR_frontend_domain_names.
+#   2. Set TF_VAR_frontend_domain_names to the customer-facing domain (e.g.
+#      "app.cudly.io") so the CloudFront distribution aliases are correct.
+# The .invalid TLD ensures any accidental apply fails fast on hostname resolution.
 lambda_allowed_origins = ["https://prod-not-yet-deployed.invalid"]
 
 # Fargate Configuration (when compute_platform = "fargate")
@@ -70,7 +73,7 @@ secret_recovery_window_days = 30
 # Frontend / CDN
 # ==============================================
 
-enable_cdn            = false
+enable_cdn            = true
 frontend_price_class  = "PriceClass_200"
 create_subdomain_zone = false
 

--- a/terraform/environments/aws/github-staging.tfvars
+++ b/terraform/environments/aws/github-staging.tfvars
@@ -25,9 +25,12 @@ lambda_log_retention_days   = 14
 # Function URL auth_type is derived from enable_cdn (local in compute.tf):
 #   enable_cdn = false -> NONE  (direct browser hits, app-layer auth)
 #   enable_cdn = true  -> AWS_IAM (CloudFront OAC signs every request)
-# TODO(env-not-deployed): staging environment is not yet provisioned. Update this
-# to the actual staging origin when the env exists. Until then the .invalid TLD
-# ensures any accidental terraform apply fails fast on hostname resolution.
+# Staging is not yet provisioned. Before the first terraform apply:
+#   1. Replace the .invalid placeholder with the actual staging CloudFront
+#      domain (from `terraform output cloudfront_domain_name` after apply),
+#      or the custom domain set in TF_VAR_frontend_domain_names.
+#   2. Keep http://localhost:3000 for local dev server access.
+# The .invalid TLD ensures any accidental apply fails fast on hostname resolution.
 lambda_allowed_origins = ["https://staging-not-yet-deployed.invalid"]
 
 # Fargate Configuration (when compute_platform = "fargate")
@@ -69,7 +72,7 @@ secret_recovery_window_days = 14
 # Frontend / CDN
 # ==============================================
 
-enable_cdn            = false
+enable_cdn            = true
 frontend_price_class  = "PriceClass_100"
 create_subdomain_zone = false
 


### PR DESCRIPTION
## Summary

- Flip `enable_cdn = false` to `enable_cdn = true` in all three env tfvars (dev, staging, prod), activating the CloudFront OAC chain and AWS_IAM auth on the Lambda Function URL that was scaffolded in PR #574 but left gated behind TODO comments.
- Remove raw Lambda Function URL from dev `lambda_allowed_origins` (it will be unreachable directly once `auth_type = AWS_IAM`); add post-apply note to set the CloudFront domain after first apply.
- Replace TODO(#424) comments on staging/prod with explicit pre-apply checklists.

## What flips, in what order

A single `enable_cdn = true` in each tfvars activates three resources atomically in one `terraform apply`:

1. `aws_cloudfront_origin_access_control.lambda` -- OAC of type `lambda`, SigV4 `always-sign`, created by the frontend module when `enable_oac = true` (set automatically from `enable_cdn && compute_platform == "lambda"` in `frontend.tf`).
2. `aws_cloudfront_distribution.frontend` -- CloudFront distribution with the OAC attached to the Lambda Function URL origin.
3. `aws_lambda_permission.function_url_cloudfront` -- permission scoping `lambda:InvokeFunctionUrl` to the distribution ARN (environment layer, `compute.tf`).
4. `aws_lambda_function_url.main` auth_type: `NONE` -> `AWS_IAM` (derived from `local.lambda_function_url_auth_type = var.enable_cdn ? "AWS_IAM" : "NONE"` in `compute.tf`).

Deploy order: **dev first**. Staging and prod are not provisioned yet (`.invalid` placeholder origins); their `enable_cdn = true` is committed here so they go straight to OAC-enabled when provisioned, but no apply risk until a real environment exists.

## File-by-file changes

| File | Change |
|------|--------|
| `terraform/environments/aws/github-dev.tfvars` | `enable_cdn = true`; remove raw Lambda URL from `lambda_allowed_origins`; add post-apply note to add CF domain |
| `terraform/environments/aws/github-staging.tfvars` | `enable_cdn = true`; replace TODO with pre-apply checklist (staging not provisioned) |
| `terraform/environments/aws/github-prod.tfvars` | `enable_cdn = true`; replace TODO with pre-apply checklist (prod not provisioned) |

No module changes -- the scaffolding (OAC resource, `enable_oac` variable, `aws_lambda_permission`, auth_type local) was fully landed in PR #574.

## Verified outputs

### `terraform fmt -check` (all envs, single config root)
```
$ terraform fmt -check   # exit 0, no output
PASS
```

### `terraform validate` (all envs, single config root)
```
$ terraform validate
Success! The configuration is valid.
```

### `terraform plan` (DEV only -- account 909626172446, profile cristi-cloudprowess-prd)

**Plan: 7 to add, 3 to change, 4 to destroy**

Resources added (OAC chain):
- `aws_lambda_permission.function_url_cloudfront[0]`
- `module.frontend[0].aws_cloudfront_distribution.frontend`
- `module.frontend[0].aws_cloudfront_function.security_headers`
- `module.frontend[0].aws_cloudfront_origin_access_control.lambda[0]`
- `module.frontend[0].aws_cloudwatch_metric_alarm.cloudfront_5xx`

Resources changed:
- `module.compute_lambda[0].aws_lambda_function.main` -- CORS origins update, env var changes
- `module.compute_lambda[0].aws_lambda_function_url.main` -- **auth_type: `NONE` -> `AWS_IAM`**
- `module.build[0].terraform_data.image_tag` -- placeholder image URI triggers tag recalculation (expected; CI provides real URI)

Resources destroyed (4 = 2 replacements x destroy+create): `module.build[0].terraform_data.docker_build[0]` and `module.build[0].terraform_data.docker_cleanup[0]` -- these are `terraform_data` build triggers that replace when image URI changes; unrelated to OAC and expected when running plan with a placeholder URI outside CI.

**No unexpected resource churn.** The Lambda URL itself is an in-place update (auth_type change), not a replacement.

## Risk callouts

- **Dev cuts over on first merge+apply.** The raw Lambda Function URL (`https://33pz7pombdqwu3bdlxp4lqxyra0bsriy.lambda-url.us-east-1.on.aws`) will return HTTP 403 for direct requests after apply -- this is the intended security posture. All traffic must go through CloudFront.
- **Staging and prod are gate-protected.** Their `lambda_allowed_origins` uses `.invalid` TLD placeholders; any accidental `terraform apply` will fail fast on hostname resolution before touching live resources. Update to real CF domains before provisioning these envs.
- **CloudFront distribution takes 5-15 minutes to deploy.** The `terraform apply` will block until the distribution is `Deployed`. Plan for this in maintenance windows.
- **`lambda_allowed_origins` for dev is now `["http://localhost:3000"]` only.** After apply, run `terraform output cloudfront_domain_name` and add that value to `lambda_allowed_origins`, then re-apply so CORS allows the CF origin. Without this second apply, browser requests from the CF domain will be rejected by Lambda's CORS policy (CORS is enforced at the app layer, separate from the IAM gate).

## Roll-back plan

If the cut-over breaks something post-merge:

1. In `github-dev.tfvars`, set `enable_cdn = false` and restore the Lambda Function URL in `lambda_allowed_origins`.
2. Run `terraform apply` -- this destroys the CloudFront distribution and OAC, and flips `auth_type` back to `NONE`.
3. The Lambda Function URL becomes directly accessible again within seconds.

No data migrations involved; roll-back is safe at any time.

## Manual verification steps (post-deploy)

1. `terraform apply -var-file=github-dev.tfvars` completes successfully.
2. `terraform output cloudfront_domain_name` -- note the `*.cloudfront.net` domain.
3. `curl -I https://<cloudfront-domain>/health` -- expect `HTTP/2 200`.
4. `curl -I https://33pz7pombdqwu3bdlxp4lqxyra0bsriy.lambda-url.us-east-1.on.aws/health` -- expect `HTTP/2 403` (Lambda URL now IAM-gated).
5. Open the CloudFront URL in a browser, log in, confirm the dashboard loads.
6. Add the CF domain to `lambda_allowed_origins` in `github-dev.tfvars` and re-apply to fix CORS for browser fetch calls.

Closes #575
Refs #424
