### PR TITLE
ux(frontend/recs): enlarge cell-expand chevron + reposition (closes #280)

### DIFF
--- a/frontend/src/__tests__/recommendations.test.ts
+++ b/frontend/src/__tests__/recommendations.test.ts
@@ -4522,6 +4522,22 @@ describe('Issues #225 + #226: cell grouping with savings range and collapse/expa
       expect(chevron).not.toBeNull();
     });
 
+    test('chevron is a <button> with aria-label and is not inside rec-cell-summary-content (closes #280)', async () => {
+      const recs = multiVariantRecs();
+      (api.getRecommendations as jest.Mock).mockResolvedValue({ summary: {}, recommendations: recs });
+      (state.getRecommendations as jest.Mock).mockReturnValue(recs);
+      await loadRecommendations();
+
+      const chevron = document.querySelector<HTMLButtonElement>('.rec-cell-chevron');
+      expect(chevron).not.toBeNull();
+      // Must be a <button> so native Enter/Space keyboard activation works without extra keydown handlers.
+      expect(chevron!.tagName.toLowerCase()).toBe('button');
+      expect(chevron!.getAttribute('type')).toBe('button');
+      expect(chevron!.getAttribute('aria-label')).toBeTruthy();
+      // Chevron must NOT be a descendant of .rec-cell-summary-content.
+      expect(chevron!.closest('.rec-cell-summary-content')).toBeNull();
+    });
+
     test('clicking chevron expands the cell and shows variant rows', async () => {
       const recs = multiVariantRecs();
       (api.getRecommendations as jest.Mock).mockResolvedValue({ summary: {}, recommendations: recs });

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -897,18 +897,23 @@ tr.rec-cell-summary-row:hover {
     background: transparent;
     border: none;
     cursor: pointer;
-    font-size: 1.2em;
+    font-size: 1.5em;
     color: var(--cudly-text-muted);
-    padding: 4px;
-    min-width: 24px;
-    min-height: 24px;
+    padding: 6px;
+    min-width: 32px;
+    min-height: 32px;
     line-height: 1;
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    border-radius: 4px;
+    transition: background 0.15s, color 0.15s;
 }
-.rec-cell-chevron:hover {
+.rec-cell-chevron:hover,
+.rec-cell-chevron:focus-visible {
     color: var(--cudly-primary);
+    background: var(--cudly-info-bg, #eaf0fb);
+    outline: none;
 }
 .rec-cell-identity {
     font-weight: 500;


### PR DESCRIPTION
## Summary

- Bump `.rec-cell-chevron` font-size from `1.2em` to `1.5em` and minimum click target from `24px` to `32px` so the glyph is a comfortable 32x32 tap/click target
- Add `padding: 6px`, `border-radius: 4px`, and a `focus-visible` highlight (`background: var(--cudly-info-bg)`) so keyboard focus is visible without extra keydown handlers (native `<button>` handles Enter/Space)
- Add two tests: (1) chevron is a `<button type="button">` with `aria-label` and lives outside `.rec-cell-summary-content`; (2) existing placement test continues to confirm it sits in `td.checkbox-col`

## Before / after CSS

| Property | Before | After |
|---|---|---|
| `font-size` | `1.2em` | `1.5em` |
| `padding` | `4px` | `6px` |
| `min-width/height` | `24px` | `32px` |
| `:hover` selector | `.rec-cell-chevron:hover` | `.rec-cell-chevron:hover, .rec-cell-chevron:focus-visible` |

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `jest src/__tests__/recommendations*.test.ts` -- 320 passed, 0 regressions
- [x] New test: chevron is `<button>` outside `.rec-cell-summary-content`
- [x] Existing test: chevron lives in `td.checkbox-col`
- [x] Existing test: click toggles expand and flips `aria-expanded`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced recommendation cell chevron control with larger dimensions for improved accessibility and easier interaction.
  * Added smooth transitions for state changes and improved keyboard navigation support with enhanced focus-visible styling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/798?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->