### PR TITLE
fix(frontend/tests): assign Purchaser group to admin mocks (carve-out follow-up)

### DIFF
--- a/frontend/src/__tests__/execute-mode-toggle.test.ts
+++ b/frontend/src/__tests__/execute-mode-toggle.test.ts
@@ -56,11 +56,21 @@ jest.mock('../toast', () => ({
 }));
 
 import * as state from '../state';
+import { ADMINISTRATORS_GROUP_ID, PURCHASER_GROUP_ID } from '../permissions';
 
+// 'admin' represents a fully-capable admin: Administrators + Purchaser group
+// membership (mirrors the auto-migration that adds existing admins to the
+// Purchaser group on first deploy of issue #923). Both groups are needed:
+// ADMINISTRATORS_GROUP_ID for isAdmin() (gates execute-any/execute-own), and
+// PURCHASER_GROUP_ID for isPurchaser() (gates the carved-out execute:purchases
+// / approve-any:purchases / retry-any:purchases verbs from issue #923).
+// 'user' and 'readonly' have no group memberships and thus no execute access.
 type UserRole = 'admin' | 'user' | 'readonly';
 const mockUser = (role: UserRole | null) => {
   (state.getCurrentUser as jest.Mock).mockReturnValue(
-    role === null ? null : { id: 'u', email: 'u@example.com', role },
+    role === null
+      ? null
+      : { id: 'u', email: 'u@example.com', groups: role === 'admin' ? [ADMINISTRATORS_GROUP_ID, PURCHASER_GROUP_ID] : [] },
   );
 };
 

--- a/frontend/src/__tests__/purchase-execution-toast.test.ts
+++ b/frontend/src/__tests__/purchase-execution-toast.test.ts
@@ -46,6 +46,12 @@ jest.mock('../recommendations', () => ({
   clearPurchaseModalRecommendations: jest.fn(),
   getFanOutBuckets: jest.fn(),
   clearFanOutBuckets: jest.fn(),
+  // app.ts calls getExecuteMode() and clearExecuteMode() in
+  // handleExecutePurchase (issue #289 / PR #924 carve-out).
+  // Default getExecuteMode to '' (approval path) so existing toast tests
+  // that don't exercise the direct-execute path are unaffected.
+  getExecuteMode: jest.fn().mockReturnValue(''),
+  clearExecuteMode: jest.fn(),
 }));
 
 jest.mock('../plans', () => ({

--- a/frontend/src/__tests__/recommendations.test.ts
+++ b/frontend/src/__tests__/recommendations.test.ts
@@ -1393,12 +1393,21 @@ describe('Recommendations Module', () => {
     });
 
     test('shows purchase summary', async () => {
+      // Use a non-admin session so the approval-required note renders instead
+      // of the execute-mode toggle (issue #923 carve-out: execute-any/own is
+      // gated on isAdmin(), which requires the Administrators group; a regular
+      // user without group membership sees the approval-required note).
+      // Restore the default admin mock after this test so sibling tests are
+      // unaffected; the outer beforeEach only calls clearAllMocks() which does
+      // not reset return values.
+      (state.getCurrentUser as jest.Mock).mockReturnValue({ id: 'u-reg', email: 'user@example.com', groups: [] });
       const recommendations = [
         { id: 'rec-2', provider: 'aws' as const, service: 'ec2', resource_type: 't3.medium', region: 'us-east-1', count: 5, term: 1, savings: 100, upfront_cost: 500 },
         { id: 'rec-3', provider: 'aws' as const, service: 'rds', resource_type: 'db.r5.large', region: 'us-east-1', count: 2, term: 1, savings: 200, upfront_cost: 1000 }
       ];
 
       await openPurchaseModal(recommendations);
+      (state.getCurrentUser as jest.Mock).mockReturnValue({ id: 'u-admin', email: 'admin@example.com', groups: ['00000000-0000-5000-8000-000000000001'] });
 
       const details = document.getElementById('purchase-details');
       // Issue #320: the modal now renders a full breakdown table with column
@@ -1433,6 +1442,26 @@ describe('Recommendations Module', () => {
     // wording so a regression that reverts to the misleading "Execute
     // Purchase" framing fails this suite.
     describe('approval-required messaging (issue #288)', () => {
+      beforeEach(() => {
+        // These tests exercise the approval-required path that renders the
+        // explanatory note. After issue #923 / PR #924, the execute-mode
+        // toggle renders only for sessions with execute-any:purchases or
+        // execute-own:purchases (both gated on isAdmin()). Using a regular
+        // user here ensures the approval-required note is rendered and the
+        // execute-mode toggle is absent, which is what the assertions below
+        // expect. The admin execute-mode toggle path is covered in
+        // execute-mode-toggle.test.ts.
+        (state.getCurrentUser as jest.Mock).mockReturnValue({ id: 'u-reg', email: 'user@example.com', groups: [] });
+      });
+
+      afterEach(() => {
+        // Restore the default admin mock so tests in sibling describe blocks
+        // are not affected by this scope's non-admin override. The outer
+        // beforeEach only calls clearAllMocks() which does not reset return
+        // values, so we must restore explicitly.
+        (state.getCurrentUser as jest.Mock).mockReturnValue({ id: 'u-admin', email: 'admin@example.com', groups: ['00000000-0000-5000-8000-000000000001'] });
+      });
+
       const baseRec = {
         id: 'rec-288',
         provider: 'aws' as const,


### PR DESCRIPTION
## Summary

- Three frontend test suites missed by PR #924's fix wave were breaking CI on every open PR against `feat/multicloud-web-frontend`
- Root cause: each suite had admin session fixtures that pre-dated the Purchaser group carve-out from issues #923/#924
- Fix: add `PURCHASER_GROUP_ID` to admin mocks + add missing `getExecuteMode`/`clearExecuteMode` stubs to the recommendations mock factory

## Root cause (points to #924)

PR #924 carved out `execute:purchases`, `approve-any:purchases`, and `retry-any:purchases` from `admin:*` and required Purchaser group membership for those verbs. It fixed four test suites but missed these three:

1. `execute-mode-toggle.test.ts`: `mockUser('admin')` produced `{ role: 'admin' }` with no `groups` array. `canAccess('execute-any', 'purchases')` falls back to `isAdmin()`, which requires `ADMINISTRATORS_GROUP_ID` in `user.groups`. Without a groups array, `isAdmin()` returned false and the execute-mode toggle never rendered (3 tests failed).

2. `purchase-execution-toast.test.ts`: the `jest.mock('../recommendations')` factory was missing `getExecuteMode` and `clearExecuteMode`. `app.ts` calls both in `handleExecutePurchase` (introduced in the #289/#924 wave). Every single-record test threw `TypeError: getExecuteMode is not a function` at line 328 of `app.ts` before reaching the toast assertions (12 tests failed).

3. `recommendations.test.ts`: the default state mock had `groups: ['00000000-0000-5000-8000-000000000001']` (Administrators only). `canAccess('execute-any', 'purchases')` is NOT a carved-out verb so it calls `isAdmin()` (not `isPurchaser()`), meaning admin-group membership alone caused the execute-mode toggle to render. Three tests expecting the approval-required note saw the toggle text instead.

## Per-suite fix

- **execute-mode-toggle.test.ts**: Import `ADMINISTRATORS_GROUP_ID` and `PURCHASER_GROUP_ID` from `../permissions`; `mockUser('admin')` now produces `groups: [ADMINISTRATORS_GROUP_ID, PURCHASER_GROUP_ID]` (mirrors the auto-migration pattern from #924). Non-admin roles produce `groups: []`. **3 tests updated.**

- **purchase-execution-toast.test.ts**: Add `getExecuteMode: jest.fn().mockReturnValue('')` and `clearExecuteMode: jest.fn()` to the recommendations mock factory. The approval path default (`''`) leaves all existing toast assertions unaffected. **1 mock factory updated, 12 previously-failing tests now pass.**

- **recommendations.test.ts**: The three approval-required note tests override `getCurrentUser` to a non-admin user (`groups: []`) so the approval note renders instead of the execute-mode toggle. A paired restore call / `afterEach` restores the admin user to prevent mock state from leaking into sibling describe blocks. **3 tests updated.**

## Test plan

- [x] `npx jest src/__tests__/execute-mode-toggle.test.ts` - 6/6 pass
- [x] `npx jest src/__tests__/purchase-execution-toast.test.ts` - 21/21 pass
- [x] `npx jest src/__tests__/recommendations.test.ts` - 367/367 pass
- [x] `npx tsc --noEmit` - clean
- [ ] CI green on `feat/multicloud-web-frontend` after merge
