### PR TITLE
style(frontend/recs): align cost-period selector inline with toolbar controls

### DIFF
--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -708,6 +708,24 @@ th .column-filter-btn.active {
     font-size: 0.85em;
     color: var(--cudly-text-muted);
 }
+/* "Show costs: <period>" selector: keep the label and select inline and
+   vertically centered so the control sits on the same line as the count,
+   Expand all and Columns, instead of the small label stacking above the
+   taller select (the base `select` style is bigger than the bar's buttons). */
+.recommendations-filter-status .cost-period-selector-wrapper {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    white-space: nowrap;
+}
+.recommendations-filter-status .cost-period-selector-label {
+    color: var(--cudly-text-muted);
+}
+.recommendations-filter-status .cost-period-select {
+    padding: 0.25rem 0.6rem;
+    font-size: 0.85em;
+    line-height: 1.2;
+}
 .recommendations-filter-status .clear-filters {
     background: var(--cudly-info-bg);
     border: 1px solid #a9c7f5;


### PR DESCRIPTION
## Problem

On the Recommendations toolbar, the **"Show costs:"** label stacked *above* the period dropdown instead of sitting on the same line as the count / **Expand all** / **Columns** (see issue screenshot).

## Cause

`.recommendations-filter-status` is already `display:flex; align-items:center`, but `.cost-period-selector-wrapper` (the span holding the label + `<select>`) had **no CSS**. The base `select` style (`forms.css`: `padding:0.5rem; font-size:0.9rem`) is taller than the bar's buttons, so the small label aligned to the select's baseline and rendered above it.

## Fix (CSS-only, scoped to the bar)

- `.cost-period-selector-wrapper` → `inline-flex; align-items:center; gap` so the label + select are side-by-side, vertically centered.
- `.cost-period-select` → match the bar buttons' `padding:0.25rem 0.6rem; font-size:0.85em`.

Now the count, **Expand all**, **Show costs: <period>** and **Columns** all sit on one line, vertically centered.

_CSS-only; no behavior change. The bundle is verified by the "Build frontend" CI check (local build skipped — fresh worktree without node_modules)._