### PR TITLE
chore(ci): document/add Frontend build (PR) as required status check (closes #377)

### DIFF
--- a/docs/ci-required-checks.md
+++ b/docs/ci-required-checks.md
@@ -8,15 +8,21 @@ CUDly repository and the admin commands needed to enforce them.
 PR #232 (merged 2026-05-03) added `.github/workflows/frontend-build.yml`,
 which runs `npm ci`, `npm run typecheck`, and `npm run build` on every PR
 touching `frontend/**`. The workflow shipped, but the corresponding
-`Frontend build (PR)` check was never added to the branch-protection
+`Build frontend` check was never added to the branch-protection
 required-checks list. A PR that breaks the frontend build can currently be
 merged without a block (issue #377).
+
+> **Note on context naming**: GitHub branch-protection contexts are derived
+> from the **job `name:`** field, not the workflow `name:` field. The workflow
+> is named `Frontend build (PR)` but its single job is named `Build frontend`,
+> so the context GitHub reports (and that must be entered here) is
+> `Build frontend`.
 
 ## Required checks -- canonical list
 
 Both `feat/multicloud-web-frontend` and `main` should require:
 
-- `Frontend build (PR)`
+- `Build frontend`
 - Any other checks already present at the time an admin applies this runbook
   (retrieve the live list first; see Step 1 below).
 
@@ -45,12 +51,12 @@ Replace `EXISTING_CHECK_1` etc. with the contexts returned by Step 1:
 gh api -X PATCH \
   repos/LeanerCloud/CUDly/branches/feat/multicloud-web-frontend/protection/required_status_checks \
   -F 'contexts[]=EXISTING_CHECK_1' \
-  -F 'contexts[]=Frontend build (PR)'
+  -F 'contexts[]=Build frontend'
 
 gh api -X PATCH \
   repos/LeanerCloud/CUDly/branches/main/protection/required_status_checks \
   -F 'contexts[]=EXISTING_CHECK_1' \
-  -F 'contexts[]=Frontend build (PR)'
+  -F 'contexts[]=Build frontend'
 ```
 
 ### Step 3 -- create protection from scratch (if Step 1 returned 404)
@@ -64,7 +70,7 @@ gh api -X PUT \
 {
   "required_status_checks": {
     "strict": true,
-    "contexts": ["Frontend build (PR)"]
+    "contexts": ["Build frontend"]
   },
   "enforce_admins": false,
   "required_pull_request_reviews": null,
@@ -78,7 +84,7 @@ gh api -X PUT \
 {
   "required_status_checks": {
     "strict": true,
-    "contexts": ["Frontend build (PR)"]
+    "contexts": ["Build frontend"]
   },
   "enforce_admins": false,
   "required_pull_request_reviews": null,
@@ -97,12 +103,12 @@ gh api repos/LeanerCloud/CUDly/branches/main/protection \
   --jq '.required_status_checks.contexts'
 ```
 
-Both should include `"Frontend build (PR)"`.
+Both should include `"Build frontend"`.
 
 ### Step 5 -- smoke test
 
 Open a draft PR with a deliberate TypeScript error in `frontend/` and confirm
-that the `Frontend build (PR)` check turns red and the merge button is blocked.
+that the `Build frontend` check turns red and the merge button is blocked.
 
 ## Notes
 
@@ -110,4 +116,4 @@ that the `Frontend build (PR)` check turns red and the merge button is blocked.
   merging; adjust if that is too strict for the current workflow.
 - The GitHub UI path for the same change is: Settings > Branches >
   Branch protection rules > Edit rule > "Require status checks to pass" >
-  search for `Frontend build (PR)` > save.
+  search for `Build frontend` > save.

--- a/docs/ci-required-checks.md
+++ b/docs/ci-required-checks.md
@@ -12,6 +12,10 @@ touching `frontend/**`. The workflow shipped, but the corresponding
 required-checks list. A PR that breaks the frontend build can currently be
 merged without a block (issue #377).
 
+The workflow targets the `main` branch only. The `feat/multicloud-web-frontend`
+trigger was removed in the commit that merged that branch into `main`
+(`4f7d429a8`), so `Build frontend` only ever runs for PRs targeting `main`.
+
 > **Note on context naming**: GitHub branch-protection contexts are derived
 > from the **job `name:`** field, not the workflow `name:` field. The workflow
 > is named `Frontend build (PR)` but its single job is named `Build frontend`,
@@ -20,7 +24,7 @@ merged without a block (issue #377).
 
 ## Required checks -- canonical list
 
-Both `feat/multicloud-web-frontend` and `main` should require:
+`main` should require:
 
 - `Build frontend`
 - Any other checks already present at the time an admin applies this runbook
@@ -30,17 +34,14 @@ Both `feat/multicloud-web-frontend` and `main` should require:
 
 These commands require repo-admin permission on LeanerCloud/CUDly.
 
-### Step 1 -- retrieve the current required checks for each branch
+### Step 1 -- retrieve the current required checks for main
 
 ```bash
-gh api repos/LeanerCloud/CUDly/branches/feat/multicloud-web-frontend/protection \
-  --jq '.required_status_checks.contexts'
-
 gh api repos/LeanerCloud/CUDly/branches/main/protection \
   --jq '.required_status_checks.contexts'
 ```
 
-If either returns `"Branch not protected"` (HTTP 404), the protection rule
+If this returns `"Branch not protected"` (HTTP 404), the protection rule
 must be created from scratch; use the `gh api -X PUT` form in Step 3.
 
 ### Step 2 -- add the check to an already-protected branch
@@ -48,11 +49,6 @@ must be created from scratch; use the `gh api -X PUT` form in Step 3.
 Replace `EXISTING_CHECK_1` etc. with the contexts returned by Step 1:
 
 ```bash
-gh api -X PATCH \
-  repos/LeanerCloud/CUDly/branches/feat/multicloud-web-frontend/protection/required_status_checks \
-  -F 'contexts[]=EXISTING_CHECK_1' \
-  -F 'contexts[]=Build frontend'
-
 gh api -X PATCH \
   repos/LeanerCloud/CUDly/branches/main/protection/required_status_checks \
   -F 'contexts[]=EXISTING_CHECK_1' \
@@ -64,20 +60,6 @@ gh api -X PATCH \
 Adjust `required_pull_request_reviews` and `enforce_admins` to taste:
 
 ```bash
-gh api -X PUT \
-  repos/LeanerCloud/CUDly/branches/feat/multicloud-web-frontend/protection \
-  --input - <<'EOF'
-{
-  "required_status_checks": {
-    "strict": true,
-    "contexts": ["Build frontend"]
-  },
-  "enforce_admins": false,
-  "required_pull_request_reviews": null,
-  "restrictions": null
-}
-EOF
-
 gh api -X PUT \
   repos/LeanerCloud/CUDly/branches/main/protection \
   --input - <<'EOF'
@@ -96,14 +78,11 @@ EOF
 ### Step 4 -- verify
 
 ```bash
-gh api repos/LeanerCloud/CUDly/branches/feat/multicloud-web-frontend/protection \
-  --jq '.required_status_checks.contexts'
-
 gh api repos/LeanerCloud/CUDly/branches/main/protection \
   --jq '.required_status_checks.contexts'
 ```
 
-Both should include `"Build frontend"`.
+The output should include `"Build frontend"`.
 
 ### Step 5 -- smoke test
 

--- a/docs/ci-required-checks.md
+++ b/docs/ci-required-checks.md
@@ -1,0 +1,113 @@
+# CI Required Status Checks
+
+This document records the canonical set of required status checks for the
+CUDly repository and the admin commands needed to enforce them.
+
+## Context
+
+PR #232 (merged 2026-05-03) added `.github/workflows/frontend-build.yml`,
+which runs `npm ci`, `npm run typecheck`, and `npm run build` on every PR
+touching `frontend/**`. The workflow shipped, but the corresponding
+`Frontend build (PR)` check was never added to the branch-protection
+required-checks list. A PR that breaks the frontend build can currently be
+merged without a block (issue #377).
+
+## Required checks -- canonical list
+
+Both `feat/multicloud-web-frontend` and `main` should require:
+
+- `Frontend build (PR)`
+- Any other checks already present at the time an admin applies this runbook
+  (retrieve the live list first; see Step 1 below).
+
+## Admin steps
+
+These commands require repo-admin permission on LeanerCloud/CUDly.
+
+### Step 1 -- retrieve the current required checks for each branch
+
+```bash
+gh api repos/LeanerCloud/CUDly/branches/feat/multicloud-web-frontend/protection \
+  --jq '.required_status_checks.contexts'
+
+gh api repos/LeanerCloud/CUDly/branches/main/protection \
+  --jq '.required_status_checks.contexts'
+```
+
+If either returns `"Branch not protected"` (HTTP 404), the protection rule
+must be created from scratch; use the `gh api -X PUT` form in Step 3.
+
+### Step 2 -- add the check to an already-protected branch
+
+Replace `EXISTING_CHECK_1` etc. with the contexts returned by Step 1:
+
+```bash
+gh api -X PATCH \
+  repos/LeanerCloud/CUDly/branches/feat/multicloud-web-frontend/protection/required_status_checks \
+  -F 'contexts[]=EXISTING_CHECK_1' \
+  -F 'contexts[]=Frontend build (PR)'
+
+gh api -X PATCH \
+  repos/LeanerCloud/CUDly/branches/main/protection/required_status_checks \
+  -F 'contexts[]=EXISTING_CHECK_1' \
+  -F 'contexts[]=Frontend build (PR)'
+```
+
+### Step 3 -- create protection from scratch (if Step 1 returned 404)
+
+Adjust `required_pull_request_reviews` and `enforce_admins` to taste:
+
+```bash
+gh api -X PUT \
+  repos/LeanerCloud/CUDly/branches/feat/multicloud-web-frontend/protection \
+  --input - <<'EOF'
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": ["Frontend build (PR)"]
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": null,
+  "restrictions": null
+}
+EOF
+
+gh api -X PUT \
+  repos/LeanerCloud/CUDly/branches/main/protection \
+  --input - <<'EOF'
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": ["Frontend build (PR)"]
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": null,
+  "restrictions": null
+}
+EOF
+```
+
+### Step 4 -- verify
+
+```bash
+gh api repos/LeanerCloud/CUDly/branches/feat/multicloud-web-frontend/protection \
+  --jq '.required_status_checks.contexts'
+
+gh api repos/LeanerCloud/CUDly/branches/main/protection \
+  --jq '.required_status_checks.contexts'
+```
+
+Both should include `"Frontend build (PR)"`.
+
+### Step 5 -- smoke test
+
+Open a draft PR with a deliberate TypeScript error in `frontend/` and confirm
+that the `Frontend build (PR)` check turns red and the merge button is blocked.
+
+## Notes
+
+- The `strict` flag in Step 3 requires the branch to be up to date before
+  merging; adjust if that is too strict for the current workflow.
+- The GitHub UI path for the same change is: Settings > Branches >
+  Branch protection rules > Edit rule > "Require status checks to pass" >
+  search for `Frontend build (PR)` > save.


### PR DESCRIPTION
## Summary

- Adds `docs/ci-required-checks.md` documenting the canonical required status
  checks for `feat/multicloud-web-frontend` and `main`, including step-by-step
  admin commands (closes #377).
- The API call to add `Frontend build (PR)` as a required check was attempted
  but both branches currently have no protection rule (HTTP 404). Because
  creating protection rules from scratch requires repo-admin permissions, the
  runbook documents the exact `gh api -X PUT` command an admin must run.

## Admin action required

Neither `feat/multicloud-web-frontend` nor `main` has a branch protection
rule yet. A repo-admin must follow `docs/ci-required-checks.md` Step 3 to
create protection and add `Frontend build (PR)` to required checks.

## Test plan

- [ ] Admin runs Step 3 commands from `docs/ci-required-checks.md`
- [ ] Admin runs Step 4 to verify both branches list `Frontend build (PR)`
- [ ] Admin opens a draft PR with a deliberate TS error in `frontend/` and
  confirms merge is blocked until the check turns green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added documentation for continuous integration branch protection requirements and setup procedures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/849?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->