### PR TITLE
fix(server): serve /version on Lambda (excluded from static-path fallback)

### DIFF
--- a/internal/server/static.go
+++ b/internal/server/static.go
@@ -170,7 +170,11 @@ func staticDirFromEnv() string {
 }
 
 // isStaticPath returns true if the path should be handled by the static file
-// server rather than the API. API paths start with /api/ or are /health.
+// server rather than the API. API paths start with /api/ or are /health or
+// /version. /version is a public root-path endpoint (build metadata, no auth)
+// registered in the API router table; it must not fall through to the SPA
+// fallback on the Lambda path, matching the explicit mux.HandleFunc("/version")
+// registration used on the HTTP/Cloud Run path in internal/server/http.go.
 // OIDC discovery paths (/.well-known/*) are intercepted earlier by the
 // transport layer via api.IsOIDCDiscoveryPath, so they never reach here.
 func isStaticPath(urlPath string) bool {
@@ -181,6 +185,9 @@ func isStaticPath(urlPath string) bool {
 		return false
 	}
 	if clean == "/health" {
+		return false
+	}
+	if clean == "/version" {
 		return false
 	}
 	return true

--- a/internal/server/static_test.go
+++ b/internal/server/static_test.go
@@ -94,6 +94,8 @@ func TestIsStaticPath(t *testing.T) {
 		{"/app/dashboard", true},
 		{"//health", false}, // double-slash normalised to /health
 		{"//api/test", false},
+		{"/version", false},  // public build-metadata endpoint must reach API, not SPA
+		{"//version", false}, // double-slash normalised to /version
 	}
 	for _, tt := range tests {
 		t.Run(tt.path, func(t *testing.T) {


### PR DESCRIPTION
## Root cause

`isStaticPath()` in `internal/server/static.go` only excluded `/api/*` and
`/health` from the SPA file-server fallback. `/version` was not in the
allowlist, so on the **Lambda Function URL path** (`handleLambdaHTTPEvent`) the
check `isStaticPath("/version") == true` caused the request to be routed to
`serveLambdaStatic`, which served `index.html` instead of JSON.

The **HTTP / Cloud Run / Fargate path** (`CreateHTTPServer` in
`internal/server/http.go`) was unaffected because `mux.HandleFunc("/version",
app.handleVersion)` is registered explicitly before the SPA catch-all handler,
so the Go ServeMux routes it correctly regardless of `isStaticPath`.

The `/version` route has been in the API router table since PR #901
(`ExactPath: "/version"`, `Auth: AuthPublic`). Once `isStaticPath("/version")`
returns false, `app.API.HandleRequest` handles it correctly on the Lambda path
too.

Verified live before the fix:
```
curl https://33pz7pombdqwu3bdlxp4lqxyra0bsriy.lambda-url.us-east-1.on.aws/version
# returned text/html (index.html)
```

## Fix

Add `clean == "/version"` to the `isStaticPath` allowlist using the same
pattern as `/health`. Updated the function doc comment to mention `/version` as
a public root-path endpoint and explain why it must bypass the SPA fallback.

## Tests

Added two cases to `TestIsStaticPath` in `internal/server/static_test.go`:
- `{"/version", false}` - direct path
- `{"//version", false}` - double-slash input normalised by `path.Clean`

All 334 tests in `./internal/server/...` pass. `gofmt` and `go vet` clean.

## Notes

No issue to close - discovered during deploy debugging of the #901 build-version
diagnostic endpoint on a Lambda Function URL deployment. Behaviour is now
consistent across all deployment targets (Lambda, Cloud Run, Fargate).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected routing logic to ensure the `/version` endpoint is properly directed to the API handler instead of incorrectly falling through to static content serving.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->