### PR TITLE
chore(ci): gofmt base-drifted Go files to unblock pre-commit

### DIFF
--- a/internal/auth/service_password.go
+++ b/internal/auth/service_password.go
@@ -30,9 +30,9 @@ var dummyPasswordHash = "$2a$12$iAMeexq41AwZ2Dj9oAvGfeVHQxK5ffLPPTNxwPB8bsf7olA7
 
 // Password validation constants following NIST guidelines
 const (
-	minPasswordLength       = 12  // Minimum password length
-	maxPasswordLength       = 128 // Maximum password length to prevent bcrypt DoS
-	passwordHistorySize     = 5   // Number of previous passwords to remember
+	minPasswordLength     = 12  // Minimum password length
+	maxPasswordLength     = 128 // Maximum password length to prevent bcrypt DoS
+	passwordHistorySize   = 5   // Number of previous passwords to remember
 	repeatedCharThreshold = 3   // Number of identical consecutive characters to reject
 
 	// PasswordResetRateLimit is the minimum interval between password reset requests
@@ -498,8 +498,8 @@ func redactEmail(email string) string {
 	if dot < 0 || dot == 0 {
 		domain = "***"
 	} else {
-		tld := domain[dot:]   // ".com"
-		host := domain[:dot]  // "example"
+		tld := domain[dot:]  // ".com"
+		host := domain[:dot] // "example"
 		if len(host) <= 2 {
 			domain = "***" + tld
 		} else {

--- a/internal/credentials/cipher_extra_test.go
+++ b/internal/credentials/cipher_extra_test.go
@@ -256,7 +256,6 @@ func TestDecrypt_BadBase64Ciphertext(t *testing.T) {
 	assert.Contains(t, err.Error(), "decode ciphertext")
 }
 
-
 // TestDecodeHexKey_ExactlyCorrect preserves existing coverage.
 func TestDecodeHexKey_ExactlyCorrect(t *testing.T) {
 	key, err := decodeHexKey(strings.Repeat("ff", 32))

--- a/internal/database/open_from_env_test.go
+++ b/internal/database/open_from_env_test.go
@@ -55,15 +55,15 @@ func TestOpenFromEnv_MissingConfig(t *testing.T) {
 func TestOpenFromEnv_NoPasswordSecret(t *testing.T) {
 	// Provide a structurally valid config that will fail at the TCP dial.
 	env := map[string]string{
-		"DB_HOST":         "127.0.0.1",
-		"DB_PORT":         "19999", // nothing listening here
-		"DB_NAME":         "testdb",
-		"DB_USER":         "testuser",
-		"DB_PASSWORD":     "testpass",
-		"DB_SSL_MODE":     "disable",
-		"DB_MAX_CONN_IDLE_TIME":    "1s",
-		"DB_MAX_CONN_LIFETIME":     "1s",
-		"DB_HEALTH_CHECK_PERIOD":   "1s",
+		"DB_HOST":                "127.0.0.1",
+		"DB_PORT":                "19999", // nothing listening here
+		"DB_NAME":                "testdb",
+		"DB_USER":                "testuser",
+		"DB_PASSWORD":            "testpass",
+		"DB_SSL_MODE":            "disable",
+		"DB_MAX_CONN_IDLE_TIME":  "1s",
+		"DB_MAX_CONN_LIFETIME":   "1s",
+		"DB_HEALTH_CHECK_PERIOD": "1s",
 	}
 	originals := make(map[string]string, len(env))
 	for k, v := range env {

--- a/internal/execution/fanout_test.go
+++ b/internal/execution/fanout_test.go
@@ -122,7 +122,7 @@ func TestFanOut_ContextCancelled_BlockedSemaphore(t *testing.T) {
 			func(ctx context.Context, id string) (string, error) {
 				if id == "first" {
 					started <- struct{}{} // tell the test we have the slot
-					<-release            // wait until the test says go
+					<-release             // wait until the test says go
 					return "ok", nil
 				}
 				return "should-not-run", nil

--- a/providers/azure/services/compute/client_test.go
+++ b/providers/azure/services/compute/client_test.go
@@ -1325,12 +1325,12 @@ func TestCheckAndRegisterCapacityProvider_NonTwoxx(t *testing.T) {
 func TestExtractVMPricing_SingularOneYear(t *testing.T) {
 	items := []AzureRetailPriceItem{
 		{
-			CurrencyCode:    "USD",
-			RetailPrice:     0.096,
-			UnitPrice:       0.096,
-			ArmRegionName:   "eastus",
-			ArmSKUName:      "Standard_D2s_v3",
-			Type:            "Consumption",
+			CurrencyCode:  "USD",
+			RetailPrice:   0.096,
+			UnitPrice:     0.096,
+			ArmRegionName: "eastus",
+			ArmSKUName:    "Standard_D2s_v3",
+			Type:          "Consumption",
 		},
 		{
 			CurrencyCode:    "USD",


### PR DESCRIPTION
## Root cause

The base branch `feat/multicloud-web-frontend` ships five Go files that fail `gofmt`, causing the `go-fmt` pre-commit hook to fail on **every open PR** when CI runs `pre-commit run --all-files` (which checks the whole tree, not just the PR diff).

## What this PR does

Runs `gofmt -w` on all five affected files. The diff is **purely whitespace/alignment** (comment-column alignment, struct-literal field alignment, one stray blank line). No token changes; confirmed with `git diff` hunk-by-hunk review.

## Files changed

- `internal/auth/service_password.go` -- comment-column alignment
- `internal/database/open_from_env_test.go` -- struct-literal field alignment
- `internal/credentials/cipher_extra_test.go` -- stray blank line
- `providers/azure/services/compute/client_test.go` -- struct-literal field alignment
- `internal/execution/fanout_test.go` -- comment-column alignment

## Verification

- `gofmt -l .` returns empty after the change (all files clean)
- `go build ./...` passes with no errors

Closes #1096

Unblocks #1090, #1091, and every other open PR that fails the `--all-files` go-fmt hook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code formatting and whitespace alignment updates across test and utility files with no impact to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->