### PR TITLE
sec(iac): scope SecretsManagerDescribe to specific actions (closes #430)

### DIFF
--- a/terraform/environments/aws/ci-cd-permissions/policy_data.tf
+++ b/terraform/environments/aws/ci-cd-permissions/policy_data.tf
@@ -190,12 +190,6 @@ resource "aws_iam_policy" "data" {
         Resource = "arn:aws:secretsmanager:*:*:secret:cudly-*"
       },
       {
-        Sid      = "SecretsManagerDescribe"
-        Effect   = "Allow"
-        Action   = ["secretsmanager:ListSecrets"]
-        Resource = "*"
-      },
-      {
         Sid    = "S3TerraformState"
         Effect = "Allow"
         Action = [


### PR DESCRIPTION
## Summary

- Removes the `SecretsManagerDescribe` IAM policy block from `terraform/environments/aws/ci-cd-permissions/policy_data.tf`
- That block granted `secretsmanager:ListSecrets` on `Resource = "*"`, letting the CI/CD role enumerate all secret names in the account
- `secretsmanager:ListSecrets` is already present in the `SecretsManager` block scoped to `arn:aws:secretsmanager:*:*:secret:cudly-*`, so no functionality is lost

## Test plan

- [ ] `terraform fmt -check` passes (no format changes needed)
- [ ] `terraform validate` passes: `Success! The configuration is valid.`
- [ ] No ARM template changes needed (ARM is Azure-only; no AWS Secrets Manager policy there)
- [ ] CI policy parity check passes (single-file change, no cross-IaC parity concern)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted AWS Secrets Manager listing permissions to specific resources, reducing overly broad access scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->