### PR TITLE
fix(cli): add recover() guard to queryRDSInstancesInRegions worker goroutine

### DIFF
--- a/cmd/multi_service_engine_versions.go
+++ b/cmd/multi_service_engine_versions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -112,6 +113,13 @@ func queryRDSInstancesInRegions(ctx context.Context, awsCfg aws.Config, regions 
 		go func(regionName string) {
 			defer wg.Done()
 			defer func() { <-sem }() // release semaphore
+			defer func() {
+				if r := recover(); r != nil {
+					buf := make([]byte, 4096)
+					n := runtime.Stack(buf, false)
+					log.Printf("ERROR: panic in region worker (region=%s): %v\n%s", regionName, r, buf[:n])
+				}
+			}()
 			queryRDSInstancesInRegion(ctx, awsCfg, regionName, instanceVersions, &mu)
 		}(aws.ToString(region.RegionName))
 	}


### PR DESCRIPTION
## Summary

- `cmd/multi_service_engine_versions.go:112` spawns one goroutine per AWS region that calls `queryRDSInstancesInRegion` (map writes + AWS SDK calls, both can panic). A panic in one region's worker crashed the whole CLI process, silently aborting all remaining regions.
- Add a deferred `recover()` that logs the panic with region context (`log.Printf("ERROR: panic in region worker (region=%s): %v\n%s", regionName, r, buf[:n])`), then allows the goroutine to exit cleanly. The other workers continue and `wg.Wait()` collects their results.
- Mirrors the pattern applied to Lambda fire-and-forget goroutines in PR #859 (issue #672).

Closes #997

## Test plan

- [x] `go build ./cmd/...` succeeds.
- [x] `go test ./cmd/...` passes (all existing tests green).
- [x] Pattern mirrors `internal/execution/fanout.go` recover() guard which has a unit test asserting panic isolation (`TestFanOut_PanicInFn`).

## Labels (mirrored from issue #997)

`priority/p3` `severity/low` `urgency/eventually` `impact/internal` `effort/xs` `type/bug` `triaged`

---
_Generated by [Claude Code](https://claude.ai/code/session_014XhBX2VZ6aGAn85GoHsYaj)_