### PR TITLE
fix(frontend/test): stub escapeHtmlAttr in utils mocks (Build frontend CI red)

### DIFF
--- a/frontend/src/__tests__/allowed-accounts.test.ts
+++ b/frontend/src/__tests__/allowed-accounts.test.ts
@@ -55,6 +55,10 @@ jest.mock('../utils', () => ({
   formatDate: jest.fn((val: string) => (val ? new Date(val).toLocaleDateString() : '')),
   formatTerm: jest.fn((years: number) => (years == null ? '' : `${years} Year${years === 1 ? '' : 's'}`)),
   escapeHtml: jest.fn((str: string) => str || ''),
+  escapeHtmlAttr: jest.fn((str: string | null | undefined) => {
+    if (!str) return '';
+    return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  }),
   populateAccountFilter: jest.fn(() => Promise.resolve()),
 }));
 

--- a/frontend/src/__tests__/history-approval-queue.test.ts
+++ b/frontend/src/__tests__/history-approval-queue.test.ts
@@ -37,6 +37,10 @@ jest.mock('../utils', () => ({
   formatDate: jest.fn((val) => (val ? new Date(val).toLocaleDateString() : '')),
   formatTerm: jest.fn((years) => (years == null ? '' : `${years} Year${years === 1 ? '' : 's'}`)),
   escapeHtml: jest.fn((str) => str || ''),
+  escapeHtmlAttr: jest.fn((str: string | null | undefined) => {
+    if (!str) return '';
+    return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  }),
   populateAccountFilter: jest.fn(() => Promise.resolve()),
 }));
 

--- a/frontend/src/__tests__/history-approve-button.test.ts
+++ b/frontend/src/__tests__/history-approve-button.test.ts
@@ -35,6 +35,10 @@ jest.mock('../utils', () => ({
   formatDate: jest.fn((val) => (val ? new Date(val).toLocaleDateString() : '')),
   formatTerm: jest.fn((years) => (years == null ? '' : `${years} Year${years === 1 ? '' : 's'}`)),
   escapeHtml: jest.fn((str) => str || ''),
+  escapeHtmlAttr: jest.fn((str: string | null | undefined) => {
+    if (!str) return '';
+    return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  }),
   populateAccountFilter: jest.fn(() => Promise.resolve()),
 }));
 

--- a/frontend/src/__tests__/history-cancel-button.test.ts
+++ b/frontend/src/__tests__/history-cancel-button.test.ts
@@ -32,6 +32,10 @@ jest.mock('../utils', () => ({
   formatDate: jest.fn((val) => (val ? new Date(val).toLocaleDateString() : '')),
   formatTerm: jest.fn((years) => (years == null ? '' : `${years} Year${years === 1 ? '' : 's'}`)),
   escapeHtml: jest.fn((str) => str || ''),
+  escapeHtmlAttr: jest.fn((str: string | null | undefined) => {
+    if (!str) return '';
+    return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  }),
   populateAccountFilter: jest.fn(() => Promise.resolve()),
 }));
 

--- a/frontend/src/__tests__/history-cancel-permissions.test.ts
+++ b/frontend/src/__tests__/history-cancel-permissions.test.ts
@@ -34,6 +34,10 @@ jest.mock('../utils', () => ({
   formatDate: jest.fn((val) => (val ? new Date(val).toLocaleDateString() : '')),
   formatTerm: jest.fn((years) => (years == null ? '' : `${years} Year${years === 1 ? '' : 's'}`)),
   escapeHtml: jest.fn((str) => str || ''),
+  escapeHtmlAttr: jest.fn((str: string | null | undefined) => {
+    if (!str) return '';
+    return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  }),
   populateAccountFilter: jest.fn(() => Promise.resolve()),
 }));
 

--- a/frontend/src/__tests__/history-retry-button.test.ts
+++ b/frontend/src/__tests__/history-retry-button.test.ts
@@ -41,6 +41,10 @@ jest.mock('../utils', () => ({
   formatDate: jest.fn((val) => (val ? new Date(val).toLocaleDateString() : '')),
   formatTerm: jest.fn((years) => (years == null ? '' : `${years} Year${years === 1 ? '' : 's'}`)),
   escapeHtml: jest.fn((str) => str || ''),
+  escapeHtmlAttr: jest.fn((str: string | null | undefined) => {
+    if (!str) return '';
+    return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  }),
   populateAccountFilter: jest.fn(() => Promise.resolve()),
 }));
 

--- a/frontend/src/__tests__/plans.test.ts
+++ b/frontend/src/__tests__/plans.test.ts
@@ -107,6 +107,10 @@ jest.mock('../utils', () => ({
   formatRampSchedule: jest.fn((val) => val || 'Unknown'),
   getStatusBadge: jest.fn(() => ({ class: 'active', label: 'Active' })),
   escapeHtml: jest.fn((str) => str || ''),
+  escapeHtmlAttr: jest.fn((str: string | null | undefined) => {
+    if (!str) return '';
+    return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  }),
   formatCurrency: jest.fn((val) => `$${val || 0}`),
   populateAccountFilter: jest.fn(() => Promise.resolve()),
   // providerBadgeHtml added for H1 fix: returns a deterministic span so XSS


### PR DESCRIPTION
Seven jest suites omitted `escapeHtmlAttr` from their `jest.mock('../utils', ...)` factory, causing `TypeError: (0 , utils_1.escapeHtmlAttr) is not a function` when `plans.ts`/`history.ts` render. Added the stub already present in `history.test.ts` (encodes `& < > " '`) to each affected suite. No production code changes. After fix: 2497 tests pass, only the 2 pre-existing timezone failures in `utils.test.ts` remain, `tsc --noEmit` is clean.

Closes #1115