### PR TITLE
feat(frontend/mobile): viewport + touch-target + safe-area foundations

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -2,7 +2,8 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <meta name="format-detection" content="telephone=no">
     <!-- Content Security Policy: Restrict resource loading to prevent XSS.
          frame-ancestors is intentionally omitted here because browsers ignore
          it in <meta>; it is delivered via the response header from
@@ -348,7 +349,7 @@
                                     <span class="info-icon">&#9432;<span class="tooltip-text">Email address for purchase notifications and approval requests.</span></span>
                                 </div>
                                 <div class="setting-input">
-                                    <input type="email" id="setting-notification-email" placeholder="admin@example.com" required aria-label="Notification email address">
+                                    <input type="email" id="setting-notification-email" placeholder="admin@example.com" required aria-label="Notification email address" autocomplete="email">
                                 </div>
                             </div>
                             <div class="setting-row">
@@ -386,7 +387,7 @@
                                     <span class="info-icon">&#9432;<span class="tooltip-text">How many days before a scheduled purchase to send email notification.</span></span>
                                 </div>
                                 <div class="setting-input">
-                                    <input type="number" id="setting-notification-days" value="3" min="1" max="30">
+                                    <input type="number" id="setting-notification-days" value="3" min="1" max="30" inputmode="numeric" pattern="[0-9]*">
                                 </div>
                             </div>
                             <div class="setting-row">
@@ -395,7 +396,7 @@
                                     <span class="info-icon">&#9432;<span class="tooltip-text">Age (in hours) at which the recommendations cache is considered stale and a background refresh fires automatically. Set to 0 to disable automatic background refresh (the cron scheduler and manual Refresh button still work). Valid range: 0&ndash;8760 (up to one year). Default: 24.</span></span>
                                 </div>
                                 <div class="setting-input">
-                                    <input type="number" id="setting-recs-stale-hours" value="24" min="0" max="8760" step="1">
+                                    <input type="number" id="setting-recs-stale-hours" value="24" min="0" max="8760" step="1" inputmode="numeric" pattern="[0-9]*">
                                 </div>
                             </div>
                         </fieldset>
@@ -444,7 +445,7 @@
                                 <label for="setting-default-coverage">Target Coverage (%)</label>
                             </div>
                             <div class="setting-input">
-                                <input type="number" id="setting-default-coverage" value="80" min="0" max="100">
+                                <input type="number" id="setting-default-coverage" value="80" min="0" max="100" inputmode="numeric" pattern="[0-9]*">
                             </div>
                         </div>
                     </fieldset>
@@ -475,7 +476,7 @@
                                 <label for="setting-grace-aws"><span class="provider-badge aws">AWS</span> grace period (days)</label>
                             </div>
                             <div class="setting-input">
-                                <input type="number" id="setting-grace-aws" value="7" min="0" max="30" step="1">
+                                <input type="number" id="setting-grace-aws" value="7" min="0" max="30" step="1" inputmode="numeric" pattern="[0-9]*">
                             </div>
                         </div>
                         <div class="setting-row">
@@ -483,7 +484,7 @@
                                 <label for="setting-grace-azure"><span class="provider-badge azure">Azure</span> grace period (days)</label>
                             </div>
                             <div class="setting-input">
-                                <input type="number" id="setting-grace-azure" value="7" min="0" max="30" step="1">
+                                <input type="number" id="setting-grace-azure" value="7" min="0" max="30" step="1" inputmode="numeric" pattern="[0-9]*">
                             </div>
                         </div>
                         <div class="setting-row">
@@ -491,7 +492,7 @@
                                 <label for="setting-grace-gcp"><span class="provider-badge gcp">GCP</span> grace period (days)</label>
                             </div>
                             <div class="setting-input">
-                                <input type="number" id="setting-grace-gcp" value="7" min="0" max="30" step="1">
+                                <input type="number" id="setting-grace-gcp" value="7" min="0" max="30" step="1" inputmode="numeric" pattern="[0-9]*">
                             </div>
                         </div>
                     </fieldset>
@@ -539,7 +540,7 @@
                                 <p class="service-default-hint">EC2, Fargate, Lambda — most flexible</p>
                                 <label>Term: <select id="aws-savings-plans-compute-term"><option value="1">1 Year</option><option value="3" selected>3 Years</option></select></label>
                                 <label>Payment: <select id="aws-savings-plans-compute-payment"><option value="no-upfront">No Upfront</option><option value="partial-upfront">Partial</option><option value="all-upfront" selected>All Upfront</option></select></label>
-                                <label>Coverage %: <input type="number" id="aws-savings-plans-compute-coverage" min="0" max="100" value="80"></label>
+                                <label>Coverage %: <input type="number" id="aws-savings-plans-compute-coverage" min="0" max="100" value="80" inputmode="numeric" pattern="[0-9]*"></label>
                                 <label class="toggle-label"><input type="checkbox" id="aws-savings-plans-compute-enabled" checked> Enabled</label>
                             </div>
                             <div class="service-default-card">
@@ -547,7 +548,7 @@
                                 <p class="service-default-hint">EC2 only, region-locked — deepest discount</p>
                                 <label>Term: <select id="aws-savings-plans-ec2instance-term"><option value="1">1 Year</option><option value="3" selected>3 Years</option></select></label>
                                 <label>Payment: <select id="aws-savings-plans-ec2instance-payment"><option value="no-upfront">No Upfront</option><option value="partial-upfront">Partial</option><option value="all-upfront" selected>All Upfront</option></select></label>
-                                <label>Coverage %: <input type="number" id="aws-savings-plans-ec2instance-coverage" min="0" max="100" value="80"></label>
+                                <label>Coverage %: <input type="number" id="aws-savings-plans-ec2instance-coverage" min="0" max="100" value="80" inputmode="numeric" pattern="[0-9]*"></label>
                                 <label class="toggle-label"><input type="checkbox" id="aws-savings-plans-ec2instance-enabled" checked> Enabled</label>
                             </div>
                             <div class="service-default-card">
@@ -555,7 +556,7 @@
                                 <p class="service-default-hint">SageMaker training/inference</p>
                                 <label>Term: <select id="aws-savings-plans-sagemaker-term"><option value="1">1 Year</option><option value="3" selected>3 Years</option></select></label>
                                 <label>Payment: <select id="aws-savings-plans-sagemaker-payment"><option value="no-upfront">No Upfront</option><option value="partial-upfront">Partial</option><option value="all-upfront" selected>All Upfront</option></select></label>
-                                <label>Coverage %: <input type="number" id="aws-savings-plans-sagemaker-coverage" min="0" max="100" value="80"></label>
+                                <label>Coverage %: <input type="number" id="aws-savings-plans-sagemaker-coverage" min="0" max="100" value="80" inputmode="numeric" pattern="[0-9]*"></label>
                                 <label class="toggle-label"><input type="checkbox" id="aws-savings-plans-sagemaker-enabled" checked> Enabled</label>
                             </div>
                             <div class="service-default-card">
@@ -563,7 +564,7 @@
                                 <p class="service-default-hint">Reserved for future AWS Database Savings Plans (currently not GA; defaults stored for forward-compatibility)</p>
                                 <label>Term: <select id="aws-savings-plans-database-term"><option value="1">1 Year</option><option value="3" selected>3 Years</option></select></label>
                                 <label>Payment: <select id="aws-savings-plans-database-payment"><option value="no-upfront">No Upfront</option><option value="partial-upfront">Partial</option><option value="all-upfront" selected>All Upfront</option></select></label>
-                                <label>Coverage %: <input type="number" id="aws-savings-plans-database-coverage" min="0" max="100" value="80"></label>
+                                <label>Coverage %: <input type="number" id="aws-savings-plans-database-coverage" min="0" max="100" value="80" inputmode="numeric" pattern="[0-9]*"></label>
                                 <label class="toggle-label"><input type="checkbox" id="aws-savings-plans-database-enabled" checked> Enabled</label>
                             </div>
                         </div>
@@ -836,7 +837,7 @@
                                 </select>
                             </label>
                         </div>
-                        <label>Target Coverage (%): <input type="number" id="plan-coverage" value="80" min="0" max="100"></label>
+                        <label>Target Coverage (%): <input type="number" id="plan-coverage" value="80" min="0" max="100" inputmode="numeric" pattern="[0-9]*"></label>
                     </div>
 
                     <div class="form-section">
@@ -866,8 +867,8 @@
                         </div>
                         <div id="custom-ramp-config" class="hidden">
                             <div class="form-row">
-                                <label>Coverage Per Step (%): <input type="number" id="ramp-step-percent" value="20" min="1" max="100"></label>
-                                <label>Interval (Days): <input type="number" id="ramp-interval-days" value="7" min="1" max="365"></label>
+                                <label>Coverage Per Step (%): <input type="number" id="ramp-step-percent" value="20" min="1" max="100" inputmode="numeric" pattern="[0-9]*"></label>
+                                <label>Interval (Days): <input type="number" id="ramp-interval-days" value="7" min="1" max="365" inputmode="numeric" pattern="[0-9]*"></label>
                             </div>
                         </div>
                     </div>
@@ -892,7 +893,7 @@
                                 <span class="info-icon">&#9432;<span class="tooltip-text">Send email notification this many days before each scheduled purchase.</span></span>
                             </div>
                             <div class="setting-input">
-                                <input type="number" id="plan-notify-days" value="3" min="1" max="30">
+                                <input type="number" id="plan-notify-days" value="3" min="1" max="30" inputmode="numeric" pattern="[0-9]*">
                             </div>
                         </div>
                         <div class="setting-row">
@@ -1142,7 +1143,7 @@
                         </select>
                     </label>
                     <label>Coverage (%):
-                        <input type="number" id="override-coverage" min="0" max="100" step="1" placeholder="Inherit (use global default)">
+                        <input type="number" id="override-coverage" min="0" max="100" step="1" placeholder="Inherit (use global default)" inputmode="numeric" pattern="[0-9]*">
                     </label>
 
                     <p class="help-text" id="override-form-error" role="alert"></p>

--- a/frontend/src/styles/responsive.css
+++ b/frontend/src/styles/responsive.css
@@ -1,6 +1,71 @@
 /* Responsive styles: Media queries */
 
 /* ---------------------------------------------------------------------------
+ * Mobile foundations
+ * ------------------------------------------------------------------------- */
+
+/* Tap-highlight: remove the default iOS/Android blue flash on touch; each
+ * interactive element supplies its own :active style instead so the tap
+ * feedback is intentional rather than accidental. */
+button,
+a,
+[role="button"] {
+    -webkit-tap-highlight-color: transparent;
+}
+
+button:active,
+a:active,
+[role="button"]:active {
+    opacity: 0.85;
+}
+
+/* Safe-area insets: protect content from the iOS notch (top) and home
+ * indicator (bottom). The fixed topbar sits at top:0 so it needs the top
+ * inset; the main scrollable area needs bottom padding so the last row of
+ * content is not obscured by the home bar. */
+.app-topbar {
+    padding-top: max(0px, env(safe-area-inset-top));
+}
+
+.app-shell {
+    padding-bottom: env(safe-area-inset-bottom);
+}
+
+/* Touch-target minimums: apply only on coarse-pointer (touch) devices so
+ * the compact desktop layout is unaffected. 44x44px matches Apple HIG and
+ * WCAG 2.5.8 guidance for minimum touch-target size. */
+@media (pointer: coarse) {
+    .btn,
+    button,
+    [role="button"],
+    input[type="submit"],
+    input[type="button"],
+    input[type="reset"],
+    select,
+    input[type="checkbox"],
+    input[type="radio"] {
+        min-height: 44px;
+        min-width: 44px;
+    }
+
+    /* Checkboxes and radio buttons are small by design; grow them via
+     * padding on the wrapping label so the hit area expands without
+     * visually bloating the glyph. */
+    input[type="checkbox"],
+    input[type="radio"] {
+        min-height: unset;
+        min-width: unset;
+    }
+
+    label:has(> input[type="checkbox"]),
+    label:has(> input[type="radio"]) {
+        min-height: 44px;
+        display: flex;
+        align-items: center;
+    }
+}
+
+/* ---------------------------------------------------------------------------
  * Mobile navigation drawer (below 768px)
  *
  * Pattern: hamburger button in topbar toggles .sidebar-open on <body>.
@@ -11,7 +76,7 @@
  * - aria-expanded / aria-hidden toggled from app.ts:setupMobileNav().
  * ------------------------------------------------------------------------- */
 
-/* Hamburger button — mobile only */
+/* Hamburger button - mobile only */
 .hamburger {
     display: none; /* hidden above breakpoint */
     background: transparent;
@@ -47,7 +112,6 @@
 body.sidebar-open {
     overflow: hidden;
 }
-
 @media (max-width: 768px) {
     header {
         flex-direction: column;


### PR DESCRIPTION
## Summary

- Adds `viewport-fit=cover` to the existing viewport meta tag for iOS notch support
- Adds `format-detection=telephone=no` to prevent iOS auto-linking numeric data
- Adds CSS tap-highlight suppression with explicit `:active` opacity feedback
- Adds safe-area inset padding on topbar and app-shell for notch / home-bar clearance
- Adds touch-target minimums (44x44px) under `@media (pointer: coarse)` only, leaving desktop unaffected
- Adds `inputmode="numeric"` + `pattern="[0-9]*"` to all 15 numeric inputs for mobile numpad
- Adds `autocomplete="email"` to the notification email input

## Per-change rationale

**`viewport-fit=cover`**: without this, iOS clips the safe-area environment variables to nothing even when `env(safe-area-inset-*)` is declared. Required for the safe-area rules to take effect.

**`format-detection=telephone=no`**: coverage percentages, grace-period days, and other numeric values in tables would otherwise be auto-highlighted as phone numbers on iOS, creating spurious tap targets and breaking visual layout.

**Tap-highlight / `:active`**: the default browser blue flash on touch is jarring and inconsistent with the design system; replacing it with `opacity: 0.85` gives tactile feedback without clashing colors.

**Safe-area insets**: `.app-topbar` has `position: sticky; top: 0` so it must account for the notch height. `.app-shell` needs bottom padding so the last table row is not obscured by the iPhone home indicator.

**Touch-target minimums under `@media (pointer: coarse)`**: Apple HIG and WCAG 2.5.8 both cite 44x44px as the minimum. Scoping to coarse-pointer avoids bloating compact desktop buttons. Checkboxes and radio buttons grow via `label:has(>input)` to keep the glyph size unchanged.

**`inputmode="numeric"` on all 15 numeric inputs**: surfaces the number-only keyboard on mobile, removing the need to switch keyboard modes for coverage %, day counts, and ramp parameters.

**`autocomplete="email"`**: enables browser / password-manager autofill for the notification email field.

## Out of scope

Follow-up issues are being tracked separately by the mobile audit agent:
- Hamburger / drawer navigation for the sidebar on narrow viewports
- Tables to card-view below 480px
- Chart resize / aspect-ratio tuning
- Modal full-screen below 480px
- PWA manifest

## Test plan

- [ ] Load the app on an iPhone (Safari) and verify no blue flash on button tap
- [ ] Verify numeric inputs show the numeric keypad (no alpha keys)
- [ ] Verify safe-area padding is visible on a notched iPhone (topbar not clipped, last row not hidden behind home bar)
- [ ] Verify desktop layout is unchanged (buttons retain compact sizing)
- [ ] `npx tsc --noEmit` passes (confirmed clean)
- [ ] Existing test suite passes (`frontend/__tests__/html.test.ts` viewport assertion still green)

Closes #983


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Mobile Experience Improvements**
  * Enhanced numeric field input handling with optimized mobile keyboards and validation
  * Improved email field autocomplete support
  * Larger touch targets for easier mobile interactions
  * Better viewport optimization for devices with notches and safe areas
  * Refined touch interaction feedback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->