### PR TITLE
fix(api): restore base build - drop removed Session.Role from handler_purchases_test (regression from #528)

### DIFF
--- a/internal/api/handler_purchases_guards_test.go
+++ b/internal/api/handler_purchases_guards_test.go
@@ -54,31 +54,39 @@ func TestValidatePurchaseRecommendation(t *testing.T) {
 		{"valid azure monthly", mutate(func(r *config.RecommendationRecord) { r.Provider = "azure"; r.Payment = "monthly" }), false},
 		// Legacy AWS-style tokens on Azure are normalized to Azure-canonical before validation.
 		{"azure accepts legacy all-upfront (coerced to upfront)", mutate(func(r *config.RecommendationRecord) {
-			r.Provider = "azure"; r.Payment = "all-upfront"
+			r.Provider = "azure"
+			r.Payment = "all-upfront"
 		}), false},
 		{"azure accepts legacy no-upfront (coerced to monthly)", mutate(func(r *config.RecommendationRecord) {
-			r.Provider = "azure"; r.Payment = "no-upfront"
+			r.Provider = "azure"
+			r.Payment = "no-upfront"
 		}), false},
 		{"azure accepts legacy partial-upfront (coerced to upfront)", mutate(func(r *config.RecommendationRecord) {
-			r.Provider = "azure"; r.Payment = "partial-upfront"
+			r.Provider = "azure"
+			r.Payment = "partial-upfront"
 		}), false},
 		{"azure rejects unknown token", mutate(func(r *config.RecommendationRecord) {
-			r.Provider = "azure"; r.Payment = "foo"
+			r.Provider = "azure"
+			r.Payment = "foo"
 		}), true},
 		// --- GCP canonical set (monthly-only) ---
 		{"valid gcp monthly", mutate(func(r *config.RecommendationRecord) { r.Provider = "gcp"; r.Payment = "monthly" }), false},
 		// Legacy tokens on GCP are all normalized to monthly.
 		{"gcp accepts legacy upfront (coerced to monthly)", mutate(func(r *config.RecommendationRecord) {
-			r.Provider = "gcp"; r.Payment = "upfront"
+			r.Provider = "gcp"
+			r.Payment = "upfront"
 		}), false},
 		{"gcp accepts legacy all-upfront (coerced to monthly)", mutate(func(r *config.RecommendationRecord) {
-			r.Provider = "gcp"; r.Payment = "all-upfront"
+			r.Provider = "gcp"
+			r.Payment = "all-upfront"
 		}), false},
 		{"gcp accepts legacy no-upfront (coerced to monthly)", mutate(func(r *config.RecommendationRecord) {
-			r.Provider = "gcp"; r.Payment = "no-upfront"
+			r.Provider = "gcp"
+			r.Payment = "no-upfront"
 		}), false},
 		{"gcp rejects unknown token", mutate(func(r *config.RecommendationRecord) {
-			r.Provider = "gcp"; r.Payment = "foo"
+			r.Provider = "gcp"
+			r.Payment = "foo"
 		}), true},
 		// --- General ---
 		{"payment case-insensitive", mutate(func(r *config.RecommendationRecord) { r.Payment = "All-Upfront" }), false},

--- a/internal/api/handler_purchases_test.go
+++ b/internal/api/handler_purchases_test.go
@@ -1641,9 +1641,9 @@ func TestHandler_getPurchaseDetails_NotFound_IsClientError(t *testing.T) {
 	adminSession := &Session{
 		UserID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 		Email:  "admin@example.com",
-		Role:   "admin",
 	}
 	mockAuth.On("ValidateSession", ctx, "admin-token").Return(adminSession, nil)
+	mockAuth.grantAdmin()
 
 	const missingID = "dddddddd-dddd-dddd-dddd-dddddddddddd"
 	// Simulate the DB returning a generic error (as pgx does on a missing row).


### PR DESCRIPTION
## Summary

- PR #528 introduced `TestHandler_getPurchaseDetails_NotFound_IsClientError` using `Role: "admin"` in a `&Session{}` literal, but `Session.Role` was removed in #940/#907.
- This caused `go vet ./internal/api/` to fail with `unknown field Role in struct literal of type Session`, breaking the base build for anyone on `feat/multicloud-web-frontend`.
- Fix: remove the stale `Role: "admin"` field and add `mockAuth.grantAdmin()` following the established pattern used in 30+ other tests in the same file (see comment at mocks_test.go:881-897).

## Changes

- `internal/api/handler_purchases_test.go` line 1644: remove `Role: "admin"` from `adminSession` literal; add `mockAuth.grantAdmin()` so `HasPermissionAPI` is properly stubbed.
- `internal/api/handler_purchases_guards_test.go`: gofmt formatting only (semicolons split to newlines, caught by pre-commit hook).

## Verification

- `go vet ./internal/api/`: no issues
- `gofmt -l`: clean
- `go build ./...`: success
- `go test ./internal/api/ -count=1`: 1458 passed
- `SKIP=terraform_validate pre-commit run --all-files`: all passed

## Test plan

- [ ] CI passes on this branch
- [ ] `go vet ./internal/api/` returns 0 issues
- [ ] `TestHandler_getPurchaseDetails_NotFound_IsClientError` passes and still asserts the 404 ClientError regression for #431