### PR TITLE
fix(inventory+history): address post-merge CR findings on #792 (closes #896)

### DIFF
--- a/frontend/src/history.ts
+++ b/frontend/src/history.ts
@@ -210,18 +210,19 @@ export async function loadHistory(): Promise<void> {
   // Issue #344 T3: skeleton rows for the purchase-history table. 8
   // rows matches the typical first-page row count so the skeleton
   // doesn't shrink dramatically when real data arrives. Column count
-  // (11) mirrors the rendered table headers in renderHistoryList:
+  // (12) mirrors the rendered table headers in renderHistoryList:
   // Status / Date / Provider / Service / Type / Region / Count /
-  // Term / Upfront Cost / Monthly Savings / Plan.
+  // Term / Upfront Cost / Monthly Cost / Monthly Savings / Plan.
   const listEl = document.getElementById('history-list');
-  if (listEl) showSkeletonRows(listEl, 8, 11);
-  // Pending-approval queue card (issue #340 sub-task): 3 rows x 8
-  // cols matches the queue table shape (Date / Provider / Service /
-  // Count / Upfront / Monthly Savings / Created by / Actions). The
-  // queue is typically much shorter than the full history list, so
-  // 3 rows is a sensible skeleton size.
+  if (listEl) showSkeletonRows(listEl, 8, 12);
+  // Pending-approval queue card (issue #340 sub-task): 3 rows x 12
+  // cols matches the queue table shape (Date / Account / Provider /
+  // Service / Count / Term / Payment / Monthly Cost / Upfront Cost /
+  // Monthly Savings / Created by / Actions). The queue is typically
+  // much shorter than the full history list, so 3 rows is a sensible
+  // skeleton size.
   const queueEl = document.getElementById('purchases-approval-queue');
-  if (queueEl) showSkeletonRows(queueEl, 3, 8);
+  if (queueEl) showSkeletonRows(queueEl, 3, 12);
 
   try {
     // Provider/account filters live in state.ts now (mutated by topbar chips).

--- a/frontend/src/inventory.ts
+++ b/frontend/src/inventory.ts
@@ -110,7 +110,7 @@ export async function loadActiveCommitments(): Promise<void> {
   // account chip is single-select; forward only when exactly one is active.
   const accountID = accountIDs.length === 1 ? accountIDs[0] : undefined;
 
-  // 5 rows × 10 cols matches the rendered table shape (see
+  // 5 rows × 11 cols matches the rendered table shape (see
   // renderActiveCommitmentsTable). The renderer wipes the container's
   // children for a clean handoff from the skeleton.
   showSkeletonRows(container, 5, ACTIVE_COMMITMENTS_COLS);


### PR DESCRIPTION
## Summary

Follow-up to #792: CodeRabbit posted a substantive review on #792 about an hour after the PR was merged, so the findings could not be addressed in-PR. This PR applies the three valid findings.

Closes #896.

## Findings + disposition

All three findings re-verified against the post-merge tip of `feat/multicloud-web-frontend` and still present.

| # | Location | Finding | Disposition |
|---|----------|---------|-------------|
| 1 | `frontend/src/history.ts:217` | `showSkeletonRows(listEl, 8, 11)` — purchase-history table now renders 12 `<th>` (`Status / Date / Provider / Service / Type / Region / Count / Term / Upfront Cost / Monthly Cost / Monthly Savings / Plan`). Comment lines 213-215 also out of sync. | Fixed: 11 → 12 + comment updated |
| 2 | `frontend/src/history.ts:224` | `showSkeletonRows(queueEl, 3, 8)` — approval queue table now renders 12 `<th>` (`Date / Account / Provider / Service / Count / Term / Payment / Monthly Cost / Upfront Cost / Monthly Savings / Created by / Actions`). Comment lines 218-222 also out of sync. | Fixed: 8 → 12 + comment updated |
| 3 | `frontend/src/inventory.ts:86` | Comment says "5 rows × 10 cols" but `ACTIVE_COMMITMENTS_COLS = 11` (line 72) after #792 added "Monthly savings". Runtime is already correct (call site uses the constant); comment is the only thing stale. | Fixed: comment 10 → 11 |

None of the findings were dismissed as stale or out-of-scope. No new follow-up issues were filed (the review surfaced no architectural concerns beyond the column-count mismatches).

## Verification

```
cd frontend
npx jest --testPathPattern='(inventory|history)'   # 10 suites / 202 tests passing
npx tsc --noEmit                                   # no errors
```

The renderer's runtime behaviour is unchanged — these are skeleton placeholder column counts (cosmetic, pre-data), and tests don't assert the skeleton cell count, so no test changes are required.

## Test plan

- [x] `npx jest --testPathPattern='(inventory|history)'` green (10 suites / 202 tests)
- [x] `npx tsc --noEmit` clean
- [x] Cross-checked all three skeleton call sites against the rendered `<th>` lists in `renderHistoryList`, the pending-approval queue (`history.ts:946-959`), and `renderActiveCommitmentsTable`'s `headers` array (`inventory.ts:156`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed skeleton loading display for history tables to show correct column count.
  * Fixed pending-approval-queue skeleton to display correct number of columns during loading.

* **Documentation**
  * Updated internal documentation to accurately reflect table structure specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->