### PR TITLE
fix(test): use groups not legacy role in recommendations-lookback mockUser (closes #935)

### DIFF
--- a/frontend/src/__tests__/recommendations-lookback.test.ts
+++ b/frontend/src/__tests__/recommendations-lookback.test.ts
@@ -20,6 +20,7 @@ import {
 import * as api from '../api';
 import { refreshRecommendations as refreshRecsAPI } from '../api/recommendations';
 import { showToast } from '../toast';
+import { ADMINISTRATORS_GROUP_ID } from '../permissions';
 
 jest.mock('../api', () => ({
   getRecommendations: jest.fn().mockResolvedValue({ summary: {}, recommendations: [], regions: [] }),
@@ -74,7 +75,7 @@ import * as state from '../state';
 
 const mockUser = (role: string | null) => {
   (state.getCurrentUser as jest.Mock).mockReturnValue(
-    role === null ? null : { id: 'u', email: 'u@example.com', role },
+    role === null ? null : { id: 'u', email: 'u@example.com', groups: role === 'admin' ? [ADMINISTRATORS_GROUP_ID] : [] },
   );
 };
 


### PR DESCRIPTION
closes #935

## Summary

- `mockUser` in `recommendations-lookback.test.ts` was still using the pre-#917 legacy `role` field
- After the group-membership authz migration (#912/#917), `isAdmin()` reads `user.groups`, so the old fixture always yielded `canEdit === false`, the lookback change listener was never attached, and 11 tests failed on the base branch
- Added import of `ADMINISTRATORS_GROUP_ID` from `../permissions` and switched `mockUser` to set `groups: [ADMINISTRATORS_GROUP_ID]` for admin, `groups: []` for non-admin roles -- mirrors the pattern in `recommendations-permissions.test.ts`

## Test plan

- [ ] Before fix: `npm test -- recommendations-lookback` shows 11 failed, 6 passed
- [ ] After fix: `npm test -- recommendations-lookback` shows 17 passed, 0 failed
- [ ] `npm run build` succeeds with no errors