### PR TITLE
feat(ui/opportunities): expose AWS recommendation lookback selector (closes #909)

### DIFF
--- a/frontend/src/__tests__/recommendations-lookback.test.ts
+++ b/frontend/src/__tests__/recommendations-lookback.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Issue #909: Opportunities lookback selector tests.
+ *
+ * Verifies:
+ *   - the 7/30/60-day selector prefills from /api/config
+ *   - admin sees an editable control with the AWS-scope tooltip
+ *   - non-admin (user / readonly) sees the control disabled with the
+ *     no-permission tooltip (backend stays authoritative)
+ *   - changing the value persists the full config (override only the
+ *     lookback, not wiping other fields), triggers a recommendations
+ *     refresh, and reloads the list
+ *   - a persist failure toasts the error and reverts the selector
+ *   - a tampered/out-of-range value is rejected client-side
+ */
+import {
+  loadRecommendations,
+  resetCachedGlobalConfig,
+  resetAutoRefreshInFlight,
+} from '../recommendations';
+import * as api from '../api';
+import { refreshRecommendations as refreshRecsAPI } from '../api/recommendations';
+import { showToast } from '../toast';
+
+jest.mock('../api', () => ({
+  getRecommendations: jest.fn().mockResolvedValue({ summary: {}, recommendations: [], regions: [] }),
+  refreshRecommendations: jest.fn(),
+  getConfig: jest.fn(),
+  updateConfig: jest.fn().mockResolvedValue({}),
+  listAccounts: jest.fn().mockResolvedValue([]),
+  listAccountServiceOverrides: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('../api/recommendations', () => ({
+  getRecommendationsFreshness: jest.fn().mockResolvedValue({
+    // Fresh (within the 24h budget) so the auto-refresh-on-open path does
+    // not fire and interfere with the explicit change-driven refresh.
+    last_collected_at: new Date().toISOString(),
+    last_collection_error: null,
+  }),
+  refreshRecommendations: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock('../state', () => ({
+  getCurrentProvider: jest.fn().mockReturnValue('all'),
+  setCurrentProvider: jest.fn(),
+  getCurrentAccountIDs: jest.fn().mockReturnValue([]),
+  setCurrentAccountIDs: jest.fn(),
+  getRecommendations: jest.fn().mockReturnValue([]),
+  getRecommendationByID: jest.fn().mockReturnValue(undefined),
+  setRecommendations: jest.fn(),
+  getSelectedRecommendationIDs: jest.fn().mockReturnValue(new Set()),
+  clearSelectedRecommendations: jest.fn(),
+  addSelectedRecommendation: jest.fn(),
+  removeSelectedRecommendation: jest.fn(),
+  getRecommendationsSort: jest.fn().mockReturnValue({ column: 'savings', direction: 'desc' }),
+  setRecommendationsSort: jest.fn(),
+  getRecommendationsColumnFilters: jest.fn().mockReturnValue({}),
+  setRecommendationsColumnFilter: jest.fn(),
+  clearAllRecommendationsColumnFilters: jest.fn(),
+  getVisibleRecommendations: jest.fn().mockReturnValue([]),
+  setVisibleRecommendations: jest.fn(),
+  getCostPeriod: jest.fn().mockReturnValue('monthly'),
+  setCostPeriod: jest.fn(),
+  getHiddenColumns: jest.fn().mockReturnValue(new Set()),
+  setHiddenColumns: jest.fn(),
+  getCurrentUser: jest.fn(),
+}));
+
+jest.mock('../toast', () => ({
+  showToast: jest.fn().mockReturnValue({ dismiss: jest.fn() }),
+}));
+
+import * as state from '../state';
+
+const mockUser = (role: string | null) => {
+  (state.getCurrentUser as jest.Mock).mockReturnValue(
+    role === null ? null : { id: 'u', email: 'u@example.com', role },
+  );
+};
+
+const setupDom = () => {
+  const recsTab = document.createElement('div');
+  recsTab.id = 'opportunities-tab';
+  recsTab.className = 'tab-content active';
+  const summary = document.createElement('div');
+  summary.id = 'recommendations-summary';
+  const toolbar = document.createElement('div');
+  toolbar.id = 'recommendations-toolbar';
+  toolbar.className = 'recommendations-toolbar';
+  const list = document.createElement('div');
+  list.id = 'recommendations-list';
+  recsTab.append(summary, toolbar, list);
+  document.body.replaceChildren(recsTab);
+};
+
+const getSelect = () => document.getElementById('recs-lookback-days') as HTMLSelectElement | null;
+
+// A realistic full GlobalConfig so we can assert the change handler does
+// not wipe sibling fields when it round-trips the config on save.
+const baseConfig = {
+  enabled_providers: ['aws', 'azure', 'gcp'],
+  default_term: 3,
+  default_payment: 'all-upfront',
+  default_coverage: 80,
+  auto_collect: true,
+  collection_schedule: 'daily',
+  notification_days_before: 7,
+  recommendations_cache_stale_hours: 24,
+  recommendations_lookback_days: 30,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  resetCachedGlobalConfig();
+  resetAutoRefreshInFlight();
+  setupDom();
+  (api.getConfig as jest.Mock).mockResolvedValue({ global: baseConfig });
+});
+
+describe('Opportunities lookback selector (issue #909)', () => {
+  test('prefills the selector from the current config value', async () => {
+    mockUser('admin');
+    await loadRecommendations();
+    const select = getSelect();
+    expect(select).not.toBeNull();
+    expect(select!.value).toBe('30');
+    // All three accepted enum options present.
+    expect([...select!.options].map(o => o.value)).toEqual(['7', '30', '60']);
+  });
+
+  test('defaults to 7 when the config omits the lookback field', async () => {
+    mockUser('admin');
+    (api.getConfig as jest.Mock).mockResolvedValue({ global: { enabled_providers: ['aws'] } });
+    await loadRecommendations();
+    expect(getSelect()!.value).toBe('7');
+  });
+
+  test('admin sees an enabled control with the AWS-scope tooltip', async () => {
+    mockUser('admin');
+    await loadRecommendations();
+    const select = getSelect()!;
+    expect(select.disabled).toBe(false);
+    const tip = document.querySelector('#recommendations-toolbar .tooltip-text')!;
+    expect(tip.textContent).toContain('AWS recommendations only');
+    expect(tip.textContent).toContain('Azure and GCP are unaffected');
+  });
+
+  test.each(['user', 'readonly', null])('non-admin (%s) sees a disabled control with a permission tooltip', async (role) => {
+    mockUser(role);
+    await loadRecommendations();
+    const select = getSelect()!;
+    expect(select.disabled).toBe(true);
+    const tip = document.querySelector('#recommendations-toolbar .tooltip-text')!;
+    expect(tip.textContent).toContain('admin');
+  });
+
+  test('changing the value persists the full config (override only lookback) and refreshes', async () => {
+    mockUser('admin');
+    await loadRecommendations();
+    const select = getSelect()!;
+
+    select.value = '60';
+    select.dispatchEvent(new Event('change'));
+    // Let the async change handler settle (persist + refresh + reload).
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(api.updateConfig).toHaveBeenCalledTimes(1);
+    const sent = (api.updateConfig as jest.Mock).mock.calls[0][0];
+    expect(sent.recommendations_lookback_days).toBe(60);
+    // Sibling fields preserved -- a partial PUT would have wiped these.
+    expect(sent.enabled_providers).toEqual(['aws', 'azure', 'gcp']);
+    expect(sent.default_term).toBe(3);
+    expect(sent.collection_schedule).toBe('daily');
+
+    // Re-collect triggered for the new window.
+    expect(refreshRecsAPI).toHaveBeenCalledTimes(1);
+  });
+
+  test('does nothing when the value is unchanged', async () => {
+    mockUser('admin');
+    await loadRecommendations();
+    const select = getSelect()!;
+    select.value = '30'; // same as baseConfig
+    select.dispatchEvent(new Event('change'));
+    await new Promise(r => setTimeout(r, 0));
+    expect(api.updateConfig).not.toHaveBeenCalled();
+    expect(refreshRecsAPI).not.toHaveBeenCalled();
+  });
+
+  test('persist failure toasts an error and reverts the selector', async () => {
+    mockUser('admin');
+    (api.updateConfig as jest.Mock).mockRejectedValueOnce(new Error('boom'));
+    await loadRecommendations();
+    const select = getSelect()!;
+
+    select.value = '60';
+    select.dispatchEvent(new Event('change'));
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(refreshRecsAPI).not.toHaveBeenCalled();
+    // Reverted to the last-known value, re-enabled.
+    expect(select.value).toBe('30');
+    expect(select.disabled).toBe(false);
+    const errToast = (showToast as jest.Mock).mock.calls.find(
+      (c) => c[0].kind === 'error' && /lookback/i.test(c[0].message),
+    );
+    expect(errToast).toBeTruthy();
+  });
+});

--- a/frontend/src/__tests__/recommendations-lookback.test.ts
+++ b/frontend/src/__tests__/recommendations-lookback.test.ts
@@ -208,4 +208,30 @@ describe('Opportunities lookback selector (issue #909)', () => {
     );
     expect(errToast).toBeTruthy();
   });
+
+  test.each(['999', '0', '-1', '0x3c', '7e0', '', ' 7', 'abc'])(
+    'tampered/out-of-range value "%s" is rejected client-side without persisting',
+    async (badValue) => {
+      mockUser('admin');
+      await loadRecommendations();
+      const select = getSelect()!;
+
+      // Directly invoke the change handler with an injected bad value to
+      // simulate a tampered DOM (the real <select> only exposes the three
+      // enum options, so dispatchEvent would fire the legitimate value).
+      select.value = badValue;
+      select.dispatchEvent(new Event('change'));
+      await new Promise(r => setTimeout(r, 0));
+
+      // No persist should have been attempted.
+      expect(api.updateConfig).not.toHaveBeenCalled();
+      // Selector reverted to last-known value.
+      expect(select.value).toBe('30');
+      // Error toast surfaced.
+      const errToast = (showToast as jest.Mock).mock.calls.find(
+        (c) => c[0].kind === 'error',
+      );
+      expect(errToast).toBeTruthy();
+    },
+  );
 });

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -111,6 +111,12 @@
             <!-- Opportunities Tab (renamed from Recommendations in #340) -->
             <div id="opportunities-tab" class="tab-content" role="tabpanel" aria-labelledby="opportunities-tab-btn">
                 <section id="recommendations-summary"></section>
+                <!-- Issue #909: AWS lookback selector + scope tooltip.
+                     Populated by recommendations.ts:renderLookbackToolbar on
+                     load (prefilled from /api/config; disabled for non-admin
+                     sessions). Changing it persists recommendations_lookback_days
+                     and triggers a recommendations re-collect for the new window. -->
+                <section id="recommendations-toolbar" class="recommendations-toolbar"></section>
                 <!-- Per-column header filters replace the old top filter bar.
                      The Clear-filters badge + aria-live count are injected
                      by recommendations.ts:renderFilterStatusBar above the

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -615,28 +615,36 @@ function renderLookbackToolbar(): void {
  * the error so the user never silently keeps a stale view.
  */
 async function onLookbackChange(rawValue: string): Promise<void> {
-  // feedback_strict_int_parse: reject anything that isn't a clean integer,
-  // then constrain to the accepted enum so a tampered DOM can't push an
-  // out-of-range value the backend would 400 on.
-  const parsed = Number(rawValue);
+  // feedback_strict_int_parse: reject non-decimal-integer strings (e.g.
+  // "0x3c", "7e0", " 7", "") before converting, then constrain to the
+  // accepted enum so a tampered DOM can't push an out-of-range value.
   const previous = currentLookbackDays();
   const select = document.getElementById('recs-lookback-days') as HTMLSelectElement | null;
 
-  if (!Number.isInteger(parsed) || !(LOOKBACK_OPTIONS as readonly number[]).includes(parsed)) {
+  if (!/^\d+$/.test(rawValue) || !Number.isInteger(Number(rawValue)) || !(LOOKBACK_OPTIONS as readonly number[]).includes(Number(rawValue))) {
     // toast renders via textContent, so no escaping is needed (escaping here
     // would double-encode and show literal entities).
     showToast({ message: `Invalid lookback window: ${rawValue}`, kind: 'error' });
     if (select) select.value = String(previous);
     return;
   }
+  const parsed = Number(rawValue);
   if (parsed === previous) return;
 
   // The backend config PUT preserves the two recommendation cycle-params
   // when omitted but writes every other absent field as its zero value, so
   // we must round-trip the full cached config and override only the
-  // lookback. cachedGlobalConfig is populated on load; if it is somehow
-  // absent, send a minimal valid payload that still carries the field.
-  const base = cachedGlobalConfig ?? {};
+  // lookback. Block the save if the config cache is not yet populated —
+  // falling back to {} would wipe every other global setting on the PUT.
+  if (!cachedGlobalConfig) {
+    showToast({
+      message: 'Settings are still loading. Please retry once configuration has loaded.',
+      kind: 'error',
+    });
+    if (select) select.value = String(previous);
+    return;
+  }
+  const base = cachedGlobalConfig;
   const payload: api.Config = {
     ...(base as api.Config),
     recommendations_lookback_days: parsed,

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -18,7 +18,7 @@ import {
   type Provider as CompatProvider,
 } from './lib/purchase-compatibility';
 import type { AccountServiceOverride } from './api/accounts';
-import type { RecommendationsResponse, LocalRecommendation, RecommendationsSummary } from './types';
+import type { RecommendationsResponse, LocalRecommendation, RecommendationsSummary, GlobalConfig } from './types';
 import { openModal } from './modal';
 import { showSkeletonRows, teardownSkeleton } from './lib/skeleton';
 import { canAccess } from './permissions';
@@ -96,6 +96,38 @@ export const STALE_THRESHOLD_MS = 24 * 60 * 60 * 1000; // 24 hours
 let cachedGlobalDefaultPayment: CompatPayment = 'all-upfront';
 let cachedGlobalDefaultTerm: 1 | 3 = 1;
 
+// Issue #909: the most-recent full GlobalConfig from /api/config, cached so
+// the Opportunities lookback selector can (a) prefill its value and (b)
+// round-trip the complete config on save. The backend config PUT only
+// preserves the two recommendation cycle-params when omitted; every other
+// field that is absent/zero in the request body is written as-is, so a
+// partial PUT carrying only recommendations_lookback_days would wipe
+// enabled_providers, default_term, etc. We therefore spread the cached
+// config and override just the lookback when persisting (see
+// onLookbackChange). null until the first successful load.
+let cachedGlobalConfig: GlobalConfig | null = null;
+
+// Issue #909: the AWS Cost Explorer LookbackPeriodInDays enum. The only
+// values the backend accepts; mirrors the Admin > Settings dropdown
+// (#setting-recs-lookback-days) and config.Validate() in the Go layer.
+const LOOKBACK_OPTIONS = [7, 30, 60] as const;
+const DEFAULT_LOOKBACK_DAYS = 7;
+
+// Issue #909: tooltip text for the Opportunities lookback control. The
+// provider scope was verified against the recommendation collectors on
+// origin/feat/multicloud-web-frontend: only the AWS collector
+// (scheduler.fetchAndConvert -> RecommendationParams.LookbackPeriod)
+// consumes recommendations_lookback_days. The Azure and GCP collectors
+// call GetAllRecommendations() with no lookback parameter, so the window
+// does not affect their recommendations. Keep this wording aligned with
+// the Admin help text in index.html (#purchasing-recommendations-lookback).
+const LOOKBACK_TOOLTIP =
+  'Applies to AWS recommendations only (Cost Explorer lookback window); ' +
+  'Azure and GCP are unaffected.';
+const LOOKBACK_NO_PERMISSION_TOOLTIP =
+  'Changing the lookback window requires admin (update:config) permission. ' +
+  'Ask an administrator to adjust it in Settings.';
+
 /**
  * Inject resolved GlobalConfig defaults into the module cache.
  * Exported for testing only — not part of the public API.
@@ -120,6 +152,15 @@ export function resetExpandedCells(): void {
  */
 export function resetAutoRefreshInFlight(): void {
   autoRefreshInFlight = null;
+}
+
+/**
+ * Reset the cached GlobalConfig (issue #909). Exported for testing only —
+ * not part of the public API. Call in beforeEach so lookback-selector tests
+ * start without a stale config from a prior test.
+ */
+export function resetCachedGlobalConfig(): void {
+  cachedGlobalConfig = null;
 }
 
 // populateRecommendationsAccountFilter / populateRegionFilter / the legacy
@@ -260,8 +301,23 @@ export async function triggerAutoRefreshIfStale(
 
   if (!isStale) return;
 
+  startRecommendationsRefresh(onReload);
+}
+
+/**
+ * Kick off a recommendations re-collect, surface the three-stage toast
+ * (in-flight / success / failure), and reload the page-specific UI on
+ * success. Dedups against a refresh already in flight (#284) so the
+ * stale-on-open path and the lookback-change path (#909) can never run
+ * two concurrent collects. Returns the in-flight promise (or the existing
+ * one when a refresh is already running) so callers that need to await
+ * completion — e.g. re-enabling a control — can do so.
+ */
+function startRecommendationsRefresh(
+  onReload: () => Promise<void> = loadRecommendations,
+): Promise<void> {
   // Dedup: if a refresh is already in flight, don't start a second one.
-  if (autoRefreshInFlight) return;
+  if (autoRefreshInFlight) return autoRefreshInFlight;
 
   const inFlight = showToast({
     message: 'Refreshing recommendations…',
@@ -303,6 +359,7 @@ export async function triggerAutoRefreshIfStale(
     .finally(() => {
       autoRefreshInFlight = null;
     });
+  return autoRefreshInFlight;
 }
 
 // Issue #481: URL <-> sort-state sync. State stays the source of truth;
@@ -406,6 +463,9 @@ export async function loadRecommendations(): Promise<void> {
     // Populate the module-level GlobalConfig cache (issue #223).
     if (cfgResponse?.global) {
       const g = cfgResponse.global;
+      // Issue #909: cache the full config so the lookback selector can
+      // prefill and round-trip the complete config on save.
+      cachedGlobalConfig = g;
       const t = g.default_term;
       if (t === 1 || t === 3) cachedGlobalDefaultTerm = t;
       const validPayments: CompatPayment[] = ['all-upfront', 'partial-upfront', 'no-upfront', 'monthly'];
@@ -449,6 +509,11 @@ export async function loadRecommendations(): Promise<void> {
     lastRecommendationsSummary = data.summary || {};
     renderRecommendationsList(visibleByPreference as unknown as LocalRecommendation[]);
 
+    // Issue #909: render the lookback selector + scope tooltip in the
+    // Opportunities toolbar, prefilled from the cached config and gated
+    // by the update:config permission.
+    renderLookbackToolbar();
+
     // Auto-refresh on page open (#284): check freshness and trigger an
     // async background refresh if the cache is cold or older than 24h.
     void triggerAutoRefreshIfStale();
@@ -460,6 +525,150 @@ export async function loadRecommendations(): Promise<void> {
       const err = error as Error;
       list.innerHTML = `<p class="error">Failed to load recommendations: ${escapeHtml(err.message)}</p>`;
     }
+  }
+}
+
+/**
+ * Resolve the currently-effective lookback window (days) from the cached
+ * GlobalConfig, falling back to the backend default when absent or not one
+ * of the accepted enum values. Keeping the validation here means the
+ * selector never renders a value the backend would reject.
+ */
+function currentLookbackDays(): number {
+  const raw = cachedGlobalConfig?.recommendations_lookback_days;
+  return typeof raw === 'number' && (LOOKBACK_OPTIONS as readonly number[]).includes(raw)
+    ? raw
+    : DEFAULT_LOOKBACK_DAYS;
+}
+
+/**
+ * Issue #909: render the AWS lookback selector + scope tooltip into the
+ * Opportunities toolbar (#recommendations-toolbar). Prefilled from the
+ * cached config and gated by the update:config permission (the same
+ * permission the backend enforces on the config PUT). Non-admin sessions
+ * see the control disabled with an explanatory tooltip rather than an
+ * editable control whose only outcome would be a 403.
+ *
+ * The container's innerHTML is rebuilt on every call (initial load and
+ * after each successful change), so the previous <select> and its change
+ * listener are discarded — no listener stacking (the build-DOM-fresh
+ * analogue of removing the old listener before re-adding).
+ */
+function renderLookbackToolbar(): void {
+  const container = document.getElementById('recommendations-toolbar');
+  if (!container) return;
+
+  // Rebuild from scratch so the prior control + listener are dropped.
+  container.replaceChildren();
+
+  const canEdit = canAccess('update', 'config');
+
+  const wrap = document.createElement('div');
+  wrap.className = 'lookback-control';
+
+  const label = document.createElement('label');
+  label.setAttribute('for', 'recs-lookback-days');
+  label.textContent = 'AWS lookback';
+
+  const select = document.createElement('select');
+  select.id = 'recs-lookback-days';
+  select.disabled = !canEdit;
+  // Native title gives a hover hint on the disabled control too (disabled
+  // selects don't always relay pointer events to a wrapping tooltip span).
+  select.title = canEdit ? LOOKBACK_TOOLTIP : LOOKBACK_NO_PERMISSION_TOOLTIP;
+
+  const selected = currentLookbackDays();
+  for (const days of LOOKBACK_OPTIONS) {
+    const opt = document.createElement('option');
+    opt.value = String(days);
+    opt.textContent = `${days} days`;
+    if (days === selected) opt.selected = true;
+    select.appendChild(opt);
+  }
+
+  if (canEdit) {
+    select.addEventListener('change', () => {
+      void onLookbackChange(select.value);
+    });
+  }
+
+  // Info tooltip. textContent only (static constant, never API text) so
+  // there is no innerHTML injection surface.
+  const info = document.createElement('span');
+  info.className = 'info-icon';
+  info.textContent = 'ⓘ'; // circled lowercase i
+  const tip = document.createElement('span');
+  tip.className = 'tooltip-text';
+  tip.textContent = canEdit ? LOOKBACK_TOOLTIP : LOOKBACK_NO_PERMISSION_TOOLTIP;
+  info.appendChild(tip);
+
+  wrap.append(label, select, info);
+  container.appendChild(wrap);
+}
+
+/**
+ * Issue #909: persist a new lookback window to the global config (the same
+ * endpoint Admin > Settings uses) and trigger a recommendations re-collect
+ * for the new window, then reload the Opportunities list. The selector is
+ * disabled while the change is in flight so rapid changes can't race; a
+ * failed persist reverts the selector to the last-known value and toasts
+ * the error so the user never silently keeps a stale view.
+ */
+async function onLookbackChange(rawValue: string): Promise<void> {
+  // feedback_strict_int_parse: reject anything that isn't a clean integer,
+  // then constrain to the accepted enum so a tampered DOM can't push an
+  // out-of-range value the backend would 400 on.
+  const parsed = Number(rawValue);
+  const previous = currentLookbackDays();
+  const select = document.getElementById('recs-lookback-days') as HTMLSelectElement | null;
+
+  if (!Number.isInteger(parsed) || !(LOOKBACK_OPTIONS as readonly number[]).includes(parsed)) {
+    // toast renders via textContent, so no escaping is needed (escaping here
+    // would double-encode and show literal entities).
+    showToast({ message: `Invalid lookback window: ${rawValue}`, kind: 'error' });
+    if (select) select.value = String(previous);
+    return;
+  }
+  if (parsed === previous) return;
+
+  // The backend config PUT preserves the two recommendation cycle-params
+  // when omitted but writes every other absent field as its zero value, so
+  // we must round-trip the full cached config and override only the
+  // lookback. cachedGlobalConfig is populated on load; if it is somehow
+  // absent, send a minimal valid payload that still carries the field.
+  const base = cachedGlobalConfig ?? {};
+  const payload: api.Config = {
+    ...(base as api.Config),
+    recommendations_lookback_days: parsed,
+  };
+
+  if (select) select.disabled = true;
+  try {
+    await api.updateConfig(payload);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('Failed to persist lookback window:', err);
+    showToast({ message: `Failed to update lookback window: ${message}`, kind: 'error' });
+    if (select) {
+      select.value = String(previous);
+      select.disabled = false;
+    }
+    return;
+  }
+
+  // Reflect the persisted value in the cache so currentLookbackDays() and
+  // the next renderLookbackToolbar() stay consistent even before reload.
+  cachedGlobalConfig = { ...base, recommendations_lookback_days: parsed };
+
+  // Re-collect for the new window, then reload the list. loadRecommendations
+  // rebuilds the toolbar (re-enabling the select) on success; on a refresh
+  // failure the toast surfaces the error and we re-enable here so the
+  // control isn't left stuck disabled.
+  try {
+    await startRecommendationsRefresh();
+  } finally {
+    const el = document.getElementById('recs-lookback-days') as HTMLSelectElement | null;
+    if (el) el.disabled = !canAccess('update', 'config');
   }
 }
 

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -1168,6 +1168,25 @@ tr.rec-variant-row:hover td:not(.checkbox-col) {
 }
 
 /* Info icon tooltip */
+/* Issue #909: Opportunities lookback selector toolbar. */
+.recommendations-toolbar {
+    display: flex;
+    justify-content: flex-end;
+    margin: 0.5rem 0;
+}
+
+.recommendations-toolbar:empty {
+    display: none;
+}
+
+.lookback-control {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.85rem;
+    color: var(--cudly-text-muted);
+}
+
 .info-icon {
     display: inline-block;
     cursor: help;


### PR DESCRIPTION
Closes #909.

## What

Exposes the recommendation **lookback window** (7 / 30 / 60 days) directly in the **Opportunities** view, mirroring the Admin > Settings control. Both read and write the same global `recommendations_lookback_days`, so changing one is reflected by the other on next load.

## Verified provider scope

Grepped the recommendation collectors on `origin/feat/multicloud-web-frontend`. Only the **AWS** collector consumes the field: `scheduler.fetchAndConvert` builds `RecommendationParams.LookbackPeriod` from `RecommendationsLookbackDays`. The Azure and GCP collectors call `GetAllRecommendations()` with no lookback parameter. So the tooltip says:

> Applies to AWS recommendations only (Cost Explorer lookback window); Azure and GCP are unaffected.

(Disabled non-admin variant: "Changing the lookback window requires admin (update:config) permission. Ask an administrator to adjust it in Settings.")

## Behaviour

- Selector rendered into a new `#recommendations-toolbar`, prefilled from `/api/config` (default 7).
- **Permissions:** gated by `canAccess('update', 'config')` (the same permission the backend enforces). Non-admin sessions see a disabled control with an explanatory tooltip, never an editable control whose only outcome is a 403. Backend stays authoritative.
- **On change:** strict-integer + enum validation, then persist the **full** cached config with only the lookback overridden. The backend PUT preserves only the two recommendation cycle-params when omitted, so a partial body carrying just `recommendations_lookback_days` would wipe `enabled_providers`, `default_term`, etc. Then it triggers a recommendations re-collect for the new window and reloads the list. The selector is disabled while in flight; a persist failure reverts the value and toasts the error (never silently leaves stale data).
- Extracted the shared refresh + toast + reload block into `startRecommendationsRefresh` so the stale-on-open path (#284) and the lookback-change path dedup against a single in-flight collect.

## Tests

New `frontend/src/__tests__/recommendations-lookback.test.ts`: prefill from config, default-to-7, admin enabled + AWS-scope tooltip, non-admin (user/readonly/null) disabled + permission tooltip, change persists full config + triggers refresh + reloads, no-op when unchanged, persist failure reverts + toasts. Full `recommendations|settings` jest suite green (515 tests). Type-check + production build clean. No backend changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a lookback selector in the Opportunities tab to configure how many days to search for recommendations; changes persist and trigger a refresh.
* **Permissions**
  * Selector enabled/disabled and tooltip text vary by user role.
* **Bug Fixes**
  * Reverts UI on failed saves and shows error toasts; ignores tampered/out-of-range values.
* **Tests**
  * End-to-end tests covering prefill, persistence, role behavior, refresh triggering, no-op saves, failure handling, and client-side validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->