### PR TITLE
fix(frontend/test): add missing escapeHtmlAttr stub to utils mock

### DIFF
--- a/frontend/src/__tests__/plans-range-validation.test.ts
+++ b/frontend/src/__tests__/plans-range-validation.test.ts
@@ -76,6 +76,15 @@ jest.mock('../utils', () => ({
   formatRampSchedule: jest.fn((v) => v ?? ''),
   getStatusBadge: jest.fn(() => ({ class: 'active', label: 'Active' })),
   escapeHtml: jest.fn((s) => s ?? ''),
+  escapeHtmlAttr: jest.fn((str: string | null | undefined) => {
+    if (str == null) return '';
+    return str
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }),
   formatCurrency: jest.fn((v) => `$${v}`),
   populateAccountFilter: jest.fn(() => Promise.resolve()),
 }));


### PR DESCRIPTION
## Problem

`plans-range-validation.test.ts` uses a closed mock factory for `../utils` that lists every util function explicitly. When `escapeHtmlAttr` was added to `utils.ts` it was not added to this factory, so any test that exercises `renderPlannedPurchaseRow` or `renderPlanCard` threw `TypeError: escapeHtmlAttr is not a function`, failing the entire suite in CI.

The two other XSS test files (`xss-provider-class.test.ts`, `xss-purchase-status.test.ts`) use `jest.requireActual` with `...actual` spread, so they inherit the real implementation automatically and were not affected.

## Fix

Add `escapeHtmlAttr` to the closed mock factory in `plans-range-validation.test.ts` with a faithful HTML-attribute escape implementation (same character set the real `utils.ts` function escapes).

## Verification

All 42 tests in `plans-range-validation.test.ts` pass locally after this change.

## Labels (mirrored from #1115)

`priority/p2` | `severity/medium` | `urgency/this-sprint` | `impact/internal` | `effort/s` | `type/bug` | `triaged`

Closes #1115

---
_Generated by [Claude Code](https://claude.ai/code/session_01WR6EXxhD8wtUghbTxHtxmb)_