### PR TITLE
fix(purchases): mask idempotency token in EC2 RI re-drive log (closes #656)

### DIFF
--- a/providers/aws/services/ec2/client.go
+++ b/providers/aws/services/ec2/client.go
@@ -134,7 +134,7 @@ func (c *Client) PurchaseCommitment(ctx context.Context, rec common.Recommendati
 			return result, result.Error
 		}
 		if found {
-			log.Printf("EC2 RI for idempotency token %s already exists (%s); skipping purchase (issue #636 re-drive)", opts.IdempotencyToken, existingID)
+			log.Printf("EC2 RI for idempotency token %s already exists (%s); skipping purchase (issue #636 re-drive)", common.MaskToken(opts.IdempotencyToken), existingID)
 			result.Success = true
 			result.CommitmentID = existingID
 			return result, nil

--- a/providers/aws/services/ec2/client_test.go
+++ b/providers/aws/services/ec2/client_test.go
@@ -820,3 +820,48 @@ func TestBuildEC2OfferingQuery_ValidPlatform(t *testing.T) {
 	assert.Equal(t, types.RIProductDescription("Linux/UNIX"), q.productDesc)
 	assert.Equal(t, types.Tenancy("default"), q.tenancy)
 }
+
+// TestPurchaseCommitment_IdempotencySkipLogMasked asserts that the re-drive
+// skip-log line emits a masked token (first 8 chars + "..."), not the raw
+// 64-char idempotency token (issue #656).
+func TestPurchaseCommitment_IdempotencySkipLogMasked(t *testing.T) {
+	t.Parallel()
+	mockEC2 := &MockEC2Client{}
+	t.Cleanup(func() { mockEC2.AssertExpectations(t) })
+	client := &Client{client: mockEC2, region: "us-east-1"}
+
+	token := common.DeriveIdempotencyToken("exec-idem-656", 0)
+
+	// Simulate that an RI tagged with this token already exists (re-drive path).
+	mockEC2.On("DescribeReservedInstances", mock.Anything, mock.MatchedBy(func(in *ec2.DescribeReservedInstancesInput) bool {
+		for _, f := range in.Filters {
+			if aws.ToString(f.Name) == "tag:"+common.IdempotencyTagKey {
+				return len(f.Values) == 1 && f.Values[0] == token
+			}
+		}
+		return false
+	})).Return(&ec2.DescribeReservedInstancesOutput{
+		ReservedInstances: []types.ReservedInstances{
+			{ReservedInstancesId: aws.String("ri-existing-656")},
+		},
+	}, nil).Once()
+
+	rec := common.Recommendation{
+		ResourceType:  "t3.micro",
+		Count:         1,
+		PaymentOption: "all-upfront",
+		Term:          "1yr",
+		Details:       &common.ComputeDetails{Platform: "Linux/UNIX", Tenancy: "default", Scope: "Region"},
+	}
+
+	result, err := client.PurchaseCommitment(context.Background(), rec, common.PurchaseOptions{IdempotencyToken: token})
+
+	assert.NoError(t, err)
+	assert.True(t, result.Success)
+	assert.Equal(t, "ri-existing-656", result.CommitmentID)
+
+	// Assert the masked form matches what MaskToken produces (first 8 chars + "...").
+	masked := common.MaskToken(token)
+	assert.Equal(t, token[:8]+"...", masked, "MaskToken shape: first 8 chars + ellipsis")
+	assert.NotEqual(t, token, masked, "masked token must not equal raw token")
+}

--- a/providers/aws/services/ec2/client_test.go
+++ b/providers/aws/services/ec2/client_test.go
@@ -1,8 +1,11 @@
 package ec2
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"log"
+	"os"
 	"testing"
 	"time"
 
@@ -824,13 +827,24 @@ func TestBuildEC2OfferingQuery_ValidPlatform(t *testing.T) {
 // TestPurchaseCommitment_IdempotencySkipLogMasked asserts that the re-drive
 // skip-log line emits a masked token (first 8 chars + "..."), not the raw
 // 64-char idempotency token (issue #656).
+//
+// This is a real §4 regression test: it captures the bytes written to the
+// standard logger and asserts both that the raw token is absent AND that
+// the masked form is present.  Reverting line 137 of client.go to log
+// opts.IdempotencyToken raw causes the NotContains assertion to fail.
 func TestPurchaseCommitment_IdempotencySkipLogMasked(t *testing.T) {
-	t.Parallel()
+	// Not parallel: we swap the global log writer and must restore it before
+	// any other test that also captures the logger races with us.
 	mockEC2 := &MockEC2Client{}
 	t.Cleanup(func() { mockEC2.AssertExpectations(t) })
 	client := &Client{client: mockEC2, region: "us-east-1"}
 
 	token := common.DeriveIdempotencyToken("exec-idem-656", 0)
+
+	// Capture the standard logger so we can assert what is actually emitted.
+	var logBuf bytes.Buffer
+	log.SetOutput(&logBuf)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
 
 	// Simulate that an RI tagged with this token already exists (re-drive path).
 	mockEC2.On("DescribeReservedInstances", mock.Anything, mock.MatchedBy(func(in *ec2.DescribeReservedInstancesInput) bool {
@@ -860,8 +874,14 @@ func TestPurchaseCommitment_IdempotencySkipLogMasked(t *testing.T) {
 	assert.True(t, result.Success)
 	assert.Equal(t, "ri-existing-656", result.CommitmentID)
 
-	// Assert the masked form matches what MaskToken produces (first 8 chars + "...").
+	// Core regression assertions: the re-drive log line must contain the masked
+	// form and must NOT contain the full raw token.
+	logOutput := logBuf.String()
 	masked := common.MaskToken(token)
+	assert.Contains(t, logOutput, masked, "re-drive log must emit the masked token")
+	assert.NotContains(t, logOutput, token, "re-drive log must NOT emit the raw idempotency token")
+
+	// Sanity-check that MaskToken itself has the expected shape (first 8 chars + "...").
 	assert.Equal(t, token[:8]+"...", masked, "MaskToken shape: first 8 chars + ellipsis")
 	assert.NotEqual(t, token, masked, "masked token must not equal raw token")
 }


### PR DESCRIPTION
## Summary

- Wraps `opts.IdempotencyToken` with `common.MaskToken` in the EC2 RI idempotency-guard skip log (`providers/aws/services/ec2/client.go:137`), bringing EC2 in line with the five sibling executors (RDS, ElastiCache, MemoryDB, OpenSearch, Redshift) fixed in PR #652.
- No import changes needed -- `pkg/common` is already imported.
- Adds `TestPurchaseCommitment_IdempotencySkipLogMasked` asserting the re-drive path returns success and that `MaskToken` produces the `<first-8>...` shape, not the raw 64-char token.

## Test plan

- [x] `go build ./...` clean
- [x] `go test github.com/LeanerCloud/CUDly/providers/aws/services/ec2/...` -- 40 tests pass (39 before + 1 new)
- [x] Audited all 6 AWS service executors: RDS, ElastiCache, MemoryDB, OpenSearch, Redshift already use `MaskToken`; SavingsPlans passes token as `ClientToken` with no skip log


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Sensitive idempotency token values in EC2 purchase commitment logs are now masked to prevent exposure of authentication credentials in plaintext, significantly improving security posture while preserving comprehensive operational logging and audit trail capabilities

## Tests
* Added test case verifying correct token masking behavior in EC2 purchase commitment operations when handling idempotency request scenarios and log verification

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LeanerCloud/CUDly/pull/855?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->