### PR TITLE
fix(aws/savingsplans): paginate GetExistingCommitments via NextToken loop

### DIFF
--- a/providers/aws/services/savingsplans/client.go
+++ b/providers/aws/services/savingsplans/client.go
@@ -104,21 +104,13 @@ func (c *Client) GetRecommendations(ctx context.Context, params common.Recommend
 	return []common.Recommendation{}, nil
 }
 
-// GetExistingCommitments retrieves existing Savings Plans
+// GetExistingCommitments retrieves existing Savings Plans across all pages.
+// DescribeSavingsPlans is paginated (NextToken on both input and output); the
+// original single-call implementation silently truncated to the first page,
+// causing CUDly to under-report existing SPs and recommend redundant purchases
+// (issue #1019). The loop mirrors the NextToken accumulator used in the
+// MemoryDB and OpenSearch commitment fetches.
 func (c *Client) GetExistingCommitments(ctx context.Context) ([]common.Commitment, error) {
-	input := &savingsplans.DescribeSavingsPlansInput{
-		States: []types.SavingsPlanState{
-			types.SavingsPlanStateActive,
-			types.SavingsPlanStatePendingReturn,
-			types.SavingsPlanStateQueued,
-		},
-	}
-
-	result, err := c.client.DescribeSavingsPlans(ctx, input)
-	if err != nil {
-		return nil, fmt.Errorf("failed to describe Savings Plans: %w", err)
-	}
-
 	// Each client is scoped to one plan type, so partition the API result by
 	// SavingsPlanType and only return commitments matching this client's type.
 	// The provider registers four SP services and calls GetExistingCommitments
@@ -128,40 +120,75 @@ func (c *Client) GetExistingCommitments(ctx context.Context) ([]common.Commitmen
 	// `case common.ServiceSavingsPlans` branch in provider.go's
 	// GetServiceClient): in that mode, return every commitment unfiltered
 	// to match pre-split behaviour. Per-plan-type clients still partition.
-	commitments := make([]common.Commitment, 0, len(result.SavingsPlans))
+	commitments := make([]common.Commitment, 0)
 	service := c.GetServiceType()
+	page := 0
+	var nextToken *string
 
-	for _, sp := range result.SavingsPlans {
-		if sp.SavingsPlanId == nil {
-			continue
-		}
-		if c.planType != "" && sp.SavingsPlanType != c.planType {
-			continue
-		}
-
-		commitment := common.Commitment{
-			Provider:       common.ProviderAWS,
-			CommitmentID:   *sp.SavingsPlanId,
-			CommitmentType: common.CommitmentSavingsPlan,
-			Service:        service,
-			Region:         aws.ToString(sp.Region),
-			ResourceType:   string(sp.SavingsPlanType),
-			Count:          1, // Savings Plans don't have a count
-			State:          string(sp.State),
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
 		}
 
-		if sp.Start != nil {
-			if startTime, err := time.Parse(time.RFC3339, *sp.Start); err == nil {
-				commitment.StartDate = startTime
+		page++
+		if page > maxCommitmentPages {
+			log.Printf("WARNING: savingsplans.GetExistingCommitments reached page cap (%d) — returning partial results (issue #1019)",
+				maxCommitmentPages)
+			break
+		}
+
+		input := &savingsplans.DescribeSavingsPlansInput{
+			States: []types.SavingsPlanState{
+				types.SavingsPlanStateActive,
+				types.SavingsPlanStatePendingReturn,
+				types.SavingsPlanStateQueued,
+			},
+			NextToken:  nextToken,
+			MaxResults: aws.Int32(100),
+		}
+
+		result, err := c.client.DescribeSavingsPlans(ctx, input)
+		if err != nil {
+			return nil, fmt.Errorf("failed to describe Savings Plans: %w", err)
+		}
+
+		for _, sp := range result.SavingsPlans {
+			if sp.SavingsPlanId == nil {
+				continue
 			}
-		}
-		if sp.End != nil {
-			if endTime, err := time.Parse(time.RFC3339, *sp.End); err == nil {
-				commitment.EndDate = endTime
+			if c.planType != "" && sp.SavingsPlanType != c.planType {
+				continue
 			}
+
+			commitment := common.Commitment{
+				Provider:       common.ProviderAWS,
+				CommitmentID:   *sp.SavingsPlanId,
+				CommitmentType: common.CommitmentSavingsPlan,
+				Service:        service,
+				Region:         aws.ToString(sp.Region),
+				ResourceType:   string(sp.SavingsPlanType),
+				Count:          1, // Savings Plans don't have a count
+				State:          string(sp.State),
+			}
+
+			if sp.Start != nil {
+				if startTime, err := time.Parse(time.RFC3339, *sp.Start); err == nil {
+					commitment.StartDate = startTime
+				}
+			}
+			if sp.End != nil {
+				if endTime, err := time.Parse(time.RFC3339, *sp.End); err == nil {
+					commitment.EndDate = endTime
+				}
+			}
+
+			commitments = append(commitments, commitment)
 		}
 
-		commitments = append(commitments, commitment)
+		if result.NextToken == nil || aws.ToString(result.NextToken) == "" {
+			break
+		}
+		nextToken = result.NextToken
 	}
 
 	return commitments, nil
@@ -326,6 +353,14 @@ func convertPaymentOption(paymentOption string) types.SavingsPlanPaymentOption {
 // pages to walk before giving up. Exceeding the cap returns a diagnostic error
 // instead of timing out the Lambda budget (issue #688).
 const maxOfferingPages = 5
+
+// maxCommitmentPages is the maximum number of DescribeSavingsPlans pages to
+// walk when listing existing commitments. 100 pages * 100 items/page = 10,000
+// SPs, which is a realistic upper bound for even large enterprise accounts.
+// Exceeding the cap logs a warning but still returns the commitments collected
+// so far, consistent with the #691 guidance (data loss is worse than a
+// truncation warning for the commitment path).
+const maxCommitmentPages = 100
 
 // lookupOfferingID performs the API call(s) to find the offering ID.
 // DescribeSavingsPlansOfferings already accepts PlanTypes/Durations/PaymentOptions

--- a/providers/aws/services/savingsplans/client.go
+++ b/providers/aws/services/savingsplans/client.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"sort"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -303,10 +304,27 @@ func (c *Client) findOfferingID(ctx context.Context, rec common.Recommendation, 
 	log.Printf("purchase[%s]: SavingsPlans findOfferingID starting (planType=%s term=%s payment=%s)",
 		tag, planType, rec.Term, rec.PaymentOption)
 
+	// Pin to USD so non-USD currency offerings are excluded server-side.
+	// EC2Instance SPs are region-scoped; add a region filter so only the
+	// offering for the client's region is returned. Compute, SageMaker, and
+	// Database SPs are global and do not carry a region property.
 	input := &savingsplans.DescribeSavingsPlansOfferingsInput{
 		PlanTypes:      []types.SavingsPlanType{planType},
 		Durations:      []int64{termSeconds},
 		PaymentOptions: []types.SavingsPlanPaymentOption{paymentOption},
+		Currencies:     []types.CurrencyCode{types.CurrencyCodeUsd},
+	}
+	if planType == types.SavingsPlanTypeEc2Instance {
+		if c.region == "" {
+			log.Printf("purchase[%s]: SavingsPlans findOfferingID: client region is empty; skipping region filter", tag)
+		} else {
+			input.Filters = []types.SavingsPlanOfferingFilterElement{
+				{
+					Name:   types.SavingsPlanOfferingFilterAttributeRegion,
+					Values: []string{c.region},
+				},
+			}
+		}
 	}
 
 	offeringID, err := c.lookupOfferingID(ctx, input)
@@ -374,12 +392,15 @@ const maxOfferingPages = 5
 const maxCommitmentPages = 100
 
 // lookupOfferingID performs the API call(s) to find the offering ID.
-// DescribeSavingsPlansOfferings already accepts PlanTypes/Durations/PaymentOptions
-// filters that narrow the result set, so only a handful of results are expected
-// on the first page. Pagination with a cap is added as a safety net.
+// DescribeSavingsPlansOfferings accepts PlanTypes/Durations/PaymentOptions/
+// Currencies/Filters that narrow the result set to at most a handful of
+// results. All pages are accumulated so the caller receives a stable,
+// lexicographically-sorted first offering rather than a result that depends
+// on AWS response ordering (finding 08-L1).
 func (c *Client) lookupOfferingID(ctx context.Context, input *savingsplans.DescribeSavingsPlansOfferingsInput) (string, error) {
 	t0 := time.Now()
 	page := 0
+	var offeringIDs []string
 	for {
 		if err := ctx.Err(); err != nil {
 			return "", err
@@ -404,7 +425,7 @@ func (c *Client) lookupOfferingID(ctx context.Context, input *savingsplans.Descr
 			if offering.OfferingId == nil {
 				continue
 			}
-			return *offering.OfferingId, nil
+			offeringIDs = append(offeringIDs, *offering.OfferingId)
 		}
 
 		if result.NextToken == nil || aws.ToString(result.NextToken) == "" {
@@ -413,7 +434,13 @@ func (c *Client) lookupOfferingID(ctx context.Context, input *savingsplans.Descr
 		input.NextToken = result.NextToken
 	}
 
-	return "", fmt.Errorf("no Savings Plans offerings found after %d page(s) (issue #688)", page)
+	if len(offeringIDs) == 0 {
+		return "", fmt.Errorf("no Savings Plans offerings found after %d page(s) (issue #688)", page)
+	}
+	// Sort for a stable, deterministic tie-break when multiple offerings
+	// survive the server-side filters. The first ID after sorting is returned.
+	sort.Strings(offeringIDs)
+	return offeringIDs[0], nil
 }
 
 // ValidateOffering checks if a Savings Plans offering exists

--- a/providers/aws/services/savingsplans/client.go
+++ b/providers/aws/services/savingsplans/client.go
@@ -153,36 +153,9 @@ func (c *Client) GetExistingCommitments(ctx context.Context) ([]common.Commitmen
 		}
 
 		for _, sp := range result.SavingsPlans {
-			if sp.SavingsPlanId == nil {
-				continue
+			if commitment, ok := c.toCommitment(sp, service); ok {
+				commitments = append(commitments, commitment)
 			}
-			if c.planType != "" && sp.SavingsPlanType != c.planType {
-				continue
-			}
-
-			commitment := common.Commitment{
-				Provider:       common.ProviderAWS,
-				CommitmentID:   *sp.SavingsPlanId,
-				CommitmentType: common.CommitmentSavingsPlan,
-				Service:        service,
-				Region:         aws.ToString(sp.Region),
-				ResourceType:   string(sp.SavingsPlanType),
-				Count:          1, // Savings Plans don't have a count
-				State:          string(sp.State),
-			}
-
-			if sp.Start != nil {
-				if startTime, err := time.Parse(time.RFC3339, *sp.Start); err == nil {
-					commitment.StartDate = startTime
-				}
-			}
-			if sp.End != nil {
-				if endTime, err := time.Parse(time.RFC3339, *sp.End); err == nil {
-					commitment.EndDate = endTime
-				}
-			}
-
-			commitments = append(commitments, commitment)
 		}
 
 		if result.NextToken == nil || aws.ToString(result.NextToken) == "" {
@@ -192,6 +165,44 @@ func (c *Client) GetExistingCommitments(ctx context.Context) ([]common.Commitmen
 	}
 
 	return commitments, nil
+}
+
+// toCommitment converts a single DescribeSavingsPlans entry into a
+// common.Commitment, returning ok=false for entries that should be skipped
+// (missing ID, or a plan type that does not match this client's scope). It is
+// split out of GetExistingCommitments to keep that function under the
+// cyclomatic limit.
+func (c *Client) toCommitment(sp types.SavingsPlan, service common.ServiceType) (common.Commitment, bool) {
+	if sp.SavingsPlanId == nil {
+		return common.Commitment{}, false
+	}
+	if c.planType != "" && sp.SavingsPlanType != c.planType {
+		return common.Commitment{}, false
+	}
+
+	commitment := common.Commitment{
+		Provider:       common.ProviderAWS,
+		CommitmentID:   *sp.SavingsPlanId,
+		CommitmentType: common.CommitmentSavingsPlan,
+		Service:        service,
+		Region:         aws.ToString(sp.Region),
+		ResourceType:   string(sp.SavingsPlanType),
+		Count:          1, // Savings Plans don't have a count
+		State:          string(sp.State),
+	}
+
+	if sp.Start != nil {
+		if startTime, err := time.Parse(time.RFC3339, *sp.Start); err == nil {
+			commitment.StartDate = startTime
+		}
+	}
+	if sp.End != nil {
+		if endTime, err := time.Parse(time.RFC3339, *sp.End); err == nil {
+			commitment.EndDate = endTime
+		}
+	}
+
+	return commitment, true
 }
 
 // PurchaseCommitment purchases a Savings Plan

--- a/providers/aws/services/savingsplans/client_test.go
+++ b/providers/aws/services/savingsplans/client_test.go
@@ -1114,3 +1114,164 @@ func TestLookupOfferingID_HappyPath(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "offering-ok", id)
 }
+
+// TestFindOfferingID_SendsUSDCurrencyFilter asserts that findOfferingID always
+// includes a USD currency filter in the DescribeSavingsPlansOfferings request
+// (finding 08-L1). Without the filter the API may return non-USD offerings
+// and a blind [0] pick selects the wrong offering.
+func TestFindOfferingID_SendsUSDCurrencyFilter(t *testing.T) {
+	mockSP := &MockSavingsPlansClient{}
+	t.Cleanup(func() { mockSP.AssertExpectations(t) })
+	client := &Client{client: mockSP, region: "us-east-1", planType: types.SavingsPlanTypeCompute}
+
+	mockSP.On("DescribeSavingsPlansOfferings", mock.Anything,
+		mock.MatchedBy(func(in *savingsplans.DescribeSavingsPlansOfferingsInput) bool {
+			return len(in.Currencies) == 1 && in.Currencies[0] == types.CurrencyCodeUsd
+		})).
+		Return(&savingsplans.DescribeSavingsPlansOfferingsOutput{
+			SearchResults: []types.SavingsPlanOffering{
+				{OfferingId: aws.String("offering-usd")},
+			},
+		}, nil).Once()
+
+	id, err := client.findOfferingID(context.Background(), spRec(), "")
+	require.NoError(t, err)
+	assert.Equal(t, "offering-usd", id)
+}
+
+// TestFindOfferingID_EC2InstanceSendsRegionFilter asserts that an EC2Instance
+// client adds a region filter element to the request (finding 08-L1). EC2
+// Instance SPs are region-scoped; picking without a region filter risks
+// selecting an offering for the wrong region.
+func TestFindOfferingID_EC2InstanceSendsRegionFilter(t *testing.T) {
+	mockSP := &MockSavingsPlansClient{}
+	t.Cleanup(func() { mockSP.AssertExpectations(t) })
+	client := &Client{client: mockSP, region: "eu-west-1", planType: types.SavingsPlanTypeEc2Instance}
+
+	mockSP.On("DescribeSavingsPlansOfferings", mock.Anything,
+		mock.MatchedBy(func(in *savingsplans.DescribeSavingsPlansOfferingsInput) bool {
+			for _, f := range in.Filters {
+				if f.Name == types.SavingsPlanOfferingFilterAttributeRegion &&
+					len(f.Values) == 1 && f.Values[0] == "eu-west-1" {
+					return true
+				}
+			}
+			return false
+		})).
+		Return(&savingsplans.DescribeSavingsPlansOfferingsOutput{
+			SearchResults: []types.SavingsPlanOffering{
+				{OfferingId: aws.String("offering-eu")},
+			},
+		}, nil).Once()
+
+	rec := common.Recommendation{
+		Service:       common.ServiceSavingsPlansEC2Instance,
+		ResourceType:  "EC2Instance",
+		PaymentOption: "no-upfront",
+		Term:          "1yr",
+		Details: &common.SavingsPlanDetails{
+			PlanType:         "EC2Instance",
+			HourlyCommitment: 1.0,
+		},
+	}
+	id, err := client.findOfferingID(context.Background(), rec, "")
+	require.NoError(t, err)
+	assert.Equal(t, "offering-eu", id)
+}
+
+// TestFindOfferingID_ComputeNoRegionFilter asserts that a Compute SP client
+// does NOT attach a region filter (Compute SPs are global, not region-scoped).
+func TestFindOfferingID_ComputeNoRegionFilter(t *testing.T) {
+	mockSP := &MockSavingsPlansClient{}
+	t.Cleanup(func() { mockSP.AssertExpectations(t) })
+	client := &Client{client: mockSP, region: "us-east-1", planType: types.SavingsPlanTypeCompute}
+
+	mockSP.On("DescribeSavingsPlansOfferings", mock.Anything,
+		mock.MatchedBy(func(in *savingsplans.DescribeSavingsPlansOfferingsInput) bool {
+			// Compute SPs must not carry any region filter.
+			for _, f := range in.Filters {
+				if f.Name == types.SavingsPlanOfferingFilterAttributeRegion {
+					return false
+				}
+			}
+			return true
+		})).
+		Return(&savingsplans.DescribeSavingsPlansOfferingsOutput{
+			SearchResults: []types.SavingsPlanOffering{
+				{OfferingId: aws.String("offering-global")},
+			},
+		}, nil).Once()
+
+	id, err := client.findOfferingID(context.Background(), spRec(), "")
+	require.NoError(t, err)
+	assert.Equal(t, "offering-global", id)
+}
+
+// TestLookupOfferingID_DeterministicSort asserts that when multiple offerings
+// survive the server-side filters, lookupOfferingID returns the lexicographically
+// smallest offering ID rather than relying on unspecified AWS response ordering
+// (finding 08-L1). Pre-fix code returned SearchResults[0] without sorting,
+// making the result nondeterministic across API calls.
+func TestLookupOfferingID_DeterministicSort(t *testing.T) {
+	mockSP := &MockSavingsPlansClient{}
+	t.Cleanup(func() { mockSP.AssertExpectations(t) })
+	client := &Client{client: mockSP, region: "us-east-1", planType: types.SavingsPlanTypeCompute}
+
+	// Return three offerings in reverse-alphabetical order. The fix must sort
+	// them so "offering-aaa" (the lexicographically smallest) is returned, not
+	// "offering-zzz" (the one AWS happened to put first).
+	mockSP.On("DescribeSavingsPlansOfferings", mock.Anything, mock.Anything).
+		Return(&savingsplans.DescribeSavingsPlansOfferingsOutput{
+			SearchResults: []types.SavingsPlanOffering{
+				{OfferingId: aws.String("offering-zzz")},
+				{OfferingId: aws.String("offering-mmm")},
+				{OfferingId: aws.String("offering-aaa")},
+			},
+		}, nil).Once()
+
+	id, err := client.findOfferingID(context.Background(), spRec(), "")
+	require.NoError(t, err)
+	// Pre-fix: would return "offering-zzz" (first in response).
+	// Post-fix: returns "offering-aaa" (lexicographically smallest).
+	assert.Equal(t, "offering-aaa", id,
+		"findOfferingID must sort results deterministically before selecting")
+}
+
+// TestLookupOfferingID_DeterministicSortAcrossPages asserts that the
+// deterministic sort operates across ALL accumulated pages, not just within a
+// single page (finding 08-L1 multi-page variant).
+func TestLookupOfferingID_DeterministicSortAcrossPages(t *testing.T) {
+	mockSP := &MockSavingsPlansClient{}
+	t.Cleanup(func() { mockSP.AssertExpectations(t) })
+	client := &Client{client: mockSP, region: "us-east-1", planType: types.SavingsPlanTypeCompute}
+
+	// Page 1 returns a "later" offering ID.
+	mockSP.On("DescribeSavingsPlansOfferings", mock.Anything,
+		mock.MatchedBy(func(in *savingsplans.DescribeSavingsPlansOfferingsInput) bool {
+			return in.NextToken == nil
+		})).
+		Return(&savingsplans.DescribeSavingsPlansOfferingsOutput{
+			SearchResults: []types.SavingsPlanOffering{
+				{OfferingId: aws.String("offering-zzz")},
+			},
+			NextToken: aws.String("tok-2"),
+		}, nil).Once()
+
+	// Page 2 returns an "earlier" offering ID. Without cross-page sort, the
+	// pre-fix code would have already returned "offering-zzz" from page 1.
+	mockSP.On("DescribeSavingsPlansOfferings", mock.Anything,
+		mock.MatchedBy(func(in *savingsplans.DescribeSavingsPlansOfferingsInput) bool {
+			return in.NextToken != nil && *in.NextToken == "tok-2"
+		})).
+		Return(&savingsplans.DescribeSavingsPlansOfferingsOutput{
+			SearchResults: []types.SavingsPlanOffering{
+				{OfferingId: aws.String("offering-aaa")},
+			},
+			NextToken: nil,
+		}, nil).Once()
+
+	id, err := client.findOfferingID(context.Background(), spRec(), "")
+	require.NoError(t, err)
+	assert.Equal(t, "offering-aaa", id,
+		"findOfferingID must sort across pages before selecting")
+}

--- a/providers/aws/services/savingsplans/client_test.go
+++ b/providers/aws/services/savingsplans/client_test.go
@@ -257,6 +257,104 @@ func TestClient_GetExistingCommitments_UmbrellaMode(t *testing.T) {
 	mockClient.AssertExpectations(t)
 }
 
+// TestClient_GetExistingCommitments_Pagination verifies that
+// GetExistingCommitments drives DescribeSavingsPlans across all pages and
+// accumulates every item. This is the regression test for issue #1019: the
+// original single-call implementation silently dropped page 2+ commitments,
+// causing CUDly to under-count existing SPs and recommend redundant purchases.
+//
+// The test fails on pre-fix code (only 1 item returned from page 1) and passes
+// after the NextToken accumulator loop is in place (both items returned).
+func TestClient_GetExistingCommitments_Pagination(t *testing.T) {
+	mockClient := &MockSavingsPlansClient{}
+	t.Cleanup(func() { mockClient.AssertExpectations(t) })
+
+	// Page 1: returns one SP and a NextToken signalling more pages.
+	mockClient.On("DescribeSavingsPlans", mock.Anything, mock.MatchedBy(func(input *savingsplans.DescribeSavingsPlansInput) bool {
+		return input.NextToken == nil
+	})).Return(&savingsplans.DescribeSavingsPlansOutput{
+		SavingsPlans: []types.SavingsPlan{
+			{
+				SavingsPlanId:   aws.String("sp-page1"),
+				SavingsPlanType: types.SavingsPlanTypeCompute,
+				State:           types.SavingsPlanStateActive,
+				Region:          aws.String("us-east-1"),
+			},
+		},
+		NextToken: aws.String("token-page2"),
+	}, nil).Once()
+
+	// Page 2: returns the second SP with no further NextToken.
+	mockClient.On("DescribeSavingsPlans", mock.Anything, mock.MatchedBy(func(input *savingsplans.DescribeSavingsPlansInput) bool {
+		return input.NextToken != nil && *input.NextToken == "token-page2"
+	})).Return(&savingsplans.DescribeSavingsPlansOutput{
+		SavingsPlans: []types.SavingsPlan{
+			{
+				SavingsPlanId:   aws.String("sp-page2"),
+				SavingsPlanType: types.SavingsPlanTypeCompute,
+				State:           types.SavingsPlanStateActive,
+				Region:          aws.String("us-west-2"),
+			},
+		},
+		NextToken: nil,
+	}, nil).Once()
+
+	client := &Client{
+		client:   mockClient,
+		region:   "us-east-1",
+		planType: types.SavingsPlanTypeCompute,
+	}
+
+	result, err := client.GetExistingCommitments(context.Background())
+	require.NoError(t, err)
+	// Both pages must be accumulated: pre-fix returns 1, post-fix returns 2.
+	require.Len(t, result, 2, "GetExistingCommitments must paginate and accumulate all SPs")
+	ids := []string{result[0].CommitmentID, result[1].CommitmentID}
+	assert.Contains(t, ids, "sp-page1")
+	assert.Contains(t, ids, "sp-page2")
+}
+
+// TestClient_GetExistingCommitments_CtxCancellation verifies that a cancelled
+// context is treated as a hard stop in the pagination loop (not accumulated as
+// lastErr while the loop continues). Per feedback_ctx_cancel_terminal: context
+// cancellation is terminal in API fan-out loops.
+func TestClient_GetExistingCommitments_CtxCancellation(t *testing.T) {
+	mockClient := &MockSavingsPlansClient{}
+	t.Cleanup(func() { mockClient.AssertExpectations(t) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// First page succeeds and returns a NextToken; the cancel fires before
+	// the loop re-checks ctx.Err() at the top of the second iteration.
+	mockClient.On("DescribeSavingsPlans", mock.Anything, mock.MatchedBy(func(input *savingsplans.DescribeSavingsPlansInput) bool {
+		return input.NextToken == nil
+	})).Return(&savingsplans.DescribeSavingsPlansOutput{
+		SavingsPlans: []types.SavingsPlan{
+			{
+				SavingsPlanId:   aws.String("sp-1"),
+				SavingsPlanType: types.SavingsPlanTypeCompute,
+				State:           types.SavingsPlanStateActive,
+			},
+		},
+		NextToken: aws.String("token-page2"),
+	}, nil).Run(func(args mock.Arguments) {
+		// Cancel after the first page is returned so the loop's ctx.Err()
+		// check at the top of iteration 2 fires before any second API call.
+		cancel()
+	}).Once()
+
+	client := &Client{
+		client:   mockClient,
+		region:   "us-east-1",
+		planType: types.SavingsPlanTypeCompute,
+	}
+
+	_, err := client.GetExistingCommitments(ctx)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled,
+		"GetExistingCommitments must propagate ctx.Err() verbatim on cancellation")
+}
+
 // TestClient_findOfferingID_RejectsMismatchedPlanType pins the
 // per-plan-type isolation post-split: a client scoped to one plan type
 // must refuse to look up an offering for a different plan type, even if
@@ -988,7 +1086,7 @@ func TestLookupOfferingID_PaginationCapFires(t *testing.T) {
 			}, nil).Once()
 	}
 
-	_, err := client.findOfferingID(context.Background(), spRec())
+	_, err := client.findOfferingID(context.Background(), spRec(), "")
 
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "pagination cap reached")
@@ -1011,7 +1109,7 @@ func TestLookupOfferingID_HappyPath(t *testing.T) {
 			},
 		}, nil).Once()
 
-	id, err := client.findOfferingID(context.Background(), spRec())
+	id, err := client.findOfferingID(context.Background(), spRec(), "")
 
 	assert.NoError(t, err)
 	assert.Equal(t, "offering-ok", id)


### PR DESCRIPTION
## Summary

- `GetExistingCommitments` in `services/savingsplans/client.go` was calling `DescribeSavingsPlans` once with no `NextToken` loop, silently truncating to the first page of results.
- On accounts with more SPs than one page, CUDly under-reported existing commitments, causing duplicate-detection and expiry-coverage math to recommend or auto-purchase redundant SPs (financial overspend).
- Adds the standard NextToken accumulator loop with a `ctx.Err()` terminal guard and a `maxCommitmentPages=100` page cap, consistent with the MemoryDB and OpenSearch commitment fetches and the ctx-cancel pattern from the `feedback_ctx_cancel_terminal` memory entry.
- Also fixes a pre-existing build break: two `TestLookupOfferingID_*` tests called `findOfferingID` with 2 args after its signature grew to 3 args on this branch; updated to pass empty string as `execID`.

Closes #1019

## Test plan

- [x] `TestClient_GetExistingCommitments_Pagination`: two-page mock asserts both items accumulated (would fail on pre-fix code returning only page 1)
- [x] `TestClient_GetExistingCommitments_CtxCancellation`: cancel fires after page 1; asserts `context.Canceled` propagates verbatim (not swallowed)
- [x] All 57 savingsplans tests pass (`go test ./services/savingsplans/...`)
- [x] All 726 aws provider tests pass (`go test ./...` from `providers/aws`)
- [x] Root-level `go build ./...` passes; 2 pre-existing `auth` test failures are unrelated to this change (confirmed by running without changes)

## Scope expanded

Added finding **08-L1 (SP portion)** from the code-review remaining-findings plan (FOLD-1039 bucket):

`findOfferingID` called `DescribeSavingsPlansOfferings` without narrowing by
currency or region, then returned `SearchResults[0]` without sorting. AWS does
not guarantee response ordering, so when multiple offerings matched (e.g. USD
vs CNY, or global vs region-scoped) the selected offering ID was
nondeterministic.

Changes in commit `9d292dcf5`:
- Added `Currencies: [USD]` to `DescribeSavingsPlansOfferingsInput` to exclude non-USD offerings server-side.
- For EC2Instance SPs (the only region-scoped SP type), added a `SavingsPlanOfferingFilterAttributeRegion` filter element using `c.region`. Compute, SageMaker, and Database SPs are global and receive no region filter.
- Changed `lookupOfferingID` to accumulate all offering IDs across pages, sort lexicographically, then return the first - stable regardless of AWS response ordering.
- Added 5 regression tests covering: USD filter sent, EC2Instance region filter sent, Compute no region filter, deterministic single-page sort, deterministic cross-page sort.
- All 731 aws provider tests pass after the change.

Also closes #1066
