### PR TITLE
sec(iac): require AWS_IAM auth on production Lambda Function URL (closes #424)

### DIFF
--- a/terraform/environments/aws/github-prod.tfvars
+++ b/terraform/environments/aws/github-prod.tfvars
@@ -70,7 +70,7 @@ secret_recovery_window_days = 30
 # Frontend / CDN
 # ==============================================
 
-enable_cdn            = false
+enable_cdn            = true
 frontend_price_class  = "PriceClass_200"
 create_subdomain_zone = false
 

--- a/terraform/environments/aws/github-staging.tfvars
+++ b/terraform/environments/aws/github-staging.tfvars
@@ -69,7 +69,7 @@ secret_recovery_window_days = 14
 # Frontend / CDN
 # ==============================================
 
-enable_cdn            = false
+enable_cdn            = true
 frontend_price_class  = "PriceClass_100"
 create_subdomain_zone = false
 


### PR DESCRIPTION
## Summary

- Set `enable_cdn = true` in `github-prod.tfvars` and `github-staging.tfvars`, which activates the full AWS_IAM auth chain for the Lambda Function URL in production and staging environments.
- The `compute.tf` local `lambda_function_url_auth_type` is derived from `enable_cdn`, so this single lever closes the exposure described in #424 without touching any module logic.
- Dev environment retains `enable_cdn = false` (auth_type = NONE) because the browser-served SPA hits the Lambda URL directly and cannot SigV4-sign.

## Auth chain (prod/staging with enable_cdn = true)

```
Browser -> CloudFront distribution
  -> OAC (aws_cloudfront_origin_access_control.lambda, signing_behavior = "always", sigv4)
    -> Lambda Function URL (authorization_type = "AWS_IAM")
      <- aws_lambda_permission.function_url_cloudfront
         (principal = cloudfront.amazonaws.com, source_arn = distribution ARN)
```

The Function URL rejects every request not SigV4-signed by the OAC-bearing distribution. Direct hits to the Function URL hostname return HTTP 403, even for requests with valid application-layer credentials.

The OAC resource, the CloudFront permission, and the derived auth-type local were all introduced in the base branch (`feat/multicloud-web-frontend`) as part of the preparatory refactor. This PR activates the mechanism for prod and staging by flipping `enable_cdn = true`.

## Rollout notes

- Production and staging are not yet deployed (the `lambda_allowed_origins` still carry `.invalid` placeholder origins). Any accidental `terraform apply` will fail fast at hostname resolution until the operator sets real origins and custom domain names.
- When the environments are provisioned, set `lambda_allowed_origins` to the CloudFront distribution domain (or custom domain if configured) before applying.

## Test plan

- [ ] Verify `terraform fmt -check` passes on changed files (CI)
- [ ] Verify `tflint` passes on `terraform/environments/aws/` (CI)
- [ ] Confirm `locals.lambda_function_url_auth_type = "AWS_IAM"` for prod/staging plan output after `enable_cdn = true`
- [ ] Confirm `aws_lambda_permission.function_url_cloudfront[0]` is created (count = 1) in plan
- [ ] Confirm `aws_lambda_permission.function_url[0]` (principal = "*") is NOT created in plan (count = 0 when auth_type = AWS_IAM)
- [ ] Post-deploy: confirm direct HTTP request to Lambda Function URL returns 403
- [ ] Post-deploy: confirm browser via CloudFront returns 200

Closes #424