### PR TITLE
chore(terraform): remove committed tfplan.lt + gitignore plan files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,7 +104,9 @@ backend.hcl
 
 # Terraform plan files
 tfplan
+tfplan.*
 *.tfplan
+*.tfplan.*
 
 # Terraform state and outputs
 terraform-apply-*.txt

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -33,8 +33,10 @@ terraform.rc
 !.terraform.lock.hcl
 
 # Plan files
+tfplan
+tfplan.*
 *.tfplan
-*.tfplan.json
+*.tfplan.*
 
 # Environment-specific variable files
 environments/**/terraform.tfvars


### PR DESCRIPTION
## Summary

- Adds `tfplan.*` and `*.tfplan.*` gitignore patterns to both `.gitignore` and `terraform/.gitignore` to prevent Terraform plan binaries from being committed.
- Documents the issue introduced by commit `afea1b7fa`, which accidentally committed `terraform/environments/aws/ci-cd-permissions/tfplan.lt` (26,944 bytes) -- a build artifact that can contain sensitive resource and state details.

Closes #1098

## Root cause

The existing `.gitignore` had `tfplan` (exact name) and `*.tfplan` (suffix), but not `tfplan.*`, so `tfplan.lt` slipped through. The file itself is only present on the `fix/706-partially-completed-chip` branch (introduced by `afea1b7fa`). That branch must remove the file via `git rm terraform/environments/aws/ci-cd-permissions/tfplan.lt` before it merges into `feat/multicloud-web-frontend`.

## gitignore rules added

In `.gitignore` and `terraform/.gitignore`:
```
tfplan.*
*.tfplan.*
```

After this PR, `git check-ignore -v terraform/environments/aws/ci-cd-permissions/tfplan.lt` correctly matches `terraform/.gitignore:37:tfplan.*`.

## Test plan

- [x] `git check-ignore -v terraform/environments/aws/ci-cd-permissions/tfplan.lt` returns a match
- [ ] Branch carrying `afea1b7fa` removes `tfplan.lt` via `git rm` before merging
- [ ] CI passes (change is .gitignore-only, no Go/frontend code touched)