### PR TITLE
perf(frontend/mfa): lazy-load qrcode out of main bundle (closes #511)

### DIFF
--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -80,10 +80,22 @@ module.exports = (env, argv) => {
       ],
       splitChunks: {
         cacheGroups: {
+          // qrcode is only used during MFA enrollment (dynamic import).
+          // Give it its own async chunk so it never lands in vendors.js.
+          qrcode: {
+            test: /[\\/]node_modules[\\/]qrcode[\\/]/,
+            name: 'qrcode',
+            chunks: 'async',
+            priority: 20,
+            enforce: true
+          },
           vendor: {
             test: /[\\/]node_modules[\\/]/,
             name: 'vendors',
-            chunks: 'all'
+            // 'initial' means only synchronously-imported packages go here;
+            // async-only deps (e.g. qrcode) stay in their own lazy chunks.
+            chunks: 'initial',
+            priority: 10
           }
         }
       }


### PR DESCRIPTION
## Summary

- `auth.ts` already uses `import('qrcode')` dynamically (PR #509), but the vendor `splitChunks` cache group had `chunks: 'all'`, which captured async imports too -- so qrcode still ended up in `vendors.js` on every page load.
- Added a dedicated `qrcode` cache group (`chunks: 'async'`, priority 20) so webpack emits it as its own on-demand chunk.
- Changed the vendor cache group to `chunks: 'initial'` (priority 10) so only synchronously-imported packages land in `vendors.js`.

## Bundle output (production build)

**Before:**
```
js/vendors.175b9550.js  224 KiB   [initial, in main entrypoint]
Entrypoint app: 608 KiB
```

**After:**
```
js/vendors.4e1021cc.js        200 KiB   [initial, in main entrypoint]
js/qrcode.f45fe2e9.chunk.js    22.6 KiB  [async, loaded on first enrollment click]
Entrypoint app: 584 KiB  (-24 KiB)
```

`vendors.js` shrank by 24 KiB (10.7%). The qrcode chunk is fetched only when the user clicks "Set up two-factor authentication" in the profile modal.

## Test plan

- [x] `npx tsc --noEmit` -- no type errors
- [x] `npx jest` -- 2142 tests pass, 0 failures (including `auth-mfa-enroll.test.ts`)
- [x] `npm run build` -- `qrcode.*.chunk.js` present in `dist/js/`, absent from entrypoint list
- [ ] Manual: open profile, observe no qrcode chunk in Network panel until "Set up two-factor authentication" is clicked
