### PR TITLE
fix(auth/users): persist email change in admin update path (closes #892)

### DIFF
--- a/internal/auth/service_api.go
+++ b/internal/auth/service_api.go
@@ -231,6 +231,14 @@ func (s *Service) UpdateUserAPI(ctx context.Context, userID string, reqInterface
 	if req.Role != "" {
 		authReq.Role = &req.Role
 	}
+	// Wire email through so admins can edit other users' email addresses.
+	// Before #892 this field was silently dropped: the API accepted email
+	// in the JSON, the handler returned 200, and the user's email column
+	// was never touched, producing a false-positive success toast and
+	// (worst case) a sign-in lockout once the user lost the old address.
+	if req.Email != "" {
+		authReq.Email = &req.Email
+	}
 	user, err := s.UpdateUser(ctx, userID, authReq)
 	if err != nil {
 		return nil, err

--- a/internal/auth/service_api_test.go
+++ b/internal/auth/service_api_test.go
@@ -210,6 +210,80 @@ func TestService_UpdateUserAPI(t *testing.T) {
 		mockStore.AssertExpectations(t)
 	})
 
+	// Regression for issue #892: before the fix, UpdateUserAPI dropped
+	// req.Email on the floor; the API would return 200, the success
+	// toast would fire, but the users.email column was never touched. We
+	// assert that (a) the email-uniqueness lookup happens (proves the
+	// admin path runs the same validation as self-edit), and (b) the
+	// user persisted via store.UpdateUser carries the new email value,
+	// NOT just that the call succeeded.
+	t.Run("successful email update persists to store", func(t *testing.T) {
+		mockStore := new(MockStore)
+		mockEmail := new(MockEmailSender)
+		service := createTestService(mockStore, mockEmail)
+
+		existingUser := &User{
+			ID:    "user-123",
+			Email: "old@example.com",
+			Role:  RoleAdmin,
+		}
+
+		mockStore.On("GetUserByID", ctx, "user-123").Return(existingUser, nil).Once()
+		// Uniqueness check: new email not yet in use.
+		mockStore.On("GetUserByEmail", ctx, "new@example.com").Return(nil, nil).Once()
+		// Capture the User passed to UpdateUser and assert its email is
+		// the NEW one. Without the fix, this fails because the User would
+		// still carry old@example.com.
+		mockStore.On("UpdateUser", ctx, mock.MatchedBy(func(u *User) bool {
+			return u != nil && u.ID == "user-123" && u.Email == "new@example.com"
+		})).Return(nil).Once()
+
+		req := APIUpdateUserRequest{
+			Email: "new@example.com",
+		}
+
+		result, err := service.UpdateUserAPI(ctx, "user-123", req)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		apiUser, ok := result.(*APIUser)
+		require.True(t, ok)
+		assert.Equal(t, "new@example.com", apiUser.Email,
+			"returned APIUser must reflect the new email; the frontend's success toast keys off this response")
+
+		mockStore.AssertExpectations(t)
+	})
+
+	t.Run("email update rejects duplicate address", func(t *testing.T) {
+		mockStore := new(MockStore)
+		mockEmail := new(MockEmailSender)
+		service := createTestService(mockStore, mockEmail)
+
+		existingUser := &User{
+			ID:    "user-123",
+			Email: "old@example.com",
+			Role:  RoleAdmin,
+		}
+		conflictingUser := &User{
+			ID:    "user-456",
+			Email: "taken@example.com",
+		}
+
+		mockStore.On("GetUserByID", ctx, "user-123").Return(existingUser, nil).Once()
+		mockStore.On("GetUserByEmail", ctx, "taken@example.com").Return(conflictingUser, nil).Once()
+
+		req := APIUpdateUserRequest{
+			Email: "taken@example.com",
+		}
+
+		result, err := service.UpdateUserAPI(ctx, "user-123", req)
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "email already in use")
+
+		mockStore.AssertExpectations(t)
+	})
+
 	t.Run("invalid request type", func(t *testing.T) {
 		mockStore := new(MockStore)
 		mockEmail := new(MockEmailSender)

--- a/internal/auth/service_user.go
+++ b/internal/auth/service_user.go
@@ -290,6 +290,16 @@ func (s *Service) UpdateUser(ctx context.Context, userID string, req UpdateUserR
 		return nil, err
 	}
 
+	// Email is mutated through updateUserEmail rather than applyUpdateUserRequest
+	// because it requires a DB lookup (uniqueness check) and format validation
+	// (same rules as the self-edit profile path; see updateUserEmail and #868
+	// for the TLD constraint). Issue #892.
+	if req.Email != nil {
+		if err := s.updateUserEmail(ctx, user, *req.Email); err != nil {
+			return nil, err
+		}
+	}
+
 	if err := s.store.UpdateUser(ctx, user); err != nil {
 		return nil, fmt.Errorf("failed to update user: %w", err)
 	}

--- a/internal/auth/types.go
+++ b/internal/auth/types.go
@@ -235,8 +235,15 @@ type CreateUserRequest struct {
 	GroupIDs []string `json:"group_ids,omitempty"`
 }
 
-// UpdateUserRequest for updating user details
+// UpdateUserRequest for updating user details.
+//
+// Email is a pointer so callers can distinguish "not sending email" (nil)
+// from "explicitly setting email to a new value". This matters because the
+// service layer applies email changes via updateUserEmail, which performs
+// format validation and uniqueness checks that must NOT run on no-op
+// updates that only touch role/groups/active.
 type UpdateUserRequest struct {
+	Email    *string  `json:"email,omitempty"`
 	Role     *string  `json:"role,omitempty"`
 	GroupIDs []string `json:"group_ids,omitempty"`
 	Active   *bool    `json:"active,omitempty"`


### PR DESCRIPTION
## Summary

Fixes #892. Editing another user's email via the admin Users page reported success but never persisted the change — the new email was silently dropped on the service-layer boundary, so the user remained signed in (or locked out) with the old address.

## Root cause

`internal/auth/service_api.go:222-239`. `Service.UpdateUserAPI` built an internal `UpdateUserRequest` from the API payload but only copied `Role` and `Groups`. `req.Email` was read off the JSON (it's a real field on `APIUpdateUserRequest`), then thrown away. Downstream `Service.UpdateUser` fetched the existing user and called `store.UpdateUser` with the unchanged `user.Email` value, so the SQL `UPDATE users SET email = $2 ...` wrote the OLD email back. The handler returned 200, the frontend's success toast fired, the database row was unchanged.

## Why the toast lied

The frontend's `updateUser` (`frontend/src/api/users.ts:48`) keys success off HTTP 200. The backend returned 200 with the (unchanged) `APIUser` JSON. Without a per-field comparison against the request, the frontend has no way to detect that the server silently ignored a field — and there's no good reason it should need to. The contract has to hold server-side.

## Why existing tests didn't catch it

`TestService_UpdateUserAPI/successful user update` (service_api_test.go:183) exercised only `Role` and `Groups`. No prior test passed `Email:` in an `APIUpdateUserRequest`, so the silent drop was never observed.

## Fix shape

Minimal: wire the field through the layer that was dropping it. Reuses the existing `s.updateUserEmail` helper (already used by the self-edit profile path at `service_user.go:376`), which performs format validation (TLD constraint per #868) and uniqueness check. No duplication, no new validation logic.

- `internal/auth/types.go`: add `Email *string` to `UpdateUserRequest` (pointer matches the `Role *string` pattern so callers can distinguish "not sending" from "sending empty").
- `internal/auth/service_api.go`: copy `req.Email` into `authReq.Email` when non-empty.
- `internal/auth/service_user.go`: call `s.updateUserEmail` in `UpdateUser` when `req.Email != nil`.

`mapAuthError` already maps `ErrInvalidEmail` → 400 and `ErrEmailInUse` → 409, so error surfacing is correct for free.

## Regression test

`TestService_UpdateUserAPI` gains two subtests:

- `successful email update persists to store` — assertion on the `User` captured by `store.UpdateUser` (must carry the NEW email), not on the HTTP status. Without the fix, this subtest fails because the captured `User` still carries the old email.
- `email update rejects duplicate address` — asserts the uniqueness check surfaces `ErrEmailInUse` (handler maps to 409).

Stash-verified: both subtests fail against pre-fix code, pass with fix applied. The pre-existing role-only subtest is unchanged and still passes.

## Test plan

- [x] `gofmt -l internal/auth/` (clean)
- [x] `go vet ./internal/auth/...` (clean)
- [x] `go build ./...` (clean)
- [x] `go test ./internal/auth/... ./internal/api/... -count=1` (1854 pass)
- [x] Stash-verified the regression test fails on pre-fix code and passes with fix.
- [ ] Post-merge: manual smoke via admin UI — edit another user's email, confirm DB row updated and the user can sign in with the new address.

## Scope discipline

Only the admin email-edit path is touched. `UpdateUserProfile` (self-edit) is unchanged — already worked. No drive-by refactors. Other update paths (`Active`, `Role`) keep their existing semantics.

closes #892
