### PR TITLE
log: silence 'service config not found' on per-rec lookup (closes #263)

### DIFF
--- a/internal/config/recommendation_overrides.go
+++ b/internal/config/recommendation_overrides.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"context"
+	"errors"
 	"fmt"
 )
 
@@ -48,6 +49,10 @@ func (c *globalConfigCache) lookup(ctx context.Context, store AccountConfigReade
 	}
 	fetched, err := store.GetServiceConfig(ctx, provider, service)
 	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			c.missing[k] = true
+			return nil, nil
+		}
 		return nil, fmt.Errorf("get service config %s/%s: %w", provider, service, err)
 	}
 	if fetched == nil {

--- a/internal/config/recommendation_overrides_test.go
+++ b/internal/config/recommendation_overrides_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -253,4 +254,21 @@ func TestResolveAccountConfigsForRecs_OverrideErrorPropagates(t *testing.T) {
 	got, err := ResolveAccountConfigsForRecs(context.Background(), reader, recs)
 	assert.Error(t, err)
 	assert.Empty(t, got)
+}
+
+// TestResolveAccountConfigsForRecs_ErrNotFoundAbsorbed verifies that when
+// GetServiceConfig returns a wrapped ErrNotFound (the no-rows case), the
+// lookup treats it as absent rather than propagating it as an error. This
+// is the root scenario of issue #263: the INFO log firing on every refresh
+// for services that legitimately have no global config row.
+func TestResolveAccountConfigsForRecs_ErrNotFoundAbsorbed(t *testing.T) {
+	reader := &fakeAccountConfigReader{
+		globalErr: fmt.Errorf("service config not found for aws:rds: %w", ErrNotFound),
+	}
+	recs := []RecommendationRecord{acctRec("acct-A", "aws", "rds")}
+
+	got, err := ResolveAccountConfigsForRecs(context.Background(), reader, recs)
+	assert.NoError(t, err, "ErrNotFound from GetServiceConfig must not propagate as an error")
+	assert.Empty(t, got, "triple skipped when global is absent and no override")
+	assert.Equal(t, 1, reader.globalCalls, "global fetched once")
 }

--- a/internal/config/store_postgres.go
+++ b/internal/config/store_postgres.go
@@ -352,7 +352,7 @@ func (s *PostgresStore) GetServiceConfig(ctx context.Context, provider, service 
 
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, fmt.Errorf("service config not found for %s:%s", provider, service)
+			return nil, fmt.Errorf("service config not found for %s:%s: %w", provider, service, ErrNotFound)
 		}
 		return nil, fmt.Errorf("failed to get service config: %w", err)
 	}

--- a/internal/config/store_postgres.go
+++ b/internal/config/store_postgres.go
@@ -1833,7 +1833,7 @@ func (s *PostgresStore) GetActivePurchaseHistory(ctx context.Context, asOf time.
 // number, unknown provider) matches account_id with no provider gate. Providers
 // are sorted for deterministic SQL. The OR is wrapped in parentheses so it
 // composes with the surrounding AND chain.
-func appendAccountPredicate(conds []string, args []any, accountIDs []string, externalIDsByProvider map[string][]string) ([]string, []any) { //nolint:gocritic // unnamedResult: return names would conflict with body locals
+func appendAccountPredicate(conds []string, args []any, accountIDs []string, externalIDsByProvider map[string][]string) (outConds []string, outArgs []any) {
 	if len(accountIDs) == 0 && len(externalIDsByProvider) == 0 {
 		return conds, args
 	}

--- a/internal/config/store_postgres_mock_test.go
+++ b/internal/config/store_postgres_mock_test.go
@@ -131,7 +131,7 @@ func (s *testablePostgresStore) GetServiceConfig(ctx context.Context, provider, 
 
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, errors.New("service config not found")
+			return nil, fmt.Errorf("service config not found for %s:%s: %w", provider, service, ErrNotFound)
 		}
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

- `PostgresStore.GetServiceConfig` was returning a plain error on `pgx.ErrNoRows`, not wrapping `ErrNotFound`, so `globalConfigCache.lookup` propagated it as a real error on every recommendation refresh for services without a global config row.
- Wrap the no-rows path as `%w ErrNotFound` in both `PostgresStore.GetServiceConfig` (production) and the `testablePostgresStore` mock so callers get a consistent sentinel.
- In `globalConfigCache.lookup`, use `errors.Is(err, ErrNotFound)` to treat the absent-config case as `(nil, nil)` rather than returning an error, silencing the INFO log noise on each refresh cycle.

## Test plan

- [ ] `go build ./...` clean
- [ ] `go test github.com/LeanerCloud/CUDly/internal/api/... github.com/LeanerCloud/CUDly/internal/config/...` passes (1906 tests)
- [ ] `TestGetServiceConfig_NotFound` still asserts `assert.Error` + `assert.Contains("not found")` -- both hold because the wrapped error message still contains "not found"
- [ ] `TestResolveAccountConfigsForRecs_GlobalAbsentCachedNegative` confirms the absent-global case is cached as missing (no second fetch) with no error returned

Closes #263.
