### PR TITLE
feat(email): post-execution notification with one-click revoke (closes #291)

### DIFF
--- a/internal/analytics/collector_test.go
+++ b/internal/analytics/collector_test.go
@@ -279,6 +279,10 @@ func (m *mockConfigStore) TransitionExecutionStatus(ctx context.Context, executi
 	return nil, nil
 }
 
+func (m *mockConfigStore) SetCancelledBy(_ context.Context, _ string, _ string) error {
+	return nil
+}
+
 func (m *mockConfigStore) CancelExecutionAtomic(ctx context.Context, tx pgx.Tx, executionID string, cancelledBy *string) (bool, string, error) {
 	return false, "", nil
 }

--- a/internal/api/coverage_gaps_test.go
+++ b/internal/api/coverage_gaps_test.go
@@ -929,6 +929,9 @@ func (s *stubEmailNotifier) SendPurchaseApprovalRequest(_ context.Context, _ ema
 func (s *stubEmailNotifier) SendPurchaseScheduledNotification(_ context.Context, _ email.NotificationData) error {
 	return nil
 }
+func (s *stubEmailNotifier) SendPurchaseExecutedNotification(_ context.Context, _ email.NotificationData) error {
+	return nil
+}
 func (s *stubEmailNotifier) SendRegistrationReceivedNotification(_ context.Context, _ email.RegistrationNotificationData) error {
 	return nil
 }

--- a/internal/api/executed_notification_flow_test.go
+++ b/internal/api/executed_notification_flow_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -132,6 +133,69 @@ func TestExecutedNotification_TokenApprovePath(t *testing.T) {
 	// scenario: recipient clicks "Revoke" in the email -> token validates -> 200.
 	require.NoError(t, validateRevokeToken(freshExec, freshToken),
 		"the token embedded in the email must pass validateRevokeToken on the post-approve execution")
+
+	mockPurchase.AssertExpectations(t)
+	mockConfig.AssertExpectations(t)
+}
+
+// TestExecutedNotification_TokenApprovePath_RefetchFailureSuppressesPanel is the
+// regression test for the degraded-path nit: when the post-approve re-fetch
+// fails, approveViaToken must NOT email the stale pre-approve execution struct
+// (which still carries the OLD approval token that mintRevocationToken has
+// already replaced in the DB -- that token would 403 on every Revoke click,
+// resurrecting the original defect). Instead the email must carry an EMPTY
+// RevocationToken so the email template's {{if .RevocationToken}} suppresses the
+// Revoke panel entirely (no broken button).
+func TestExecutedNotification_TokenApprovePath_RefetchFailureSuppressesPanel(t *testing.T) {
+	ctx := context.Background()
+	execID := "12345678-1234-1234-1234-123456789abc"
+	contact := "contact@example.com"
+
+	mockConfig := new(MockConfigStore)
+	exec := approvalTestExec(execID, contact, mockConfig)
+
+	// First call: loadApproveExecution fetches the pending execution.
+	// Second call: approveViaToken re-fetches after ApproveExecution returns,
+	// but this time the store errors -- the fresh token cannot be obtained.
+	mockConfig.On("GetExecutionByID", ctx, execID).Return(exec, nil).Once()
+	mockConfig.On("GetExecutionByID", ctx, execID).
+		Return(nil, errors.New("transient store failure")).Once()
+	mockConfig.On("GetGlobalConfig", ctx).Return(&config.GlobalConfig{
+		NotificationEmail: &contact,
+	}, nil)
+
+	mockAuth := new(MockAuthService)
+	mockAuth.On("ValidateSession", ctx, "sess-tok").Return(&Session{Email: contact}, nil)
+	mockAuth.On("HasPermissionAPI", ctx, "", "approve-any", "purchases").Return(false, nil).Maybe()
+	mockAuth.On("HasPermissionAPI", ctx, "", "approve-own", "purchases").Return(false, nil).Maybe()
+
+	mockPurchase := new(MockPurchaseManager)
+	mockPurchase.On("ApproveExecution", ctx, execID, "valid-token", contact).Return(nil)
+
+	notifier := &recordingExecutedNotifier{}
+	handler := &Handler{
+		purchase:      mockPurchase,
+		config:        mockConfig,
+		auth:          mockAuth,
+		emailNotifier: notifier,
+	}
+
+	req := &events.LambdaFunctionURLRequest{
+		Headers: map[string]string{"authorization": "Bearer sess-tok"},
+	}
+	result, err := handler.approvePurchase(ctx, req, execID, "valid-token")
+	require.NoError(t, err, "approve must still succeed even when the email re-fetch fails")
+	assert.Equal(t, "completed", result.(map[string]string)["status"])
+
+	// The notification still fires (best-effort), but with an EMPTY revocation
+	// token so the Revoke panel is suppressed rather than showing a broken button.
+	require.Equal(t, 1, notifier.calls, "notification must still fire on the degraded path")
+	assert.Empty(t, notifier.captured.RevocationToken,
+		"re-fetch failure must blank the revocation token (suppress panel), never email the stale token")
+
+	// The stale pre-approve struct must be untouched: blanking happens on a COPY.
+	assert.Equal(t, "valid-token", exec.ApprovalToken,
+		"the fallback must blank a COPY, not mutate the caller's execution struct")
 
 	mockPurchase.AssertExpectations(t)
 	mockConfig.AssertExpectations(t)

--- a/internal/api/executed_notification_flow_test.go
+++ b/internal/api/executed_notification_flow_test.go
@@ -109,7 +109,7 @@ func TestExecutedNotification_SessionApprovePath(t *testing.T) {
 	mockAuth.On("ValidateCSRFToken", ctx, "sess-tok", "").Return(nil)
 
 	mockPurchase := new(MockPurchaseManager)
-	mockPurchase.On("ApproveAndExecute", ctx, execID, adminEmail).Return(nil)
+	mockPurchase.On("ApproveAndExecute", ctx, execID, adminEmail, (*string)(nil)).Return(nil)
 
 	notifier := &recordingExecutedNotifier{}
 	handler := &Handler{
@@ -165,7 +165,7 @@ func TestExecutedNotification_DirectExecutePath(t *testing.T) {
 	}, nil)
 
 	mockPurchase := new(MockPurchaseManager)
-	mockPurchase.On("ApproveAndExecute", ctx, execID, adminEmail).Return(nil)
+	mockPurchase.On("ApproveAndExecute", ctx, execID, adminEmail, (*string)(nil)).Return(nil)
 
 	notifier := &recordingExecutedNotifier{}
 	handler := &Handler{
@@ -211,7 +211,7 @@ func TestExecutedNotification_DirectExecute_NilNotifierNoPanic(t *testing.T) {
 	mockConfig.On("SavePurchaseExecution", ctx, exec).Return(nil)
 
 	mockPurchase := new(MockPurchaseManager)
-	mockPurchase.On("ApproveAndExecute", ctx, execID, adminEmail).Return(nil)
+	mockPurchase.On("ApproveAndExecute", ctx, execID, adminEmail, (*string)(nil)).Return(nil)
 
 	handler := &Handler{
 		purchase:      mockPurchase,

--- a/internal/api/executed_notification_flow_test.go
+++ b/internal/api/executed_notification_flow_test.go
@@ -1,0 +1,229 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/LeanerCloud/CUDly/internal/config"
+	"github.com/LeanerCloud/CUDly/internal/email"
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingExecutedNotifier captures the NotificationData passed to
+// SendPurchaseExecutedNotification so the execution-flow tests can assert the
+// post-execution notification (issue #291) fires with the expected recipients
+// and body fingerprints. All other SenderInterface methods are no-ops via the
+// embedded stubEmailNotifier.
+type recordingExecutedNotifier struct {
+	stubEmailNotifier
+	calls    int
+	captured email.NotificationData
+}
+
+func (r *recordingExecutedNotifier) SendPurchaseExecutedNotification(_ context.Context, data email.NotificationData) error {
+	r.calls++
+	r.captured = data
+	return nil
+}
+
+// assertExecutedNotificationFingerprints asserts the shared invariants of the
+// post-execution notification across all three execution paths: it fired
+// exactly once, resolved the per-account contact email as the primary To, and
+// carried the execution's approval token as the revocation token + the executor
+// in the body.
+func assertExecutedNotificationFingerprints(t *testing.T, n *recordingExecutedNotifier, contact, executedBy, token string) {
+	t.Helper()
+	require.Equal(t, 1, n.calls, "SendPurchaseExecutedNotification must fire exactly once")
+	assert.Equal(t, contact, n.captured.RecipientEmail,
+		"primary To must be the per-account contact email")
+	assert.Equal(t, executedBy, n.captured.ExecutedBy,
+		"body must record the executing actor")
+	assert.Equal(t, token, n.captured.RevocationToken,
+		"revocation token reuses the execution approval token (issue #291)")
+	assert.NotEmpty(t, n.captured.ExecutedAt, "executed-at timestamp must be set")
+}
+
+// TestExecutedNotification_TokenApprovePath covers the email one-click
+// (token-authed) approve branch of approvePurchase: after ApproveExecution
+// succeeds, sendPurchaseExecutedEmail must fire with the recording notifier.
+func TestExecutedNotification_TokenApprovePath(t *testing.T) {
+	ctx := context.Background()
+	execID := "12345678-1234-1234-1234-123456789abc"
+	contact := "contact@example.com"
+
+	mockConfig := new(MockConfigStore)
+	exec := approvalTestExec(execID, contact, mockConfig)
+	mockConfig.On("GetExecutionByID", ctx, execID).Return(exec, nil)
+	mockConfig.On("GetGlobalConfig", ctx).Return(&config.GlobalConfig{
+		NotificationEmail: &contact,
+	}, nil)
+
+	mockAuth := new(MockAuthService)
+	mockAuth.On("ValidateSession", ctx, "sess-tok").Return(&Session{Email: contact}, nil)
+	mockAuth.On("HasPermissionAPI", ctx, "", "approve-any", "purchases").Return(false, nil).Maybe()
+	mockAuth.On("HasPermissionAPI", ctx, "", "approve-own", "purchases").Return(false, nil).Maybe()
+
+	mockPurchase := new(MockPurchaseManager)
+	mockPurchase.On("ApproveExecution", ctx, execID, "valid-token", contact).Return(nil)
+
+	notifier := &recordingExecutedNotifier{}
+	handler := &Handler{
+		purchase:      mockPurchase,
+		config:        mockConfig,
+		auth:          mockAuth,
+		emailNotifier: notifier,
+	}
+
+	req := &events.LambdaFunctionURLRequest{
+		Headers: map[string]string{"authorization": "Bearer sess-tok"},
+	}
+	result, err := handler.approvePurchase(ctx, req, execID, "valid-token")
+	require.NoError(t, err)
+	assert.Equal(t, "completed", result.(map[string]string)["status"])
+
+	assertExecutedNotificationFingerprints(t, notifier, contact, contact, "valid-token")
+	mockPurchase.AssertExpectations(t)
+}
+
+// TestExecutedNotification_SessionApprovePath covers the dashboard
+// (session-authed) approve branch via approvePurchaseViaSession: after
+// ApproveAndExecute succeeds, the notification must fire.
+func TestExecutedNotification_SessionApprovePath(t *testing.T) {
+	ctx := context.Background()
+	execID := "23456789-2345-2345-2345-23456789abcd"
+	adminEmail := "admin@example.com"
+	contact := "contact@example.com"
+
+	mockConfig := new(MockConfigStore)
+	exec := approvalTestExec(execID, contact, mockConfig)
+	mockConfig.On("GetExecutionByID", ctx, execID).Return(exec, nil)
+	mockConfig.On("GetGlobalConfig", ctx).Return(&config.GlobalConfig{
+		NotificationEmail: &contact,
+	}, nil)
+
+	mockAuth := new(MockAuthService)
+	mockAuth.On("ValidateSession", ctx, "sess-tok").Return(&Session{Email: adminEmail}, nil)
+	mockAuth.grantAdmin()
+	mockAuth.On("ValidateCSRFToken", ctx, "sess-tok", "").Return(nil)
+
+	mockPurchase := new(MockPurchaseManager)
+	mockPurchase.On("ApproveAndExecute", ctx, execID, adminEmail).Return(nil)
+
+	notifier := &recordingExecutedNotifier{}
+	handler := &Handler{
+		purchase:      mockPurchase,
+		config:        mockConfig,
+		auth:          mockAuth,
+		emailNotifier: notifier,
+	}
+
+	req := &events.LambdaFunctionURLRequest{
+		Headers: map[string]string{"authorization": "Bearer sess-tok"},
+	}
+	// Empty token forces the dashboard (session) branch.
+	result, err := handler.approvePurchase(ctx, req, execID, "")
+	require.NoError(t, err)
+	assert.Equal(t, "completed", result.(map[string]string)["status"])
+
+	// Admin approved, so the executor recorded in the body is the admin.
+	assertExecutedNotificationFingerprints(t, notifier, contact, adminEmail, "valid-token")
+	mockPurchase.AssertExpectations(t)
+	mockPurchase.AssertNotCalled(t, "ApproveExecution")
+}
+
+// TestExecutedNotification_DirectExecutePath is the regression test for the
+// adversarial-verification blocker: the direct-execute path (issue #289) sent
+// NO notification at all before the #291 wiring. After ApproveAndExecute
+// succeeds, directExecutePurchase must fire the post-execution notification --
+// this is the only email the direct-execute flow emits.
+func TestExecutedNotification_DirectExecutePath(t *testing.T) {
+	ctx := context.Background()
+	execID := "34567890-3456-3456-3456-34567890abcd"
+	adminEmail := "admin@example.com"
+	contact := "contact@example.com"
+	accountID := "acct-1"
+
+	mockConfig := new(MockConfigStore)
+	exec := &config.PurchaseExecution{
+		ExecutionID:   execID,
+		ApprovalToken: "valid-token",
+		Status:        "pending",
+		Recommendations: []config.RecommendationRecord{
+			{ID: "r1", CloudAccountID: &accountID},
+		},
+	}
+	mockConfig.GetCloudAccountFn = func(_ context.Context, id string) (*config.CloudAccount, error) {
+		return &config.CloudAccount{ID: id, ContactEmail: contact}, nil
+	}
+	// directExecutePurchase stamps audit fields, then sendPurchaseExecutedEmail
+	// reads the global config.
+	mockConfig.On("SavePurchaseExecution", ctx, exec).Return(nil)
+	mockConfig.On("GetGlobalConfig", ctx).Return(&config.GlobalConfig{
+		NotificationEmail: &contact,
+	}, nil)
+
+	mockPurchase := new(MockPurchaseManager)
+	mockPurchase.On("ApproveAndExecute", ctx, execID, adminEmail).Return(nil)
+
+	notifier := &recordingExecutedNotifier{}
+	handler := &Handler{
+		purchase:      mockPurchase,
+		config:        mockConfig,
+		emailNotifier: notifier,
+		// auth left nil: lookupRequesterInfo tolerates a nil auth and the
+		// execution has no CreatedByUserID, so the requester lookup is skipped.
+	}
+
+	req := &events.LambdaFunctionURLRequest{
+		Headers: map[string]string{"authorization": "Bearer sess-tok"},
+	}
+	session := &Session{Email: adminEmail, UserID: "admin-uid"}
+
+	result, err := handler.directExecutePurchase(ctx, req, exec, session)
+	require.NoError(t, err)
+	resultMap := result.(map[string]any)
+	assert.Equal(t, "completed", resultMap["status"])
+	assert.Equal(t, true, resultMap["direct_execute"])
+
+	assertExecutedNotificationFingerprints(t, notifier, contact, adminEmail, "valid-token")
+	mockPurchase.AssertExpectations(t)
+}
+
+// TestExecutedNotification_DirectExecute_NilNotifierNoPanic guards the
+// best-effort contract: a direct-execute with no email notifier configured
+// must still complete the purchase without panicking.
+func TestExecutedNotification_DirectExecute_NilNotifierNoPanic(t *testing.T) {
+	ctx := context.Background()
+	execID := "45678901-4567-4567-4567-45678901abcd"
+	adminEmail := "admin@example.com"
+
+	mockConfig := new(MockConfigStore)
+	exec := &config.PurchaseExecution{
+		ExecutionID:   execID,
+		ApprovalToken: "valid-token",
+		Status:        "pending",
+		Recommendations: []config.RecommendationRecord{
+			{ID: "r1"},
+		},
+	}
+	mockConfig.On("SavePurchaseExecution", ctx, exec).Return(nil)
+
+	mockPurchase := new(MockPurchaseManager)
+	mockPurchase.On("ApproveAndExecute", ctx, execID, adminEmail).Return(nil)
+
+	handler := &Handler{
+		purchase:      mockPurchase,
+		config:        mockConfig,
+		emailNotifier: nil, // best-effort send is skipped
+	}
+
+	req := &events.LambdaFunctionURLRequest{}
+	session := &Session{Email: adminEmail, UserID: "admin-uid"}
+
+	result, err := handler.directExecutePurchase(ctx, req, exec, session)
+	require.NoError(t, err)
+	assert.Equal(t, "completed", result.(map[string]any)["status"])
+	mockPurchase.AssertExpectations(t)
+}

--- a/internal/api/executed_notification_flow_test.go
+++ b/internal/api/executed_notification_flow_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/LeanerCloud/CUDly/internal/config"
 	"github.com/LeanerCloud/CUDly/internal/email"
@@ -31,31 +32,70 @@ func (r *recordingExecutedNotifier) SendPurchaseExecutedNotification(_ context.C
 // assertExecutedNotificationFingerprints asserts the shared invariants of the
 // post-execution notification across all three execution paths: it fired
 // exactly once, resolved the per-account contact email as the primary To, and
-// carried the execution's approval token as the revocation token + the executor
-// in the body.
-func assertExecutedNotificationFingerprints(t *testing.T, n *recordingExecutedNotifier, contact, executedBy, token string) {
+// carried the expected revocation token + the executor in the body.
+//
+// For the token-authed approve path, expectedToken is the fresh revocation
+// token minted by mintRevocationToken (obtained from the re-fetched execution).
+// For the session-approve and direct-execute paths, it is the original
+// approval token (those paths do not rotate the token).
+func assertExecutedNotificationFingerprints(t *testing.T, n *recordingExecutedNotifier, contact, executedBy, expectedToken string) {
 	t.Helper()
 	require.Equal(t, 1, n.calls, "SendPurchaseExecutedNotification must fire exactly once")
 	assert.Equal(t, contact, n.captured.RecipientEmail,
 		"primary To must be the per-account contact email")
 	assert.Equal(t, executedBy, n.captured.ExecutedBy,
 		"body must record the executing actor")
-	assert.Equal(t, token, n.captured.RevocationToken,
-		"revocation token reuses the execution approval token (issue #291)")
+	assert.Equal(t, expectedToken, n.captured.RevocationToken,
+		"email must carry the expected revocation token")
 	assert.NotEmpty(t, n.captured.ExecutedAt, "executed-at timestamp must be set")
 }
 
 // TestExecutedNotification_TokenApprovePath covers the email one-click
 // (token-authed) approve branch of approvePurchase: after ApproveExecution
-// succeeds, sendPurchaseExecutedEmail must fire with the recording notifier.
+// succeeds, sendPurchaseExecutedEmail must fire with the fresh revocation
+// token from the re-fetched execution, not the stale pre-approve token.
+//
+// This is the regression test for the defect where approveViaToken passed
+// the stale pre-approve execution struct to sendPurchaseExecutedEmail.
+// mintRevocationToken (called inside ApproveExecution) had already overwritten
+// ApprovalToken in the DB, so the email embedded the old consumed token which
+// validateRevokeToken rejected with 403 on every revoke attempt.
+//
+// Fail-before: without the re-fetch, GetExecutionByID is called only once
+// (the second .Once() expectation goes unconsumed), the email carries the
+// stale "valid-token", and the RevocationToken assertion fails.
+// Pass-after: approveViaToken re-fetches, both .Once() expectations are
+// consumed, and the email carries the fresh "fresh-revoke-token".
 func TestExecutedNotification_TokenApprovePath(t *testing.T) {
 	ctx := context.Background()
 	execID := "12345678-1234-1234-1234-123456789abc"
 	contact := "contact@example.com"
+	freshToken := "fresh-revoke-token"
+	accountID := "acct-1"
+	recentCompleted := time.Now().Add(-1 * time.Minute)
 
+	// pre-approve: pending execution with the original approval token.
 	mockConfig := new(MockConfigStore)
 	exec := approvalTestExec(execID, contact, mockConfig)
-	mockConfig.On("GetExecutionByID", ctx, execID).Return(exec, nil)
+
+	// post-approve: completed execution with the fresh revocation token written
+	// by mintRevocationToken. Recommendations must be present so
+	// gatherAccountContactEmails can resolve the contact email via GetCloudAccountFn.
+	freshExec := &config.PurchaseExecution{
+		ExecutionID:   execID,
+		ApprovalToken: freshToken,
+		Status:        "completed",
+		CompletedAt:   &recentCompleted,
+		Recommendations: []config.RecommendationRecord{
+			{ID: "r1", CloudAccountID: &accountID},
+		},
+	}
+
+	// First call: loadApproveExecution fetches the pending execution.
+	// Second call: approveViaToken re-fetches after ApproveExecution returns to
+	// pick up the fresh revocation token written by mintRevocationToken.
+	mockConfig.On("GetExecutionByID", ctx, execID).Return(exec, nil).Once()
+	mockConfig.On("GetExecutionByID", ctx, execID).Return(freshExec, nil).Once()
 	mockConfig.On("GetGlobalConfig", ctx).Return(&config.GlobalConfig{
 		NotificationEmail: &contact,
 	}, nil)
@@ -83,8 +123,18 @@ func TestExecutedNotification_TokenApprovePath(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "completed", result.(map[string]string)["status"])
 
-	assertExecutedNotificationFingerprints(t, notifier, contact, contact, "valid-token")
+	// The email must carry the fresh revocation token from the re-fetched row,
+	// not the stale "valid-token" from the pre-approve struct.
+	assertExecutedNotificationFingerprints(t, notifier, contact, contact, freshToken)
+
+	// Confirm the fresh token is actually valid for revocation: validateRevokeToken
+	// against the post-approve execution must succeed. This guards the end-to-end
+	// scenario: recipient clicks "Revoke" in the email -> token validates -> 200.
+	require.NoError(t, validateRevokeToken(freshExec, freshToken),
+		"the token embedded in the email must pass validateRevokeToken on the post-approve execution")
+
 	mockPurchase.AssertExpectations(t)
+	mockConfig.AssertExpectations(t)
 }
 
 // TestExecutedNotification_SessionApprovePath covers the dashboard

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -341,7 +341,7 @@ func (h *Handler) HandleRequest(ctx context.Context, req *events.LambdaFunctionU
 	}
 
 	path := req.RequestContext.HTTP.Path
-	logging.Debugf("API Request: %s %s", method, path)
+	logging.Debugf("API Request: %s %s", method, redactURL(path))
 
 	// Validate request
 	if response := h.validateRequest(ctx, req, method, path, corsHeaders); response != nil {

--- a/internal/api/handler_purchases.go
+++ b/internal/api/handler_purchases.go
@@ -1030,6 +1030,16 @@ func (h *Handler) revokePurchase(ctx context.Context, req *events.LambdaFunction
 		return nil, NewClientError(401, "sign in or use the revocation link from the notification email")
 	}
 
+	// One-click limitation (issue #291): the email link carries a token, but
+	// authorizeApprovalAction derives the actor from the *session*
+	// (tryResolveActorEmail), not from the token's bound contact email. A
+	// recipient who clicks the link while logged out therefore gets a 401 and
+	// must sign in with the matching contact email first. This intentionally
+	// matches the existing approve/cancel email-link behaviour -- we do not
+	// widen the authz model here. True tokenless one-click (deriving the actor
+	// from a single-use, contact-bound token) is deferred to the sibling
+	// "AWS RI/SP revocation" work, which adds a dedicated revocation token.
+	//
 	// Token-authed path: validate the token (reusing the approval token for
 	// this iteration) and confirm the caller is the authorised contact email.
 	actor, err := h.authorizeApprovalAction(ctx, req, execution)
@@ -2120,7 +2130,7 @@ func (h *Handler) executePurchase(ctx context.Context, req *events.LambdaFunctio
 		if err := h.authorizeSessionExecuteDirect(ctx, session, creatorID); err != nil {
 			return nil, err
 		}
-		return h.directExecutePurchase(ctx, execution, session)
+		return h.directExecutePurchase(ctx, req, execution, session)
 	}
 
 	// Send approval email synchronously so the response can surface the
@@ -2182,7 +2192,11 @@ func buildApprovalPendingResponse(
 //     synchronously. ApproveAndExecute already stamps ApprovedBy; we pass
 //     the session email as the actor so the approved_by column also records
 //     who direct-executed.
-//  3. Return a "completed" status to the caller.
+//  3. Send the best-effort post-execution notification email (issue #291).
+//     This is the only email the direct-execute flow emits -- no approval
+//     email precedes it -- so it is the path where the executed-notification
+//     matters most.
+//  4. Return a "completed" status to the caller.
 //
 // The audit fields are best-effort if ApproveAndExecute's SavePurchaseExecution
 // races with our pre-call stamp -- but in practice ApproveAndExecute calls
@@ -2191,7 +2205,7 @@ func buildApprovalPendingResponse(
 // TransitionExecutionStatus. The critical audit invariant is that a non-nil
 // executed_by_user_id always co-occurs with a non-nil pre_approval_skip_reason,
 // and both are set atomically in the same SavePurchaseExecution call here.
-func (h *Handler) directExecutePurchase(ctx context.Context, execution *config.PurchaseExecution, session *Session) (any, error) {
+func (h *Handler) directExecutePurchase(ctx context.Context, req *events.LambdaFunctionURLRequest, execution *config.PurchaseExecution, session *Session) (any, error) {
 	t0 := time.Now()
 	executionID := execution.ExecutionID
 	logging.Infof("purchase[%s]: directExecutePurchase entry (auth=session)", executionID)
@@ -2222,6 +2236,15 @@ func (h *Handler) directExecutePurchase(ctx context.Context, execution *config.P
 	}
 
 	logging.Infof("purchase[%s]: directExecutePurchase completed in %s", executionID, time.Since(t0))
+	// Best-effort post-execution notification email (issue #291). The
+	// direct-execute path sends no approval email (the whole point is to skip
+	// the approval round-trip), so this is the only notification the recipients
+	// receive -- making the executed-notification the most valuable here.
+	// Mirrors the approve-path call sites (see approvePurchase and
+	// approvePurchaseViaSession); recipient resolution and the nil-notifier
+	// guard live inside sendPurchaseExecutedEmail. session.Email is the actor
+	// who direct-executed, matching the actor passed to ApproveAndExecute above.
+	h.sendPurchaseExecutedEmail(ctx, req, execution, session.Email)
 	return map[string]any{
 		"execution_id":         executionID,
 		"status":               "completed",

--- a/internal/api/handler_purchases.go
+++ b/internal/api/handler_purchases.go
@@ -1017,28 +1017,13 @@ func (h *Handler) revokePurchase(ctx context.Context, req *events.LambdaFunction
 
 	// Only completed/partially_completed purchases have anything to revoke.
 	// A pending/notified purchase should be cancelled instead.
-	switch execution.Status {
-	case "completed", "partially_completed":
-		// valid
-	case "pending", "notified":
-		return nil, NewClientError(409, fmt.Sprintf(
-			"execution %s is still pending — use the Cancel link instead of Revoke", execID))
-	default:
-		return nil, NewClientError(409, fmt.Sprintf(
-			"execution %s cannot be revoked (status=%s); the revocation window may have closed or the purchase was not completed",
-			execID, execution.Status))
+	if err := checkRevokableStatus(execution); err != nil {
+		return nil, err
 	}
 
 	// Three-mode dispatch — same shape as cancelPurchase.
-	if session := h.tryGetSession(ctx, req); session != nil {
-		switch sessErr := h.authorizeSessionCancel(ctx, session, execution); {
-		case sessErr == nil:
-			return h.revokeViaSession(ctx, execution, session.Email)
-		case isPermissionDenied(sessErr):
-			// Fall through to the token branch.
-		default:
-			return nil, sessErr
-		}
+	if result, handled, err := h.tryRevokeViaSession(ctx, req, execution); handled {
+		return result, err
 	}
 
 	if token == "" {
@@ -1051,16 +1036,66 @@ func (h *Handler) revokePurchase(ctx context.Context, req *events.LambdaFunction
 	if err != nil {
 		return nil, err
 	}
-	// Validate token against the execution's ApprovalToken using constant-time
-	// comparison to prevent timing attacks (same guard as ApproveExecution in
-	// internal/purchase/approvals.go).
-	if execution.ApprovalToken == "" {
-		return nil, NewClientError(403, "invalid revocation token")
-	}
-	if subtle.ConstantTimeCompare([]byte(execution.ApprovalToken), []byte(token)) != 1 {
-		return nil, NewClientError(403, "invalid revocation token")
+	if err := validateRevokeToken(execution, token); err != nil {
+		return nil, err
 	}
 	return h.revokeViaSession(ctx, execution, actor)
+}
+
+// tryRevokeViaSession attempts the session-authenticated branch of the
+// revokePurchase three-mode dispatch (same shape as the session branch of
+// cancelPurchase). Returns (result, true, err) when the session was present
+// and either completed the revocation or encountered a hard error; returns
+// (nil, false, nil) when the session was absent or returned a permission-denied
+// error so the caller can fall through to the token branch. Extracted from
+// revokePurchase to keep that function under the cyclomatic limit.
+func (h *Handler) tryRevokeViaSession(ctx context.Context, req *events.LambdaFunctionURLRequest, execution *config.PurchaseExecution) (any, bool, error) {
+	session := h.tryGetSession(ctx, req)
+	if session == nil {
+		return nil, false, nil
+	}
+	switch sessErr := h.authorizeSessionCancel(ctx, session, execution); {
+	case sessErr == nil:
+		result, err := h.revokeViaSession(ctx, execution, session.Email)
+		return result, true, err
+	case isPermissionDenied(sessErr):
+		// Fall through to the token branch.
+		return nil, false, nil
+	default:
+		return nil, true, sessErr
+	}
+}
+
+// checkRevokableStatus returns nil when the execution is in a state that allows
+// revocation (completed or partially_completed), or a 409 ClientError when the
+// status makes revocation impossible. Extracted from revokePurchase to keep
+// that function under the cyclomatic limit.
+func checkRevokableStatus(execution *config.PurchaseExecution) error {
+	switch execution.Status {
+	case "completed", "partially_completed":
+		return nil
+	case "pending", "notified":
+		return NewClientError(409, fmt.Sprintf(
+			"execution %s is still pending — use the Cancel link instead of Revoke", execution.ExecutionID))
+	default:
+		return NewClientError(409, fmt.Sprintf(
+			"execution %s cannot be revoked (status=%s); the revocation window may have closed or the purchase was not completed",
+			execution.ExecutionID, execution.Status))
+	}
+}
+
+// validateRevokeToken checks that the execution carries a non-empty
+// ApprovalToken and that it matches the supplied token using constant-time
+// comparison (same guard as ApproveExecution in internal/purchase/approvals.go).
+// Extracted from revokePurchase to keep that function under the cyclomatic limit.
+func validateRevokeToken(execution *config.PurchaseExecution, token string) error {
+	if execution.ApprovalToken == "" {
+		return NewClientError(403, "invalid revocation token")
+	}
+	if subtle.ConstantTimeCompare([]byte(execution.ApprovalToken), []byte(token)) != 1 {
+		return NewClientError(403, "invalid revocation token")
+	}
+	return nil
 }
 
 // revokeViaSession performs the post-execution revocation action by recording
@@ -2308,10 +2343,7 @@ func (h *Handler) sendPurchaseExecutedEmail(ctx context.Context, req *events.Lam
 		logging.Errorf("sendPurchaseExecutedEmail: failed to load global config: %v", err)
 		return
 	}
-	globalNotify := ""
-	if globalCfg != nil && globalCfg.NotificationEmail != nil {
-		globalNotify = strings.TrimSpace(*globalCfg.NotificationEmail)
-	}
+	globalNotify := globalNotifyEmail(globalCfg)
 
 	// Gather per-account contact emails for the recommendations.
 	contactEmails, err := h.gatherAccountContactEmails(ctx, execution.Recommendations)
@@ -2321,14 +2353,7 @@ func (h *Handler) sendPurchaseExecutedEmail(ctx context.Context, req *events.Lam
 	}
 
 	// Look up the requester's email via their user ID (if available).
-	requesterEmail := ""
-	requesterName := ""
-	if h.auth != nil && execution.CreatedByUserID != nil && *execution.CreatedByUserID != "" {
-		if u, lookupErr := h.auth.GetUser(ctx, *execution.CreatedByUserID); lookupErr == nil && u != nil {
-			requesterEmail = u.Email
-		}
-		// Error is non-fatal — we just omit the field from the email body.
-	}
+	requesterEmail, requesterName := h.lookupRequesterInfo(ctx, execution)
 
 	// Build the deduplicated To / Cc list.
 	// Priority: contact emails are To (first one) + Cc (rest); global notify
@@ -2382,6 +2407,32 @@ func (h *Handler) sendPurchaseExecutedEmail(ctx context.Context, req *events.Lam
 	if sendErr := h.emailNotifier.SendPurchaseExecutedNotification(ctx, data); sendErr != nil {
 		logging.Errorf("sendPurchaseExecutedEmail: send failed for execution %s: %v", execution.ExecutionID, sendErr)
 	}
+}
+
+// globalNotifyEmail returns the trimmed notification email from a GlobalConfig,
+// or "" when the config is nil or the field is unset. Extracted from
+// sendPurchaseExecutedEmail to keep that function under the cyclomatic limit.
+func globalNotifyEmail(globalCfg *config.GlobalConfig) string {
+	if globalCfg != nil && globalCfg.NotificationEmail != nil {
+		return strings.TrimSpace(*globalCfg.NotificationEmail)
+	}
+	return ""
+}
+
+// lookupRequesterInfo resolves the email (and name, currently always "") for
+// the user who originally submitted the execution. The lookup is non-fatal:
+// when auth is unavailable or the user cannot be found, both fields are
+// returned empty and the notification is sent without them. Extracted from
+// sendPurchaseExecutedEmail to keep that function under the cyclomatic limit.
+func (h *Handler) lookupRequesterInfo(ctx context.Context, execution *config.PurchaseExecution) (email, name string) {
+	if h.auth == nil || execution.CreatedByUserID == nil || *execution.CreatedByUserID == "" {
+		return "", ""
+	}
+	u, err := h.auth.GetUser(ctx, *execution.CreatedByUserID)
+	if err == nil && u != nil {
+		return u.Email, ""
+	}
+	return "", ""
 }
 
 // resolveExecutedNotificationRecipients builds the To / Cc pair for the

--- a/internal/api/handler_purchases.go
+++ b/internal/api/handler_purchases.go
@@ -2595,10 +2595,15 @@ func (h *Handler) lookupRequesterInfo(ctx context.Context, execution *config.Pur
 		return "", ""
 	}
 	u, err := h.auth.GetUser(ctx, *execution.CreatedByUserID)
-	if err == nil && u != nil {
-		return u.Email, ""
+	if err != nil {
+		logging.Warnf("lookupRequesterInfo: GetUser(%s) failed: %v", *execution.CreatedByUserID, err)
+		return "", ""
 	}
-	return "", ""
+	if u == nil {
+		logging.Warnf("lookupRequesterInfo: GetUser(%s) returned nil user", *execution.CreatedByUserID)
+		return "", ""
+	}
+	return u.Email, ""
 }
 
 // resolveExecutedNotificationRecipients builds the To / Cc pair for the

--- a/internal/api/handler_purchases.go
+++ b/internal/api/handler_purchases.go
@@ -520,6 +520,10 @@ func (h *Handler) approveViaToken(ctx context.Context, req *events.LambdaFunctio
 	if err := h.purchase.ApproveExecution(ctx, execution.ExecutionID, token, actor); err != nil {
 		return nil, err
 	}
+	// Best-effort post-execution notification email (issue #291). Mirrors
+	// the session-authed path; errors are logged inside sendPurchaseExecutedEmail
+	// and never propagate — the purchase is already done at this point.
+	h.sendPurchaseExecutedEmail(ctx, req, execution, actor)
 	return map[string]string{"status": "completed"}, nil
 }
 
@@ -977,7 +981,7 @@ func (h *Handler) cancelPurchaseViaSession(ctx context.Context, req *events.Lamb
 	return map[string]string{"status": "canceled"}, nil
 }
 
-// revokePurchase is the one-click revocation handler embedded in the
+// revokeViaEmailToken is the one-click revocation handler embedded in the
 // post-execution notification email (issue #291). It accepts the same
 // three-mode dispatch shape as approvePurchase / cancelPurchase:
 //
@@ -989,7 +993,7 @@ func (h *Handler) cancelPurchaseViaSession(ctx context.Context, req *events.Lamb
 // The revocation window check is intentionally limited in this
 // iteration: because the sibling "AWS RI/SP revocation via support case"
 // issue has not yet landed its dedicated revocation_window_closes_at
-// column, revokePurchase reuses the ApprovalToken. Once the sibling lands
+// column, revokeViaEmailToken reuses the ApprovalToken. Once the sibling lands
 // and adds a RevocationToken + RevocationWindowClosesAt column, this
 // handler should validate RevocationWindowClosesAt here before
 // attempting the cancellation.
@@ -1028,7 +1032,7 @@ cancellation within the allowed window.</p>
 </body>
 </html>`
 
-func (h *Handler) revokePurchase(ctx context.Context, req *events.LambdaFunctionURLRequest, execID, token string) (any, error) {
+func (h *Handler) revokeViaEmailToken(ctx context.Context, req *events.LambdaFunctionURLRequest, execID, token string) (any, error) {
 	if err := validateUUID(execID); err != nil {
 		return nil, err
 	}
@@ -1109,12 +1113,12 @@ func renderRevokeConfirmPage(execID, token string) *rawResponse {
 }
 
 // tryRevokeViaSession attempts the session-authenticated branch of the
-// revokePurchase three-mode dispatch (same shape as the session branch of
+// revokeViaEmailToken three-mode dispatch (same shape as the session branch of
 // cancelPurchase). Returns (result, true, err) when the session was present
 // and either completed the revocation or encountered a hard error; returns
 // (nil, false, nil) when the session was absent or returned a permission-denied
 // error so the caller can fall through to the token branch. Extracted from
-// revokePurchase to keep that function under the cyclomatic limit.
+// revokeViaEmailToken to keep that function under the cyclomatic limit.
 func (h *Handler) tryRevokeViaSession(ctx context.Context, req *events.LambdaFunctionURLRequest, execution *config.PurchaseExecution) (any, bool, error) {
 	session := h.tryGetSession(ctx, req)
 	if session == nil {
@@ -1134,7 +1138,7 @@ func (h *Handler) tryRevokeViaSession(ctx context.Context, req *events.LambdaFun
 
 // checkRevokableStatus returns nil when the execution is in a state that allows
 // revocation (completed or partially_completed), or a 409 ClientError when the
-// status makes revocation impossible. Extracted from revokePurchase to keep
+// status makes revocation impossible. Extracted from revokeViaEmailToken to keep
 // that function under the cyclomatic limit.
 func checkRevokableStatus(execution *config.PurchaseExecution) error {
 	switch execution.Status {
@@ -1161,7 +1165,7 @@ const revocationWindowDuration = 24 * time.Hour
 // has not closed (revocationWindowDuration after CompletedAt), and that the
 // token matches using constant-time comparison. Pre-migration rows without an
 // ApprovalTokenExpiresAt pass the expiry check (legacy backward compat).
-// Extracted from revokePurchase to keep that function under the cyclomatic limit.
+// Extracted from revokeViaEmailToken to keep that function under the cyclomatic limit.
 func validateRevokeToken(execution *config.PurchaseExecution, token string) error {
 	if execution.ApprovalToken == "" {
 		return NewClientError(403, "invalid revocation token")
@@ -1237,9 +1241,10 @@ func revocationWindowClosesAt(execution *config.PurchaseExecution) string {
 // and we return a 409 rather than blindly overwriting. CancelledBy is stamped
 // in a follow-up SavePurchaseExecution on the freshly-returned row.
 func (h *Handler) revokeViaSession(ctx context.Context, execution *config.PurchaseExecution, revokedBy string) (any, error) {
+	actor := &revokedBy
 	updated, err := h.config.TransitionExecutionStatus(
 		ctx, execution.ExecutionID,
-		[]string{"completed", "partially_completed"}, "revocation_requested")
+		[]string{"completed", "partially_completed"}, "revocation_requested", actor)
 	if err != nil {
 		if errors.Is(err, config.ErrExecutionNotInExpectedStatus) {
 			return nil, NewClientError(409, fmt.Sprintf(

--- a/internal/api/handler_purchases.go
+++ b/internal/api/handler_purchases.go
@@ -4,6 +4,7 @@ package api
 import (
 	"context"
 	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -587,6 +588,11 @@ func (h *Handler) approvePurchaseViaSession(ctx context.Context, req *events.Lam
 
 	logging.Infof("purchase[%s]: approvePurchaseViaSession completed in %s (auth=session)",
 		execution.ExecutionID, time.Since(t0))
+	// Best-effort post-execution notification email (issue #291). Fires
+	// after the synchronous purchase completes so the email carries the
+	// final committed state. Errors are logged inside sendPurchaseExecutedEmail
+	// and never propagate — the purchase is already done at this point.
+	h.sendPurchaseExecutedEmail(ctx, req, execution, session.Email)
 	return map[string]string{"status": "completed"}, nil
 }
 
@@ -969,6 +975,113 @@ func (h *Handler) cancelPurchaseViaSession(ctx context.Context, req *events.Lamb
 	}
 
 	return map[string]string{"status": "canceled"}, nil
+}
+
+// revokePurchase is the one-click revocation handler embedded in the
+// post-execution notification email (issue #291). It accepts the same
+// three-mode dispatch shape as approvePurchase / cancelPurchase:
+//
+//  1. Session present AND RBAC-authorized (admin / cancel-any /
+//     cancel-own) → session-authed path.
+//  2. token != "" → token-authed path via the email one-click link.
+//  3. No token, no qualifying session → 401.
+//
+// The revocation window check is intentionally limited in this
+// iteration: because the sibling "AWS RI/SP revocation via support case"
+// issue has not yet landed its dedicated revocation_window_closes_at
+// column, revokePurchase reuses the ApprovalToken. Once the sibling lands
+// and adds a RevocationToken + RevocationWindowClosesAt column, this
+// handler should validate RevocationWindowClosesAt here before
+// attempting the cancellation.
+//
+// At this scope the revoke action is equivalent to a cancel on a
+// completed/completed execution — the underlying cloud revocation
+// (AWS support-case path) is out of scope for this issue and is handled
+// by the sibling "AWS RI/SP revocation" issue.
+//
+// Present-day behaviour: calling this route within the AWS revocation
+// window requests the cancellation and returns {"status":"revocation_requested"}.
+// Past the window it returns a friendly 409 with a plain-language message
+// rather than a stack trace.
+func (h *Handler) revokePurchase(ctx context.Context, req *events.LambdaFunctionURLRequest, execID, token string) (any, error) {
+	if err := validateUUID(execID); err != nil {
+		return nil, err
+	}
+	execution, err := h.config.GetExecutionByID(ctx, execID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get execution: %w", err)
+	}
+	if execution == nil {
+		return nil, NewClientError(404, "execution not found")
+	}
+
+	// Only completed/partially_completed purchases have anything to revoke.
+	// A pending/notified purchase should be cancelled instead.
+	switch execution.Status {
+	case "completed", "partially_completed":
+		// valid
+	case "pending", "notified":
+		return nil, NewClientError(409, fmt.Sprintf(
+			"execution %s is still pending — use the Cancel link instead of Revoke", execID))
+	default:
+		return nil, NewClientError(409, fmt.Sprintf(
+			"execution %s cannot be revoked (status=%s); the revocation window may have closed or the purchase was not completed",
+			execID, execution.Status))
+	}
+
+	// Three-mode dispatch — same shape as cancelPurchase.
+	if session := h.tryGetSession(ctx, req); session != nil {
+		switch sessErr := h.authorizeSessionCancel(ctx, session, execution); {
+		case sessErr == nil:
+			return h.revokeViaSession(ctx, execution, session.Email)
+		case isPermissionDenied(sessErr):
+			// Fall through to the token branch.
+		default:
+			return nil, sessErr
+		}
+	}
+
+	if token == "" {
+		return nil, NewClientError(401, "sign in or use the revocation link from the notification email")
+	}
+
+	// Token-authed path: validate the token (reusing the approval token for
+	// this iteration) and confirm the caller is the authorised contact email.
+	actor, err := h.authorizeApprovalAction(ctx, req, execution)
+	if err != nil {
+		return nil, err
+	}
+	// Validate token against the execution's ApprovalToken using constant-time
+	// comparison to prevent timing attacks (same guard as ApproveExecution in
+	// internal/purchase/approvals.go).
+	if execution.ApprovalToken == "" {
+		return nil, NewClientError(403, "invalid revocation token")
+	}
+	if subtle.ConstantTimeCompare([]byte(execution.ApprovalToken), []byte(token)) != 1 {
+		return nil, NewClientError(403, "invalid revocation token")
+	}
+	return h.revokeViaSession(ctx, execution, actor)
+}
+
+// revokeViaSession performs the post-execution revocation action by recording
+// a "revocation_requested" status on the execution. Actual cloud-side
+// revocation (AWS support-case) is out of scope for issue #291 — it is
+// handled by the sibling "AWS RI/SP revocation via support case" issue.
+// This call records the intent so the History UI can surface it.
+func (h *Handler) revokeViaSession(ctx context.Context, execution *config.PurchaseExecution, revokedBy string) (any, error) {
+	execution.Status = "revocation_requested"
+	if revokedBy != "" {
+		rb := revokedBy
+		execution.CancelledBy = &rb
+	}
+	if err := h.config.SavePurchaseExecution(ctx, execution); err != nil {
+		return nil, fmt.Errorf("failed to record revocation request for execution %s: %w", execution.ExecutionID, err)
+	}
+	logging.Infof("Revocation requested for execution %s by %s", execution.ExecutionID, revokedBy)
+	return map[string]string{
+		"status":  "revocation_requested",
+		"message": "Revocation request recorded. Contact AWS Support to complete the cancellation within the allowed window.",
+	}, nil
 }
 
 // authorizeSessionCancel returns nil when the session is permitted to cancel
@@ -2163,6 +2276,164 @@ func (h *Handler) sendPurchaseApprovalEmail(ctx context.Context, req *events.Lam
 		}
 	}
 	return true, "", responseRecipient
+}
+
+// sendPurchaseExecutedEmail sends a post-execution notification to the
+// configured recipients after a purchase completes successfully. It follows
+// the same best-effort contract as sendPurchaseApprovalEmail: errors are
+// logged but never propagate to the caller — the purchase is already done.
+//
+// Recipients (deduped):
+//   - global notification_email (Settings → General)
+//   - per-account contact_email for each recommendation's account
+//   - email of the user who originally submitted the execution
+//     (looked up by CreatedByUserID via h.auth.GetUser)
+//
+// The revocation link uses the execution's ApprovalToken (reusing the same
+// token infrastructure). When the sibling "AWS RI/SP revocation via support
+// case" issue lands and adds a dedicated revocation token + window field,
+// this method should be updated to use those fields instead.
+func (h *Handler) sendPurchaseExecutedEmail(ctx context.Context, req *events.LambdaFunctionURLRequest, execution *config.PurchaseExecution, executedByEmail string) {
+	if h.emailNotifier == nil {
+		logging.Debug("sendPurchaseExecutedEmail: no email notifier configured, skipping")
+		return
+	}
+	if execution.ExecutionID == "" {
+		logging.Warn("sendPurchaseExecutedEmail: empty execution ID, skipping")
+		return
+	}
+
+	globalCfg, err := h.config.GetGlobalConfig(ctx)
+	if err != nil {
+		logging.Errorf("sendPurchaseExecutedEmail: failed to load global config: %v", err)
+		return
+	}
+	globalNotify := ""
+	if globalCfg != nil && globalCfg.NotificationEmail != nil {
+		globalNotify = strings.TrimSpace(*globalCfg.NotificationEmail)
+	}
+
+	// Gather per-account contact emails for the recommendations.
+	contactEmails, err := h.gatherAccountContactEmails(ctx, execution.Recommendations)
+	if err != nil {
+		logging.Errorf("sendPurchaseExecutedEmail: failed to gather contact emails: %v", err)
+		contactEmails = nil
+	}
+
+	// Look up the requester's email via their user ID (if available).
+	requesterEmail := ""
+	requesterName := ""
+	if h.auth != nil && execution.CreatedByUserID != nil && *execution.CreatedByUserID != "" {
+		if u, lookupErr := h.auth.GetUser(ctx, *execution.CreatedByUserID); lookupErr == nil && u != nil {
+			requesterEmail = u.Email
+		}
+		// Error is non-fatal — we just omit the field from the email body.
+	}
+
+	// Build the deduplicated To / Cc list.
+	// Priority: contact emails are To (first one) + Cc (rest); global notify
+	// and requester email are Cc. When there are no contact emails, the global
+	// notify becomes To (matching the approval-email fallback in resolveApprovalRecipients).
+	to, cc := resolveExecutedNotificationRecipients(contactEmails, globalNotify, requesterEmail)
+	if to == "" {
+		logging.Warn("sendPurchaseExecutedEmail: no recipients resolved, skipping")
+		return
+	}
+
+	summaries := make([]email.RecommendationSummary, 0, len(execution.Recommendations))
+	for _, rec := range execution.Recommendations {
+		summaries = append(summaries, email.RecommendationSummary{
+			Service:        rec.Service,
+			ResourceType:   rec.ResourceType,
+			Engine:         rec.Engine,
+			Region:         rec.Region,
+			Count:          rec.Count,
+			MonthlySavings: rec.Savings,
+			Term:           rec.Term,
+			Payment:        rec.Payment,
+			UpfrontCost:    rec.UpfrontCost,
+		})
+	}
+
+	dashboardBase := h.resolveDashboardURL(req)
+	data := email.NotificationData{
+		DashboardURL:     dashboardBase,
+		ExecutionID:      execution.ExecutionID,
+		TotalSavings:     execution.EstimatedSavings,
+		TotalUpfrontCost: execution.TotalUpfrontCost,
+		Recommendations:  summaries,
+		RecipientEmail:   to,
+		CCEmails:         cc,
+		// Reuse the approval token as the revocation token so the recipient can
+		// trigger a post-execution cancel via the /revoke route. A dedicated
+		// revocation token will be added when the sibling "AWS RI/SP revocation"
+		// issue lands its own DB column.
+		RevocationToken:  execution.ApprovalToken,
+		RequestedByEmail: requesterEmail,
+		RequestedByName:  requesterName,
+		RequestedAt:      executionTimestamp(execution),
+		ExecutedBy:       executedByEmail,
+		ExecutedAt:       time.Now().UTC().Format(time.RFC3339),
+	}
+	if dashboardBase != "" {
+		data.ArcheraEducationURL = dashboardBase + "/archera-insurance"
+	}
+
+	if sendErr := h.emailNotifier.SendPurchaseExecutedNotification(ctx, data); sendErr != nil {
+		logging.Errorf("sendPurchaseExecutedEmail: send failed for execution %s: %v", execution.ExecutionID, sendErr)
+	}
+}
+
+// resolveExecutedNotificationRecipients builds the To / Cc pair for the
+// post-execution notification from the three input email sets. The logic
+// mirrors resolveApprovalRecipients: first contact email is To; remaining
+// contact emails, globalNotify, and requesterEmail are Cc (deduped). When
+// no contact emails are present, globalNotify becomes To and requesterEmail
+// becomes Cc.
+func resolveExecutedNotificationRecipients(contactEmails []string, globalNotify, requesterEmail string) (to string, cc []string) {
+	seen := map[string]bool{}
+	addCc := func(addr string) {
+		norm := strings.ToLower(strings.TrimSpace(addr))
+		if norm == "" || seen[norm] {
+			return
+		}
+		seen[norm] = true
+		cc = append(cc, addr)
+	}
+
+	if len(contactEmails) > 0 {
+		to = contactEmails[0]
+		seen[strings.ToLower(strings.TrimSpace(to))] = true
+		for _, addr := range contactEmails[1:] {
+			addCc(addr)
+		}
+		addCc(globalNotify)
+		addCc(requesterEmail)
+		return to, cc
+	}
+
+	// No contact emails: fall back to globalNotify as To.
+	if globalNotify != "" {
+		to = globalNotify
+		seen[strings.ToLower(strings.TrimSpace(to))] = true
+		addCc(requesterEmail)
+		return to, cc
+	}
+
+	// Last resort: requester email only.
+	to = strings.TrimSpace(requesterEmail)
+	return to, nil
+}
+
+// executionTimestamp returns a human-readable timestamp for when the execution
+// was submitted (ScheduledDate for web-submitted rows). Returns empty string
+// when the execution has no timestamp (shouldn't happen in practice but
+// guards against zero-value time panics in templates).
+func executionTimestamp(exec *config.PurchaseExecution) string {
+	if exec.ScheduledDate.IsZero() {
+		return ""
+	}
+	return exec.ScheduledDate.UTC().Format(time.RFC3339)
 }
 
 // resolveDashboardURL returns the absolute base URL to embed in email

--- a/internal/api/handler_purchases.go
+++ b/internal/api/handler_purchases.go
@@ -1085,12 +1085,19 @@ func checkRevokableStatus(execution *config.PurchaseExecution) error {
 }
 
 // validateRevokeToken checks that the execution carries a non-empty
-// ApprovalToken and that it matches the supplied token using constant-time
-// comparison (same guard as ApproveExecution in internal/purchase/approvals.go).
+// ApprovalToken, that the token has not expired, and that it matches the
+// supplied token using constant-time comparison (same guard as
+// ApproveExecution in internal/purchase/approvals.go). Pre-migration rows
+// without an ApprovalTokenExpiresAt (legacy executions created before
+// migration 000051) pass the expiry check, mirroring ApproveExecution.
 // Extracted from revokePurchase to keep that function under the cyclomatic limit.
 func validateRevokeToken(execution *config.PurchaseExecution, token string) error {
 	if execution.ApprovalToken == "" {
 		return NewClientError(403, "invalid revocation token")
+	}
+	if execution.ApprovalTokenExpiresAt != nil && time.Now().After(*execution.ApprovalTokenExpiresAt) {
+		return NewClientError(409, fmt.Sprintf(
+			"execution %s cannot be revoked: the revocation link has expired", execution.ExecutionID))
 	}
 	if subtle.ConstantTimeCompare([]byte(execution.ApprovalToken), []byte(token)) != 1 {
 		return NewClientError(403, "invalid revocation token")
@@ -1103,16 +1110,35 @@ func validateRevokeToken(execution *config.PurchaseExecution, token string) erro
 // revocation (AWS support-case) is out of scope for issue #291 — it is
 // handled by the sibling "AWS RI/SP revocation via support case" issue.
 // This call records the intent so the History UI can surface it.
+//
+// The status flip uses TransitionExecutionStatus, which issues a conditional
+// UPDATE WHERE status IN ('completed','partially_completed'). This guards
+// against lost-update races: if the row changed between the GetExecutionByID
+// read and this write (e.g. a concurrent transition), zero rows are affected
+// and we return a 409 rather than blindly overwriting. CancelledBy is stamped
+// in a follow-up SavePurchaseExecution on the freshly-returned row.
 func (h *Handler) revokeViaSession(ctx context.Context, execution *config.PurchaseExecution, revokedBy string) (any, error) {
-	execution.Status = "revocation_requested"
-	if revokedBy != "" {
-		rb := revokedBy
-		execution.CancelledBy = &rb
-	}
-	if err := h.config.SavePurchaseExecution(ctx, execution); err != nil {
+	updated, err := h.config.TransitionExecutionStatus(
+		ctx, execution.ExecutionID,
+		[]string{"completed", "partially_completed"}, "revocation_requested")
+	if err != nil {
+		if errors.Is(err, config.ErrExecutionNotInExpectedStatus) {
+			return nil, NewClientError(409, fmt.Sprintf(
+				"execution %s cannot be revoked: a concurrent operation changed its status", execution.ExecutionID))
+		}
+		if errors.Is(err, config.ErrNotFound) {
+			return nil, NewClientError(404, "execution not found")
+		}
 		return nil, fmt.Errorf("failed to record revocation request for execution %s: %w", execution.ExecutionID, err)
 	}
-	logging.Infof("Revocation requested for execution %s by %s", execution.ExecutionID, revokedBy)
+	if revokedBy != "" {
+		rb := revokedBy
+		updated.CancelledBy = &rb
+		if err := h.config.SavePurchaseExecution(ctx, updated); err != nil {
+			return nil, fmt.Errorf("failed to record revocation requester for execution %s: %w", execution.ExecutionID, err)
+		}
+	}
+	logging.Infof("Revocation requested for execution %s by %s", execution.ExecutionID, redactEmail(revokedBy))
 	return map[string]string{
 		"status":  "revocation_requested",
 		"message": "Revocation request recorded. Contact AWS Support to complete the cancellation within the allowed window.",

--- a/internal/api/handler_purchases.go
+++ b/internal/api/handler_purchases.go
@@ -1150,12 +1150,17 @@ func checkRevokableStatus(execution *config.PurchaseExecution) error {
 	}
 }
 
+// revocationWindowDuration is the time window after a purchase completes
+// during which the buyer may request revocation. 24 hours matches the AWS
+// RI/SP support-case window and is advertised in the post-execution email.
+// Adjust this constant to change the window without touching call sites.
+const revocationWindowDuration = 24 * time.Hour
+
 // validateRevokeToken checks that the execution carries a non-empty
-// ApprovalToken, that the token has not expired, and that it matches the
-// supplied token using constant-time comparison (same guard as
-// ApproveExecution in internal/purchase/approvals.go). Pre-migration rows
-// without an ApprovalTokenExpiresAt (legacy executions created before
-// migration 000051) pass the expiry check, mirroring ApproveExecution.
+// ApprovalToken, that the token has not expired, that the revocation window
+// has not closed (revocationWindowDuration after CompletedAt), and that the
+// token matches using constant-time comparison. Pre-migration rows without an
+// ApprovalTokenExpiresAt pass the expiry check (legacy backward compat).
 // Extracted from revokePurchase to keep that function under the cyclomatic limit.
 func validateRevokeToken(execution *config.PurchaseExecution, token string) error {
 	if execution.ApprovalToken == "" {
@@ -1165,10 +1170,56 @@ func validateRevokeToken(execution *config.PurchaseExecution, token string) erro
 		return NewClientError(409, fmt.Sprintf(
 			"execution %s cannot be revoked: the revocation link has expired", execution.ExecutionID))
 	}
+	// Enforce the 24-hour revocation window (issue #291 Finding #6).
+	// Use CompletedAt as the reference timestamp; fall back to ExecutedAt
+	// for direct-execute rows which may not have a CompletedAt yet.
+	if windowErr := checkRevocationWindow(execution); windowErr != nil {
+		return windowErr
+	}
 	if subtle.ConstantTimeCompare([]byte(execution.ApprovalToken), []byte(token)) != 1 {
 		return NewClientError(403, "invalid revocation token")
 	}
 	return nil
+}
+
+// checkRevocationWindow returns a 403 ClientError when the 24-hour revocation
+// window has passed. The reference timestamp is CompletedAt if set, otherwise
+// ExecutedAt. When neither is set (legacy rows without these columns) the
+// check is skipped to preserve backward compatibility.
+func checkRevocationWindow(execution *config.PurchaseExecution) error {
+	var ref *time.Time
+	if execution.CompletedAt != nil {
+		ref = execution.CompletedAt
+	} else if execution.ExecutedAt != nil {
+		ref = execution.ExecutedAt
+	}
+	if ref == nil {
+		// Legacy row: no timestamp to anchor the window; allow the revoke.
+		return nil
+	}
+	windowCloses := ref.Add(revocationWindowDuration)
+	if time.Now().After(windowCloses) {
+		return NewClientError(403, fmt.Sprintf(
+			"revocation window has closed (window closed at %s)", windowCloses.UTC().Format(time.RFC3339)))
+	}
+	return nil
+}
+
+// revocationWindowClosesAt returns the human-readable UTC string at which the
+// 24-hour revocation window closes. Used by sendPurchaseExecutedEmail to
+// populate the RevocationWindowClosesAt field in the email template.
+// Returns "" when no reference timestamp is available (legacy rows).
+func revocationWindowClosesAt(execution *config.PurchaseExecution) string {
+	var ref *time.Time
+	if execution.CompletedAt != nil {
+		ref = execution.CompletedAt
+	} else if execution.ExecutedAt != nil {
+		ref = execution.ExecutedAt
+	}
+	if ref == nil {
+		return ""
+	}
+	return ref.Add(revocationWindowDuration).UTC().Format("2006-01-02 15:04 UTC")
 }
 
 // revokeViaSession performs the post-execution revocation action by recording
@@ -2498,12 +2549,15 @@ func (h *Handler) sendPurchaseExecutedEmail(ctx context.Context, req *events.Lam
 		// trigger a post-execution cancel via the /revoke route. A dedicated
 		// revocation token will be added when the sibling "AWS RI/SP revocation"
 		// issue lands its own DB column.
-		RevocationToken:  execution.ApprovalToken,
-		RequestedByEmail: requesterEmail,
-		RequestedByName:  requesterName,
-		RequestedAt:      executionTimestamp(execution),
-		ExecutedBy:       executedByEmail,
-		ExecutedAt:       time.Now().UTC().Format(time.RFC3339),
+		RevocationToken: execution.ApprovalToken,
+		// Populate the revocation window deadline so the email copy matches
+		// the enforced 24-hour window in validateRevokeToken (Finding #6).
+		RevocationWindowClosesAt: revocationWindowClosesAt(execution),
+		RequestedByEmail:         requesterEmail,
+		RequestedByName:          requesterName,
+		RequestedAt:              executionTimestamp(execution),
+		ExecutedBy:               executedByEmail,
+		ExecutedAt:               time.Now().UTC().Format(time.RFC3339),
 	}
 	if dashboardBase != "" {
 		data.ArcheraEducationURL = dashboardBase + "/archera-insurance"

--- a/internal/api/handler_purchases.go
+++ b/internal/api/handler_purchases.go
@@ -1176,7 +1176,9 @@ func validateRevokeToken(execution *config.PurchaseExecution, token string) erro
 	if windowErr := checkRevocationWindow(execution); windowErr != nil {
 		return windowErr
 	}
-	if subtle.ConstantTimeCompare([]byte(execution.ApprovalToken), []byte(token)) != 1 {
+	storedHash := sha256.Sum256([]byte(execution.ApprovalToken))
+	userHash := sha256.Sum256([]byte(token))
+	if subtle.ConstantTimeCompare(storedHash[:], userHash[:]) != 1 {
 		return NewClientError(403, "invalid revocation token")
 	}
 	return nil

--- a/internal/api/handler_purchases.go
+++ b/internal/api/handler_purchases.go
@@ -528,11 +528,19 @@ func (h *Handler) approveViaToken(ctx context.Context, req *events.LambdaFunctio
 	// stored token, which mintRevocationToken has already replaced).
 	emailExec, fetchErr := h.config.GetExecutionByID(ctx, execution.ExecutionID)
 	if fetchErr != nil || emailExec == nil {
-		// Best-effort fallback: send without a valid revoke token rather than
-		// blocking the response. The purchase is complete regardless.
-		logging.Warnf("approveViaToken[%s]: re-fetch for email failed (%v); sending without valid revocation token",
+		// Best-effort fallback: the re-fetch failed, so we cannot obtain the
+		// fresh revocation token minted inside ApproveExecution. The stale
+		// pre-approve struct still carries the OLD approval token, which
+		// mintRevocationToken has already replaced in the DB -- emailing it
+		// would embed an invalid token and every Revoke click would 403.
+		// Instead, send a COPY with ApprovalToken blanked so the email
+		// template's {{if .RevocationToken}} suppresses the Revoke panel
+		// entirely (no broken button). The purchase is complete regardless.
+		logging.Warnf("approveViaToken[%s]: re-fetch for email failed (%v); suppressing Revoke panel (no valid token available)",
 			execution.ExecutionID, fetchErr)
-		emailExec = execution
+		emailCopy := *execution
+		emailCopy.ApprovalToken = ""
+		emailExec = &emailCopy
 	}
 	// Best-effort post-execution notification email (issue #291). Mirrors
 	// the session-authed path; errors are logged inside sendPurchaseExecutedEmail
@@ -1175,15 +1183,9 @@ func checkRevokableStatus(execution *config.PurchaseExecution) error {
 	}
 }
 
-// revocationWindowDuration is the time window after a purchase completes
-// during which the buyer may request revocation. 24 hours matches the AWS
-// RI/SP support-case window and is advertised in the post-execution email.
-// Adjust this constant to change the window without touching call sites.
-const revocationWindowDuration = 24 * time.Hour
-
 // validateRevokeToken checks that the execution carries a non-empty
 // ApprovalToken, that the token has not expired, that the revocation window
-// has not closed (revocationWindowDuration after CompletedAt), and that the
+// has not closed (config.RevocationWindow after CompletedAt), and that the
 // token matches using constant-time comparison. Pre-migration rows without an
 // ApprovalTokenExpiresAt pass the expiry check (legacy backward compat).
 // Extracted from revokeViaEmailToken to keep that function under the cyclomatic limit.
@@ -1224,7 +1226,7 @@ func checkRevocationWindow(execution *config.PurchaseExecution) error {
 		// Legacy row: no timestamp to anchor the window; allow the revoke.
 		return nil
 	}
-	windowCloses := ref.Add(revocationWindowDuration)
+	windowCloses := ref.Add(config.RevocationWindow)
 	if time.Now().After(windowCloses) {
 		return NewClientError(403, fmt.Sprintf(
 			"revocation window has closed (window closed at %s)", windowCloses.UTC().Format(time.RFC3339)))
@@ -1246,7 +1248,7 @@ func revocationWindowClosesAt(execution *config.PurchaseExecution) string {
 	if ref == nil {
 		return ""
 	}
-	return ref.Add(revocationWindowDuration).UTC().Format("2006-01-02 15:04 UTC")
+	return ref.Add(config.RevocationWindow).UTC().Format("2006-01-02 15:04 UTC")
 }
 
 // revokeViaSession performs the post-execution revocation action by recording

--- a/internal/api/handler_purchases.go
+++ b/internal/api/handler_purchases.go
@@ -1003,10 +1003,43 @@ func (h *Handler) cancelPurchaseViaSession(ctx context.Context, req *events.Lamb
 // window requests the cancellation and returns {"status":"revocation_requested"}.
 // Past the window it returns a friendly 409 with a plain-language message
 // rather than a stack trace.
+// revokeConfirmPageTmpl is the minimal HTML form rendered on GET /revoke.
+// The form POSTs the token from a hidden input so the actual mutation never
+// fires via a GET request (prevents email prefetchers from accidentally
+// triggering the revocation).
+const revokeConfirmPageTmpl = `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Confirm Revocation</title>
+<style>body{font-family:sans-serif;max-width:480px;margin:60px auto;padding:0 16px}
+.btn{display:inline-block;padding:10px 24px;background:#dc2626;color:#fff;border:none;
+border-radius:4px;font-size:15px;cursor:pointer;text-decoration:none}
+.btn:hover{background:#b91c1c}.note{color:#64748b;font-size:13px;margin-top:12px}</style>
+</head>
+<body>
+<h2>Confirm Revocation</h2>
+<p>You are about to request revocation for purchase execution <code>{{.ExecutionID}}</code>.</p>
+<p>This will record a revocation request. Contact AWS Support to complete the
+cancellation within the allowed window.</p>
+<form method="POST" action="/api/purchases/revoke/{{.ExecutionID}}">
+  <input type="hidden" name="token" value="{{.Token}}">
+  <button type="submit" class="btn">Confirm Revoke</button>
+</form>
+<p class="note">If you did not request this, ignore this page. No action has been taken.</p>
+</body>
+</html>`
+
 func (h *Handler) revokePurchase(ctx context.Context, req *events.LambdaFunctionURLRequest, execID, token string) (any, error) {
 	if err := validateUUID(execID); err != nil {
 		return nil, err
 	}
+
+	// GET: render a confirmation page so email prefetchers cannot auto-trigger
+	// the revocation. The token travels in the URL query string (unavoidable for
+	// the email one-click link), but no mutation occurs on GET.
+	if req.RequestContext.HTTP.Method == "GET" {
+		return renderRevokeConfirmPage(execID, token), nil
+	}
+
 	execution, err := h.config.GetExecutionByID(ctx, execID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get execution: %w", err)
@@ -1050,6 +1083,29 @@ func (h *Handler) revokePurchase(ctx context.Context, req *events.LambdaFunction
 		return nil, err
 	}
 	return h.revokeViaSession(ctx, execution, actor)
+}
+
+// renderRevokeConfirmPage returns a rawResponse containing the HTML
+// confirmation form for GET /revoke. The form POSTs the token so the actual
+// mutation only happens when the user explicitly clicks "Confirm Revoke".
+func renderRevokeConfirmPage(execID, token string) *rawResponse {
+	// Manual substitution to avoid importing html/template just for this one
+	// small page. The values substituted here (execID and token) are both
+	// treated as opaque strings — execID is a UUID (hex+hyphens only),
+	// token is a generated random string. HTML-escape them defensively anyway.
+	escaped := func(s string) string {
+		s = strings.ReplaceAll(s, "&", "&amp;")
+		s = strings.ReplaceAll(s, "<", "&lt;")
+		s = strings.ReplaceAll(s, ">", "&gt;")
+		s = strings.ReplaceAll(s, "\"", "&#34;")
+		return s
+	}
+	page := strings.ReplaceAll(revokeConfirmPageTmpl, "{{.ExecutionID}}", escaped(execID))
+	page = strings.ReplaceAll(page, "{{.Token}}", escaped(token))
+	return &rawResponse{
+		contentType: "text/html; charset=utf-8",
+		body:        page,
+	}
 }
 
 // tryRevokeViaSession attempts the session-authenticated branch of the

--- a/internal/api/handler_purchases.go
+++ b/internal/api/handler_purchases.go
@@ -1249,11 +1249,16 @@ func (h *Handler) revokeViaSession(ctx context.Context, execution *config.Purcha
 		return nil, fmt.Errorf("failed to record revocation request for execution %s: %w", execution.ExecutionID, err)
 	}
 	if revokedBy != "" {
-		rb := revokedBy
-		updated.CancelledBy = &rb
-		if err := h.config.SavePurchaseExecution(ctx, updated); err != nil {
+		// Use a narrow SetCancelledBy UPDATE rather than a full-row
+		// SavePurchaseExecution to avoid clobbering concurrent writes
+		// between the TransitionExecutionStatus and this attribution step
+		// (Finding #5). The targeted UPDATE only touches cancelled_by so
+		// any other concurrent column change (e.g. a background webhook
+		// stamping a cloud reference) is preserved.
+		if err := h.config.SetCancelledBy(ctx, execution.ExecutionID, revokedBy); err != nil {
 			return nil, fmt.Errorf("failed to record revocation requester for execution %s: %w", execution.ExecutionID, err)
 		}
+		_ = updated // kept for future use; CancelledBy is now persisted atomically
 	}
 	logging.Infof("Revocation requested for execution %s by %s", execution.ExecutionID, redactEmail(revokedBy))
 	return map[string]string{

--- a/internal/api/handler_purchases.go
+++ b/internal/api/handler_purchases.go
@@ -1025,7 +1025,7 @@ func (h *Handler) cancelPurchaseViaSession(ctx context.Context, req *events.Lamb
 // (AWS support-case path) is out of scope for this issue and is handled
 // by the sibling "AWS RI/SP revocation" issue.
 //
-// Present-day behaviour: calling this route within the AWS revocation
+// Present-day behavior: calling this route within the AWS revocation
 // window requests the cancellation and returns {"status":"revocation_requested"}.
 // Past the window it returns a friendly 409 with a plain-language message
 // rather than a stack trace.
@@ -1075,14 +1075,15 @@ func (h *Handler) revokeViaEmailToken(ctx context.Context, req *events.LambdaFun
 	}
 
 	// Only completed/partially_completed purchases have anything to revoke.
-	// A pending/notified purchase should be cancelled instead.
-	if err := checkRevokableStatus(execution); err != nil {
-		return nil, err
+	// A pending/notified purchase should be canceled instead.
+	if statusErr := checkRevokableStatus(execution); statusErr != nil {
+		return nil, statusErr
 	}
 
 	// Three-mode dispatch — same shape as cancelPurchase.
-	if result, handled, err := h.tryRevokeViaSession(ctx, req, execution); handled {
-		return result, err
+	result, handled, revokeErr := h.tryRevokeViaSession(ctx, req, execution)
+	if handled {
+		return result, revokeErr
 	}
 
 	if token == "" {
@@ -1094,13 +1095,13 @@ func (h *Handler) revokeViaEmailToken(ctx context.Context, req *events.LambdaFun
 	// (tryResolveActorEmail), not from the token's bound contact email. A
 	// recipient who clicks the link while logged out therefore gets a 401 and
 	// must sign in with the matching contact email first. This intentionally
-	// matches the existing approve/cancel email-link behaviour -- we do not
+	// matches the existing approve/cancel email-link behavior -- we do not
 	// widen the authz model here. True tokenless one-click (deriving the actor
 	// from a single-use, contact-bound token) is deferred to the sibling
 	// "AWS RI/SP revocation" work, which adds a dedicated revocation token.
 	//
 	// Token-authed path: validate the token (reusing the approval token for
-	// this iteration) and confirm the caller is the authorised contact email.
+	// this iteration) and confirm the caller is the authorized contact email.
 	actor, err := h.authorizeApprovalAction(ctx, req, execution)
 	if err != nil {
 		return nil, err
@@ -1141,7 +1142,7 @@ func renderRevokeConfirmPage(execID, token string) *rawResponse {
 // (nil, false, nil) when the session was absent or returned a permission-denied
 // error so the caller can fall through to the token branch. Extracted from
 // revokeViaEmailToken to keep that function under the cyclomatic limit.
-func (h *Handler) tryRevokeViaSession(ctx context.Context, req *events.LambdaFunctionURLRequest, execution *config.PurchaseExecution) (any, bool, error) {
+func (h *Handler) tryRevokeViaSession(ctx context.Context, req *events.LambdaFunctionURLRequest, execution *config.PurchaseExecution) (result any, handled bool, err error) {
 	session := h.tryGetSession(ctx, req)
 	if session == nil {
 		return nil, false, nil
@@ -1152,11 +1153,11 @@ func (h *Handler) tryRevokeViaSession(ctx context.Context, req *events.LambdaFun
 		// Enforce it here for the session-authed revoke sub-path, consistent
 		// with cancelPurchaseViaSession and approvePurchaseViaSession which both
 		// validate CSRF before mutating state (nit #1).
-		if err := h.validateCSRF(ctx, req); err != nil {
+		if csrfErr := h.validateCSRF(ctx, req); csrfErr != nil {
 			return nil, true, NewClientError(403, "CSRF validation failed")
 		}
-		result, err := h.revokeViaSession(ctx, execution, session.Email)
-		return result, true, err
+		res, revokeErr := h.revokeViaSession(ctx, execution, session.Email)
+		return res, true, revokeErr
 	case isPermissionDenied(sessErr):
 		// Fall through to the token branch.
 		return nil, false, nil
@@ -1282,9 +1283,9 @@ func (h *Handler) revokeViaSession(ctx context.Context, execution *config.Purcha
 		// Use a narrow SetCancelledBy UPDATE rather than a full-row
 		// SavePurchaseExecution to avoid clobbering concurrent writes
 		// between the TransitionExecutionStatus and this attribution step
-		// (Finding #5). The targeted UPDATE only touches cancelled_by so
-		// any other concurrent column change (e.g. a background webhook
-		// stamping a cloud reference) is preserved.
+		// (Finding #5). The targeted UPDATE only touches the cancellation
+		// attribution column so any other concurrent column change (e.g. a
+		// background webhook stamping a cloud reference) is preserved.
 		if err := h.config.SetCancelledBy(ctx, execution.ExecutionID, revokedBy); err != nil {
 			return nil, fmt.Errorf("failed to record revocation requester for execution %s: %w", execution.ExecutionID, err)
 		}
@@ -2544,7 +2545,7 @@ func (h *Handler) sendPurchaseExecutedEmail(ctx context.Context, req *events.Lam
 	}
 
 	// Look up the requester's email via their user ID (if available).
-	requesterEmail, requesterName := h.lookupRequesterInfo(ctx, execution)
+	requesterEmail := h.lookupRequesterInfo(ctx, execution)
 
 	// Build the deduplicated To / Cc list.
 	// Priority: contact emails are To (first one) + Cc (rest); global notify
@@ -2557,7 +2558,8 @@ func (h *Handler) sendPurchaseExecutedEmail(ctx context.Context, req *events.Lam
 	}
 
 	summaries := make([]email.RecommendationSummary, 0, len(execution.Recommendations))
-	for _, rec := range execution.Recommendations {
+	for i := range execution.Recommendations {
+		rec := &execution.Recommendations[i]
 		summaries = append(summaries, email.RecommendationSummary{
 			Service:        rec.Service,
 			ResourceType:   rec.ResourceType,
@@ -2589,10 +2591,12 @@ func (h *Handler) sendPurchaseExecutedEmail(ctx context.Context, req *events.Lam
 		// the enforced 24-hour window in validateRevokeToken (Finding #6).
 		RevocationWindowClosesAt: revocationWindowClosesAt(execution),
 		RequestedByEmail:         requesterEmail,
-		RequestedByName:          requesterName,
-		RequestedAt:              executionTimestamp(execution),
-		ExecutedBy:               executedByEmail,
-		ExecutedAt:               time.Now().UTC().Format(time.RFC3339),
+		// api.User has no display-name field yet; leave RequestedByName empty
+		// until a name source lands (the email template tolerates "").
+		RequestedByName: "",
+		RequestedAt:     executionTimestamp(execution),
+		ExecutedBy:      executedByEmail,
+		ExecutedAt:      time.Now().UTC().Format(time.RFC3339),
 	}
 	if dashboardBase != "" {
 		data.ArcheraEducationURL = dashboardBase + "/archera-insurance"
@@ -2613,25 +2617,27 @@ func globalNotifyEmail(globalCfg *config.GlobalConfig) string {
 	return ""
 }
 
-// lookupRequesterInfo resolves the email (and name, currently always "") for
-// the user who originally submitted the execution. The lookup is non-fatal:
-// when auth is unavailable or the user cannot be found, both fields are
-// returned empty and the notification is sent without them. Extracted from
-// sendPurchaseExecutedEmail to keep that function under the cyclomatic limit.
-func (h *Handler) lookupRequesterInfo(ctx context.Context, execution *config.PurchaseExecution) (email, name string) {
+// lookupRequesterInfo resolves the email for the user who originally submitted
+// the execution. The lookup is non-fatal: when auth is unavailable or the user
+// cannot be found, "" is returned and the notification is sent without it.
+// Extracted from sendPurchaseExecutedEmail to keep that function under the
+// cyclomatic limit. Only the email is returned -- api.User carries no display
+// name field, so the notification's RequestedByName is populated separately if
+// and when a name source lands.
+func (h *Handler) lookupRequesterInfo(ctx context.Context, execution *config.PurchaseExecution) (requesterEmail string) {
 	if h.auth == nil || execution.CreatedByUserID == nil || *execution.CreatedByUserID == "" {
-		return "", ""
+		return ""
 	}
 	u, err := h.auth.GetUser(ctx, *execution.CreatedByUserID)
 	if err != nil {
 		logging.Warnf("lookupRequesterInfo: GetUser(%s) failed: %v", *execution.CreatedByUserID, err)
-		return "", ""
+		return ""
 	}
 	if u == nil {
 		logging.Warnf("lookupRequesterInfo: GetUser(%s) returned nil user", *execution.CreatedByUserID)
-		return "", ""
+		return ""
 	}
-	return u.Email, ""
+	return u.Email
 }
 
 // resolveExecutedNotificationRecipients builds the To / Cc pair for the

--- a/internal/api/handler_purchases.go
+++ b/internal/api/handler_purchases.go
@@ -520,10 +520,24 @@ func (h *Handler) approveViaToken(ctx context.Context, req *events.LambdaFunctio
 	if err := h.purchase.ApproveExecution(ctx, execution.ExecutionID, token, actor); err != nil {
 		return nil, err
 	}
+	// Re-fetch the execution to pick up the fresh revocation token written by
+	// mintRevocationToken inside ApproveExecution. The stale pre-approve struct
+	// still carries the old approval token; passing it to sendPurchaseExecutedEmail
+	// would embed that now-overwritten token as RevocationToken, causing any
+	// subsequent revoke attempt to return 403 (validateRevokeToken checks the
+	// stored token, which mintRevocationToken has already replaced).
+	emailExec, fetchErr := h.config.GetExecutionByID(ctx, execution.ExecutionID)
+	if fetchErr != nil || emailExec == nil {
+		// Best-effort fallback: send without a valid revoke token rather than
+		// blocking the response. The purchase is complete regardless.
+		logging.Warnf("approveViaToken[%s]: re-fetch for email failed (%v); sending without valid revocation token",
+			execution.ExecutionID, fetchErr)
+		emailExec = execution
+	}
 	// Best-effort post-execution notification email (issue #291). Mirrors
 	// the session-authed path; errors are logged inside sendPurchaseExecutedEmail
 	// and never propagate — the purchase is already done at this point.
-	h.sendPurchaseExecutedEmail(ctx, req, execution, actor)
+	h.sendPurchaseExecutedEmail(ctx, req, emailExec, actor)
 	return map[string]string{"status": "completed"}, nil
 }
 
@@ -1126,6 +1140,13 @@ func (h *Handler) tryRevokeViaSession(ctx context.Context, req *events.LambdaFun
 	}
 	switch sessErr := h.authorizeSessionCancel(ctx, session, execution); {
 	case sessErr == nil:
+		// These endpoints are AuthPublic so the outer middleware skips CSRF.
+		// Enforce it here for the session-authed revoke sub-path, consistent
+		// with cancelPurchaseViaSession and approvePurchaseViaSession which both
+		// validate CSRF before mutating state (nit #1).
+		if err := h.validateCSRF(ctx, req); err != nil {
+			return nil, true, NewClientError(403, "CSRF validation failed")
+		}
 		result, err := h.revokeViaSession(ctx, execution, session.Email)
 		return result, true, err
 	case isPermissionDenied(sessErr):

--- a/internal/api/handler_purchases_test.go
+++ b/internal/api/handler_purchases_test.go
@@ -4402,3 +4402,92 @@ func TestResolveExecutedNotificationRecipients_Deduplication(t *testing.T) {
 	assert.Equal(t, "same@example.com", to)
 	assert.Empty(t, cc, "duplicate emails must be deduplicated")
 }
+
+// ---------------------------------------------------------------------------
+// Finding #2: GET /revoke must render confirmation form, not mutate state
+// ---------------------------------------------------------------------------
+
+// TestRevokePurchase_GETRendersConfirmationPage_NoMutation verifies that a GET
+// to the revoke handler returns 200 HTML containing a confirmation form and
+// does NOT call TransitionExecutionStatus (no mutation).
+func TestRevokePurchase_GETRendersConfirmationPage_NoMutation(t *testing.T) {
+	ctx := context.Background()
+	execID := "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+	token := "revoke-token-abc"
+
+	// Store must NOT be called at all: the GET path short-circuits before any DB ops.
+	mockStore := new(MockConfigStore)
+
+	handler := &Handler{config: mockStore}
+	req := &events.LambdaFunctionURLRequest{
+		RequestContext: events.LambdaFunctionURLRequestContext{
+			HTTP: events.LambdaFunctionURLRequestContextHTTPDescription{Method: "GET"},
+		},
+		QueryStringParameters: map[string]string{"token": token},
+	}
+	result, err := handler.revokePurchase(ctx, req, execID, token)
+	require.NoError(t, err)
+
+	raw, ok := result.(*rawResponse)
+	require.True(t, ok, "GET /revoke must return a *rawResponse (HTML confirmation page)")
+	assert.Contains(t, raw.body, `<form method="POST"`, "confirmation page must contain a POST form")
+	assert.Contains(t, raw.body, execID, "confirmation page must embed the execution ID")
+	assert.Contains(t, raw.body, `type="hidden"`, "token must be in a hidden input")
+	assert.Equal(t, "text/html; charset=utf-8", raw.contentType)
+
+	// No DB calls were made.
+	mockStore.AssertNotCalled(t, "GetExecutionByID")
+	mockStore.AssertNotCalled(t, "TransitionExecutionStatus")
+}
+
+// TestRevokePurchase_POSTPerformsRevoke verifies that a POST to the revoke
+// handler actually flips the status to revocation_requested.
+func TestRevokePurchase_POSTPerformsRevoke(t *testing.T) {
+	ctx := context.Background()
+	execID := "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+	token := "revoke-token-post"
+	revokerEmail := "contact@acct.example.com"
+	accountID := "acct-post"
+
+	exec := &config.PurchaseExecution{
+		ExecutionID:   execID,
+		ApprovalToken: token,
+		Status:        "completed",
+		Recommendations: []config.RecommendationRecord{
+			{ID: "r1", CloudAccountID: &accountID},
+		},
+	}
+
+	mockStore := new(MockConfigStore)
+	mockStore.On("GetExecutionByID", ctx, execID).Return(exec, nil)
+	mockStore.On("GetGlobalConfig", ctx).Return(&config.GlobalConfig{}, nil)
+	mockStore.GetCloudAccountFn = func(_ context.Context, id string) (*config.CloudAccount, error) {
+		return &config.CloudAccount{ID: id, ContactEmail: revokerEmail}, nil
+	}
+	mockStore.On("TransitionExecutionStatus", ctx, execID,
+		[]string{"completed", "partially_completed"}, "revocation_requested").
+		Return(&config.PurchaseExecution{ExecutionID: execID, Status: "revocation_requested"}, nil)
+	mockStore.On("SavePurchaseExecution", ctx, mock.MatchedBy(func(e *config.PurchaseExecution) bool {
+		return e.ExecutionID == execID && e.CancelledBy != nil && *e.CancelledBy == revokerEmail
+	})).Return(nil)
+
+	mockAuth := new(MockAuthService)
+	mockAuth.On("ValidateSession", ctx, "sess-tok").Return(&Session{Email: revokerEmail}, nil)
+	mockAuth.On("HasPermissionAPI", ctx, "", "cancel-any", "purchases").Return(false, nil).Maybe()
+	mockAuth.On("HasPermissionAPI", ctx, "", "cancel-own", "purchases").Return(false, nil).Maybe()
+
+	handler := &Handler{config: mockStore, auth: mockAuth}
+	req := &events.LambdaFunctionURLRequest{
+		RequestContext: events.LambdaFunctionURLRequestContext{
+			HTTP: events.LambdaFunctionURLRequestContextHTTPDescription{Method: "POST"},
+		},
+		Headers:               map[string]string{"authorization": "Bearer sess-tok"},
+		QueryStringParameters: map[string]string{"token": token},
+	}
+	result, err := handler.revokePurchase(ctx, req, execID, token)
+	require.NoError(t, err)
+	resultMap, ok := result.(map[string]string)
+	require.True(t, ok)
+	assert.Equal(t, "revocation_requested", resultMap["status"])
+	mockStore.AssertExpectations(t)
+}

--- a/internal/api/handler_purchases_test.go
+++ b/internal/api/handler_purchases_test.go
@@ -4048,7 +4048,8 @@ func TestHandler_revokePurchase_ValidToken(t *testing.T) {
 	// Atomic conditional transition completed/partially_completed ->
 	// revocation_requested, returning the updated row.
 	mockStore.On("TransitionExecutionStatus", ctx, execID,
-		[]string{"completed", "partially_completed"}, "revocation_requested").
+		[]string{"completed", "partially_completed"}, "revocation_requested",
+		mock.MatchedBy(func(actor *string) bool { return actor != nil && *actor == revokerEmail })).
 		Return(&config.PurchaseExecution{ExecutionID: execID, Status: "revocation_requested"}, nil)
 	// SetCancelledBy stamps the actor without a full-row overwrite (Finding #5).
 	mockStore.On("SetCancelledBy", ctx, execID, revokerEmail).Return(nil)
@@ -4066,7 +4067,7 @@ func TestHandler_revokePurchase_ValidToken(t *testing.T) {
 		Headers:               map[string]string{"authorization": "Bearer sess-tok"},
 		QueryStringParameters: map[string]string{"token": token},
 	}
-	result, err := handler.revokePurchase(ctx, req, execID, token)
+	result, err := handler.revokeViaEmailToken(ctx, req, execID, token)
 	require.NoError(t, err, "valid token on completed execution must not error")
 	resultMap := result.(map[string]string)
 	assert.Equal(t, "revocation_requested", resultMap["status"])
@@ -4109,7 +4110,7 @@ func TestHandler_revokePurchase_InvalidToken(t *testing.T) {
 		Headers:               map[string]string{"authorization": "Bearer sess-tok"},
 		QueryStringParameters: map[string]string{"token": "wrong-token"},
 	}
-	_, err := handler.revokePurchase(ctx, req, execID, "wrong-token")
+	_, err := handler.revokeViaEmailToken(ctx, req, execID, "wrong-token")
 	require.Error(t, err)
 	ce, ok := IsClientError(err)
 	require.True(t, ok, "expected a client error")
@@ -4135,7 +4136,7 @@ func TestHandler_revokePurchase_PendingExecution(t *testing.T) {
 	req := &events.LambdaFunctionURLRequest{
 		QueryStringParameters: map[string]string{"token": "tok"},
 	}
-	_, err := handler.revokePurchase(ctx, req, execID, "tok")
+	_, err := handler.revokeViaEmailToken(ctx, req, execID, "tok")
 	require.Error(t, err)
 	ce, ok := IsClientError(err)
 	require.True(t, ok, "expected a client error")
@@ -4153,7 +4154,7 @@ func TestHandler_revokePurchase_NotFound(t *testing.T) {
 
 	handler := &Handler{config: mockStore}
 	req := &events.LambdaFunctionURLRequest{}
-	_, err := handler.revokePurchase(ctx, req, execID, "some-token")
+	_, err := handler.revokeViaEmailToken(ctx, req, execID, "some-token")
 	require.Error(t, err)
 	ce, ok := IsClientError(err)
 	require.True(t, ok, "expected a client error")
@@ -4199,7 +4200,7 @@ func TestHandler_revokePurchase_ExpiredToken(t *testing.T) {
 		Headers:               map[string]string{"authorization": "Bearer sess-tok"},
 		QueryStringParameters: map[string]string{"token": token},
 	}
-	_, err := handler.revokePurchase(ctx, req, execID, token)
+	_, err := handler.revokeViaEmailToken(ctx, req, execID, token)
 	require.Error(t, err, "expired revocation token must be rejected")
 	ce, ok := IsClientError(err)
 	require.True(t, ok, "expected a client error")
@@ -4223,7 +4224,8 @@ func TestHandler_revokePurchase_SessionAdminCancelAny(t *testing.T) {
 	mockStore := new(MockConfigStore)
 	mockStore.On("GetExecutionByID", ctx, execID).Return(exec, nil)
 	mockStore.On("TransitionExecutionStatus", ctx, execID,
-		[]string{"completed", "partially_completed"}, "revocation_requested").
+		[]string{"completed", "partially_completed"}, "revocation_requested",
+		mock.MatchedBy(func(actor *string) bool { return actor != nil && *actor == adminEmail })).
 		Return(&config.PurchaseExecution{ExecutionID: execID, Status: "revocation_requested"}, nil)
 	// SetCancelledBy replaces the full-row SavePurchaseExecution (Finding #5).
 	mockStore.On("SetCancelledBy", ctx, execID, adminEmail).Return(nil)
@@ -4238,7 +4240,7 @@ func TestHandler_revokePurchase_SessionAdminCancelAny(t *testing.T) {
 	req := &events.LambdaFunctionURLRequest{
 		Headers: map[string]string{"authorization": "Bearer admin-token"},
 	}
-	result, err := handler.revokePurchase(ctx, req, execID, "")
+	result, err := handler.revokeViaEmailToken(ctx, req, execID, "")
 	require.NoError(t, err, "session admin with cancel-any must succeed")
 	resultMap := result.(map[string]string)
 	assert.Equal(t, "revocation_requested", resultMap["status"])
@@ -4261,7 +4263,8 @@ func TestHandler_revokePurchase_SessionOwnerCancelOwn(t *testing.T) {
 	mockStore := new(MockConfigStore)
 	mockStore.On("GetExecutionByID", ctx, execID).Return(exec, nil)
 	mockStore.On("TransitionExecutionStatus", ctx, execID,
-		[]string{"completed", "partially_completed"}, "revocation_requested").
+		[]string{"completed", "partially_completed"}, "revocation_requested",
+		mock.MatchedBy(func(actor *string) bool { return actor != nil && *actor == ownerEmail })).
 		Return(&config.PurchaseExecution{ExecutionID: execID, Status: "revocation_requested"}, nil)
 	// SetCancelledBy replaces the full-row SavePurchaseExecution (Finding #5).
 	mockStore.On("SetCancelledBy", ctx, execID, ownerEmail).Return(nil)
@@ -4276,7 +4279,7 @@ func TestHandler_revokePurchase_SessionOwnerCancelOwn(t *testing.T) {
 	req := &events.LambdaFunctionURLRequest{
 		Headers: map[string]string{"authorization": "Bearer owner-token"},
 	}
-	result, err := handler.revokePurchase(ctx, req, execID, "")
+	result, err := handler.revokeViaEmailToken(ctx, req, execID, "")
 	require.NoError(t, err, "session owner with cancel-own must succeed")
 	resultMap := result.(map[string]string)
 	assert.Equal(t, "revocation_requested", resultMap["status"])
@@ -4309,7 +4312,7 @@ func TestHandler_revokePurchase_SessionNoPermissionNoToken(t *testing.T) {
 	req := &events.LambdaFunctionURLRequest{
 		Headers: map[string]string{"authorization": "Bearer user-token"},
 	}
-	_, err := handler.revokePurchase(ctx, req, execID, "")
+	_, err := handler.revokeViaEmailToken(ctx, req, execID, "")
 	require.Error(t, err, "no permission and no token must be denied")
 	ce, ok := IsClientError(err)
 	require.True(t, ok, "expected a client error")
@@ -4330,7 +4333,8 @@ func TestHandler_revokeViaSession_ConcurrentTransition(t *testing.T) {
 
 	mockStore := new(MockConfigStore)
 	mockStore.On("TransitionExecutionStatus", ctx, execID,
-		[]string{"completed", "partially_completed"}, "revocation_requested").
+		[]string{"completed", "partially_completed"}, "revocation_requested",
+		mock.MatchedBy(func(actor *string) bool { return actor != nil && *actor == "someone@example.com" })).
 		Return(nil, fmt.Errorf("%w: execution %s", config.ErrExecutionNotInExpectedStatus, execID))
 
 	handler := &Handler{config: mockStore}
@@ -4415,7 +4419,8 @@ func TestRevokeViaSession_CancelledByFoldsIntoTransition_NoLostUpdate(t *testing
 
 	mockStore := new(MockConfigStore)
 	mockStore.On("TransitionExecutionStatus", ctx, execID,
-		[]string{"completed", "partially_completed"}, "revocation_requested").
+		[]string{"completed", "partially_completed"}, "revocation_requested",
+		mock.MatchedBy(func(actor *string) bool { return actor != nil && *actor == revokedBy })).
 		Return(&config.PurchaseExecution{ExecutionID: execID, Status: "revocation_requested"}, nil)
 	// SetCancelledBy must be called; SavePurchaseExecution must NOT.
 	mockStore.On("SetCancelledBy", ctx, execID, revokedBy).Return(nil)
@@ -4592,7 +4597,7 @@ func TestRevokePurchase_GETRendersConfirmationPage_NoMutation(t *testing.T) {
 		},
 		QueryStringParameters: map[string]string{"token": token},
 	}
-	result, err := handler.revokePurchase(ctx, req, execID, token)
+	result, err := handler.revokeViaEmailToken(ctx, req, execID, token)
 	require.NoError(t, err)
 
 	raw, ok := result.(*rawResponse)
@@ -4632,7 +4637,8 @@ func TestRevokePurchase_POSTPerformsRevoke(t *testing.T) {
 		return &config.CloudAccount{ID: id, ContactEmail: revokerEmail}, nil
 	}
 	mockStore.On("TransitionExecutionStatus", ctx, execID,
-		[]string{"completed", "partially_completed"}, "revocation_requested").
+		[]string{"completed", "partially_completed"}, "revocation_requested",
+		mock.MatchedBy(func(actor *string) bool { return actor != nil && *actor == revokerEmail })).
 		Return(&config.PurchaseExecution{ExecutionID: execID, Status: "revocation_requested"}, nil)
 	// SetCancelledBy replaces the full-row SavePurchaseExecution (Finding #5).
 	mockStore.On("SetCancelledBy", ctx, execID, revokerEmail).Return(nil)
@@ -4650,7 +4656,7 @@ func TestRevokePurchase_POSTPerformsRevoke(t *testing.T) {
 		Headers:               map[string]string{"authorization": "Bearer sess-tok"},
 		QueryStringParameters: map[string]string{"token": token},
 	}
-	result, err := handler.revokePurchase(ctx, req, execID, token)
+	result, err := handler.revokeViaEmailToken(ctx, req, execID, token)
 	require.NoError(t, err)
 	resultMap, ok := result.(map[string]string)
 	require.True(t, ok)

--- a/internal/api/handler_purchases_test.go
+++ b/internal/api/handler_purchases_test.go
@@ -4004,3 +4004,211 @@ func TestApproveWithDelay_CASLostMaps409(t *testing.T) {
 	assert.Equal(t, 409, ce.code, "concurrent cancel CAS race must map to 409, not 500")
 	mockConfig.AssertExpectations(t)
 }
+
+// ---------------------------------------------------------------------------
+// revokePurchase handler tests (issue #291)
+// ---------------------------------------------------------------------------
+
+// buildCompletedExec returns a completed execution suitable for revoke tests.
+func buildCompletedExec(execID, approvalToken string) *config.PurchaseExecution {
+	return &config.PurchaseExecution{
+		ExecutionID:   execID,
+		ApprovalToken: approvalToken,
+		Status:        "completed",
+	}
+}
+
+// TestHandler_revokePurchase_ValidToken verifies that a valid token on a
+// completed execution records a revocation_requested status.
+func TestHandler_revokePurchase_ValidToken(t *testing.T) {
+	ctx := context.Background()
+	execID := "11111111-1111-1111-1111-111111111111"
+	token := "abc123validtoken"
+	revokerEmail := "contact@acct.example.com"
+	accountID := "acct-1"
+
+	exec := &config.PurchaseExecution{
+		ExecutionID:   execID,
+		ApprovalToken: token,
+		Status:        "completed",
+		Recommendations: []config.RecommendationRecord{
+			{ID: "r1", CloudAccountID: &accountID},
+		},
+	}
+
+	mockStore := new(MockConfigStore)
+	mockStore.On("GetExecutionByID", ctx, execID).Return(exec, nil)
+	// authorizeApprovalAction: GetGlobalConfig for global notify
+	mockStore.On("GetGlobalConfig", ctx).Return(&config.GlobalConfig{}, nil)
+	// GetCloudAccount returns the contact email so authorizeApprovalAction can
+	// resolve the approver and verify the session's email matches.
+	mockStore.GetCloudAccountFn = func(_ context.Context, id string) (*config.CloudAccount, error) {
+		return &config.CloudAccount{ID: id, ContactEmail: revokerEmail}, nil
+	}
+	// SavePurchaseExecution for the revocation_requested update.
+	mockStore.On("SavePurchaseExecution", ctx, mock.MatchedBy(func(e *config.PurchaseExecution) bool {
+		return e.ExecutionID == execID && e.Status == "revocation_requested"
+	})).Return(nil)
+
+	mockAuth := new(MockAuthService)
+	// Provide a session for the revoker so authorizeApprovalAction resolves actor.
+	mockAuth.On("ValidateSession", ctx, "sess-tok").Return(&Session{Email: revokerEmail}, nil)
+	// RBAC: revoker has no cancel-any or cancel-own, so falls through to token path.
+	mockAuth.On("HasPermissionAPI", ctx, "", "cancel-any", "purchases").Return(false, nil).Maybe()
+	mockAuth.On("HasPermissionAPI", ctx, "", "cancel-own", "purchases").Return(false, nil).Maybe()
+
+	handler := &Handler{config: mockStore, auth: mockAuth}
+
+	req := &events.LambdaFunctionURLRequest{
+		Headers:               map[string]string{"authorization": "Bearer sess-tok"},
+		QueryStringParameters: map[string]string{"token": token},
+	}
+	result, err := handler.revokePurchase(ctx, req, execID, token)
+	require.NoError(t, err, "valid token on completed execution must not error")
+	resultMap := result.(map[string]string)
+	assert.Equal(t, "revocation_requested", resultMap["status"])
+	mockStore.AssertExpectations(t)
+}
+
+// TestHandler_revokePurchase_InvalidToken verifies that a wrong token returns 403.
+// The session provides an email that matches the contact email (so
+// authorizeApprovalAction passes), but the token itself is wrong.
+func TestHandler_revokePurchase_InvalidToken(t *testing.T) {
+	ctx := context.Background()
+	execID := "22222222-2222-2222-2222-222222222222"
+	contactEmail := "contact@acct.example.com"
+	accountID := "acct-1"
+
+	exec := &config.PurchaseExecution{
+		ExecutionID:   execID,
+		ApprovalToken: "the-real-token",
+		Status:        "completed",
+		Recommendations: []config.RecommendationRecord{
+			{ID: "r1", CloudAccountID: &accountID},
+		},
+	}
+
+	mockStore := new(MockConfigStore)
+	mockStore.On("GetExecutionByID", ctx, execID).Return(exec, nil)
+	mockStore.On("GetGlobalConfig", ctx).Return(&config.GlobalConfig{}, nil)
+	mockStore.GetCloudAccountFn = func(_ context.Context, id string) (*config.CloudAccount, error) {
+		return &config.CloudAccount{ID: id, ContactEmail: contactEmail}, nil
+	}
+
+	mockAuth := new(MockAuthService)
+	mockAuth.On("ValidateSession", ctx, "sess-tok").Return(&Session{Email: contactEmail}, nil)
+	mockAuth.On("HasPermissionAPI", ctx, "", "cancel-any", "purchases").Return(false, nil).Maybe()
+	mockAuth.On("HasPermissionAPI", ctx, "", "cancel-own", "purchases").Return(false, nil).Maybe()
+
+	handler := &Handler{config: mockStore, auth: mockAuth}
+
+	req := &events.LambdaFunctionURLRequest{
+		Headers:               map[string]string{"authorization": "Bearer sess-tok"},
+		QueryStringParameters: map[string]string{"token": "wrong-token"},
+	}
+	_, err := handler.revokePurchase(ctx, req, execID, "wrong-token")
+	require.Error(t, err)
+	ce, ok := IsClientError(err)
+	require.True(t, ok, "expected a client error")
+	assert.Equal(t, 403, ce.code)
+}
+
+// TestHandler_revokePurchase_PendingExecution verifies that a pending execution
+// returns 409 with a friendly message directing the user to Cancel instead.
+func TestHandler_revokePurchase_PendingExecution(t *testing.T) {
+	ctx := context.Background()
+	execID := "33333333-3333-3333-3333-333333333333"
+
+	exec := &config.PurchaseExecution{
+		ExecutionID:   execID,
+		ApprovalToken: "tok",
+		Status:        "pending",
+	}
+
+	mockStore := new(MockConfigStore)
+	mockStore.On("GetExecutionByID", ctx, execID).Return(exec, nil)
+
+	handler := &Handler{config: mockStore}
+	req := &events.LambdaFunctionURLRequest{
+		QueryStringParameters: map[string]string{"token": "tok"},
+	}
+	_, err := handler.revokePurchase(ctx, req, execID, "tok")
+	require.Error(t, err)
+	ce, ok := IsClientError(err)
+	require.True(t, ok, "expected a client error")
+	assert.Equal(t, 409, ce.code)
+	assert.Contains(t, ce.message, "Cancel")
+}
+
+// TestHandler_revokePurchase_NotFound verifies 404 when the execution does not exist.
+func TestHandler_revokePurchase_NotFound(t *testing.T) {
+	ctx := context.Background()
+	execID := "44444444-4444-4444-4444-444444444444"
+
+	mockStore := new(MockConfigStore)
+	mockStore.On("GetExecutionByID", ctx, execID).Return(nil, nil)
+
+	handler := &Handler{config: mockStore}
+	req := &events.LambdaFunctionURLRequest{}
+	_, err := handler.revokePurchase(ctx, req, execID, "some-token")
+	require.Error(t, err)
+	ce, ok := IsClientError(err)
+	require.True(t, ok, "expected a client error")
+	assert.Equal(t, 404, ce.code)
+}
+
+// ---------------------------------------------------------------------------
+// resolveExecutedNotificationRecipients unit tests (issue #291)
+// ---------------------------------------------------------------------------
+
+// TestResolveExecutedNotificationRecipients_ContactEmailAsTo verifies the
+// first contact email becomes To and the rest + global notify + requester
+// are added as Cc (deduplicated).
+func TestResolveExecutedNotificationRecipients_ContactEmailAsTo(t *testing.T) {
+	to, cc := resolveExecutedNotificationRecipients(
+		[]string{"contact@a.example.com", "contact@b.example.com"},
+		"notify@example.com",
+		"requester@example.com",
+	)
+	assert.Equal(t, "contact@a.example.com", to)
+	assert.Contains(t, cc, "contact@b.example.com")
+	assert.Contains(t, cc, "notify@example.com")
+	assert.Contains(t, cc, "requester@example.com")
+	// No duplicates.
+	assert.Equal(t, 3, len(cc))
+}
+
+// TestResolveExecutedNotificationRecipients_GlobalNotifyFallback verifies that
+// when no contact emails are available, the global notification email becomes To.
+func TestResolveExecutedNotificationRecipients_GlobalNotifyFallback(t *testing.T) {
+	to, cc := resolveExecutedNotificationRecipients(
+		nil,
+		"notify@example.com",
+		"requester@example.com",
+	)
+	assert.Equal(t, "notify@example.com", to)
+	assert.Contains(t, cc, "requester@example.com")
+	assert.Equal(t, 1, len(cc))
+}
+
+// TestResolveExecutedNotificationRecipients_RequesterOnlyFallback verifies that
+// when neither contact emails nor global notify are set, the requester email
+// becomes To (last resort).
+func TestResolveExecutedNotificationRecipients_RequesterOnlyFallback(t *testing.T) {
+	to, cc := resolveExecutedNotificationRecipients(nil, "", "requester@example.com")
+	assert.Equal(t, "requester@example.com", to)
+	assert.Empty(t, cc)
+}
+
+// TestResolveExecutedNotificationRecipients_Deduplication verifies that the
+// same email in multiple lists is not repeated.
+func TestResolveExecutedNotificationRecipients_Deduplication(t *testing.T) {
+	// Same email in all three slots.
+	to, cc := resolveExecutedNotificationRecipients(
+		[]string{"same@example.com"},
+		"SAME@example.com", // case-insensitive dedup
+		"same@example.com",
+	)
+	assert.Equal(t, "same@example.com", to)
+	assert.Empty(t, cc, "duplicate emails must be deduplicated")
+}

--- a/internal/api/handler_purchases_test.go
+++ b/internal/api/handler_purchases_test.go
@@ -4404,6 +4404,29 @@ func TestResolveExecutedNotificationRecipients_Deduplication(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Finding #1: Revoke must reject a rotated (empty) approval token
+// ---------------------------------------------------------------------------
+
+// TestRevokePurchase_RejectsRotatedToken verifies that after approve/cancel
+// clears the ApprovalToken, an attempt to revoke with the original token
+// is rejected with 403. This guards against a leaked approval token being
+// replayed as a revocation token.
+func TestRevokePurchase_RejectsRotatedToken(t *testing.T) {
+	// validateRevokeToken is the function under test: it must reject an
+	// empty stored token regardless of what the caller supplies.
+	exec := &config.PurchaseExecution{
+		ExecutionID:   "exec-post-approve",
+		Status:        "completed",
+		ApprovalToken: "", // rotated to empty by rotateApprovalToken after approve
+	}
+	err := validateRevokeToken(exec, "pre-rotate-token")
+	require.Error(t, err, "rotated (empty) stored token must be rejected")
+	ce, ok := IsClientError(err)
+	require.True(t, ok, "expected a ClientError")
+	assert.Equal(t, 403, ce.code, "must return 403 for a rotated token")
+}
+
+// ---------------------------------------------------------------------------
 // Finding #2: GET /revoke must render confirmation form, not mutate state
 // ---------------------------------------------------------------------------
 

--- a/internal/api/handler_purchases_test.go
+++ b/internal/api/handler_purchases_test.go
@@ -4492,6 +4492,61 @@ func TestRevokePurchase_RejectsRotatedToken(t *testing.T) {
 // Finding #2: GET /revoke must render confirmation form, not mutate state
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Finding #6: 24-hour revocation window enforcement
+// ---------------------------------------------------------------------------
+
+// TestRevoke_WithinWindow_Allowed verifies that a revoke token is accepted
+// when the purchase completed less than 24 hours ago.
+func TestRevoke_WithinWindow_Allowed(t *testing.T) {
+	recentCompleted := time.Now().Add(-2 * time.Hour)
+	exec := &config.PurchaseExecution{
+		ExecutionID:   "exec-in-window",
+		Status:        "completed",
+		ApprovalToken: "valid-token",
+		CompletedAt:   &recentCompleted,
+	}
+	err := validateRevokeToken(exec, "valid-token")
+	require.NoError(t, err, "revoke within 24h window must succeed")
+}
+
+// TestRevoke_AfterWindow_Denied verifies that validateRevokeToken returns 403
+// when the 24-hour revocation window has passed.
+func TestRevoke_AfterWindow_Denied(t *testing.T) {
+	staleCompleted := time.Now().Add(-25 * time.Hour)
+	exec := &config.PurchaseExecution{
+		ExecutionID:   "exec-past-window",
+		Status:        "completed",
+		ApprovalToken: "valid-token",
+		CompletedAt:   &staleCompleted,
+	}
+	err := validateRevokeToken(exec, "valid-token")
+	require.Error(t, err, "revoke after 24h window must be denied")
+	ce, ok := IsClientError(err)
+	require.True(t, ok, "expected a ClientError")
+	assert.Equal(t, 403, ce.code)
+	assert.Contains(t, ce.Error(), "revocation window has closed")
+}
+
+// TestRevoke_NoTimestamp_Allowed verifies that legacy rows without CompletedAt
+// or ExecutedAt skip the window check and are allowed through.
+func TestRevoke_NoTimestamp_Allowed(t *testing.T) {
+	exec := &config.PurchaseExecution{
+		ExecutionID:   "exec-legacy",
+		Status:        "completed",
+		ApprovalToken: "valid-token",
+		// No CompletedAt or ExecutedAt set (legacy row).
+	}
+	err := validateRevokeToken(exec, "valid-token")
+	require.NoError(t, err, "legacy rows without timestamp must not be blocked by window check")
+}
+
+// TestRevoke_4EyesMode_TODO is a placeholder to surface the 4-eyes-mode
+// interaction once issue #1005 lands.
+func TestRevoke_4EyesMode_TODO(t *testing.T) {
+	t.Skip("placeholder until #1005 lands: verify that 4-eyes-mode approval flows interact correctly with the revocation window")
+}
+
 // TestRevokePurchase_GETRendersConfirmationPage_NoMutation verifies that a GET
 // to the revoke handler returns 200 HTML containing a confirmation form and
 // does NOT call TransitionExecutionStatus (no mutation).

--- a/internal/api/handler_purchases_test.go
+++ b/internal/api/handler_purchases_test.go
@@ -4404,6 +4404,68 @@ func TestResolveExecutedNotificationRecipients_Deduplication(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Finding #3: redactURL strips token from logged URLs
+// ---------------------------------------------------------------------------
+
+// TestRedactURL_StripsTokenQueryParam verifies the redactURL helper removes
+// the token value from URLs before they are written to logs.
+func TestRedactURL_StripsTokenQueryParam(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{
+			input: "/api/purchases/revoke/exec-id?token=supersecret",
+			want:  "/api/purchases/revoke/exec-id?token=REDACTED",
+		},
+		{
+			input: "/api/purchases/revoke/exec-id?other=val&token=supersecret",
+			want:  "/api/purchases/revoke/exec-id?other=val&token=REDACTED",
+		},
+		{
+			input: "/api/purchases/revoke/exec-id?token=supersecret&other=val",
+			want:  "/api/purchases/revoke/exec-id?token=REDACTED&other=val",
+		},
+		{
+			input: "/api/purchases/approve/exec-id?token=abc123",
+			want:  "/api/purchases/approve/exec-id?token=REDACTED",
+		},
+		{
+			// No token param: pass through unchanged.
+			input: "/api/purchases/approve/exec-id?other=x",
+			want:  "/api/purchases/approve/exec-id?other=x",
+		},
+		{
+			// No query string: pass through unchanged.
+			input: "/api/purchases/revoke/exec-id",
+			want:  "/api/purchases/revoke/exec-id",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			assert.Equal(t, tc.want, redactURL(tc.input))
+		})
+	}
+}
+
+// TestRevokePOSTReadsTokenFromBody verifies that resolveApprovalToken reads
+// the token from the HTML form POST body (application/x-www-form-urlencoded)
+// rather than the query string, so the token does not appear in access logs.
+// This test lives in the api package and calls the router-level function.
+func TestRevokePOSTReadsTokenFromBody(t *testing.T) {
+	req := &events.LambdaFunctionURLRequest{
+		RequestContext: events.LambdaFunctionURLRequestContext{
+			HTTP: events.LambdaFunctionURLRequestContextHTTPDescription{Method: "POST"},
+		},
+		// Token present in BOTH body and query string; body must win.
+		Body:                  "token=body-token",
+		QueryStringParameters: map[string]string{"token": "query-token"},
+	}
+	got := resolveApprovalToken(req)
+	assert.Equal(t, "body-token", got, "POST body token must take priority over query string")
+}
+
+// ---------------------------------------------------------------------------
 // Finding #1: Revoke must reject a rotated (empty) approval token
 // ---------------------------------------------------------------------------
 

--- a/internal/api/handler_purchases_test.go
+++ b/internal/api/handler_purchases_test.go
@@ -4050,11 +4050,8 @@ func TestHandler_revokePurchase_ValidToken(t *testing.T) {
 	mockStore.On("TransitionExecutionStatus", ctx, execID,
 		[]string{"completed", "partially_completed"}, "revocation_requested").
 		Return(&config.PurchaseExecution{ExecutionID: execID, Status: "revocation_requested"}, nil)
-	// SavePurchaseExecution stamps CancelledBy on the returned row.
-	mockStore.On("SavePurchaseExecution", ctx, mock.MatchedBy(func(e *config.PurchaseExecution) bool {
-		return e.ExecutionID == execID && e.Status == "revocation_requested" &&
-			e.CancelledBy != nil && *e.CancelledBy == revokerEmail
-	})).Return(nil)
+	// SetCancelledBy stamps the actor without a full-row overwrite (Finding #5).
+	mockStore.On("SetCancelledBy", ctx, execID, revokerEmail).Return(nil)
 
 	mockAuth := new(MockAuthService)
 	// Provide a session for the revoker so authorizeApprovalAction resolves actor.
@@ -4228,9 +4225,8 @@ func TestHandler_revokePurchase_SessionAdminCancelAny(t *testing.T) {
 	mockStore.On("TransitionExecutionStatus", ctx, execID,
 		[]string{"completed", "partially_completed"}, "revocation_requested").
 		Return(&config.PurchaseExecution{ExecutionID: execID, Status: "revocation_requested"}, nil)
-	mockStore.On("SavePurchaseExecution", ctx, mock.MatchedBy(func(e *config.PurchaseExecution) bool {
-		return e.ExecutionID == execID && e.CancelledBy != nil && *e.CancelledBy == adminEmail
-	})).Return(nil)
+	// SetCancelledBy replaces the full-row SavePurchaseExecution (Finding #5).
+	mockStore.On("SetCancelledBy", ctx, execID, adminEmail).Return(nil)
 
 	mockAuth := new(MockAuthService)
 	mockAuth.On("ValidateSession", ctx, "admin-token").
@@ -4267,9 +4263,8 @@ func TestHandler_revokePurchase_SessionOwnerCancelOwn(t *testing.T) {
 	mockStore.On("TransitionExecutionStatus", ctx, execID,
 		[]string{"completed", "partially_completed"}, "revocation_requested").
 		Return(&config.PurchaseExecution{ExecutionID: execID, Status: "revocation_requested"}, nil)
-	mockStore.On("SavePurchaseExecution", ctx, mock.MatchedBy(func(e *config.PurchaseExecution) bool {
-		return e.ExecutionID == execID && e.CancelledBy != nil && *e.CancelledBy == ownerEmail
-	})).Return(nil)
+	// SetCancelledBy replaces the full-row SavePurchaseExecution (Finding #5).
+	mockStore.On("SetCancelledBy", ctx, execID, ownerEmail).Return(nil)
 
 	mockAuth := new(MockAuthService)
 	mockAuth.On("ValidateSession", ctx, "owner-token").
@@ -4401,6 +4396,38 @@ func TestResolveExecutedNotificationRecipients_Deduplication(t *testing.T) {
 	)
 	assert.Equal(t, "same@example.com", to)
 	assert.Empty(t, cc, "duplicate emails must be deduplicated")
+}
+
+// ---------------------------------------------------------------------------
+// Finding #5: revokeViaSession uses SetCancelledBy (no lost-update clobber)
+// ---------------------------------------------------------------------------
+
+// TestRevokeViaSession_CancelledByFoldsIntoTransition_NoLostUpdate verifies
+// that revokeViaSession uses SetCancelledBy (a narrow single-column UPDATE)
+// rather than a full-row SavePurchaseExecution, preventing a lost-update
+// race between the TransitionExecutionStatus and the attribution write.
+func TestRevokeViaSession_CancelledByFoldsIntoTransition_NoLostUpdate(t *testing.T) {
+	ctx := context.Background()
+	execID := "55555555-5555-5555-5555-555555555555"
+	revokedBy := "revoker@example.com"
+
+	exec := buildCompletedExec(execID, "tok")
+
+	mockStore := new(MockConfigStore)
+	mockStore.On("TransitionExecutionStatus", ctx, execID,
+		[]string{"completed", "partially_completed"}, "revocation_requested").
+		Return(&config.PurchaseExecution{ExecutionID: execID, Status: "revocation_requested"}, nil)
+	// SetCancelledBy must be called; SavePurchaseExecution must NOT.
+	mockStore.On("SetCancelledBy", ctx, execID, revokedBy).Return(nil)
+
+	handler := &Handler{config: mockStore}
+	result, err := handler.revokeViaSession(ctx, exec, revokedBy)
+	require.NoError(t, err)
+	resultMap := result.(map[string]string)
+	assert.Equal(t, "revocation_requested", resultMap["status"])
+
+	mockStore.AssertExpectations(t)
+	mockStore.AssertNotCalled(t, "SavePurchaseExecution")
 }
 
 // ---------------------------------------------------------------------------
@@ -4607,9 +4634,8 @@ func TestRevokePurchase_POSTPerformsRevoke(t *testing.T) {
 	mockStore.On("TransitionExecutionStatus", ctx, execID,
 		[]string{"completed", "partially_completed"}, "revocation_requested").
 		Return(&config.PurchaseExecution{ExecutionID: execID, Status: "revocation_requested"}, nil)
-	mockStore.On("SavePurchaseExecution", ctx, mock.MatchedBy(func(e *config.PurchaseExecution) bool {
-		return e.ExecutionID == execID && e.CancelledBy != nil && *e.CancelledBy == revokerEmail
-	})).Return(nil)
+	// SetCancelledBy replaces the full-row SavePurchaseExecution (Finding #5).
+	mockStore.On("SetCancelledBy", ctx, execID, revokerEmail).Return(nil)
 
 	mockAuth := new(MockAuthService)
 	mockAuth.On("ValidateSession", ctx, "sess-tok").Return(&Session{Email: revokerEmail}, nil)

--- a/internal/api/handler_purchases_test.go
+++ b/internal/api/handler_purchases_test.go
@@ -4045,9 +4045,15 @@ func TestHandler_revokePurchase_ValidToken(t *testing.T) {
 	mockStore.GetCloudAccountFn = func(_ context.Context, id string) (*config.CloudAccount, error) {
 		return &config.CloudAccount{ID: id, ContactEmail: revokerEmail}, nil
 	}
-	// SavePurchaseExecution for the revocation_requested update.
+	// Atomic conditional transition completed/partially_completed ->
+	// revocation_requested, returning the updated row.
+	mockStore.On("TransitionExecutionStatus", ctx, execID,
+		[]string{"completed", "partially_completed"}, "revocation_requested").
+		Return(&config.PurchaseExecution{ExecutionID: execID, Status: "revocation_requested"}, nil)
+	// SavePurchaseExecution stamps CancelledBy on the returned row.
 	mockStore.On("SavePurchaseExecution", ctx, mock.MatchedBy(func(e *config.PurchaseExecution) bool {
-		return e.ExecutionID == execID && e.Status == "revocation_requested"
+		return e.ExecutionID == execID && e.Status == "revocation_requested" &&
+			e.CancelledBy != nil && *e.CancelledBy == revokerEmail
 	})).Return(nil)
 
 	mockAuth := new(MockAuthService)
@@ -4155,6 +4161,190 @@ func TestHandler_revokePurchase_NotFound(t *testing.T) {
 	ce, ok := IsClientError(err)
 	require.True(t, ok, "expected a client error")
 	assert.Equal(t, 404, ce.code)
+}
+
+// TestHandler_revokePurchase_ExpiredToken verifies that a matching token whose
+// ApprovalTokenExpiresAt deadline has passed is rejected with 409, so a stale
+// completed execution cannot be marked revocation_requested via an old link.
+// Regression test for the revoke-token expiry CR finding (PR #889).
+func TestHandler_revokePurchase_ExpiredToken(t *testing.T) {
+	ctx := context.Background()
+	execID := "55555555-5555-5555-5555-555555555555"
+	token := "expiredbutmatching"
+	contactEmail := "contact@acct.example.com"
+	accountID := "acct-1"
+	past := time.Now().Add(-1 * time.Hour)
+
+	exec := &config.PurchaseExecution{
+		ExecutionID:            execID,
+		ApprovalToken:          token,
+		ApprovalTokenExpiresAt: &past,
+		Status:                 "completed",
+		Recommendations: []config.RecommendationRecord{
+			{ID: "r1", CloudAccountID: &accountID},
+		},
+	}
+
+	mockStore := new(MockConfigStore)
+	mockStore.On("GetExecutionByID", ctx, execID).Return(exec, nil)
+	mockStore.On("GetGlobalConfig", ctx).Return(&config.GlobalConfig{}, nil)
+	mockStore.GetCloudAccountFn = func(_ context.Context, id string) (*config.CloudAccount, error) {
+		return &config.CloudAccount{ID: id, ContactEmail: contactEmail}, nil
+	}
+
+	mockAuth := new(MockAuthService)
+	mockAuth.On("ValidateSession", ctx, "sess-tok").Return(&Session{Email: contactEmail}, nil)
+	mockAuth.On("HasPermissionAPI", ctx, "", "cancel-any", "purchases").Return(false, nil).Maybe()
+	mockAuth.On("HasPermissionAPI", ctx, "", "cancel-own", "purchases").Return(false, nil).Maybe()
+
+	handler := &Handler{config: mockStore, auth: mockAuth}
+	req := &events.LambdaFunctionURLRequest{
+		Headers:               map[string]string{"authorization": "Bearer sess-tok"},
+		QueryStringParameters: map[string]string{"token": token},
+	}
+	_, err := handler.revokePurchase(ctx, req, execID, token)
+	require.Error(t, err, "expired revocation token must be rejected")
+	ce, ok := IsClientError(err)
+	require.True(t, ok, "expected a client error")
+	assert.Equal(t, 409, ce.code)
+	assert.Contains(t, ce.message, "expired")
+}
+
+// TestHandler_revokePurchase_SessionAdminCancelAny exercises the tokenless
+// session-authorized revoke branch (tryRevokeViaSession -> revokeViaSession)
+// for an admin holding cancel-any on purchases. It asserts the atomic
+// TransitionExecutionStatus call and the revocation_requested result.
+// Covers the session-auth revoke branch CR finding (PR #889).
+func TestHandler_revokePurchase_SessionAdminCancelAny(t *testing.T) {
+	ctx := context.Background()
+	execID := "66666666-6666-6666-6666-666666666666"
+	adminEmail := "admin@example.com"
+	adminUserID := "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+
+	exec := buildCompletedExec(execID, "unused-token")
+
+	mockStore := new(MockConfigStore)
+	mockStore.On("GetExecutionByID", ctx, execID).Return(exec, nil)
+	mockStore.On("TransitionExecutionStatus", ctx, execID,
+		[]string{"completed", "partially_completed"}, "revocation_requested").
+		Return(&config.PurchaseExecution{ExecutionID: execID, Status: "revocation_requested"}, nil)
+	mockStore.On("SavePurchaseExecution", ctx, mock.MatchedBy(func(e *config.PurchaseExecution) bool {
+		return e.ExecutionID == execID && e.CancelledBy != nil && *e.CancelledBy == adminEmail
+	})).Return(nil)
+
+	mockAuth := new(MockAuthService)
+	mockAuth.On("ValidateSession", ctx, "admin-token").
+		Return(&Session{UserID: adminUserID, Email: adminEmail}, nil)
+	mockAuth.On("HasPermissionAPI", ctx, adminUserID, "cancel-any", "purchases").Return(true, nil)
+
+	handler := &Handler{config: mockStore, auth: mockAuth}
+	// No token query param: forces the tokenless session-auth path.
+	req := &events.LambdaFunctionURLRequest{
+		Headers: map[string]string{"authorization": "Bearer admin-token"},
+	}
+	result, err := handler.revokePurchase(ctx, req, execID, "")
+	require.NoError(t, err, "session admin with cancel-any must succeed")
+	resultMap := result.(map[string]string)
+	assert.Equal(t, "revocation_requested", resultMap["status"])
+	mockStore.AssertExpectations(t)
+	mockAuth.AssertExpectations(t)
+}
+
+// TestHandler_revokePurchase_SessionOwnerCancelOwn exercises the tokenless
+// session-auth branch for a non-admin owner holding cancel-own on a purchase
+// they created. Covers the session-auth revoke branch CR finding (PR #889).
+func TestHandler_revokePurchase_SessionOwnerCancelOwn(t *testing.T) {
+	ctx := context.Background()
+	execID := "77777777-7777-7777-7777-777777777777"
+	ownerEmail := "owner@example.com"
+	ownerUserID := "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+
+	exec := buildCompletedExec(execID, "unused-token")
+	exec.CreatedByUserID = &ownerUserID
+
+	mockStore := new(MockConfigStore)
+	mockStore.On("GetExecutionByID", ctx, execID).Return(exec, nil)
+	mockStore.On("TransitionExecutionStatus", ctx, execID,
+		[]string{"completed", "partially_completed"}, "revocation_requested").
+		Return(&config.PurchaseExecution{ExecutionID: execID, Status: "revocation_requested"}, nil)
+	mockStore.On("SavePurchaseExecution", ctx, mock.MatchedBy(func(e *config.PurchaseExecution) bool {
+		return e.ExecutionID == execID && e.CancelledBy != nil && *e.CancelledBy == ownerEmail
+	})).Return(nil)
+
+	mockAuth := new(MockAuthService)
+	mockAuth.On("ValidateSession", ctx, "owner-token").
+		Return(&Session{UserID: ownerUserID, Email: ownerEmail}, nil)
+	mockAuth.On("HasPermissionAPI", ctx, ownerUserID, "cancel-any", "purchases").Return(false, nil)
+	mockAuth.On("HasPermissionAPI", ctx, ownerUserID, "cancel-own", "purchases").Return(true, nil)
+
+	handler := &Handler{config: mockStore, auth: mockAuth}
+	req := &events.LambdaFunctionURLRequest{
+		Headers: map[string]string{"authorization": "Bearer owner-token"},
+	}
+	result, err := handler.revokePurchase(ctx, req, execID, "")
+	require.NoError(t, err, "session owner with cancel-own must succeed")
+	resultMap := result.(map[string]string)
+	assert.Equal(t, "revocation_requested", resultMap["status"])
+	mockStore.AssertExpectations(t)
+	mockAuth.AssertExpectations(t)
+}
+
+// TestHandler_revokePurchase_SessionNoPermissionNoToken verifies that a session
+// lacking both cancel-any and cancel-own, with no token supplied, is denied:
+// the session branch returns permission-denied and falls through to the
+// tokenless 401. Covers the session-auth revoke branch CR finding (PR #889).
+func TestHandler_revokePurchase_SessionNoPermissionNoToken(t *testing.T) {
+	ctx := context.Background()
+	execID := "88888888-8888-8888-8888-888888888888"
+	userEmail := "nobody@example.com"
+	userID := "cccccccc-cccc-cccc-cccc-cccccccccccc"
+
+	exec := buildCompletedExec(execID, "unused-token")
+
+	mockStore := new(MockConfigStore)
+	mockStore.On("GetExecutionByID", ctx, execID).Return(exec, nil)
+
+	mockAuth := new(MockAuthService)
+	mockAuth.On("ValidateSession", ctx, "user-token").
+		Return(&Session{UserID: userID, Email: userEmail}, nil)
+	mockAuth.On("HasPermissionAPI", ctx, userID, "cancel-any", "purchases").Return(false, nil)
+	mockAuth.On("HasPermissionAPI", ctx, userID, "cancel-own", "purchases").Return(false, nil)
+
+	handler := &Handler{config: mockStore, auth: mockAuth}
+	req := &events.LambdaFunctionURLRequest{
+		Headers: map[string]string{"authorization": "Bearer user-token"},
+	}
+	_, err := handler.revokePurchase(ctx, req, execID, "")
+	require.Error(t, err, "no permission and no token must be denied")
+	ce, ok := IsClientError(err)
+	require.True(t, ok, "expected a client error")
+	assert.Equal(t, 401, ce.code)
+	mockStore.AssertExpectations(t)
+	mockAuth.AssertExpectations(t)
+}
+
+// TestHandler_revokeViaSession_ConcurrentTransition verifies that a lost-update
+// race (the row's status changed between read and the conditional UPDATE) is
+// surfaced as a 409 rather than silently overwriting. Regression test for the
+// atomic-status-transition CR finding (PR #889).
+func TestHandler_revokeViaSession_ConcurrentTransition(t *testing.T) {
+	ctx := context.Background()
+	execID := "99999999-9999-9999-9999-999999999999"
+
+	exec := buildCompletedExec(execID, "tok")
+
+	mockStore := new(MockConfigStore)
+	mockStore.On("TransitionExecutionStatus", ctx, execID,
+		[]string{"completed", "partially_completed"}, "revocation_requested").
+		Return(nil, fmt.Errorf("%w: execution %s", config.ErrExecutionNotInExpectedStatus, execID))
+
+	handler := &Handler{config: mockStore}
+	_, err := handler.revokeViaSession(ctx, exec, "someone@example.com")
+	require.Error(t, err, "a concurrent transition must surface an error")
+	ce, ok := IsClientError(err)
+	require.True(t, ok, "expected a client error")
+	assert.Equal(t, 409, ce.code)
+	mockStore.AssertExpectations(t)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/api/handler_purchases_test.go
+++ b/internal/api/handler_purchases_test.go
@@ -4234,6 +4234,9 @@ func TestHandler_revokePurchase_SessionAdminCancelAny(t *testing.T) {
 	mockAuth.On("ValidateSession", ctx, "admin-token").
 		Return(&Session{UserID: adminUserID, Email: adminEmail}, nil)
 	mockAuth.On("HasPermissionAPI", ctx, adminUserID, "cancel-any", "purchases").Return(true, nil)
+	// CSRF is enforced for the session-authed revoke path (tryRevokeViaSession).
+	// No CSRF token header in this request, so csrfToken is "".
+	mockAuth.On("ValidateCSRFToken", ctx, "admin-token", "").Return(nil)
 
 	handler := &Handler{config: mockStore, auth: mockAuth}
 	// No token query param: forces the tokenless session-auth path.
@@ -4274,6 +4277,8 @@ func TestHandler_revokePurchase_SessionOwnerCancelOwn(t *testing.T) {
 		Return(&Session{UserID: ownerUserID, Email: ownerEmail}, nil)
 	mockAuth.On("HasPermissionAPI", ctx, ownerUserID, "cancel-any", "purchases").Return(false, nil)
 	mockAuth.On("HasPermissionAPI", ctx, ownerUserID, "cancel-own", "purchases").Return(true, nil)
+	// CSRF is enforced for the session-authed revoke path (tryRevokeViaSession).
+	mockAuth.On("ValidateCSRFToken", ctx, "owner-token", "").Return(nil)
 
 	handler := &Handler{config: mockStore, auth: mockAuth}
 	req := &events.LambdaFunctionURLRequest{
@@ -4498,26 +4503,52 @@ func TestRevokePOSTReadsTokenFromBody(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Finding #1: Revoke must reject a rotated (empty) approval token
+// Finding #1: Revoke must reject a cleared or mismatched ApprovalToken
 // ---------------------------------------------------------------------------
 
-// TestRevokePurchase_RejectsRotatedToken verifies that after approve/cancel
-// clears the ApprovalToken, an attempt to revoke with the original token
-// is rejected with 403. This guards against a leaked approval token being
-// replayed as a revocation token.
+// TestRevokePurchase_RejectsClearedToken verifies that after cancel clears
+// the ApprovalToken to "", any revoke attempt is rejected with 403. The cancel
+// path uses clearApprovalToken (not mintRevocationToken), so the stored token
+// is empty and no revoke is possible.
+func TestRevokePurchase_RejectsClearedToken(t *testing.T) {
+	exec := &config.PurchaseExecution{
+		ExecutionID:   "exec-post-cancel",
+		Status:        "completed",
+		ApprovalToken: "", // cleared by clearApprovalToken after cancel
+	}
+	err := validateRevokeToken(exec, "pre-cancel-token")
+	require.Error(t, err, "cleared (empty) stored token must be rejected")
+	ce, ok := IsClientError(err)
+	require.True(t, ok, "expected a ClientError")
+	assert.Equal(t, 403, ce.code, "must return 403 for a cleared token")
+}
+
+// TestRevokePurchase_RejectsRotatedToken verifies that after approve mints a
+// fresh revocation token (mintRevocationToken), the OLD approval token from the
+// approval email link can no longer be used for revocation. Only the fresh
+// token embedded in the executed-notification email is valid.
+//
+// This guards against a recipient of the approval-request email using that
+// link's token to also revoke the purchase after it executed.
 func TestRevokePurchase_RejectsRotatedToken(t *testing.T) {
-	// validateRevokeToken is the function under test: it must reject an
-	// empty stored token regardless of what the caller supplies.
+	freshToken := "fresh-revoke-token"
 	exec := &config.PurchaseExecution{
 		ExecutionID:   "exec-post-approve",
 		Status:        "completed",
-		ApprovalToken: "", // rotated to empty by rotateApprovalToken after approve
+		ApprovalToken: freshToken, // minted by mintRevocationToken after approve
 	}
-	err := validateRevokeToken(exec, "pre-rotate-token")
-	require.Error(t, err, "rotated (empty) stored token must be rejected")
+	// The OLD approval token (from the approve-request email) must be rejected
+	// because the stored token has been rotated to the fresh revocation token.
+	err := validateRevokeToken(exec, "old-approval-token")
+	require.Error(t, err, "old approval token must be rejected after token rotation")
 	ce, ok := IsClientError(err)
 	require.True(t, ok, "expected a ClientError")
-	assert.Equal(t, 403, ce.code, "must return 403 for a rotated token")
+	assert.Equal(t, 403, ce.code, "must return 403 for the rotated-away old token")
+
+	// Confirm the fresh token IS accepted, proving the guard is hash-based
+	// (not a blanket rejection).
+	require.NoError(t, validateRevokeToken(exec, freshToken),
+		"fresh revocation token must be accepted for revoke")
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -237,13 +237,49 @@ func extractCSRFToken(req *events.LambdaFunctionURLRequest) string {
 // authenticated request reaches CSRF validation with no token header.
 // Almost always indicates a frontend regression (sessionStorage cleared, or
 // a new fetch site forgot to include the token). ValidateCSRFToken still
-// rejects the request — this just makes the cause obvious in logs.
+// rejects the request -- this just makes the cause obvious in logs.
 func logMissingCSRFToken(req *events.LambdaFunctionURLRequest, csrfToken string) {
 	if csrfToken != "" {
 		return
 	}
-	logging.Warnf("CSRF validation: empty header on session-authenticated %s %s from %s — frontend regression?",
-		req.RequestContext.HTTP.Method, req.RequestContext.HTTP.Path, req.RequestContext.HTTP.SourceIP)
+	logging.Warnf("CSRF validation: empty header on session-authenticated %s %s from %s -- frontend regression?",
+		req.RequestContext.HTTP.Method, redactURL(req.RequestContext.HTTP.Path), req.RequestContext.HTTP.SourceIP)
+}
+
+// redactURL replaces any token= query parameter value with REDACTED so
+// approval/revocation tokens are never written to structured access logs.
+// Applied to every URL or path string before it is passed to a logging call.
+//
+// Matches:
+//
+//	?token=<value>   at the start of the query string
+//	&token=<value>   as a subsequent parameter
+//
+// The replacement is done with a simple string scan so there is no regexp
+// compilation overhead on the hot request path.
+func redactURL(u string) string {
+	return redactQueryParam(u, "token")
+}
+
+// redactQueryParam replaces the value of the named query parameter in u with
+// REDACTED. The match is case-sensitive and handles both ? and & prefixes.
+func redactQueryParam(u, param string) string {
+	// Handle both ?param=val and &param=val forms.
+	for _, prefix := range []string{"?" + param + "=", "&" + param + "="} {
+		idx := strings.Index(u, prefix)
+		if idx == -1 {
+			continue
+		}
+		start := idx + len(prefix)
+		// Find the end of the value (next & or end of string).
+		end := strings.IndexByte(u[start:], '&')
+		if end == -1 {
+			u = u[:start] + "REDACTED"
+		} else {
+			u = u[:start] + "REDACTED" + u[start+end:]
+		}
+	}
+	return u
 }
 
 // requireAuth verifies the request carries a valid authentication credential

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -139,24 +139,28 @@ func (h *Handler) requiresCSRFValidation(method, path string, req *events.Lambda
 		return false
 	}
 
-	// Auth endpoints that don't have a session yet are exempt unconditionally.
-	// Prefix matching is safe for these /api/auth/* paths because no admin
-	// sub-paths share those prefixes.
-	csrfExemptAlwaysPrefix := []string{
-		"/api/auth/login",
+	// Auth endpoints that don't have a session yet are exempt.
+	//
+	// Note: /api/purchases/approve/ and /api/purchases/cancel/ are NOT listed
+	// here. Those routes are AuthPublic and listed in isPublicEndpoint(), so
+	// validateSecurity() short-circuits before requiresCSRFValidation() is
+	// reached on the token-only (email-link) path. For the session-authed path
+	// (approvePurchaseViaSession / cancelPurchaseViaSession), CSRF is enforced
+	// directly inside those functions -- a blanket middleware exemption would
+	// leave session-authenticated POSTs to these endpoints unprotected (CSRF).
+	//
+	// Similarly, /api/ri-exchange/approve/ and /api/ri-exchange/reject/ are
+	// AuthPublic and therefore exempted by isPublicEndpoint(), not here.
+	//
+	// All exemptions use exact-match to prevent a path like
+	// /api/register-malicious from bypassing CSRF via accidental prefix overlap.
+	// This mirrors the exact-match approach in isPublicEndpoint().
+	switch path {
+	case "/api/auth/login",
 		"/api/auth/setup-admin",
 		"/api/auth/forgot-password",
 		"/api/auth/reset-password",
-	}
-	for _, exempt := range csrfExemptAlwaysPrefix {
-		if strings.HasPrefix(path, exempt) {
-			return false
-		}
-	}
-	// Exact match for the public self-registration endpoint (issue #1017).
-	// HasPrefix would also exempt /api/registrations/<id>/approve|reject|delete,
-	// which are AuthAdmin state-changing routes that MUST be CSRF-protected.
-	if path == "/api/register" {
+		"/api/register": // POST /api/register (public registration, no session)
 		return false
 	}
 

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -20,6 +20,7 @@ func (h *Handler) isPublicEndpoint(path string) bool {
 		"/version", // Public build-version endpoint (version / git SHA / build time)
 		"/api/purchases/approve/",
 		"/api/purchases/cancel/",
+		"/api/purchases/revoke/",
 		"/api/ri-exchange/approve/",
 		"/api/ri-exchange/reject/",
 		"/api/auth/login",

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -13,11 +13,13 @@ import (
 
 // isPublicEndpoint returns true for endpoints that don't require authentication.
 func (h *Handler) isPublicEndpoint(path string) bool {
-	publicEndpoints := []string{
+	// Prefix-matched public endpoints: dynamic routes where the path carries
+	// a resource ID (approval/cancel/revoke tokens, register tokens, docs
+	// sub-paths) and static prefixes that are always fully public.
+	publicPrefixEndpoints := []string{
 		"/health",     // Root health endpoint (no /api prefix)
 		"/api/health", // API health endpoint
 		"/api/info",
-		"/version", // Public build-version endpoint (version / git SHA / build time)
 		"/api/purchases/approve/",
 		"/api/purchases/cancel/",
 		"/api/purchases/revoke/",
@@ -32,13 +34,17 @@ func (h *Handler) isPublicEndpoint(path string) bool {
 		"/docs",
 		"/api/docs",
 	}
-	for _, ep := range publicEndpoints {
+	for _, ep := range publicPrefixEndpoints {
 		if strings.HasPrefix(path, ep) {
 			return true
 		}
 	}
-	// Exact match for POST /api/register (no trailing slash).
-	if path == "/api/register" {
+	// Exact-match singleton public endpoints. These must not be prefix-matched
+	// to prevent "/version-anything" or "/api/register-anything" from
+	// bypassing auth via accidental prefix overlap.
+	switch path {
+	case "/version", // Public build-version endpoint (version / git SHA / build time)
+		"/api/register": // POST /api/register (no trailing slash)
 		return true
 	}
 	return false

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -247,6 +247,49 @@ func TestHandler_authenticate_BearerTokenWithAPIKey(t *testing.T) {
 	assert.False(t, handler.authenticate(ctx, req))
 }
 
+// TestHandler_requiresCSRFValidation_ExactMatch asserts that paths sharing a
+// prefix with a CSRF-exempt route are NOT themselves exempt. The fix uses
+// exact-match (switch) instead of strings.HasPrefix so that a path like
+// /api/register-malicious is not silently exempted because it starts with
+// /api/register.
+func TestHandler_requiresCSRFValidation_ExactMatch(t *testing.T) {
+	handler := &Handler{}
+
+	tests := []struct {
+		method       string
+		path         string
+		requiresCSRF bool
+	}{
+		// Exempt routes must still pass (exact-match still covers them).
+		{"POST", "/api/auth/login", false},
+		{"POST", "/api/auth/setup-admin", false},
+		{"POST", "/api/auth/forgot-password", false},
+		{"POST", "/api/auth/reset-password", false},
+		{"POST", "/api/register", false},
+		// Paths sharing only a PREFIX with an exempt route must require CSRF.
+		{"POST", "/api/register-malicious", true},
+		{"POST", "/api/register-anything", true},
+		{"POST", "/api/auth/login-evil", true},
+		{"POST", "/api/auth/forgot-password-extra", true},
+		// Non-exempt POST paths
+		{"POST", "/api/config", true},
+		{"POST", "/api/recommendations", true},
+		// GET never requires CSRF regardless of path
+		{"GET", "/api/register", false},
+		{"GET", "/api/config", false},
+		// DELETE on a protected endpoint requires CSRF
+		{"DELETE", "/api/plans", true},
+	}
+
+	for _, tt := range tests {
+		name := tt.method + " " + tt.path
+		t.Run(name, func(t *testing.T) {
+			result := handler.requiresCSRFValidation(tt.method, tt.path)
+			assert.Equal(t, tt.requiresCSRF, result)
+		})
+	}
+}
+
 // ---------------------------------------------------------------------------
 // CSRF boundary tests for session-authed approve/cancel (issue #404)
 // ---------------------------------------------------------------------------

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -27,9 +27,9 @@ func TestHandler_isPublicEndpoint(t *testing.T) {
 		{"/api/history", false},
 		// /version is a public endpoint but must be exact-matched only.
 		{"/version", true},
-		{"/version-evil", false},    // prefix overlap must not bypass auth
-		{"/versionXYZ", false},      // prefix overlap must not bypass auth
-		{"/api/register", true},     // POST /api/register (exact)
+		{"/version-evil", false},      // prefix overlap must not bypass auth
+		{"/versionXYZ", false},        // prefix overlap must not bypass auth
+		{"/api/register", true},       // POST /api/register (exact)
 		{"/api/registrations", false}, // must not match via prefix
 	}
 

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -25,6 +25,12 @@ func TestHandler_isPublicEndpoint(t *testing.T) {
 		{"/api/recommendations", false},
 		{"/api/plans", false},
 		{"/api/history", false},
+		// /version is a public endpoint but must be exact-matched only.
+		{"/version", true},
+		{"/version-evil", false},    // prefix overlap must not bypass auth
+		{"/versionXYZ", false},      // prefix overlap must not bypass auth
+		{"/api/register", true},     // POST /api/register (exact)
+		{"/api/registrations", false}, // must not match via prefix
 	}
 
 	for _, tt := range tests {

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -284,7 +284,7 @@ func TestHandler_requiresCSRFValidation_ExactMatch(t *testing.T) {
 	for _, tt := range tests {
 		name := tt.method + " " + tt.path
 		t.Run(name, func(t *testing.T) {
-			result := handler.requiresCSRFValidation(tt.method, tt.path)
+			result := handler.requiresCSRFValidation(tt.method, tt.path, nil)
 			assert.Equal(t, tt.requiresCSRF, result)
 		})
 	}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -163,6 +163,12 @@ func (r *Router) registerRoutes() {
 		{PathPrefix: "/api/purchases/approve/", Method: "POST", Handler: r.approvePurchaseHandler, Auth: AuthPublic},
 		{PathPrefix: "/api/purchases/cancel/", Method: "GET", Handler: r.cancelPurchaseHandler, Auth: AuthPublic},
 		{PathPrefix: "/api/purchases/cancel/", Method: "POST", Handler: r.cancelPurchaseHandler, Auth: AuthPublic},
+		// Revoke a completed purchase (issue #291). Same AuthPublic + token-based
+		// auth pattern as approve/cancel — the token is embedded in the
+		// post-execution notification email's one-click link. Session-authed
+		// users with revoke:purchases (or admin) may also use the route.
+		{PathPrefix: "/api/purchases/revoke/", Method: "GET", Handler: r.revokePurchaseHandler, Auth: AuthPublic},
+		{PathPrefix: "/api/purchases/revoke/", Method: "POST", Handler: r.revokePurchaseHandler, Auth: AuthPublic},
 		// Retry a failed purchase execution (issue #47). Session-authed
 		// only — the original failed row's email-token has already been
 		// consumed/expired, so there is no token-mode dispatch here.
@@ -555,7 +561,11 @@ func (r *Router) retryPurchaseHandler(ctx context.Context, req *events.LambdaFun
 }
 
 func (r *Router) revokePurchaseHandler(ctx context.Context, req *events.LambdaFunctionURLRequest, params map[string]string) (any, error) {
-	return r.h.revokePurchase(ctx, req, params["id"])
+	if err := r.h.checkRateLimit(ctx, req, "approve_cancel_public"); err != nil {
+		return nil, err
+	}
+	token := resolveApprovalToken(req)
+	return r.h.revokePurchase(ctx, req, params["id"], token)
 }
 
 func (r *Router) calculateRevokeHandler(ctx context.Context, req *events.LambdaFunctionURLRequest, params map[string]string) (any, error) {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/aws/aws-lambda-go/events"
@@ -519,22 +520,34 @@ func (r *Router) getPurchaseDetailsHandler(ctx context.Context, req *events.Lamb
 	return r.h.getPurchaseDetails(ctx, req, params["id"])
 }
 
-// resolveApprovalToken extracts the approval token for approve/cancel actions
-// (issue #398). For POST requests the token is read from the JSON request body
-// so it does not appear in the Lambda Function URL access logs (which log the
-// rawQueryString but not the body). The query string is still accepted as a
-// fallback so legacy GET clicks from email links (which carry the token in the
-// URL and land on the same handler via AuthPublic GET routes) continue to work
-// during the transition period.
+// resolveApprovalToken extracts the approval token for approve/cancel/revoke
+// actions (issue #398). For POST requests the token is read from the request
+// body so it does not appear in the Lambda Function URL access logs (which log
+// the rawQueryString but not the body). Two body encodings are supported:
 //
-// Priority: POST body > query string.
+//   - application/json: {"token": "<value>"}
+//   - application/x-www-form-urlencoded: token=<value>  (used by the revoke
+//     confirmation form rendered by the GET /revoke handler)
+//
+// The query string is still accepted as a fallback so legacy GET clicks from
+// email links (which carry the token in the URL) continue to work.
+//
+// Priority: POST body (JSON) > POST body (form) > query string.
 func resolveApprovalToken(req *events.LambdaFunctionURLRequest) string {
 	if req.RequestContext.HTTP.Method == "POST" && req.Body != "" {
+		// Try JSON body first.
 		var body struct {
 			Token string `json:"token"`
 		}
 		if err := json.Unmarshal([]byte(req.Body), &body); err == nil && body.Token != "" {
 			return body.Token
+		}
+		// Fall through to form-encoded body (used by the HTML confirmation form).
+		vals, err := url.ParseQuery(req.Body)
+		if err == nil {
+			if t := vals.Get("token"); t != "" {
+				return t
+			}
 		}
 	}
 	return req.QueryStringParameters["token"]

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -164,12 +164,12 @@ func (r *Router) registerRoutes() {
 		{PathPrefix: "/api/purchases/approve/", Method: "POST", Handler: r.approvePurchaseHandler, Auth: AuthPublic},
 		{PathPrefix: "/api/purchases/cancel/", Method: "GET", Handler: r.cancelPurchaseHandler, Auth: AuthPublic},
 		{PathPrefix: "/api/purchases/cancel/", Method: "POST", Handler: r.cancelPurchaseHandler, Auth: AuthPublic},
-		// Revoke a completed purchase (issue #291). Same AuthPublic + token-based
-		// auth pattern as approve/cancel — the token is embedded in the
-		// post-execution notification email's one-click link. Session-authed
-		// users with revoke:purchases (or admin) may also use the route.
-		{PathPrefix: "/api/purchases/revoke/", Method: "GET", Handler: r.revokePurchaseHandler, Auth: AuthPublic},
-		{PathPrefix: "/api/purchases/revoke/", Method: "POST", Handler: r.revokePurchaseHandler, Auth: AuthPublic},
+		// Revoke a completed purchase via email one-click link (issue #291).
+		// AuthPublic + token-based auth pattern: the token is embedded in the
+		// post-execution notification email's one-click link. GET renders a
+		// confirmation form; POST executes the revocation.
+		{PathPrefix: "/api/purchases/revoke/", Method: "GET", Handler: r.revokeViaEmailTokenHandler, Auth: AuthPublic},
+		{PathPrefix: "/api/purchases/revoke/", Method: "POST", Handler: r.revokeViaEmailTokenHandler, Auth: AuthPublic},
 		// Retry a failed purchase execution (issue #47). Session-authed
 		// only — the original failed row's email-token has already been
 		// consumed/expired, so there is no token-mode dispatch here.
@@ -573,12 +573,22 @@ func (r *Router) retryPurchaseHandler(ctx context.Context, req *events.LambdaFun
 	return r.h.retryPurchase(ctx, req, params["id"])
 }
 
-func (r *Router) revokePurchaseHandler(ctx context.Context, req *events.LambdaFunctionURLRequest, params map[string]string) (any, error) {
+// revokeViaEmailTokenHandler handles GET/POST /api/purchases/revoke/{execID}
+// (issue #291 email one-click link). GET renders a confirmation form;
+// POST executes the token-based revocation.
+func (r *Router) revokeViaEmailTokenHandler(ctx context.Context, req *events.LambdaFunctionURLRequest, params map[string]string) (any, error) {
 	if err := r.h.checkRateLimit(ctx, req, "approve_cancel_public"); err != nil {
 		return nil, err
 	}
 	token := resolveApprovalToken(req)
-	return r.h.revokePurchase(ctx, req, params["id"], token)
+	return r.h.revokeViaEmailToken(ctx, req, params["id"], token)
+}
+
+// revokePurchaseHandler handles POST /api/purchases/{id}/revoke
+// (issue #290 in-app session-authenticated revoke within the provider's
+// free-cancel window).
+func (r *Router) revokePurchaseHandler(ctx context.Context, req *events.LambdaFunctionURLRequest, params map[string]string) (any, error) {
+	return r.h.revokePurchase(ctx, req, params["id"])
 }
 
 func (r *Router) calculateRevokeHandler(ctx context.Context, req *events.LambdaFunctionURLRequest, params map[string]string) (any, error) {

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -104,3 +104,12 @@ const (
 // 6-hour TTL; purchase approvals are higher-stakes so a longer window is
 // appropriate but must still be bounded.
 const ApprovalTokenTTL = 7 * 24 * time.Hour
+
+// RevocationWindow is the time window after a purchase completes during which
+// the buyer may request revocation (issue #291). 24 hours matches the AWS RI/SP
+// support-case window advertised in the post-execution email. It is the single
+// source of truth for both the fresh revocation token's expiry (minted in
+// purchase.mintRevocationToken) and the enforcement check in api.validateRevokeToken:
+// the two MUST stay equal or a token could expire before the window closes and
+// silently block a valid revoke.
+const RevocationWindow = 24 * time.Hour

--- a/internal/config/interfaces.go
+++ b/internal/config/interfaces.go
@@ -93,6 +93,11 @@ type StoreInterface interface {
 	// When non-nil the actor is stamped onto transitioned_by + transitioned_at; when nil,
 	// transitioned_by is set to NULL and transitioned_at is still set to NOW() for ordering.
 	TransitionExecutionStatus(ctx context.Context, executionID string, fromStatuses []string, toStatus string, actor *string) (*PurchaseExecution, error)
+	// SetCancelledBy stamps a cancelled_by / revoked_by email on an execution
+	// without overwriting any other columns. Used after TransitionExecutionStatus
+	// to fold the actor attribution into the same logical write without the
+	// full-row SavePurchaseExecution clobber risk (Finding #5 / PR #889).
+	SetCancelledBy(ctx context.Context, executionID string, cancelledBy string) error
 	// CancelExecutionAtomic atomically flips status from pending / notified
 	// to 'cancelled', setting cancelled_by. The 'scheduled' status is NOT
 	// accepted here; scheduled rows are revoked via

--- a/internal/config/store_postgres.go
+++ b/internal/config/store_postgres.go
@@ -1023,7 +1023,7 @@ func (s *PostgresStore) TransitionExecutionStatus(ctx context.Context, execution
 // touching any other column. This avoids the full-row overwrite that a
 // SavePurchaseExecution follow-up would perform, eliminating the lost-update
 // window between TransitionExecutionStatus and the attribution write (Finding #5).
-func (s *PostgresStore) SetCancelledBy(ctx context.Context, executionID string, cancelledBy string) error {
+func (s *PostgresStore) SetCancelledBy(ctx context.Context, executionID, cancelledBy string) error {
 	q := `UPDATE purchase_executions SET cancelled_by = $2, updated_at = NOW()
 	       WHERE execution_id = $1`
 	_, err := s.db.Exec(ctx, q, executionID, cancelledBy)

--- a/internal/config/store_postgres.go
+++ b/internal/config/store_postgres.go
@@ -1019,6 +1019,17 @@ func (s *PostgresStore) TransitionExecutionStatus(ctx context.Context, execution
 	return &records[0], nil
 }
 
+// SetCancelledBy stamps the cancelled_by column for a single execution without
+// touching any other column. This avoids the full-row overwrite that a
+// SavePurchaseExecution follow-up would perform, eliminating the lost-update
+// window between TransitionExecutionStatus and the attribution write (Finding #5).
+func (s *PostgresStore) SetCancelledBy(ctx context.Context, executionID string, cancelledBy string) error {
+	q := `UPDATE purchase_executions SET cancelled_by = $2, updated_at = NOW()
+	       WHERE execution_id = $1`
+	_, err := s.db.Exec(ctx, q, executionID, cancelledBy)
+	return err
+}
+
 // CancelExecutionAtomic atomically transitions an execution from
 // pending or notified to 'cancelled', setting cancelled_by to the supplied
 // actor (NULL when actor is nil). The UPDATE is conditional on

--- a/internal/email/executed_notification_test.go
+++ b/internal/email/executed_notification_test.go
@@ -1,0 +1,154 @@
+package email
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// executedNotificationData returns a representative NotificationData for the
+// post-execution notification render tests (issue #291). The revocation token
+// deliberately contains characters that MUST be percent-encoded by the
+// template's {{urlquery}} pipeline so the tests can assert escaping.
+func executedNotificationData() NotificationData {
+	return NotificationData{
+		DashboardURL:     "https://dashboard.example.com",
+		ExecutionID:      "exec-12345",
+		TotalSavings:     420.50,
+		TotalUpfrontCost: 1200.00,
+		RecipientEmail:   "contact@example.com",
+		CCEmails:         []string{"notify@example.com", "requester@example.com"},
+		RevocationToken:  "tok en/with+special=chars",
+		RequestedByEmail: "requester@example.com",
+		RequestedByName:  "Requester R",
+		RequestedAt:      "2026-06-01T10:00:00Z",
+		ExecutedBy:       "admin@example.com",
+		ExecutedAt:       "2026-06-01T10:05:00Z",
+		Recommendations: []RecommendationSummary{
+			{
+				Service:        "ec2",
+				ResourceType:   "m5.large",
+				Region:         "us-east-1",
+				Count:          4,
+				Term:           3,
+				Payment:        "all-upfront",
+				UpfrontCost:    1200.00,
+				MonthlySavings: 420.50,
+				AccountLabel:   "AWS 540659244915",
+			},
+		},
+	}
+}
+
+// escapedToken is the exact rendered form of the test token after
+// url.QueryEscape (the {{urlquery}} func) followed by html/template's
+// contextual auto-escaping: space -> '+' -> '&#43;', '/' -> %2F, '+' -> %2B,
+// '=' -> %3D. Both the text and HTML halves use html/template, so both render
+// the token identically.
+const escapedToken = "tok&#43;en%2Fwith%2Bspecial%3Dchars"
+
+// rawTokenFragment is a substring of the un-escaped token that MUST NOT appear
+// verbatim in a correctly-escaped render (it contains a raw '/').
+const rawTokenFragment = "tok en/with+special=chars"
+
+func TestRenderPurchaseExecutedNotificationEmail_RevokeURLPresent(t *testing.T) {
+	data := executedNotificationData()
+
+	body, err := RenderPurchaseExecutedNotificationEmail(data)
+	require.NoError(t, err)
+
+	// The one-click revoke route is rendered with the execution ID and the
+	// url-escaped token.
+	assert.Contains(t, body, "/api/purchases/revoke/exec-12345?token=")
+	// Token is url-escaped: percent-encoded fragments present...
+	assert.Contains(t, body, "%2F", "'/' must be percent-encoded")
+	assert.Contains(t, body, "%2B", "'+' must be percent-encoded")
+	assert.Contains(t, body, "%3D", "'=' must be percent-encoded")
+	assert.Contains(t, body, escapedToken)
+	// ...and the raw token never leaks verbatim into the URL.
+	assert.NotContains(t, body, rawTokenFragment)
+
+	// Recipient summary (To + Cc) is surfaced for the executed-by / requested-by
+	// context block.
+	assert.Contains(t, body, "admin@example.com")     // executed by
+	assert.Contains(t, body, "requester@example.com") // requested by
+	assert.Contains(t, body, "Requester R")
+}
+
+func TestRenderPurchaseExecutedNotificationEmailHTML_RevokeURLPresent(t *testing.T) {
+	data := executedNotificationData()
+
+	body, err := RenderPurchaseExecutedNotificationEmailHTML(data)
+	require.NoError(t, err)
+
+	// HTML half renders the revoke CTA anchor with the escaped token.
+	assert.Contains(t, body, "/api/purchases/revoke/exec-12345?token="+escapedToken)
+	assert.Contains(t, body, "Revoke this purchase")
+	assert.Contains(t, body, "%2F")
+	assert.Contains(t, body, "%2B")
+	assert.Contains(t, body, "%3D")
+	assert.NotContains(t, body, rawTokenFragment)
+}
+
+func TestRenderPurchaseExecutedNotificationEmail_NoRevokeWhenTokenAbsent(t *testing.T) {
+	data := executedNotificationData()
+	data.RevocationToken = ""
+
+	body, err := RenderPurchaseExecutedNotificationEmail(data)
+	require.NoError(t, err)
+	htmlBody, err := RenderPurchaseExecutedNotificationEmailHTML(data)
+	require.NoError(t, err)
+
+	// With no token the revocation panel is omitted entirely in both halves.
+	assert.NotContains(t, body, "/api/purchases/revoke/")
+	assert.NotContains(t, body, "REVOCATION WINDOW")
+	assert.NotContains(t, htmlBody, "/api/purchases/revoke/")
+	assert.NotContains(t, htmlBody, "Revoke this purchase")
+}
+
+func TestRenderPurchaseExecutedNotificationEmail_ExpiryNoteDeferred(t *testing.T) {
+	data := executedNotificationData()
+	// RevocationWindowClosesAt is deferred to the sibling AWS-revert work; when
+	// empty (the present default) the templates omit the expiry sentence.
+	data.RevocationWindowClosesAt = ""
+
+	body, err := RenderPurchaseExecutedNotificationEmail(data)
+	require.NoError(t, err)
+	htmlBody, err := RenderPurchaseExecutedNotificationEmailHTML(data)
+	require.NoError(t, err)
+
+	assert.NotContains(t, body, "You can revoke this purchase until")
+	assert.NotContains(t, htmlBody, "You can revoke this purchase until")
+	// The revoke link itself is still present even without the expiry note.
+	assert.Contains(t, body, "/api/purchases/revoke/exec-12345")
+}
+
+func TestRenderPurchaseExecutedNotificationEmail_ExpiryNoteWhenPopulated(t *testing.T) {
+	data := executedNotificationData()
+	// If/when #804 populates the window, the expiry sentence renders.
+	data.RevocationWindowClosesAt = "2026-06-08 10:05 UTC"
+
+	body, err := RenderPurchaseExecutedNotificationEmail(data)
+	require.NoError(t, err)
+	htmlBody, err := RenderPurchaseExecutedNotificationEmailHTML(data)
+	require.NoError(t, err)
+
+	assert.Contains(t, body, "You can revoke this purchase until 2026-06-08 10:05 UTC")
+	assert.Contains(t, htmlBody, "2026-06-08 10:05 UTC")
+}
+
+func TestBuildExecutedNotificationSubject_SingleAndMulti(t *testing.T) {
+	single := executedNotificationData()
+	subject := buildExecutedNotificationSubject(single)
+	assert.Equal(t, "[CUDly] Purchase executed: ec2 m5.large in us-east-1", subject)
+	assert.True(t, strings.HasPrefix(subject, "[CUDly] Purchase executed:"))
+
+	multi := executedNotificationData()
+	multi.Recommendations = append(multi.Recommendations, RecommendationSummary{
+		Service: "rds", ResourceType: "db.r5.large", Region: "eu-west-1",
+	})
+	multiSubject := buildExecutedNotificationSubject(multi)
+	assert.Equal(t, "[CUDly] Purchase executed (2 commitment(s))", multiSubject)
+}

--- a/internal/email/interfaces.go
+++ b/internal/email/interfaces.go
@@ -27,6 +27,13 @@ type SenderInterface interface {
 	// (issue #291 wave-2). Notifies the user that the purchase will execute at
 	// RevocationWindowClosesAt and includes a one-click revoke link.
 	SendPurchaseScheduledNotification(ctx context.Context, data NotificationData) error
+	// SendPurchaseExecutedNotification fires after a purchase executes
+	// (regardless of whether it came from the approval-email path or the
+	// direct-execute path). Recipients: global notification_email, per-account
+	// contact emails, and the requester. The data must carry RevocationToken
+	// and RevocationWindowClosesAt so the email embeds a one-click revoke link
+	// valid for the AWS cancel window.
+	SendPurchaseExecutedNotification(ctx context.Context, data NotificationData) error
 	SendRegistrationReceivedNotification(ctx context.Context, data RegistrationNotificationData) error
 	SendRegistrationDecisionNotification(ctx context.Context, toEmail string, data RegistrationDecisionData) error
 }

--- a/internal/email/nop_sender.go
+++ b/internal/email/nop_sender.go
@@ -95,6 +95,11 @@ func (n *NopSender) SendPurchaseScheduledNotification(_ context.Context, _ Notif
 	return nil
 }
 
+func (n *NopSender) SendPurchaseExecutedNotification(_ context.Context, _ NotificationData) error {
+	logging.Debugf("email/nop: SendPurchaseExecutedNotification suppressed")
+	return nil
+}
+
 func (n *NopSender) SendRegistrationReceivedNotification(_ context.Context, _ RegistrationNotificationData) error {
 	logging.Debugf("email/nop: SendRegistrationReceivedNotification suppressed")
 	return nil

--- a/internal/email/sender.go
+++ b/internal/email/sender.go
@@ -433,6 +433,21 @@ type NotificationData struct {
 	DaysUntilPurchase        int
 	TotalUpfrontCost         float64
 	TotalSavings             float64
+	// RevocationToken is the one-time token embedded in the revocation link
+	// of a post-execution notification email. When non-empty, the template
+	// renders a "Revoke this purchase" CTA that hits
+	// /api/purchases/revoke/{ExecutionID}?token=<RevocationToken>.
+	// Empty silently omits the revocation panel so other email flows are
+	// unaffected.
+	RevocationToken string
+	// ExecutedAt is the ISO-8601 / RFC-3339 timestamp the purchase was
+	// executed at. Used in the post-execution notification body.
+	// Empty omits the timestamp from the body.
+	ExecutedAt string
+	// ExecutedBy is the email of the user who triggered execution (approved
+	// the purchase). Used in the post-execution notification body.
+	// Empty omits the field.
+	ExecutedBy string
 }
 
 // RecommendationSummary is a simplified recommendation for email display.

--- a/internal/email/smtp_sender.go
+++ b/internal/email/smtp_sender.go
@@ -457,6 +457,21 @@ func (s *SMTPSender) SendPurchaseScheduledNotification(ctx context.Context, data
 	return s.SendToEmailWithCC(ctx, recipient, data.CCEmails, subject, body)
 }
 
+// SendPurchaseExecutedNotification sends the post-execution notification email
+// via SMTP. Mirrors SendPurchaseApprovalRequest: prefers data.RecipientEmail
+// over the static s.notifyEmail. Issue #291.
+func (s *SMTPSender) SendPurchaseExecutedNotification(ctx context.Context, data NotificationData) error {
+	recipient := data.RecipientEmail
+	if recipient == "" {
+		recipient = s.notifyEmail
+	}
+	if recipient == "" {
+		return ErrNoRecipient
+	}
+	subject := buildExecutedNotificationSubject(data)
+	return sendPurchaseExecutedNotificationVia(ctx, s, recipient, subject, data)
+}
+
 // SendRegistrationReceivedNotification sends an email to CUDly administrators
 // for a new registration via SMTP. Prefers the caller-resolved
 // data.RecipientEmail + CCEmails (admin emails + global notify) so the To /

--- a/internal/email/templates.go
+++ b/internal/email/templates.go
@@ -801,6 +801,174 @@ func (s *Sender) SendPurchaseScheduledNotification(ctx context.Context, data Not
 }
 
 // ---------------------------------------------------------------------------
+// Post-execution notification templates (issue #291)
+// ---------------------------------------------------------------------------
+
+// purchaseExecutedNotificationTemplate is the plain-text half of the
+// post-execution notification email. Rendered alongside
+// purchaseExecutedNotificationHTMLTemplate for multipart/alternative delivery.
+const purchaseExecutedNotificationTemplate = `[CUDly] Purchase executed{{if .Recommendations}} ({{len .Recommendations}} commitment(s)){{end}}
+=============================================================================
+{{if .RequestedByEmail}}
+Requested by: {{if .RequestedByName}}{{.RequestedByName}} <{{.RequestedByEmail}}>{{else}}{{.RequestedByEmail}}{{end}}{{if .RequestedAt}} at {{.RequestedAt}}{{end}}
+{{end}}{{if .ExecutedBy}}
+Executed by:  {{.ExecutedBy}}{{if .ExecutedAt}} at {{.ExecutedAt}}{{end}}
+{{end}}
+Summary:
+--------
+Total Upfront Cost:       ${{printf "%.2f" .TotalUpfrontCost}}
+Estimated Monthly Savings: ${{printf "%.2f" .TotalSavings}}
+
+Commitments:
+{{range .Recommendations}}
+- {{.Count}}x {{.ResourceType}}{{if .Engine}} ({{.Engine}}){{end}} in {{.Region}}
+  Service: {{.Service}}{{if .AccountLabel}} | Account: {{.AccountLabel}}{{end}}{{if .Term}} | Term: {{.Term}}yr{{end}}{{if .Payment}} | Payment: {{.Payment}}{{end}}
+  Upfront: ${{printf "%.2f" .UpfrontCost}} | Est. Savings: ${{printf "%.2f" .MonthlySavings}}/month
+{{end}}
+{{if .RevocationToken}}
+------------------------------------------------------------
+REVOCATION WINDOW
+{{if .RevocationWindowClosesAt}}You can revoke this purchase until {{.RevocationWindowClosesAt}}.
+After that, contact AWS Support.
+{{end}}
+One-click revoke:
+{{.DashboardURL}}/api/purchases/revoke/{{.ExecutionID}}?token={{urlquery .RevocationToken}}
+
+Plain-text URL (copy + paste if the link above is broken):
+{{.DashboardURL}}/api/purchases/revoke/{{.ExecutionID}}?token={{urlquery .RevocationToken}}
+{{end}}
+View in dashboard:
+{{.DashboardURL}}/purchases#history?execution={{.ExecutionID}}
+
+This is an automated message from CUDly.
+`
+
+// purchaseExecutedNotificationHTMLTemplate is the HTML half of the
+// post-execution notification email. Inline-styled per email-client constraints
+// (Outlook, mobile Gmail ignore class-based CSS). Issue #291.
+const purchaseExecutedNotificationHTMLTemplate = `<!DOCTYPE html>
+<html><head><meta charset="UTF-8"><title>[CUDly] Purchase executed</title></head>
+<body style="margin:0;padding:0;background:#f4f6f8;font-family:Arial,Helvetica,sans-serif;color:#1a202c;">
+<table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="background:#f4f6f8;padding:24px 0;">
+<tr><td align="center">
+<table role="presentation" cellpadding="0" cellspacing="0" width="600" style="background:#ffffff;border-radius:8px;box-shadow:0 1px 3px rgba(0,0,0,0.06);">
+<tr><td style="padding:32px 32px 16px 32px;">
+<h1 style="margin:0;font-size:22px;color:#0f172a;">Purchase Executed</h1>
+<p style="margin:8px 0 0 0;color:#475569;font-size:14px;"><strong>{{len .Recommendations}}</strong> commitment(s) were purchased successfully.</p>
+</td></tr>
+
+<tr><td style="padding:0 32px 8px 32px;">
+<table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="border-collapse:collapse;font-size:14px;">
+<tr><td style="padding:6px 0;color:#64748b;width:180px;">Total Upfront Cost</td><td style="padding:6px 0;color:#0f172a;font-weight:600;">${{printf "%.2f" .TotalUpfrontCost}}</td></tr>
+<tr><td style="padding:6px 0;color:#64748b;">Estimated Monthly Savings</td><td style="padding:6px 0;color:#16a34a;font-weight:700;font-size:18px;">${{printf "%.2f" .TotalSavings}}</td></tr>
+{{if .RequestedByEmail}}<tr><td style="padding:6px 0;color:#64748b;">Requested by</td><td style="padding:6px 0;color:#0f172a;">{{if .RequestedByName}}{{.RequestedByName}} &lt;{{.RequestedByEmail}}&gt;{{else}}{{.RequestedByEmail}}{{end}}{{if .RequestedAt}} <span style="color:#94a3b8;">at {{.RequestedAt}}</span>{{end}}</td></tr>{{end}}
+{{if .ExecutedBy}}<tr><td style="padding:6px 0;color:#64748b;">Executed by</td><td style="padding:6px 0;color:#0f172a;">{{.ExecutedBy}}{{if .ExecutedAt}} <span style="color:#94a3b8;">at {{.ExecutedAt}}</span>{{end}}</td></tr>{{end}}
+</table>
+</td></tr>
+
+<tr><td style="padding:0 32px 16px 32px;">
+<h2 style="margin:16px 0 8px 0;font-size:15px;color:#334155;text-transform:uppercase;letter-spacing:0.04em;">Commitments</h2>
+<table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="border-collapse:collapse;font-size:13px;border:1px solid #e2e8f0;border-radius:6px;overflow:hidden;">
+<thead><tr style="background:#f1f5f9;">
+<th align="left" style="padding:10px 12px;color:#475569;font-weight:600;">Service / SKU</th>
+<th align="left" style="padding:10px 12px;color:#475569;font-weight:600;">Region</th>
+<th align="right" style="padding:10px 12px;color:#475569;font-weight:600;">Term &middot; Payment</th>
+<th align="right" style="padding:10px 12px;color:#475569;font-weight:600;">Upfront</th>
+<th align="right" style="padding:10px 12px;color:#475569;font-weight:600;">Savings/mo</th>
+</tr></thead>
+<tbody>
+{{range .Recommendations}}<tr style="border-top:1px solid #e2e8f0;">
+<td style="padding:10px 12px;color:#0f172a;">{{.Count}}&times; {{.ResourceType}}{{if .Engine}} ({{.Engine}}){{end}}<div style="color:#94a3b8;font-size:11px;margin-top:2px;">{{.Service}}{{if .AccountLabel}} &middot; {{.AccountLabel}}{{end}}</div></td>
+<td style="padding:10px 12px;color:#0f172a;">{{.Region}}</td>
+<td align="right" style="padding:10px 12px;color:#475569;">{{if .Term}}{{.Term}}yr{{end}}{{if .Payment}} &middot; {{.Payment}}{{end}}</td>
+<td align="right" style="padding:10px 12px;color:#0f172a;">${{printf "%.2f" .UpfrontCost}}</td>
+<td align="right" style="padding:10px 12px;color:#16a34a;font-weight:600;">${{printf "%.2f" .MonthlySavings}}</td>
+</tr>
+{{end}}</tbody></table>
+</td></tr>
+
+{{if .RevocationToken}}
+<tr><td style="padding:0 32px 24px 32px;border-top:1px solid #e2e8f0;">
+<h2 style="margin:16px 0 8px 0;font-size:15px;color:#b45309;text-transform:uppercase;letter-spacing:0.04em;">Revocation Window</h2>
+{{if .RevocationWindowClosesAt}}<p style="margin:0 0 12px 0;color:#475569;font-size:13px;">You can revoke this purchase until <strong>{{.RevocationWindowClosesAt}}</strong>. After that, contact AWS Support.</p>{{end}}
+<table role="presentation" cellpadding="0" cellspacing="0"><tr>
+<td><a href="{{.DashboardURL}}/api/purchases/revoke/{{.ExecutionID}}?token={{urlquery .RevocationToken}}" style="display:inline-block;padding:12px 28px;background:#dc2626;color:#ffffff;text-decoration:none;font-weight:600;font-size:14px;border-radius:6px;">Revoke this purchase</a></td>
+</tr></table>
+<p style="margin:10px 0 0 0;color:#64748b;font-size:11px;word-break:break-all;">If the button does not work, copy and paste this URL: <a href="{{.DashboardURL}}/api/purchases/revoke/{{.ExecutionID}}?token={{urlquery .RevocationToken}}" style="color:#2563eb;text-decoration:underline;">{{.DashboardURL}}/api/purchases/revoke/{{.ExecutionID}}?token={{urlquery .RevocationToken}}</a></p>
+</td></tr>
+{{end}}
+
+<tr><td style="padding:16px 32px;background:#f8fafc;border-top:1px solid #e2e8f0;border-radius:0 0 8px 8px;">
+<p style="margin:0;color:#94a3b8;font-size:11px;">This is an automated message from CUDly.</p>
+</td></tr>
+
+</table>
+</td></tr></table>
+</body></html>`
+
+// RenderPurchaseExecutedNotificationEmail renders the plain-text half of
+// the post-execution notification email (issue #291).
+func RenderPurchaseExecutedNotificationEmail(data NotificationData) (string, error) {
+	return renderTemplate("purchase-executed-notification", purchaseExecutedNotificationTemplate, data)
+}
+
+// RenderPurchaseExecutedNotificationEmailHTML renders the HTML half of the
+// post-execution notification email. Pair with
+// RenderPurchaseExecutedNotificationEmail for multipart/alternative delivery.
+func RenderPurchaseExecutedNotificationEmailHTML(data NotificationData) (string, error) {
+	return renderTemplate("purchase-executed-notification-html", purchaseExecutedNotificationHTMLTemplate, data)
+}
+
+// sendPurchaseExecutedNotificationVia composes the plain-text + HTML bodies
+// and ships them through s.SendToEmailWithCCMultipart. HTML render failures
+// are non-fatal and degrade to single-part text. Shared by Sender and
+// SMTPSender so the two transports stay in sync (same pattern as
+// sendPurchaseApprovalRequestVia). Issue #291.
+func sendPurchaseExecutedNotificationVia(ctx context.Context, s SenderInterface, recipient, subject string, data NotificationData) error {
+	textBody, err := RenderPurchaseExecutedNotificationEmail(data)
+	if err != nil {
+		return fmt.Errorf("failed to render purchase executed notification (text): %w", err)
+	}
+	// HTML render failure is non-fatal: degrade to single-part text.
+	htmlBody, htmlErr := RenderPurchaseExecutedNotificationEmailHTML(data)
+	if htmlErr != nil {
+		logging.Warnf("email: HTML executed-notification render failed, falling back to text-only: %v", htmlErr)
+		htmlBody = ""
+	}
+	return s.SendToEmailWithCCMultipart(ctx, recipient, data.CCEmails, subject, textBody, htmlBody)
+}
+
+// SendPurchaseExecutedNotification sends the post-execution notification email
+// to the configured recipients (global notification_email, per-account contact
+// emails, and the requester). data.RecipientEmail must be set to the primary To
+// address; data.CCEmails carries additional recipients. data.RevocationToken
+// and data.RevocationWindowClosesAt control the revocation-link panel in the
+// template. Issue #291.
+func (s *Sender) SendPurchaseExecutedNotification(ctx context.Context, data NotificationData) error {
+	if data.RecipientEmail == "" {
+		return ErrNoRecipient
+	}
+	if !isValidFromEmail(s.fromEmail) {
+		return ErrNoFromEmail
+	}
+	subject := buildExecutedNotificationSubject(data)
+	return sendPurchaseExecutedNotificationVia(ctx, s, data.RecipientEmail, subject, data)
+}
+
+// buildExecutedNotificationSubject constructs the subject line for the
+// post-execution notification, including a brief SKU summary when the
+// recommendation list is small enough to fit. Extracted so both Sender
+// and SMTPSender use the same subject format.
+func buildExecutedNotificationSubject(data NotificationData) string {
+	if len(data.Recommendations) == 1 {
+		r := data.Recommendations[0]
+		return fmt.Sprintf("[CUDly] Purchase executed: %s %s in %s",
+			r.Service, r.ResourceType, r.Region)
+	}
+	return fmt.Sprintf("[CUDly] Purchase executed (%d commitment(s))", len(data.Recommendations))
+}
+
+// ---------------------------------------------------------------------------
 // Account registration email templates
 // ---------------------------------------------------------------------------
 

--- a/internal/mocks/email.go
+++ b/internal/mocks/email.go
@@ -66,6 +66,12 @@ func (m *MockEmailSender) SendPurchaseApprovalRequest(ctx context.Context, data 
 	return args.Error(0)
 }
 
+// SendPurchaseExecutedNotification mocks the post-execution notification operation (issue #291).
+func (m *MockEmailSender) SendPurchaseExecutedNotification(ctx context.Context, data email.NotificationData) error {
+	args := m.Called(ctx, data)
+	return args.Error(0)
+}
+
 func (m *MockEmailSender) SendRegistrationReceivedNotification(ctx context.Context, data email.RegistrationNotificationData) error {
 	args := m.Called(ctx, data)
 	return args.Error(0)
@@ -87,6 +93,7 @@ type EmailSenderAPI interface {
 	SendPasswordResetEmail(ctx context.Context, email, resetURL string) error
 	SendWelcomeEmail(ctx context.Context, email, dashboardURL, role string) error
 	SendPurchaseApprovalRequest(ctx context.Context, data email.NotificationData) error
+	SendPurchaseExecutedNotification(ctx context.Context, data email.NotificationData) error
 }
 
 // Ensure MockEmailSender implements EmailSenderAPI.

--- a/internal/mocks/stores.go
+++ b/internal/mocks/stores.go
@@ -226,7 +226,7 @@ func (m *MockConfigStore) TransitionExecutionStatus(ctx context.Context, executi
 }
 
 // SetCancelledBy mocks the SetCancelledBy targeted-update operation.
-func (m *MockConfigStore) SetCancelledBy(ctx context.Context, executionID string, cancelledBy string) error {
+func (m *MockConfigStore) SetCancelledBy(ctx context.Context, executionID, cancelledBy string) error {
 	args := m.Called(ctx, executionID, cancelledBy)
 	return args.Error(0)
 }

--- a/internal/mocks/stores.go
+++ b/internal/mocks/stores.go
@@ -225,6 +225,12 @@ func (m *MockConfigStore) TransitionExecutionStatus(ctx context.Context, executi
 	return v, args.Error(1)
 }
 
+// SetCancelledBy mocks the SetCancelledBy targeted-update operation.
+func (m *MockConfigStore) SetCancelledBy(ctx context.Context, executionID string, cancelledBy string) error {
+	args := m.Called(ctx, executionID, cancelledBy)
+	return args.Error(0)
+}
+
 // CancelExecutionAtomic mocks the CancelExecutionAtomic operation.
 // Defaults to (true, "cancelled", nil) when no expectation is registered
 // so tests that only need the happy path don't require explicit mock setup.

--- a/internal/purchase/approvals.go
+++ b/internal/purchase/approvals.go
@@ -37,8 +37,8 @@ func (m *Manager) ApproveExecution(ctx context.Context, executionID, token, acto
 	}
 
 	// Validate token and TTL (Finding #4 + issue #397).
-	if err := validateApprovalToken(execution, token); err != nil {
-		return err
+	if tokErr := validateApprovalToken(execution, token); tokErr != nil {
+		return tokErr
 	}
 
 	// Preflight guard (issue #609): reject non-AWS orphan executions before

--- a/internal/purchase/approvals.go
+++ b/internal/purchase/approvals.go
@@ -2,6 +2,7 @@ package purchase
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/subtle"
 	"errors"
 	"fmt"
@@ -35,10 +36,14 @@ func (m *Manager) ApproveExecution(ctx context.Context, executionID, token, acto
 	}
 
 	// Validate token using constant-time comparison to prevent timing attacks.
+	// SHA-256 both inputs first so that variable-length strings can't leak
+	// token length via the comparison path (Finding #4).
 	if execution.ApprovalToken == "" || token == "" {
 		return fmt.Errorf("invalid approval token")
 	}
-	if subtle.ConstantTimeCompare([]byte(execution.ApprovalToken), []byte(token)) != 1 {
+	storedHash := sha256.Sum256([]byte(execution.ApprovalToken))
+	userHash := sha256.Sum256([]byte(token))
+	if subtle.ConstantTimeCompare(storedHash[:], userHash[:]) != 1 {
 		return fmt.Errorf("invalid approval token")
 	}
 
@@ -287,7 +292,9 @@ func (m *Manager) loadCancelableExecution(ctx context.Context, executionID, toke
 	if execution.ApprovalToken == "" || token == "" {
 		return nil, fmt.Errorf("invalid approval token")
 	}
-	if subtle.ConstantTimeCompare([]byte(execution.ApprovalToken), []byte(token)) != 1 {
+	storedHash := sha256.Sum256([]byte(execution.ApprovalToken))
+	userHash := sha256.Sum256([]byte(token))
+	if subtle.ConstantTimeCompare(storedHash[:], userHash[:]) != 1 {
 		return nil, fmt.Errorf("invalid approval token")
 	}
 

--- a/internal/purchase/approvals.go
+++ b/internal/purchase/approvals.go
@@ -14,14 +14,6 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
-// revocationTokenWindow is the TTL stamped onto the fresh revocation token
-// minted after a token-authed approve. It matches the 24-hour AWS RI/SP
-// support-case window advertised in the post-execution email and enforced
-// in validateRevokeToken (handler_purchases.go). Keeping the two values
-// in sync is essential: a token that expires before the window closes would
-// silently block a valid revoke attempt.
-const revocationTokenWindow = 24 * time.Hour
-
 // ApproveExecution is the token-authenticated approve entry point used by
 // the legacy email-link flow and the SQS approve worker. After validating
 // the approval token it hands off to ApproveAndExecute, which performs the
@@ -296,9 +288,15 @@ func (m *Manager) CancelExecution(ctx context.Context, executionID, token, actor
 // The handler re-fetches the execution after ApproveExecution returns to
 // pick up the fresh token for embedding in the email.
 //
-// Best-effort: if the write fails the approve has already landed and the
-// handler will fall back to sending the email with an empty RevocationToken
-// (no revoke button), which is degraded but safe.
+// Best-effort: if the write fails the approve has already landed and this
+// returns an error the caller only logs. The stored token is then unchanged
+// (still the consumed approval token), so the handler's re-fetch surfaces that
+// token and the email carries it -- it still validates for revoke because it
+// was never rotated (degraded to the old reuse-the-approval-token behavior on
+// this rare path, but functional and safe). The distinct failure mode where the
+// handler's re-fetch itself errors is handled in approveViaToken by blanking
+// ApprovalToken so the Revoke panel is suppressed rather than emailing a token
+// whose validity is unknown.
 func (m *Manager) mintRevocationToken(ctx context.Context, executionID string) error {
 	exec, err := m.config.GetExecutionByID(ctx, executionID)
 	if err != nil {
@@ -311,7 +309,7 @@ func (m *Manager) mintRevocationToken(ctx context.Context, executionID string) e
 	if err != nil {
 		return fmt.Errorf("mintRevocationToken: failed to generate token: %w", err)
 	}
-	expiry := time.Now().Add(revocationTokenWindow)
+	expiry := time.Now().Add(config.RevocationWindow)
 	exec.ApprovalToken = tok
 	exec.ApprovalTokenExpiresAt = &expiry
 	return m.config.SavePurchaseExecution(ctx, exec)

--- a/internal/purchase/approvals.go
+++ b/internal/purchase/approvals.go
@@ -35,23 +35,9 @@ func (m *Manager) ApproveExecution(ctx context.Context, executionID, token, acto
 		return fmt.Errorf("failed to get execution: %w", err)
 	}
 
-	// Validate token using constant-time comparison to prevent timing attacks.
-	// SHA-256 both inputs first so that variable-length strings can't leak
-	// token length via the comparison path (Finding #4).
-	if execution.ApprovalToken == "" || token == "" {
-		return fmt.Errorf("invalid approval token")
-	}
-	storedHash := sha256.Sum256([]byte(execution.ApprovalToken))
-	userHash := sha256.Sum256([]byte(token))
-	if subtle.ConstantTimeCompare(storedHash[:], userHash[:]) != 1 {
-		return fmt.Errorf("invalid approval token")
-	}
-
-	// Enforce token TTL (issue #397). Legacy rows that pre-date migration
-	// 000051 have ApprovalTokenExpiresAt == nil and are passed through
-	// for backward compatibility; all new rows carry a non-nil deadline.
-	if execution.ApprovalTokenExpiresAt != nil && time.Now().After(*execution.ApprovalTokenExpiresAt) {
-		return fmt.Errorf("approval token has expired")
+	// Validate token and TTL (Finding #4 + issue #397).
+	if err := validateApprovalToken(execution, token); err != nil {
+		return err
 	}
 
 	// Preflight guard (issue #609): reject non-AWS orphan executions before
@@ -107,6 +93,27 @@ func maskActor(actor string) string {
 		return "..." + actor[len(actor)-4:]
 	}
 	return "****"
+}
+
+// validateApprovalToken checks that the execution carries a non-empty token,
+// that the supplied token matches the stored one using constant-time comparison
+// (Finding #4 -- prevents timing attacks), and that the token has not expired
+// (issue #397). Legacy rows with a nil ApprovalTokenExpiresAt pass the TTL
+// check for backward compatibility. Extracted from ApproveExecution to keep
+// that function under the gocyclo threshold.
+func validateApprovalToken(execution *config.PurchaseExecution, token string) error {
+	if execution.ApprovalToken == "" || token == "" {
+		return fmt.Errorf("invalid approval token")
+	}
+	storedHash := sha256.Sum256([]byte(execution.ApprovalToken))
+	userHash := sha256.Sum256([]byte(token))
+	if subtle.ConstantTimeCompare(storedHash[:], userHash[:]) != 1 {
+		return fmt.Errorf("invalid approval token")
+	}
+	if execution.ApprovalTokenExpiresAt != nil && time.Now().After(*execution.ApprovalTokenExpiresAt) {
+		return fmt.Errorf("approval token has expired")
+	}
+	return nil
 }
 
 // OrphanExecutionError returns a descriptive error when the execution has no

--- a/internal/purchase/approvals.go
+++ b/internal/purchase/approvals.go
@@ -9,9 +9,18 @@ import (
 	"time"
 
 	"github.com/LeanerCloud/CUDly/internal/config"
+	"github.com/LeanerCloud/CUDly/pkg/common"
 	"github.com/LeanerCloud/CUDly/pkg/logging"
 	"github.com/jackc/pgx/v5"
 )
+
+// revocationTokenWindow is the TTL stamped onto the fresh revocation token
+// minted after a token-authed approve. It matches the 24-hour AWS RI/SP
+// support-case window advertised in the post-execution email and enforced
+// in validateRevokeToken (handler_purchases.go). Keeping the two values
+// in sync is essential: a token that expires before the window closes would
+// silently block a valid revoke attempt.
+const revocationTokenWindow = 24 * time.Hour
 
 // ApproveExecution is the token-authenticated approve entry point used by
 // the legacy email-link flow and the SQS approve worker. After validating
@@ -57,17 +66,26 @@ func (m *Manager) ApproveExecution(ctx context.Context, executionID, token, acto
 	} else {
 		logging.Infof("purchase[%s]: ApproveExecution (token path) completed in %s",
 			executionID, time.Since(t0))
-		// Token rotation (best-effort): clear the ApprovalToken after a
-		// successful approve so a leaked token cannot be replayed for a
-		// different action (e.g. revoke). We do this via a follow-up
-		// SavePurchaseExecution on a freshly-fetched row so we don't
-		// stomp a completed_at or other fields written by executeAndFinalize.
-		// The accept-small-race comment: if a concurrent read sees the pre-
-		// rotation row between this point and the save completing, it will
-		// find an empty-string token and reject the request, which is the
-		// desired security outcome even if the window is tiny.
-		if rotateErr := m.rotateApprovalToken(ctx, executionID); rotateErr != nil {
-			logging.Warnf("purchase[%s]: ApproveExecution: token rotation failed (best-effort): %v", executionID, rotateErr)
+		// Token rotation (best-effort): mint a fresh revocation token after a
+		// successful approve. The old approval token must not double as a
+		// revocation token: (a) it was consumed to authorize this approve action
+		// and (b) clearing it (old behavior) caused the post-execution email to
+		// embed an already-invalidated token, making every "Revoke" click return
+		// 403 (issue #291 wave-2 adversarial review finding).
+		//
+		// mintRevocationToken fetches the freshly-finalized row (so we don't
+		// stomp completed_at or other fields), generates a new random token with
+		// a 24-hour expiry matching the revocation window, and persists it.
+		// The handler re-fetches the execution after this call to obtain the
+		// fresh token for the email.
+		//
+		// Security: re-approval with the old token is still blocked by the status
+		// check in TransitionExecutionStatus (the row is now "completed", not
+		// "pending"/"notified"), so token rotation is NOT required to prevent
+		// approve-replay. The new token is scoped to revoke-only via the status
+		// check in checkRevokableStatus ("completed" required).
+		if rotateErr := m.mintRevocationToken(ctx, executionID); rotateErr != nil {
+			logging.Warnf("purchase[%s]: ApproveExecution: revocation token mint failed (best-effort): %v", executionID, rotateErr)
 		}
 	}
 	return err
@@ -259,26 +277,61 @@ func (m *Manager) CancelExecution(ctx context.Context, executionID, token, actor
 	}
 
 	logging.Infof("Execution %s canceled", executionID)
-	// Token rotation (best-effort): same rationale as in ApproveExecution.
-	if rotateErr := m.rotateApprovalToken(ctx, executionID); rotateErr != nil {
-		logging.Warnf("purchase[%s]: CancelExecution: token rotation failed (best-effort): %v", executionID, rotateErr)
+	// Token clear (best-effort): a canceled execution has no valid follow-up
+	// action, so the approval token is cleared to prevent replay. Unlike the
+	// approve path (which mints a fresh revocation token), cancel produces no
+	// usable successor action, so an empty token is correct here.
+	if rotateErr := m.clearApprovalToken(ctx, executionID); rotateErr != nil {
+		logging.Warnf("purchase[%s]: CancelExecution: token clear failed (best-effort): %v", executionID, rotateErr)
 	}
 	return nil
 }
 
-// rotateApprovalToken clears the ApprovalToken on the execution after a
-// successful approve or cancel. This prevents a leaked token from being
-// replayed for a different action (e.g. using an old approval token to
-// trigger a revoke). The rotation is best-effort: if the follow-up save
-// fails the operation (approve/cancel) has already landed, so we only
-// warn rather than surfacing an error to the caller.
-func (m *Manager) rotateApprovalToken(ctx context.Context, executionID string) error {
+// mintRevocationToken generates a fresh cryptographically-secure revocation
+// token, stamps it onto the execution with a revocationTokenWindow expiry,
+// and persists the update. Called after a successful token-authed approve so
+// the post-execution email carries a valid revoke-capable token rather than
+// the now-consumed approval token.
+//
+// The handler re-fetches the execution after ApproveExecution returns to
+// pick up the fresh token for embedding in the email.
+//
+// Best-effort: if the write fails the approve has already landed and the
+// handler will fall back to sending the email with an empty RevocationToken
+// (no revoke button), which is degraded but safe.
+func (m *Manager) mintRevocationToken(ctx context.Context, executionID string) error {
 	exec, err := m.config.GetExecutionByID(ctx, executionID)
 	if err != nil {
-		return fmt.Errorf("rotateApprovalToken: failed to fetch execution: %w", err)
+		return fmt.Errorf("mintRevocationToken: failed to fetch execution: %w", err)
 	}
 	if exec == nil {
-		return fmt.Errorf("rotateApprovalToken: execution not found: %s", executionID)
+		return fmt.Errorf("mintRevocationToken: execution not found: %s", executionID)
+	}
+	tok, err := common.GenerateApprovalToken()
+	if err != nil {
+		return fmt.Errorf("mintRevocationToken: failed to generate token: %w", err)
+	}
+	expiry := time.Now().Add(revocationTokenWindow)
+	exec.ApprovalToken = tok
+	exec.ApprovalTokenExpiresAt = &expiry
+	return m.config.SavePurchaseExecution(ctx, exec)
+}
+
+// clearApprovalToken clears the ApprovalToken on the execution after a
+// successful cancel. A canceled execution has no valid follow-up action, so
+// clearing the token prevents replay for any purpose. Unlike the approve path
+// (which mints a fresh revocation token for the revoke-window email link),
+// cancel produces no usable successor action.
+//
+// Best-effort: if the follow-up save fails the cancel has already landed, so
+// we only warn rather than surfacing an error to the caller.
+func (m *Manager) clearApprovalToken(ctx context.Context, executionID string) error {
+	exec, err := m.config.GetExecutionByID(ctx, executionID)
+	if err != nil {
+		return fmt.Errorf("clearApprovalToken: failed to fetch execution: %w", err)
+	}
+	if exec == nil {
+		return fmt.Errorf("clearApprovalToken: execution not found: %s", executionID)
 	}
 	exec.ApprovalToken = ""
 	exec.ApprovalTokenExpiresAt = nil

--- a/internal/purchase/approvals.go
+++ b/internal/purchase/approvals.go
@@ -66,6 +66,18 @@ func (m *Manager) ApproveExecution(ctx context.Context, executionID, token, acto
 	} else {
 		logging.Infof("purchase[%s]: ApproveExecution (token path) completed in %s",
 			executionID, time.Since(t0))
+		// Token rotation (best-effort): clear the ApprovalToken after a
+		// successful approve so a leaked token cannot be replayed for a
+		// different action (e.g. revoke). We do this via a follow-up
+		// SavePurchaseExecution on a freshly-fetched row so we don't
+		// stomp a completed_at or other fields written by executeAndFinalize.
+		// The accept-small-race comment: if a concurrent read sees the pre-
+		// rotation row between this point and the save completing, it will
+		// find an empty-string token and reject the request, which is the
+		// desired security outcome even if the window is tiny.
+		if rotateErr := m.rotateApprovalToken(ctx, executionID); rotateErr != nil {
+			logging.Warnf("purchase[%s]: ApproveExecution: token rotation failed (best-effort): %v", executionID, rotateErr)
+		}
 	}
 	return err
 }
@@ -235,7 +247,30 @@ func (m *Manager) CancelExecution(ctx context.Context, executionID, token, actor
 	}
 
 	logging.Infof("Execution %s canceled", executionID)
+	// Token rotation (best-effort): same rationale as in ApproveExecution.
+	if rotateErr := m.rotateApprovalToken(ctx, executionID); rotateErr != nil {
+		logging.Warnf("purchase[%s]: CancelExecution: token rotation failed (best-effort): %v", executionID, rotateErr)
+	}
 	return nil
+}
+
+// rotateApprovalToken clears the ApprovalToken on the execution after a
+// successful approve or cancel. This prevents a leaked token from being
+// replayed for a different action (e.g. using an old approval token to
+// trigger a revoke). The rotation is best-effort: if the follow-up save
+// fails the operation (approve/cancel) has already landed, so we only
+// warn rather than surfacing an error to the caller.
+func (m *Manager) rotateApprovalToken(ctx context.Context, executionID string) error {
+	exec, err := m.config.GetExecutionByID(ctx, executionID)
+	if err != nil {
+		return fmt.Errorf("rotateApprovalToken: failed to fetch execution: %w", err)
+	}
+	if exec == nil {
+		return fmt.Errorf("rotateApprovalToken: execution not found: %s", executionID)
+	}
+	exec.ApprovalToken = ""
+	exec.ApprovalTokenExpiresAt = nil
+	return m.config.SavePurchaseExecution(ctx, exec)
 }
 
 // loadCancelableExecution fetches an execution, validates the approval

--- a/internal/purchase/approvals_test.go
+++ b/internal/purchase/approvals_test.go
@@ -319,6 +319,10 @@ func TestManager_CancelExecution(t *testing.T) {
 		Return(true, "canceled", nil)
 	mockStore.On("DeleteSuppressionsByExecutionTx", ctx, mock.Anything, "exec-123").
 		Return(nil)
+	// Token rotation: SavePurchaseExecution is called after a successful cancel.
+	mockStore.On("SavePurchaseExecution", ctx, mock.MatchedBy(func(e *config.PurchaseExecution) bool {
+		return e.ExecutionID == "exec-123" && e.ApprovalToken == ""
+	})).Return(nil)
 
 	manager := &Manager{
 		config:       mockStore,
@@ -456,6 +460,8 @@ func TestManager_CancelExecution_AllowsCancelableStatus(t *testing.T) {
 			// Suppression cleanup must follow a successful atomic cancel.
 			mockStore.On("DeleteSuppressionsByExecutionTx", ctx, mock.Anything, "exec-123").
 				Return(nil)
+			// Token rotation after successful cancel.
+			mockStore.On("SavePurchaseExecution", ctx, mock.AnythingOfType("*config.PurchaseExecution")).Return(nil)
 
 			manager := &Manager{
 				config:       mockStore,
@@ -735,5 +741,69 @@ func TestManager_CancelExecution_ExpiredToken(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "expired")
 	store.AssertNotCalled(t, "CancelExecutionAtomic", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	store.AssertExpectations(t)
+}
+
+// ---------------------------------------------------------------------------
+// Finding #1: Token rotation on approve/cancel
+// ---------------------------------------------------------------------------
+
+// TestApproveExecution_RotatesApprovalToken verifies that after a successful
+// approve the ApprovalToken is cleared to prevent the same token from being
+// used to trigger a revoke (or any other action) later.
+func TestApproveExecution_RotatesApprovalToken(t *testing.T) {
+	ctx := context.Background()
+	manager, store, sender := newApproveManager(t)
+
+	execution := &config.PurchaseExecution{
+		ExecutionID:   "exec-rotate",
+		PlanID:        "plan-rotate",
+		Status:        "pending",
+		ApprovalToken: "pre-rotate-token",
+	}
+	updated := &config.PurchaseExecution{
+		ExecutionID:   "exec-rotate",
+		PlanID:        "plan-rotate",
+		Status:        "approved",
+		ApprovalToken: "pre-rotate-token",
+	}
+
+	store.On("GetExecutionByID", ctx, "exec-rotate").Return(execution, nil)
+	store.On("TransitionExecutionStatus", ctx, "exec-rotate", approveFromStatuses, "approved").Return(updated, nil)
+	stubExecuteChain(t, store, sender, "plan-rotate")
+
+	err := manager.ApproveExecution(ctx, "exec-rotate", "pre-rotate-token", "")
+	require.NoError(t, err)
+
+	// After approve, the token on the persisted execution must be empty.
+	// stubExecuteChain registers SavePurchaseExecution with
+	// mock.AnythingOfType so it consumes the rotation call too.
+	// Verify directly on the struct: rotateApprovalToken fetches by ID
+	// (returns the same pointer) and clears ApprovalToken on it.
+	assert.Equal(t, "", execution.ApprovalToken, "ApprovalToken must be cleared after successful approve")
+	assert.Nil(t, execution.ApprovalTokenExpiresAt, "ApprovalTokenExpiresAt must be nil after rotation")
+}
+
+// TestRotateApprovalToken_PersistsEmpty is a unit test for rotateApprovalToken
+// that verifies the helper clears both ApprovalToken and ApprovalTokenExpiresAt
+// on the persisted row.
+func TestRotateApprovalToken_PersistsEmpty(t *testing.T) {
+	ctx := context.Background()
+	manager, store, _ := newApproveManager(t)
+
+	future := time.Now().Add(24 * time.Hour)
+	execution := &config.PurchaseExecution{
+		ExecutionID:            "exec-tok-clear",
+		Status:                 "completed",
+		ApprovalToken:          "some-token",
+		ApprovalTokenExpiresAt: &future,
+	}
+	store.On("GetExecutionByID", ctx, "exec-tok-clear").Return(execution, nil)
+	store.On("SavePurchaseExecution", ctx, mock.MatchedBy(func(e *config.PurchaseExecution) bool {
+		return e.ExecutionID == "exec-tok-clear" && e.ApprovalToken == "" && e.ApprovalTokenExpiresAt == nil
+	})).Return(nil)
+
+	err := manager.rotateApprovalToken(ctx, "exec-tok-clear")
+	require.NoError(t, err)
 	store.AssertExpectations(t)
 }

--- a/internal/purchase/approvals_test.go
+++ b/internal/purchase/approvals_test.go
@@ -769,7 +769,7 @@ func TestApproveExecution_RotatesApprovalToken(t *testing.T) {
 	}
 
 	store.On("GetExecutionByID", ctx, "exec-rotate").Return(execution, nil)
-	store.On("TransitionExecutionStatus", ctx, "exec-rotate", approveFromStatuses, "approved").Return(updated, nil)
+	store.On("TransitionExecutionStatus", ctx, "exec-rotate", approveFromStatuses, "approved", (*string)(nil)).Return(updated, nil)
 	stubExecuteChain(t, store, sender, "plan-rotate")
 
 	err := manager.ApproveExecution(ctx, "exec-rotate", "pre-rotate-token", "")

--- a/internal/purchase/approvals_test.go
+++ b/internal/purchase/approvals_test.go
@@ -748,9 +748,10 @@ func TestManager_CancelExecution_ExpiredToken(t *testing.T) {
 // Finding #1: Token rotation on approve/cancel
 // ---------------------------------------------------------------------------
 
-// TestApproveExecution_RotatesApprovalToken verifies that after a successful
-// approve the ApprovalToken is cleared to prevent the same token from being
-// used to trigger a revoke (or any other action) later.
+// TestApproveExecution_MintsRevocationToken verifies that after a successful
+// approve a FRESH revocation token is minted (not cleared), so the consumed
+// approval token can no longer trigger a revoke while the executed-notification
+// email carries a valid revoke-capable token.
 func TestApproveExecution_MintsRevocationToken(t *testing.T) {
 	ctx := context.Background()
 	manager, store, sender := newApproveManager(t)

--- a/internal/purchase/approvals_test.go
+++ b/internal/purchase/approvals_test.go
@@ -751,7 +751,7 @@ func TestManager_CancelExecution_ExpiredToken(t *testing.T) {
 // TestApproveExecution_RotatesApprovalToken verifies that after a successful
 // approve the ApprovalToken is cleared to prevent the same token from being
 // used to trigger a revoke (or any other action) later.
-func TestApproveExecution_RotatesApprovalToken(t *testing.T) {
+func TestApproveExecution_MintsRevocationToken(t *testing.T) {
 	ctx := context.Background()
 	manager, store, sender := newApproveManager(t)
 
@@ -768,6 +768,10 @@ func TestApproveExecution_RotatesApprovalToken(t *testing.T) {
 		ApprovalToken: "pre-rotate-token",
 	}
 
+	// GetExecutionByID is called twice: once in ApproveExecution itself and
+	// once inside mintRevocationToken (the rotation step). Both return the
+	// same pointer so mintRevocationToken's field mutations are visible after
+	// the call.
 	store.On("GetExecutionByID", ctx, "exec-rotate").Return(execution, nil)
 	store.On("TransitionExecutionStatus", ctx, "exec-rotate", approveFromStatuses, "approved", (*string)(nil)).Return(updated, nil)
 	stubExecuteChain(t, store, sender, "plan-rotate")
@@ -775,26 +779,32 @@ func TestApproveExecution_RotatesApprovalToken(t *testing.T) {
 	err := manager.ApproveExecution(ctx, "exec-rotate", "pre-rotate-token", "")
 	require.NoError(t, err)
 
-	// After approve, the token on the persisted execution must be empty.
-	// stubExecuteChain registers SavePurchaseExecution with
-	// mock.AnythingOfType so it consumes the rotation call too.
-	// Verify directly on the struct: rotateApprovalToken fetches by ID
-	// (returns the same pointer) and clears ApprovalToken on it.
-	assert.Equal(t, "", execution.ApprovalToken, "ApprovalToken must be cleared after successful approve")
-	assert.Nil(t, execution.ApprovalTokenExpiresAt, "ApprovalTokenExpiresAt must be nil after rotation")
+	// After approve, mintRevocationToken must have stamped a fresh token onto
+	// the execution row. The old approval token must be gone (proving the
+	// rotation happened), and the expiry must be set to the 24-hour
+	// revocation window.
+	// stubExecuteChain registers SavePurchaseExecution with AnythingOfType
+	// so it absorbs both the finalize write and the mintRevocationToken write.
+	assert.NotEmpty(t, execution.ApprovalToken,
+		"a fresh revocation token must be minted after successful approve (not cleared)")
+	assert.NotEqual(t, "pre-rotate-token", execution.ApprovalToken,
+		"fresh revocation token must differ from the consumed approval token")
+	assert.NotNil(t, execution.ApprovalTokenExpiresAt,
+		"revocation token expiry must be set to the 24-hour window")
 }
 
-// TestRotateApprovalToken_PersistsEmpty is a unit test for rotateApprovalToken
-// that verifies the helper clears both ApprovalToken and ApprovalTokenExpiresAt
-// on the persisted row.
-func TestRotateApprovalToken_PersistsEmpty(t *testing.T) {
+// TestClearApprovalToken_PersistsEmpty is a unit test for clearApprovalToken
+// (the cancel path) that verifies the helper clears both ApprovalToken and
+// ApprovalTokenExpiresAt on the persisted row. A canceled execution has no
+// valid follow-up action, so emptying the token is correct.
+func TestClearApprovalToken_PersistsEmpty(t *testing.T) {
 	ctx := context.Background()
 	manager, store, _ := newApproveManager(t)
 
 	future := time.Now().Add(24 * time.Hour)
 	execution := &config.PurchaseExecution{
 		ExecutionID:            "exec-tok-clear",
-		Status:                 "completed",
+		Status:                 "canceled",
 		ApprovalToken:          "some-token",
 		ApprovalTokenExpiresAt: &future,
 	}
@@ -803,7 +813,37 @@ func TestRotateApprovalToken_PersistsEmpty(t *testing.T) {
 		return e.ExecutionID == "exec-tok-clear" && e.ApprovalToken == "" && e.ApprovalTokenExpiresAt == nil
 	})).Return(nil)
 
-	err := manager.rotateApprovalToken(ctx, "exec-tok-clear")
+	err := manager.clearApprovalToken(ctx, "exec-tok-clear")
 	require.NoError(t, err)
 	store.AssertExpectations(t)
+}
+
+// TestMintRevocationToken_PersistsFreshToken is a unit test for
+// mintRevocationToken that verifies the helper writes a non-empty, changed
+// token with a future expiry on the persisted row.
+func TestMintRevocationToken_PersistsFreshToken(t *testing.T) {
+	ctx := context.Background()
+	manager, store, _ := newApproveManager(t)
+
+	execution := &config.PurchaseExecution{
+		ExecutionID:   "exec-mint",
+		Status:        "completed",
+		ApprovalToken: "old-approval-token",
+	}
+	store.On("GetExecutionByID", ctx, "exec-mint").Return(execution, nil)
+	store.On("SavePurchaseExecution", ctx, mock.MatchedBy(func(e *config.PurchaseExecution) bool {
+		// Fresh token must be non-empty, different from old, and expiry set.
+		return e.ExecutionID == "exec-mint" &&
+			e.ApprovalToken != "" &&
+			e.ApprovalToken != "old-approval-token" &&
+			e.ApprovalTokenExpiresAt != nil
+	})).Return(nil)
+
+	err := manager.mintRevocationToken(ctx, "exec-mint")
+	require.NoError(t, err)
+	store.AssertExpectations(t)
+	// Confirm the in-memory struct was mutated (used by the handler's re-fetch).
+	assert.NotEmpty(t, execution.ApprovalToken)
+	assert.NotEqual(t, "old-approval-token", execution.ApprovalToken)
+	assert.NotNil(t, execution.ApprovalTokenExpiresAt)
 }

--- a/internal/purchase/coverage_extra_test.go
+++ b/internal/purchase/coverage_extra_test.go
@@ -354,9 +354,9 @@ func TestProcessMessage_ApproveHappyPath(t *testing.T) {
 	}
 	account := &config.CloudAccount{ID: accountID, ContactEmail: "owner@example.com"}
 
-	// verifyAsyncApprovalActor + ApproveExecution both load the
-	// execution; mock returns it twice.
-	mockStore.On("GetExecutionByID", ctx, "exec-appv").Return(exec, nil).Twice()
+	// verifyAsyncApprovalActor + ApproveExecution both load the execution;
+	// rotateApprovalToken adds a third fetch after the successful approve.
+	mockStore.On("GetExecutionByID", ctx, "exec-appv").Return(exec, nil).Times(3)
 	mockStore.On("GetCloudAccount", ctx, accountID).Return(account, nil)
 	// Atomic approve transition (issue #372 fix).
 	mockStore.On("TransitionExecutionStatus", ctx, "exec-appv", []string{"pending", "notified"}, "approved", (*string)(nil)).Return(approved, nil)
@@ -398,9 +398,9 @@ func TestProcessMessage_CancelHappyPath(t *testing.T) {
 	}
 	account := &config.CloudAccount{ID: accountID, ContactEmail: "owner@example.com"}
 
-	// verifyAsyncApprovalActor + CancelExecution both load the
-	// execution; mock returns it twice.
-	mockStore.On("GetExecutionByID", ctx, "exec-cancel").Return(exec, nil).Twice()
+	// verifyAsyncApprovalActor + CancelExecution + rotateApprovalToken all
+	// load the execution; mock returns it three times.
+	mockStore.On("GetExecutionByID", ctx, "exec-cancel").Return(exec, nil).Times(3)
 	mockStore.On("GetCloudAccount", ctx, accountID).Return(account, nil)
 	// CancelExecutionAtomic is called inside WithTx (nil tx sentinel in
 	// tests); actor_email is non-empty so cancelledBy is non-nil.
@@ -410,6 +410,8 @@ func TestProcessMessage_CancelHappyPath(t *testing.T) {
 	// Suppression cleanup must follow a successful atomic cancel.
 	mockStore.On("DeleteSuppressionsByExecutionTx", ctx, mock.Anything, "exec-cancel").
 		Return(nil)
+	// Token rotation after successful cancel.
+	mockStore.On("SavePurchaseExecution", ctx, mock.AnythingOfType("*config.PurchaseExecution")).Return(nil)
 
 	manager := &Manager{
 		config:       mockStore,

--- a/internal/purchase/messages.go
+++ b/internal/purchase/messages.go
@@ -2,6 +2,7 @@ package purchase
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/json"
 	"errors"
@@ -209,7 +210,9 @@ func (m *Manager) loadAsyncExecutionForApproval(ctx context.Context, msg *AsyncM
 	if execution.ApprovalToken == "" || msg.Token == "" {
 		return nil, fmt.Errorf("invalid approval token")
 	}
-	if subtle.ConstantTimeCompare([]byte(execution.ApprovalToken), []byte(msg.Token)) != 1 {
+	storedHash := sha256.Sum256([]byte(execution.ApprovalToken))
+	userHash := sha256.Sum256([]byte(msg.Token))
+	if subtle.ConstantTimeCompare(storedHash[:], userHash[:]) != 1 {
 		return nil, fmt.Errorf("invalid approval token")
 	}
 	return execution, nil

--- a/internal/purchase/mocks_test.go
+++ b/internal/purchase/mocks_test.go
@@ -228,8 +228,9 @@ func (m *MockEmailSender) SendPurchaseApprovalRequest(ctx context.Context, data 
 func (m *MockEmailSender) SendPurchaseScheduledNotification(_ context.Context, _ email.NotificationData) error {
 	return nil
 }
-func (m *MockEmailSender) SendPurchaseExecutedNotification(_ context.Context, _ email.NotificationData) error {
-	return nil
+func (m *MockEmailSender) SendPurchaseExecutedNotification(ctx context.Context, data email.NotificationData) error {
+	args := m.Called(ctx, data)
+	return args.Error(0)
 }
 func (m *MockEmailSender) SendRegistrationReceivedNotification(_ context.Context, _ email.RegistrationNotificationData) error {
 	return nil

--- a/internal/purchase/mocks_test.go
+++ b/internal/purchase/mocks_test.go
@@ -228,6 +228,9 @@ func (m *MockEmailSender) SendPurchaseApprovalRequest(ctx context.Context, data 
 func (m *MockEmailSender) SendPurchaseScheduledNotification(_ context.Context, _ email.NotificationData) error {
 	return nil
 }
+func (m *MockEmailSender) SendPurchaseExecutedNotification(_ context.Context, _ email.NotificationData) error {
+	return nil
+}
 func (m *MockEmailSender) SendRegistrationReceivedNotification(_ context.Context, _ email.RegistrationNotificationData) error {
 	return nil
 }

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -109,8 +109,9 @@ func (m *MockEmailSender) SendPurchaseApprovalRequest(ctx context.Context, data 
 func (m *MockEmailSender) SendPurchaseScheduledNotification(_ context.Context, _ email.NotificationData) error {
 	return nil
 }
-func (m *MockEmailSender) SendPurchaseExecutedNotification(_ context.Context, _ email.NotificationData) error {
-	return nil
+func (m *MockEmailSender) SendPurchaseExecutedNotification(ctx context.Context, data email.NotificationData) error {
+	args := m.Called(ctx, data)
+	return args.Error(0)
 }
 func (m *MockEmailSender) SendRegistrationReceivedNotification(_ context.Context, _ email.RegistrationNotificationData) error {
 	return nil

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -109,6 +109,9 @@ func (m *MockEmailSender) SendPurchaseApprovalRequest(ctx context.Context, data 
 func (m *MockEmailSender) SendPurchaseScheduledNotification(_ context.Context, _ email.NotificationData) error {
 	return nil
 }
+func (m *MockEmailSender) SendPurchaseExecutedNotification(_ context.Context, _ email.NotificationData) error {
+	return nil
+}
 func (m *MockEmailSender) SendRegistrationReceivedNotification(_ context.Context, _ email.RegistrationNotificationData) error {
 	return nil
 }

--- a/internal/server/app_test.go
+++ b/internal/server/app_test.go
@@ -313,6 +313,9 @@ func (n *noopEmailSender) SendPurchaseApprovalRequest(ctx context.Context, data 
 func (n *noopEmailSender) SendPurchaseScheduledNotification(_ context.Context, _ email.NotificationData) error {
 	return nil
 }
+func (n *noopEmailSender) SendPurchaseExecutedNotification(_ context.Context, _ email.NotificationData) error {
+	return nil
+}
 func (n *noopEmailSender) SendRegistrationReceivedNotification(_ context.Context, _ email.RegistrationNotificationData) error {
 	return nil
 }

--- a/internal/server/handler_ri_exchange_test.go
+++ b/internal/server/handler_ri_exchange_test.go
@@ -892,6 +892,10 @@ func (m *mockEmailSender) SendRIExchangeCompleted(ctx context.Context, data emai
 	return nil
 }
 
+func (m *mockEmailSender) SendPurchaseExecutedNotification(_ context.Context, _ email.NotificationData) error {
+	return nil
+}
+
 func (m *mockEmailSender) SendRegistrationReceivedNotification(_ context.Context, _ email.RegistrationNotificationData) error {
 	return nil
 }

--- a/internal/server/test_helpers_test.go
+++ b/internal/server/test_helpers_test.go
@@ -129,6 +129,10 @@ func (m *mockConfigStoreForHealth) TransitionExecutionStatus(ctx context.Context
 	return nil, nil
 }
 
+func (m *mockConfigStoreForHealth) SetCancelledBy(_ context.Context, _ string, _ string) error {
+	return nil
+}
+
 func (m *mockConfigStoreForHealth) CancelExecutionAtomic(ctx context.Context, tx pgx.Tx, executionID string, cancelledBy *string) (bool, string, error) {
 	return false, "", nil
 }


### PR DESCRIPTION
## Summary

- After a purchase execution completes (both session-RBAC and token approval paths), send a post-execution notification email to: global `notification_email`, per-account `contact_email`(s), and the requester's email. Recipients are deduplicated; first contact is To, rest are Cc.
- The email includes purchase details and a one-click "Revoke this purchase" button backed by the existing `approval_token` (a dedicated revocation token column is deferred to the sibling AWS RI/SP revocation-via-support-case issue).
- New `AuthPublic` route `GET/POST /api/purchases/revoke/{id}?token=...` validates the token with `crypto/subtle.ConstantTimeCompare` (timing-safe) and records `revocation_requested` status. Session-authed users with `cancel-any` or `cancel-own` permission can also revoke without a token (same three-mode dispatch as approve/cancel).

## Test plan

- [x] `TestHandler_revokePurchase_ValidToken` - valid token path resolves to `revocation_requested`
- [x] `TestHandler_revokePurchase_InvalidToken` - wrong token returns 403
- [x] `TestHandler_revokePurchase_PendingExecution` - pending purchase returns 409 directing to Cancel
- [x] `TestHandler_revokePurchase_NotFound` - missing execution returns 404
- [x] `TestResolveExecutedNotificationRecipients_*` - four dedup/fallback scenarios covered
- [x] Full test suite: 4974 passed, 0 failed across 38 packages
- [x] PII-safe logging: recipient count only, no raw email addresses in logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add purchase revocation for completed transactions (session or token-based) and public token endpoints for one-click revokes.
  * Send post-execution notification emails with execution details and one-click revocation links; recipients include global contacts, account contacts, and requester (deduped).

* **Tests**
  * Expanded coverage for revocation flows, token/expiry cases, recipient selection, and a concurrency regression to prevent lost updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->