### PR TITLE
chore(iac/aws/networking): remove redundant Secrets Manager VPC endpoint

### DIFF
--- a/terraform/modules/networking/aws/main.tf
+++ b/terraform/modules/networking/aws/main.tf
@@ -83,18 +83,6 @@ resource "aws_vpc" "main" {
   tags = merge(var.tags, {
     Name = "${var.stack_name}-vpc"
   })
-
-  # In-VPC workloads (Lambda, Fargate) need egress to AWS APIs that lack
-  # IPv6 (Secrets Manager, ECR, etc). This module no longer provisions
-  # per-service interface endpoints, so NAT is the only egress path.
-  # Plan fails fast instead of producing a VPC where workloads can't
-  # reach AWS APIs.
-  lifecycle {
-    precondition {
-      condition     = var.enable_nat_gateway
-      error_message = "enable_nat_gateway must be true: this module no longer provisions per-service VPC interface endpoints, so in-VPC workloads need NAT for AWS API egress. Set enable_nat_gateway = true, or reintroduce the relevant aws_vpc_endpoint resources first."
-    }
-  }
 }
 
 # ==============================================

--- a/terraform/modules/networking/aws/main.tf
+++ b/terraform/modules/networking/aws/main.tf
@@ -1,6 +1,7 @@
 # AWS VPC Module with IPv6
-# Creates VPC with IPv6 support - no NAT Gateway or VPC Endpoints needed
-# Cost savings: ~$54/month (NAT Gateway + VPC Endpoints eliminated)
+# Creates VPC with IPv6 support. NAT (fck-nat) handles egress for ECR pulls
+# and any AWS APIs that lack IPv6, so we no longer need per-service VPC
+# interface endpoints.
 # Supports: new VPC, existing VPC, or default VPC
 
 terraform {
@@ -681,75 +682,6 @@ resource "aws_iam_role_policy" "flow_logs" {
         Resource = "*"
       }
     ]
-  })
-}
-
-# ==============================================
-# VPC Endpoints (for services without IPv6 support)
-# ==============================================
-
-# Security group for VPC endpoints
-resource "aws_security_group" "vpc_endpoints" {
-  name_prefix = "${var.stack_name}-vpc-endpoints-"
-  description = "Security group for VPC endpoints"
-  vpc_id      = local.vpc_id
-
-  # HTTPS from VPC (IPv4)
-  ingress {
-    description = "HTTPS from VPC (IPv4)"
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = [local.vpc_cidr]
-  }
-
-  # HTTPS from VPC (IPv6)
-  ingress {
-    description      = "HTTPS from VPC (IPv6)"
-    from_port        = 443
-    to_port          = 443
-    protocol         = "tcp"
-    ipv6_cidr_blocks = var.enable_ipv6 ? [local.vpc_ipv6_cidr] : []
-  }
-
-  # Allow all outbound (IPv4)
-  egress {
-    description = "Allow all outbound (IPv4)"
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  # Allow all outbound (IPv6)
-  egress {
-    description      = "Allow all outbound (IPv6)"
-    from_port        = 0
-    to_port          = 0
-    protocol         = "-1"
-    ipv6_cidr_blocks = ["::/0"]
-  }
-
-  tags = merge(var.tags, {
-    Name = "${var.stack_name}-vpc-endpoints-sg"
-  })
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-# Secrets Manager VPC Endpoint (required - no IPv6 support)
-resource "aws_vpc_endpoint" "secretsmanager" {
-  vpc_id              = local.vpc_id
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.secretsmanager"
-  vpc_endpoint_type   = "Interface"
-  subnet_ids          = local.private_subnet_ids
-  security_group_ids  = [aws_security_group.vpc_endpoints.id]
-  private_dns_enabled = true
-
-  tags = merge(var.tags, {
-    Name = "${var.stack_name}-secretsmanager-endpoint"
   })
 }
 

--- a/terraform/modules/networking/aws/main.tf
+++ b/terraform/modules/networking/aws/main.tf
@@ -83,6 +83,18 @@ resource "aws_vpc" "main" {
   tags = merge(var.tags, {
     Name = "${var.stack_name}-vpc"
   })
+
+  # In-VPC workloads (Lambda, Fargate) need egress to AWS APIs that lack
+  # IPv6 (Secrets Manager, ECR, etc). This module no longer provisions
+  # per-service interface endpoints, so NAT is the only egress path.
+  # Plan fails fast instead of producing a VPC where workloads can't
+  # reach AWS APIs.
+  lifecycle {
+    precondition {
+      condition     = var.enable_nat_gateway
+      error_message = "enable_nat_gateway must be true: this module no longer provisions per-service VPC interface endpoints, so in-VPC workloads need NAT for AWS API egress. Set enable_nat_gateway = true, or reintroduce the relevant aws_vpc_endpoint resources first."
+    }
+  }
 }
 
 # ==============================================
@@ -691,6 +703,3 @@ resource "aws_iam_role_policy" "flow_logs" {
     ]
   })
 }
-
-# Data source for current region
-data "aws_region" "current" {}

--- a/terraform/modules/networking/aws/main.tf
+++ b/terraform/modules/networking/aws/main.tf
@@ -406,6 +406,13 @@ resource "aws_subnet" "private" {
     Name = "${var.stack_name}-private-${data.aws_availability_zones.available.names[count.index]}"
     Type = "private"
   })
+
+  lifecycle {
+    precondition {
+      condition     = var.enable_nat_gateway
+      error_message = "enable_nat_gateway must be true when creating private subnets: without it, module-created private subnets have no IPv4 path to AWS services (Secrets Manager, ECR, etc.). Enable the fck-nat instance or use an existing VPC with its own egress."
+    }
+  }
 }
 
 # ==============================================

--- a/terraform/modules/networking/aws/outputs.tf
+++ b/terraform/modules/networking/aws/outputs.tf
@@ -98,4 +98,3 @@ output "database_vpc_config" {
     security_group_id     = aws_security_group.database.id
   }
 }
-

--- a/terraform/modules/networking/aws/outputs.tf
+++ b/terraform/modules/networking/aws/outputs.tf
@@ -99,18 +99,3 @@ output "database_vpc_config" {
   }
 }
 
-# VPC Endpoints
-output "vpc_endpoints_security_group_id" {
-  description = "Security group ID for VPC endpoints"
-  value       = aws_security_group.vpc_endpoints.id
-}
-
-output "secretsmanager_endpoint_id" {
-  description = "Secrets Manager VPC endpoint ID"
-  value       = aws_vpc_endpoint.secretsmanager.id
-}
-
-output "secretsmanager_endpoint_dns" {
-  description = "Secrets Manager VPC endpoint DNS names"
-  value       = aws_vpc_endpoint.secretsmanager.dns_entry
-}


### PR DESCRIPTION
## Summary

Removes the AWS Secrets Manager VPC interface endpoint and its dedicated security group / unused outputs. The endpoint is redundant: every environment already runs **fck-NAT** (`enable_nat_gateway = true` in `terraform/environments/aws/networking.tf:16`), so in-VPC Secrets Manager consumers (main Lambda, cleanup Lambda, Fargate task) reach SM over NAT just like they reach ECR and any other non-IPv6 service.

**Savings**: ~$14/mo (2 AZs × ~$7.20). NAT byte-cost delta is negligible — `GetSecretValue` payloads are tiny.

### What's removed
- `aws_vpc_endpoint.secretsmanager` (was `main.tf:743-754`)
- `aws_security_group.vpc_endpoints` — the endpoint was its sole consumer
- Three outputs (none referenced by any caller per grep): `vpc_endpoints_security_group_id`, `secretsmanager_endpoint_id`, `secretsmanager_endpoint_dns`

### What's updated
- File-header comment in `main.tf` updated to reflect actual topology (NAT present, per-service interface endpoints removed)

## Precondition for safety

`enable_nat_gateway` must remain `true` in every environment. If a future change turns NAT off, this endpoint (and likely the ECR ones too) must be reintroduced **first** or in-VPC SM calls will fail.

## Test plan

- [x] `terraform validate` clean in `terraform/environments/aws/`
- [x] `terraform fmt` no-diff
- [ ] CI pre-commit hooks green (tflint, terraform-fmt, etc.)
- [ ] Post-merge `terraform plan` in a real env should show only the endpoint + SG destroy + three output removals, no other diffs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified networking by removing automatic provisioning of service interface endpoints and related outputs.
  * Added a safeguard requiring NAT gateway to be enabled when creating private subnets to ensure IPv4 egress to managed services.
* **Documentation**
  * Clarified module header to reflect that egress is handled by the designated NAT instance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->