### PR TITLE
fix(ci): repair pre-existing base-branch test failures (closes #993)

### DIFF
--- a/frontend/src/__tests__/utils.test.ts
+++ b/frontend/src/__tests__/utils.test.ts
@@ -58,8 +58,10 @@ describe('formatCurrency', () => {
 
 describe('formatDate', () => {
   test('renders canonical "Mon DD, YYYY" form regardless of browser locale', () => {
-    // 2024-03-15 → "Mar 15, 2024" in en-US short-month format. The check
-    // is locale-invariant because formatDate forces en-US.
+    // 2024-03-15 → "Mar 15, 2024" in en-US short-month format. The check is
+    // locale-invariant (formatDate forces en-US) and timezone-invariant: a
+    // bare "YYYY-MM-DD" is parsed as local midnight, so the displayed day
+    // stays 15 even in browsers west of UTC (previously rendered "Mar 14").
     expect(formatDate('2024-03-15')).toBe('Mar 15, 2024');
   });
 
@@ -75,7 +77,17 @@ describe('formatDate', () => {
 
   test('returns empty string for invalid date', () => {
     expect(formatDate('not-a-date')).toBe('');
+    // Digit-shaped but out-of-range: must not silently roll over (month 13,
+    // day 45) into a valid date — parseDateInput round-trips and rejects it.
     expect(formatDate('2024-13-45')).toBe('');
+  });
+
+  test('does not shift a bare calendar day across the day boundary', () => {
+    // A date-only string is the intended calendar day; it must render the
+    // same day regardless of the runner's timezone (regression for the
+    // UTC-midnight off-by-one that showed "Mar 14" west of UTC).
+    expect(formatDate('2024-01-01')).toBe('Jan 1, 2024');
+    expect(formatDate('2024-12-31')).toBe('Dec 31, 2024');
   });
 });
 
@@ -135,6 +147,15 @@ describe('getDateParts', () => {
 
   test('returns zeros for invalid date', () => {
     expect(getDateParts('invalid')).toEqual({ day: 0, month: '' });
+    // Out-of-range digits must be rejected, not rolled over.
+    expect(getDateParts('2024-13-45')).toEqual({ day: 0, month: '' });
+  });
+
+  test('keeps a bare calendar day stable across timezones', () => {
+    // Regression: a date-only string parsed as UTC midnight previously
+    // reported the previous day's date west of UTC.
+    expect(getDateParts('2024-03-15').day).toBe(15);
+    expect(getDateParts('2024-01-01').day).toBe(1);
   });
 });
 

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -39,6 +39,43 @@ export function formatCurrency(
 }
 
 /**
+ * Parse a date input into a Date, treating bare calendar dates correctly.
+ *
+ * A date-only ISO string ("2024-03-15") is parsed by `new Date()` as UTC
+ * midnight; rendering it with a locale formatter then shifts it into the
+ * browser's local timezone, so a user west of UTC sees the *previous* day
+ * ("Mar 14") for a date the backend meant as a plain calendar day (e.g. a
+ * purchase's scheduled_date or a reservation end_date). Parse bare
+ * "YYYY-MM-DD" values as local midnight instead so the displayed day matches
+ * the intended calendar day in every timezone. Strings carrying a time/zone
+ * component ("2024-03-15T14:30:00Z") and Date objects are left untouched.
+ */
+function parseDateInput(date: string | Date): Date {
+  if (typeof date === 'string') {
+    const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
+    if (m) {
+      const year = Number(m[1]);
+      const month = Number(m[2]); // 1-based as written
+      const day = Number(m[3]);
+      // Local midnight for the given calendar day (Date month is 0-based).
+      const d = new Date(year, month - 1, day);
+      // Reject out-of-range components (e.g. "2024-13-45"): the Date
+      // constructor silently rolls them over instead of producing NaN, so
+      // verify the round-trip and return an Invalid Date if it doesn't match.
+      if (
+        d.getFullYear() !== year ||
+        d.getMonth() !== month - 1 ||
+        d.getDate() !== day
+      ) {
+        return new Date(NaN);
+      }
+      return d;
+    }
+  }
+  return new Date(date);
+}
+
+/**
  * Canonical date-only format used everywhere in the UI: "Apr 17, 2026".
  * The en-US locale + `month: 'short'` removes ambiguity from pure numeric
  * forms ("3/25/2026" vs "25.3.2026") and stays compact enough for table
@@ -46,7 +83,7 @@ export function formatCurrency(
  */
 export function formatDate(date: string | Date | null | undefined): string {
   if (!date) return '';
-  const d = new Date(date);
+  const d = parseDateInput(date);
   if (isNaN(d.getTime())) return '';
   return d.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
 }
@@ -111,7 +148,7 @@ export interface DateParts {
  */
 export function getDateParts(date: string | Date | null | undefined): DateParts {
   if (!date) return { day: 0, month: '' };
-  const d = new Date(date);
+  const d = parseDateInput(date);
   if (isNaN(d.getTime())) return { day: 0, month: '' };
   return {
     day: d.getDate(),

--- a/internal/auth/test_helpers.go
+++ b/internal/auth/test_helpers.go
@@ -217,6 +217,25 @@ var _ EmailSenderInterface = (*MockEmailSender)(nil)
 // calling a real key-generation path.
 var testCSRFKey = []byte("test-csrf-key-32-bytes-padded---")
 
+// TestCSRFKey returns the fixed 32-byte CSRF key shared by test services.
+// Pass it as ServiceConfig.CSRFKey so a service built via NewService derives
+// CSRF tokens deterministically (no ephemeral random key), letting tests in
+// other packages reproduce the expected token with DeriveTestCSRFToken.
+func TestCSRFKey() []byte {
+	// Return a copy so callers cannot mutate the package-level key.
+	key := make([]byte, len(testCSRFKey))
+	copy(key, testCSRFKey)
+	return key
+}
+
+// DeriveTestCSRFToken returns the CSRF token a service configured with
+// TestCSRFKey expects for the given raw session token. It reuses the
+// production derivation (HMAC-SHA256(key, rawSessionToken)) so tests assert
+// the real contract rather than duplicating the crypto.
+func DeriveTestCSRFToken(rawSessionToken string) string {
+	return deriveCSRFToken(testCSRFKey, rawSessionToken)
+}
+
 // newTestService returns a minimal Service with fast bcrypt for unit tests.
 // It has no store or email sender — use createTestService() for tests that need mocks.
 func newTestService() *Service {

--- a/internal/server/adapter_test.go
+++ b/internal/server/adapter_test.go
@@ -18,6 +18,11 @@ func createMockAuthService(t *testing.T) (*authServiceAdapter, *auth.MockStore) 
 	service := auth.NewService(auth.ServiceConfig{
 		Store:           mockStore,
 		SessionDuration: time.Hour,
+		// Pin a deterministic CSRF key so CSRF-token derivation is
+		// reproducible and hermetic. Without this, NewService generates a
+		// random ephemeral key, so any test asserting a specific derived CSRF
+		// token (TestAuthServiceAdapter_ValidateCSRFToken) cannot reproduce it.
+		CSRFKey: auth.TestCSRFKey(),
 	})
 	adapter := newAuthServiceAdapter(service)
 	return adapter, mockStore
@@ -238,7 +243,13 @@ func TestAuthServiceAdapter_ValidateCSRFToken(t *testing.T) {
 		ExpiresAt: time.Now().Add(time.Hour),
 	}, nil)
 
-	err := adapter.ValidateCSRFToken(ctx, "session-token", "csrf-token")
+	// ValidateCSRFToken recomputes the expected token as
+	// HMAC-SHA256(csrfKey, rawSessionToken); it never reads the stored
+	// CSRFToken column. Derive the matching token from the same fixed key the
+	// service was built with (auth.TestCSRFKey) so the assertion is hermetic
+	// and does not depend on an ambient CSRFKey from the environment.
+	csrfToken := auth.DeriveTestCSRFToken("session-token")
+	err := adapter.ValidateCSRFToken(ctx, "session-token", csrfToken)
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
## Summary

Repairs the pre-existing test failures that make a pristine checkout of `feat/multicloud-web-frontend` red, so every open PR stops inheriting an UNSTABLE base. Fixed in one focused commit; CSRF logic and CSRF/login security behavior are untouched.

Closes #993.

## Fixes

### 1. `internal/server` `TestAuthServiceAdapter_ValidateCSRFToken` (base flake, was red)

**Root cause:** `createMockAuthService` built the service via `auth.NewService` without a `CSRFKey`, so `NewService` generated a *random ephemeral* key on every run. The test then asserted that the literal `"csrf-token"` validates, but `ValidateCSRFToken` recomputes the expected token as `HMAC-SHA256(csrfKey, rawSessionToken)`, which a random key can never make equal to a fixed literal. It only ever "passed" if an ambient `CSRFKey` happened to derive that value, which a clean checkout never has.

**Fix (test-side, hermetic):** pin a deterministic key via a new exported `auth.TestCSRFKey()` and assert the *real* derived token via a new `auth.DeriveTestCSRFToken()` (which reuses the production `deriveCSRFToken`, no crypto duplication). The actual CSRF validation logic is unchanged; the test now exercises the real end-to-end path deterministically.

### 2. `frontend` `utils.test.ts` `formatDate` / `getDateParts` (base flake, was red outside UTC)

**Root cause (genuine code bug, not just a test-env assumption):** a date-only string like `"2024-03-15"` is parsed by `new Date()` as **UTC midnight**, then `toLocaleDateString` / `getDate()` shifts it into the browser's local timezone, so any user west of UTC saw the **previous day** ("Mar 14") for dates the backend means as plain calendar days (purchase `scheduled_date`, reservation `end_date`, etc.). The test only passed in a UTC runner.

**Fix (code-side, root cause):** parse bare `"YYYY-MM-DD"` as **local midnight** via a new `parseDateInput` helper, with round-trip validation so out-of-range digits (`"2024-13-45"`) still reject as invalid instead of silently rolling over. Full timestamps (`...T..:..Z`) and `Date` objects are left untouched (`formatDateTime` / `formatRelativeTime` keep their time-of-day behavior). Added timezone-invariance regression tests; the full frontend suite (2510 tests, 74 suites) passes in UTC, `America/Los_Angeles`, `Asia/Tokyo`, and `America/New_York`.

### 3. `internal/auth` `TestLogin_WithMFA_NoSecret` (#993 - already resolved on base)

`#993` no longer reproduces on the current base: `service.go` already routes every login-failure branch (unknown email, store error, inactive/locked account, wrong password, MFA-secret anomaly) through the single `genericLoginError` constant `"Check your email address and password and try again"`. Unknown-email and wrong-password therefore return a **byte-identical** message, preserving the anti-enumeration property the test guards. Both subcases pass. A previously-merged PR fixed it; this PR closes the issue alongside the remaining base-CI repairs.

## Verification

- `go build ./...` — success
- `go test ./internal/auth/... ./internal/server/...` — 909 passed
- `npx tsc --noEmit` (frontend) — clean
- `jest` full frontend suite — 2510 passed / 1 skipped across UTC, LA, Tokyo, NY timezones
- Each previously-failing test confirmed red on pristine base before the fix and green after.
