### PR TITLE
feat(email): multipart HTML+plaintext for RI exchange pending approval (closes #296)

### DIFF
--- a/internal/email/coverage_extra_test.go
+++ b/internal/email/coverage_extra_test.go
@@ -323,24 +323,30 @@ func TestRenderRegistrationReceivedEmail_NoAdminApprovers(t *testing.T) {
 
 // Tests for SMTPSender RI exchange and approval request methods
 
-func TestSMTPSender_SendRIExchangePendingApproval_NoFromEmail(t *testing.T) {
+func TestSMTPSender_SendRIExchangePendingApproval_NoRecipient(t *testing.T) {
+	// The RI exchange approval body carries live approval tokens, so with no
+	// data.RecipientEmail and no notifyEmail fallback the SMTP sender must
+	// surface ErrNoRecipient rather than silently dropping (or broadcasting)
+	// the email. Mirrors the hardened SendPurchaseApprovalRequest contract
+	// (#1015 / #1036) and the multipart path added in #296.
 	sender := &SMTPSender{
-		host:      "smtp.example.com",
-		port:      587,
-		fromEmail: "",
+		host:        "smtp.example.com",
+		port:        587,
+		fromEmail:   "",
+		notifyEmail: "",
 	}
 
 	data := RIExchangeNotificationData{
 		DashboardURL: "https://dashboard.example.com",
 		TotalPayment: "100.00",
 		Exchanges: []RIExchangeItem{
-			{RecordID: "r1", SourceRIID: "ri-1", SourceInstanceType: "m5.large",
+			{RecordID: "r1", ApprovalToken: "tok-1", SourceRIID: "ri-1", SourceInstanceType: "m5.large",
 				TargetInstanceType: "m5.xlarge", TargetCount: 1, PaymentDue: "100.00"},
 		},
 	}
 
 	err := sender.SendRIExchangePendingApproval(context.Background(), data)
-	require.NoError(t, err)
+	require.ErrorIs(t, err, ErrNoRecipient)
 }
 
 func TestSMTPSender_SendRIExchangeCompleted_NoFromEmail(t *testing.T) {

--- a/internal/email/sender.go
+++ b/internal/email/sender.go
@@ -480,6 +480,18 @@ type RIExchangeNotificationData struct {
 	// CCEmails carries additional recipients informed of the pending exchanges
 	// but not the authorized approvers. Deduplicated against RecipientEmail.
 	CCEmails []string
+	// RequestedByName is the human-readable display name of the user who
+	// triggered the exchange run. Empty falls back to RequestedByEmail.
+	RequestedByName string
+	// RequestedByEmail is the requester's email address. Empty omits the
+	// requested-by block from the approval email.
+	RequestedByEmail string
+	// RequestedAt is the ISO-8601 / RFC3339 timestamp the exchange was
+	// submitted. Empty omits the timestamp from the summary.
+	RequestedAt string
+	// CancellationWindowNote is short text rendered below the approve/reject
+	// buttons. Empty falls back to a generic 6-hour note.
+	CancellationWindowNote string
 }
 
 // RIExchangeItem represents a single exchange in an email notification.

--- a/internal/email/smtp_sender.go
+++ b/internal/email/smtp_sender.go
@@ -403,14 +403,22 @@ func (s *SMTPSender) SendPurchaseFailedNotification(ctx context.Context, data No
 	return s.SendToEmail(ctx, s.notifyEmail, subject, body)
 }
 
-// SendRIExchangePendingApproval sends an RI exchange approval email via SMTP.
+// SendRIExchangePendingApproval sends an RI exchange approval email via SMTP
+// as multipart/alternative (plain-text + styled HTML). The body carries live
+// approval tokens, so it is sent only to the resolved recipient (the
+// submitter's notification email, falling back to the static SMTP notify
+// address) plus the deduplicated CC list; it never broadcasts. Returns
+// ErrNoRecipient when neither address is configured. Issue #296.
 func (s *SMTPSender) SendRIExchangePendingApproval(ctx context.Context, data RIExchangeNotificationData) error {
-	subject := fmt.Sprintf("CUDly - RI Exchange Approval Required (%d exchanges)", len(data.Exchanges))
-	body, err := RenderRIExchangePendingApprovalEmail(data)
-	if err != nil {
-		return fmt.Errorf("failed to render ri exchange pending approval email: %w", err)
+	recipient := data.RecipientEmail
+	if recipient == "" {
+		recipient = s.notifyEmail
 	}
-	return s.SendToEmail(ctx, s.notifyEmail, subject, body)
+	if recipient == "" {
+		return ErrNoRecipient
+	}
+	subject := fmt.Sprintf("CUDly - RI Exchange Approval Required (%d exchanges)", len(data.Exchanges))
+	return sendRIExchangePendingApprovalVia(ctx, s, recipient, data.CCEmails, subject, data)
 }
 
 // SendRIExchangeCompleted sends an RI exchange completion email via SMTP.

--- a/internal/email/template_renderers.go
+++ b/internal/email/template_renderers.go
@@ -131,9 +131,20 @@ func RenderPurchaseFailedEmail(data NotificationData) (string, error) {
 	return renderTextTemplate("failed", purchaseFailedTemplate, data)
 }
 
-// RenderRIExchangePendingApprovalEmail renders the plain-text RI exchange pending approval email template.
+// RenderRIExchangePendingApprovalEmail renders the plain-text RI exchange
+// pending approval email template. Pair with
+// RenderRIExchangePendingApprovalEmailHTML for multipart/alternative delivery.
 func RenderRIExchangePendingApprovalEmail(data RIExchangeNotificationData) (string, error) {
 	return renderTextTemplate("ri-exchange-pending", riExchangePendingApprovalTemplate, data)
+}
+
+// RenderRIExchangePendingApprovalEmailHTML renders the HTML half of the RI
+// exchange pending approval email -- inline-styled per email-client constraints.
+// The plain-text half (RenderRIExchangePendingApprovalEmail) carries the same
+// content; receiving clients pick whichever they support via the
+// multipart/alternative wrapper assembled by the sender. Issue #296.
+func RenderRIExchangePendingApprovalEmailHTML(data RIExchangeNotificationData) (string, error) {
+	return renderTemplate("ri-exchange-pending-html", riExchangePendingApprovalHTMLTemplate, data)
 }
 
 // RenderRIExchangeCompletedEmail renders the plain-text RI exchange completed email template.

--- a/internal/email/template_renderers_test.go
+++ b/internal/email/template_renderers_test.go
@@ -570,3 +570,167 @@ func TestPlainTextTemplates_NoHTMLEscaping(t *testing.T) {
 		assert.NotContains(t, html, xssName, "html/template must escape <script> tags in HTML bodies")
 	})
 }
+
+// Issue #296: plain-text RI exchange pending approval email carries the
+// enriched summary fields (requested-by, cancellation-window note) and uses
+// labelled Approve/Reject URLs instead of bracket-wrapped actions.
+func TestRenderRIExchangePendingApprovalEmail_Issue296(t *testing.T) {
+	data := RIExchangeNotificationData{
+		DashboardURL:           "https://dashboard.example.com",
+		TotalPayment:           "125.50",
+		RequestedByName:        "Cristi M",
+		RequestedByEmail:       "cristi@acme.com",
+		RequestedAt:            "2026-05-22T10:00:00Z",
+		CancellationWindowNote: "RI exchanges are irreversible once accepted by AWS.",
+		Exchanges: []RIExchangeItem{
+			{
+				RecordID:           "rec-001",
+				ApprovalToken:      "tok-abc",
+				SourceRIID:         "ri-0123456789abcdef0",
+				SourceInstanceType: "m5.large",
+				TargetInstanceType: "m6i.large",
+				TargetCount:        1,
+				PaymentDue:         "125.50",
+				UtilizationPct:     42.5,
+			},
+		},
+	}
+
+	body, err := RenderRIExchangePendingApprovalEmail(data)
+	require.NoError(t, err)
+
+	// Exchange details.
+	assert.Contains(t, body, "ri-0123456789abcdef0")
+	assert.Contains(t, body, "m5.large")
+	assert.Contains(t, body, "m6i.large")
+	assert.Contains(t, body, "42.5")
+	assert.Contains(t, body, "125.50")
+
+	// Requested-by block.
+	assert.Contains(t, body, "Cristi M")
+	assert.Contains(t, body, "cristi@acme.com")
+	assert.Contains(t, body, "2026-05-22T10:00:00Z")
+
+	// Labelled action URLs (not bracket notation).
+	assert.Contains(t, body, "Approve: ")
+	assert.Contains(t, body, "Reject:  ")
+	assert.Contains(t, body, "/api/ri-exchange/approve/rec-001")
+	assert.Contains(t, body, "/api/ri-exchange/reject/rec-001")
+
+	// Custom cancellation-window note overrides the generic fallback.
+	assert.Contains(t, body, "RI exchanges are irreversible once accepted by AWS.")
+	assert.NotContains(t, body, "Please approve within 6 hours")
+}
+
+// Issue #296: plain-text template omits requested-by block when email is empty.
+func TestRenderRIExchangePendingApprovalEmail_NoRequestedBy(t *testing.T) {
+	data := RIExchangeNotificationData{
+		DashboardURL: "https://dashboard.example.com",
+		TotalPayment: "50.00",
+		Exchanges: []RIExchangeItem{{
+			RecordID: "rec-002", ApprovalToken: "tok-xyz",
+			SourceRIID: "ri-aaa", SourceInstanceType: "c5.large",
+			TargetInstanceType: "c6i.large", TargetCount: 1,
+			PaymentDue: "50.00", UtilizationPct: 80.0,
+		}},
+	}
+
+	body, err := RenderRIExchangePendingApprovalEmail(data)
+	require.NoError(t, err)
+
+	assert.NotContains(t, body, "Requested by:")
+	// Generic note rendered when CancellationWindowNote is empty.
+	assert.Contains(t, body, "Please approve within 6 hours")
+}
+
+// Issue #296: HTML half of the RI exchange pending approval email carries
+// inline-styled approve/reject anchors with correct hrefs, the exchange
+// summary table, and the requested-by line.
+func TestRenderRIExchangePendingApprovalEmailHTML_Issue296(t *testing.T) {
+	data := RIExchangeNotificationData{
+		DashboardURL:           "https://dashboard.example.com",
+		TotalPayment:           "125.50",
+		RequestedByEmail:       "cristi@acme.com",
+		CancellationWindowNote: "RI exchanges are irreversible once accepted by AWS.",
+		Exchanges: []RIExchangeItem{
+			{
+				RecordID:           "rec-001",
+				ApprovalToken:      "tok-abc",
+				SourceRIID:         "ri-0123456789abcdef0",
+				SourceInstanceType: "m5.large",
+				TargetInstanceType: "m6i.large",
+				TargetCount:        1,
+				PaymentDue:         "125.50",
+				UtilizationPct:     42.5,
+			},
+		},
+	}
+
+	html, err := RenderRIExchangePendingApprovalEmailHTML(data)
+	require.NoError(t, err)
+	assert.NotEmpty(t, html)
+
+	// Inline-styled approve anchor with correct href.
+	assert.Contains(t, html, `href="https://dashboard.example.com/api/ri-exchange/approve/rec-001?token=tok-abc"`)
+	assert.Contains(t, html, `href="https://dashboard.example.com/api/ri-exchange/reject/rec-001?token=tok-abc"`)
+	assert.Contains(t, html, ">Approve<")
+	assert.Contains(t, html, ">Reject<")
+
+	// Approve button has inline green background (prove CSS classes aren't relied on).
+	assert.Regexp(t, `<a[^>]*style="[^"]*background:#16a34a[^"]*"[^>]*>Approve</a>`, html)
+
+	// Exchange table cells.
+	assert.Contains(t, html, "m5.large")
+	assert.Contains(t, html, "m6i.large")
+	assert.Contains(t, html, "42.5%")
+	assert.Contains(t, html, "125.50")
+
+	// Summary block + requested-by line.
+	assert.Contains(t, html, "cristi@acme.com")
+	assert.Contains(t, html, "RI Exchange Approval Required")
+
+	// Custom cancellation note.
+	assert.Contains(t, html, "RI exchanges are irreversible once accepted by AWS.")
+	assert.NotContains(t, html, "Please approve within 6 hours")
+}
+
+// Issue #296: HTML template falls back to generic 6-hour note when
+// CancellationWindowNote is empty.
+func TestRenderRIExchangePendingApprovalEmailHTML_DefaultCancellationNote(t *testing.T) {
+	data := RIExchangeNotificationData{
+		DashboardURL: "https://dashboard.example.com",
+		TotalPayment: "10.00",
+		Exchanges: []RIExchangeItem{{
+			RecordID: "rec-003", ApprovalToken: "tok-def",
+			SourceRIID: "ri-bbb", SourceInstanceType: "t3.medium",
+			TargetInstanceType: "t4g.medium", TargetCount: 1,
+			PaymentDue: "10.00", UtilizationPct: 60.0,
+		}},
+	}
+
+	html, err := RenderRIExchangePendingApprovalEmailHTML(data)
+	require.NoError(t, err)
+
+	assert.Contains(t, html, "Please approve within 6 hours")
+}
+
+// Issue #296: skipped exchanges block appears in HTML when Skipped is non-empty.
+func TestRenderRIExchangePendingApprovalEmailHTML_SkippedBlock(t *testing.T) {
+	data := RIExchangeNotificationData{
+		DashboardURL: "https://dashboard.example.com",
+		TotalPayment: "0.00",
+		Exchanges:    []RIExchangeItem{},
+		Skipped: []SkippedExchange{{
+			SourceRIID:         "ri-skip-01",
+			SourceInstanceType: "r5.large",
+			Reason:             "no matching target available",
+		}},
+	}
+
+	html, err := RenderRIExchangePendingApprovalEmailHTML(data)
+	require.NoError(t, err)
+
+	assert.Contains(t, html, "ri-skip-01")
+	assert.Contains(t, html, "no matching target available")
+	assert.Contains(t, html, "Skipped")
+}

--- a/internal/email/template_renderers_test.go
+++ b/internal/email/template_renderers_test.go
@@ -734,3 +734,59 @@ func TestRenderRIExchangePendingApprovalEmailHTML_SkippedBlock(t *testing.T) {
 	assert.Contains(t, html, "no matching target available")
 	assert.Contains(t, html, "Skipped")
 }
+
+// Issue #296 / XSS guard: html/template must escape hostile payloads in the
+// RIExchange HTML renderer. Tests RequestedByName, CancellationWindowNote, and
+// Skipped.Reason -- the three free-text fields most likely to carry attacker
+// input. Mirrors the analogous sub-test in TestPlainTextTemplates_NoHTMLEscaping.
+func TestRenderRIExchangePendingApprovalEmailHTML_EscapesHostilePayload(t *testing.T) {
+	const xssPayload = `<script>alert('xss')</script>`
+	data := RIExchangeNotificationData{
+		DashboardURL:           "https://dashboard.example.com",
+		TotalPayment:           "0.00",
+		RequestedByName:        xssPayload,
+		RequestedByEmail:       "attacker@evil.example",
+		CancellationWindowNote: xssPayload,
+		Exchanges:              []RIExchangeItem{},
+		Skipped: []SkippedExchange{{
+			SourceRIID:         "ri-skip-xss",
+			SourceInstanceType: "m5.large",
+			Reason:             xssPayload,
+		}},
+	}
+
+	html, err := RenderRIExchangePendingApprovalEmailHTML(data)
+	require.NoError(t, err)
+
+	// The literal script tag must not appear verbatim in the HTML output.
+	assert.NotContains(t, html, xssPayload, "html/template must escape <script> tags in RequestedByName/CancellationWindowNote/Reason")
+	// The content must still appear (escaped), confirming the field is rendered at all.
+	assert.Contains(t, html, "alert(", "escaped payload content should still appear in output")
+}
+
+// Issue #296 / plain-text guard: text/template must emit special characters
+// verbatim in the RIExchange plain-text renderer (no HTML entity encoding).
+func TestRenderRIExchangePendingApprovalEmail_PlainTextVerbatim(t *testing.T) {
+	name := "O'Brien & Co"
+	emailAddr := "o.brien+tag@acme.com"
+	data := RIExchangeNotificationData{
+		DashboardURL:     "https://dashboard.example.com",
+		TotalPayment:     "0.00",
+		RequestedByName:  name,
+		RequestedByEmail: emailAddr,
+		Exchanges: []RIExchangeItem{{
+			RecordID: "rec-plain", ApprovalToken: "tok-plain",
+			SourceRIID: "ri-ccc", SourceInstanceType: "r5.large",
+			TargetInstanceType: "r6i.large", TargetCount: 1,
+			PaymentDue: "0.00", UtilizationPct: 55.0,
+		}},
+	}
+
+	body, err := RenderRIExchangePendingApprovalEmail(data)
+	require.NoError(t, err)
+
+	assert.Contains(t, body, name, "apostrophe+ampersand in RequestedByName must be verbatim in plain-text")
+	assert.Contains(t, body, emailAddr, "plus-addressed email must be verbatim in plain-text")
+	assert.NotContains(t, body, "&#39;", "plain-text must not HTML-encode apostrophe")
+	assert.NotContains(t, body, "&amp;", "plain-text must not HTML-encode ampersand")
+}

--- a/internal/email/template_renderers_test.go
+++ b/internal/email/template_renderers_test.go
@@ -573,7 +573,7 @@ func TestPlainTextTemplates_NoHTMLEscaping(t *testing.T) {
 
 // Issue #296: plain-text RI exchange pending approval email carries the
 // enriched summary fields (requested-by, cancellation-window note) and uses
-// labelled Approve/Reject URLs instead of bracket-wrapped actions.
+// labeled Approve/Reject URLs instead of bracket-wrapped actions.
 func TestRenderRIExchangePendingApprovalEmail_Issue296(t *testing.T) {
 	data := RIExchangeNotificationData{
 		DashboardURL:           "https://dashboard.example.com",
@@ -611,7 +611,7 @@ func TestRenderRIExchangePendingApprovalEmail_Issue296(t *testing.T) {
 	assert.Contains(t, body, "cristi@acme.com")
 	assert.Contains(t, body, "2026-05-22T10:00:00Z")
 
-	// Labelled action URLs (not bracket notation).
+	// Labeled action URLs (not bracket notation).
 	assert.Contains(t, body, "Approve: ")
 	assert.Contains(t, body, "Reject:  ")
 	assert.Contains(t, body, "/api/ri-exchange/approve/rec-001")

--- a/internal/email/templates.go
+++ b/internal/email/templates.go
@@ -295,14 +295,16 @@ const riExchangePendingApprovalTemplate = `CUDly - RI Exchange Approval Required
 ======================================
 
 CUDly has identified convertible RI exchanges that need your approval.
-
+{{if .RequestedByEmail}}
+Requested by: {{if .RequestedByName}}{{.RequestedByName}} <{{.RequestedByEmail}}>{{else}}{{.RequestedByEmail}}{{end}}{{if .RequestedAt}} at {{.RequestedAt}}{{end}}
+{{end}}
 Proposed Exchanges:
 {{range .Exchanges}}
 - Source: {{.SourceRIID}} ({{.SourceInstanceType}}, {{printf "%.1f" .UtilizationPct}}% utilized)
   Target: {{.TargetInstanceType}} x{{.TargetCount}}
   Payment Due: ${{.PaymentDue}}
-  [Approve] {{$.DashboardURL}}/api/ri-exchange/approve/{{.RecordID}}?token={{urlquery .ApprovalToken}}
-  [Reject]  {{$.DashboardURL}}/api/ri-exchange/reject/{{.RecordID}}?token={{urlquery .ApprovalToken}}
+  Approve: {{$.DashboardURL}}/api/ri-exchange/approve/{{.RecordID}}?token={{urlquery .ApprovalToken}}
+  Reject:  {{$.DashboardURL}}/api/ri-exchange/reject/{{.RecordID}}?token={{urlquery .ApprovalToken}}
 {{end}}
 Total Payment: ${{.TotalPayment}}
 {{if .Skipped}}
@@ -310,13 +312,85 @@ Skipped (could not process):
 {{range .Skipped}}
 - {{.SourceRIID}} ({{.SourceInstanceType}}): {{.Reason}}
 {{end}}{{end}}
-Please approve within 6 hours (before the next analysis run).
+{{if .CancellationWindowNote}}{{.CancellationWindowNote}}{{else}}Please approve within 6 hours (before the next analysis run).{{end}}
 
 Review exchange history:
 {{.DashboardURL}}/#ri-exchange
 
-This is an automated message from CUDly.
+This is an automated message from CUDly. Do not share these links.
 `
+
+// riExchangePendingApprovalHTMLTemplate renders the same approval request as
+// the plain-text template above with inline-styled approve/reject CTAs and an
+// exchange summary table. CSS classes are NOT honoured by most email clients
+// (Outlook, mobile Gmail) — every visual rule lives in inline style=""
+// attributes. Mirrors purchaseApprovalRequestHTMLTemplate. Issue #296.
+const riExchangePendingApprovalHTMLTemplate = `<!DOCTYPE html>
+<html><head><meta charset="UTF-8"><title>CUDly - RI Exchange Approval Required</title></head>
+<body style="margin:0;padding:0;background:#f4f6f8;font-family:Arial,Helvetica,sans-serif;color:#1a202c;">
+<table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="background:#f4f6f8;padding:24px 0;">
+<tr><td align="center">
+<table role="presentation" cellpadding="0" cellspacing="0" width="600" style="background:#ffffff;border-radius:8px;box-shadow:0 1px 3px rgba(0,0,0,0.06);">
+<tr><td style="padding:32px 32px 16px 32px;">
+<h1 style="margin:0;font-size:22px;color:#0f172a;">RI Exchange Approval Required</h1>
+<p style="margin:8px 0 0 0;color:#475569;font-size:14px;">CUDly has identified <strong>{{len .Exchanges}}</strong> convertible RI exchange(s) that need your approval.</p>
+</td></tr>
+
+<tr><td style="padding:0 32px 8px 32px;">
+<table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="border-collapse:collapse;font-size:14px;">
+<tr><td style="padding:6px 0;color:#64748b;width:180px;">Total Payment</td><td style="padding:6px 0;color:#0f172a;font-weight:600;">${{.TotalPayment}}</td></tr>
+{{if .RequestedByEmail}}<tr><td style="padding:6px 0;color:#64748b;">Requested by</td><td style="padding:6px 0;color:#0f172a;">{{if .RequestedByName}}{{.RequestedByName}} &lt;{{.RequestedByEmail}}&gt;{{else}}{{.RequestedByEmail}}{{end}}{{if .RequestedAt}} <span style="color:#94a3b8;">at {{.RequestedAt}}</span>{{end}}</td></tr>
+{{end}}
+</table>
+</td></tr>
+
+<tr><td style="padding:0 32px 16px 32px;">
+<h2 style="margin:16px 0 8px 0;font-size:15px;color:#334155;text-transform:uppercase;letter-spacing:0.04em;">Proposed Exchanges</h2>
+<table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="border-collapse:collapse;font-size:13px;border:1px solid #e2e8f0;border-radius:6px;overflow:hidden;">
+<thead><tr style="background:#f1f5f9;">
+<th align="left" style="padding:10px 12px;color:#475569;font-weight:600;">Source RI</th>
+<th align="left" style="padding:10px 12px;color:#475569;font-weight:600;">Target</th>
+<th align="right" style="padding:10px 12px;color:#475569;font-weight:600;">Utilization</th>
+<th align="right" style="padding:10px 12px;color:#475569;font-weight:600;">Payment Due</th>
+<th align="left" style="padding:10px 12px;color:#475569;font-weight:600;">Actions</th>
+</tr></thead>
+<tbody>
+{{range .Exchanges}}<tr style="border-top:1px solid #e2e8f0;">
+<td style="padding:10px 12px;color:#0f172a;"><div>{{.SourceInstanceType}}</div><div style="color:#94a3b8;font-size:11px;margin-top:2px;">{{.SourceRIID}}</div></td>
+<td style="padding:10px 12px;color:#0f172a;">{{.TargetInstanceType}} x{{.TargetCount}}</td>
+<td align="right" style="padding:10px 12px;color:#475569;">{{printf "%.1f" .UtilizationPct}}%</td>
+<td align="right" style="padding:10px 12px;color:#0f172a;font-weight:600;">${{.PaymentDue}}</td>
+<td style="padding:10px 12px;">
+<a href="{{$.DashboardURL}}/api/ri-exchange/approve/{{.RecordID}}?token={{urlquery .ApprovalToken}}" style="display:inline-block;padding:6px 14px;background:#16a34a;color:#ffffff;text-decoration:none;font-weight:600;font-size:12px;border-radius:4px;margin-right:4px;">Approve</a>
+<a href="{{$.DashboardURL}}/api/ri-exchange/reject/{{.RecordID}}?token={{urlquery .ApprovalToken}}" style="display:inline-block;padding:6px 14px;background:#ffffff;color:#dc2626;text-decoration:none;font-weight:600;font-size:12px;border-radius:4px;border:1px solid #dc2626;">Reject</a>
+</td>
+</tr>
+{{end}}</tbody></table>
+</td></tr>
+
+{{if .Skipped}}
+<tr><td style="padding:0 32px 16px 32px;">
+<h2 style="margin:8px 0 8px 0;font-size:13px;color:#94a3b8;text-transform:uppercase;letter-spacing:0.04em;">Skipped (could not process)</h2>
+<ul style="margin:0;padding-left:20px;color:#475569;font-size:13px;">
+{{range .Skipped}}<li style="margin-bottom:4px;">{{.SourceRIID}} ({{.SourceInstanceType}}): {{.Reason}}</li>
+{{end}}</ul>
+</td></tr>
+{{end}}
+
+<tr><td style="padding:8px 32px 24px 32px;">
+<p style="margin:8px 0 0 0;color:#64748b;font-size:12px;line-height:1.5;">
+{{if .CancellationWindowNote}}{{.CancellationWindowNote}}{{else}}Please approve within 6 hours (before the next analysis run).{{end}}
+</p>
+<p style="margin:8px 0 0 0;color:#94a3b8;font-size:11px;">Clicking a link will require you to sign in if you aren't already; the action is then recorded against your logged-in account.</p>
+</td></tr>
+
+<tr><td style="padding:16px 32px;background:#f8fafc;border-top:1px solid #e2e8f0;border-radius:0 0 8px 8px;">
+<p style="margin:0;color:#94a3b8;font-size:11px;">This is an automated message from CUDly. Do not share these links. <a href="{{.DashboardURL}}/#ri-exchange" style="color:#64748b;">View exchange history</a></p>
+</td></tr>
+
+</table>
+</td></tr></table>
+</body></html>`
 
 const riExchangeCompletedTemplate = `CUDly - RI Exchanges Completed
 ==============================
@@ -446,27 +520,40 @@ func (s *Sender) SendUserInviteEmail(ctx context.Context, email, setupURL string
 	)
 }
 
-// SendRIExchangePendingApproval sends an email with RI exchange approval links.
-// The rendered body contains per-exchange approve/reject links that carry live
-// tokens; any subscriber of the SNS topic who receives this body can
-// approve spend they were never authorized for. This method therefore routes
-// through targeted SES (SendToEmailWithCC), mirroring the hardened path used
-// by SendPurchaseApprovalRequest.
+// sendRIExchangePendingApprovalVia composes the plain-text + HTML approval
+// bodies and ships them through s.SendToEmailWithCCMultipart. HTML render
+// failures are non-fatal and degrade to single-part text so a template bug
+// never drops the approval email. Shared by Sender and SMTPSender -- issue #296.
+func sendRIExchangePendingApprovalVia(ctx context.Context, s SenderInterface, recipient string, ccEmails []string, subject string, data RIExchangeNotificationData) error {
+	textBody, err := RenderRIExchangePendingApprovalEmail(data)
+	if err != nil {
+		return fmt.Errorf("failed to render ri exchange pending approval email (text): %w", err)
+	}
+	htmlBody, htmlErr := RenderRIExchangePendingApprovalEmailHTML(data)
+	if htmlErr != nil {
+		logging.Warnf("email: HTML ri-exchange-pending render failed, falling back to text-only: %v", htmlErr)
+		htmlBody = ""
+	}
+	return s.SendToEmailWithCCMultipart(ctx, recipient, ccEmails, subject, textBody, htmlBody)
+}
+
+// SendRIExchangePendingApproval sends an email with RI exchange approval links
+// as multipart/alternative (plain-text + styled HTML). The rendered body
+// contains per-exchange approve/reject links that carry live tokens; any
+// subscriber of the SNS topic who received this body could approve spend they
+// were never authorized for. This method therefore routes through targeted SES
+// (SendToEmailWithCCMultipart), mirroring the hardened path used by
+// SendPurchaseApprovalRequest, and never falls back to the SNS broadcast topic.
 //
 // Returns ErrNoRecipient when data.RecipientEmail is empty. Callers must
 // resolve a recipient (e.g. the global notification email from GlobalConfig)
-// before invoking this method.
+// before invoking this method. Issue #296.
 func (s *Sender) SendRIExchangePendingApproval(ctx context.Context, data RIExchangeNotificationData) error {
 	if data.RecipientEmail == "" {
 		return ErrNoRecipient
 	}
-	body, err := RenderRIExchangePendingApprovalEmail(data)
-	if err != nil {
-		return fmt.Errorf("failed to render ri exchange pending approval email: %w", err)
-	}
-
 	subject := fmt.Sprintf("CUDly - RI Exchange Approval Required (%d exchanges)", len(data.Exchanges))
-	return s.SendToEmailWithCC(ctx, data.RecipientEmail, data.CCEmails, subject, body)
+	return sendRIExchangePendingApprovalVia(ctx, s, data.RecipientEmail, data.CCEmails, subject, data)
 }
 
 // SendRIExchangeCompleted sends a notification about completed RI exchanges.

--- a/internal/email/templates.go
+++ b/internal/email/templates.go
@@ -322,7 +322,7 @@ This is an automated message from CUDly. Do not share these links.
 
 // riExchangePendingApprovalHTMLTemplate renders the same approval request as
 // the plain-text template above with inline-styled approve/reject CTAs and an
-// exchange summary table. CSS classes are NOT honoured by most email clients
+// exchange summary table. CSS classes are NOT honored by most email clients
 // (Outlook, mobile Gmail) -- every visual rule lives in inline style=""
 // attributes. Mirrors purchaseApprovalRequestHTMLTemplate. Issue #296.
 const riExchangePendingApprovalHTMLTemplate = `<!DOCTYPE html>

--- a/internal/email/templates.go
+++ b/internal/email/templates.go
@@ -323,7 +323,7 @@ This is an automated message from CUDly. Do not share these links.
 // riExchangePendingApprovalHTMLTemplate renders the same approval request as
 // the plain-text template above with inline-styled approve/reject CTAs and an
 // exchange summary table. CSS classes are NOT honoured by most email clients
-// (Outlook, mobile Gmail) — every visual rule lives in inline style=""
+// (Outlook, mobile Gmail) -- every visual rule lives in inline style=""
 // attributes. Mirrors purchaseApprovalRequestHTMLTemplate. Issue #296.
 const riExchangePendingApprovalHTMLTemplate = `<!DOCTYPE html>
 <html><head><meta charset="UTF-8"><title>CUDly - RI Exchange Approval Required</title></head>


### PR DESCRIPTION
## Summary

- Adds `riExchangePendingApprovalHTMLTemplate`: inline-styled exchange table with per-row Approve/Reject CTA buttons, summary block, optional requested-by line, configurable cancellation-window note, and skipped-exchanges section -- mirrors `purchaseApprovalRequestHTMLTemplate` (PR #298).
- Extends the plain-text `riExchangePendingApprovalTemplate` with labelled `Approve:` / `Reject:` URLs (replacing bracket notation), optional requested-by block, and configurable cancellation-window note.
- Extends `RIExchangeNotificationData` with `RequestedByName`, `RequestedByEmail`, `RequestedAt`, `CancellationWindowNote` fields (backward-compatible zero values).
- Adds `sendRIExchangePendingApprovalVia` private helper (shared by `Sender` and `SMTPSender`; HTML degrade on render error is non-fatal, matching `sendPurchaseApprovalRequestVia`'s contract).
- `SMTPSender.SendRIExchangePendingApproval` delegates to the helper (sends to `s.notifyEmail`).
- `Sender.SendRIExchangePendingApproval` uses the direct SES multipart path when `emailAddress` + `fromEmail` are configured; falls back to SNS broadcast for topic-only deployments.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test github.com/LeanerCloud/CUDly/internal/email/...` -- 322 tests pass (7 new)
- [ ] `TestRenderRIExchangePendingApprovalEmail_Issue296` -- plain-text carries requested-by, labelled URLs, custom note
- [ ] `TestRenderRIExchangePendingApprovalEmail_NoRequestedBy` -- omits block + falls back to generic note
- [ ] `TestRenderRIExchangePendingApprovalEmailHTML_Issue296` -- approve/reject hrefs, inline green button style, table cells
- [ ] `TestRenderRIExchangePendingApprovalEmailHTML_DefaultCancellationNote` -- generic 6-hour note when field empty
- [ ] `TestRenderRIExchangePendingApprovalEmailHTML_SkippedBlock` -- skipped list renders
