### PR TITLE
fix(frontend/recommendations): stop runaway refresh loop hammering the collector

### DIFF
--- a/frontend/src/__tests__/recommendations.test.ts
+++ b/frontend/src/__tests__/recommendations.test.ts
@@ -143,6 +143,12 @@ describe('Recommendations Module', () => {
     });
     (recsApi.refreshRecommendations as jest.Mock).mockResolvedValue({});
     mockShowToast.mockReturnValue({ dismiss: jest.fn() });
+
+    // Reset the auto-refresh in-flight guard AND the once-per-session
+    // latch so each test starts with a clean auto-refresh state. Without
+    // this, the first stale-load test latches autoRefreshAttempted and
+    // every later test in this block would silently skip the auto-refresh.
+    resetAutoRefreshInFlight();
   });
 
   afterEach(() => {
@@ -1455,6 +1461,48 @@ describe('Recommendations Module', () => {
       expect(inFlightCall).toBeDefined();
       const inFlightOpts = inFlightCall![0] as { timeout?: number | null };
       expect(inFlightOpts.timeout).toBeNull();
+    });
+
+    // Runaway-loop regression. Reproduces the production cost incident: the
+    // backend collect SUCCEEDS (POST /recommendations/refresh resolves) but the
+    // collector never advances last_collected_at (it fails at a DB error), so
+    // freshness stays stale forever. The success path calls onReload()
+    // (loadRecommendations by default), which re-enters triggerAutoRefreshIfStale.
+    // Pre-fix this recurses and re-fires the paid collect endpoint on every
+    // reload — observed at ~4-10 calls/sec in production. Post-fix the
+    // once-per-session latch caps it at exactly one collect across repeated
+    // loads / the post-refresh reload.
+    test('runaway loop — stale-that-never-clears fires the collect exactly once across reloads (#cost-risk)', async () => {
+      mockGetRecs();
+      // Freshness is ALWAYS stale (collector never advances it).
+      (recsApi.getRecommendationsFreshness as jest.Mock).mockResolvedValue({
+        last_collected_at: null,
+        last_collection_error: null,
+      });
+      // The refresh POST SUCCEEDS (real scenario: backend returns 202), which
+      // is what drives the success-path onReload() re-entry.
+      (recsApi.refreshRecommendations as jest.Mock).mockResolvedValue({});
+
+      // First page open: should auto-refresh once. The default onReload is
+      // loadRecommendations, so the success path re-enters this whole chain.
+      await loadRecommendations();
+      // Drain the .then(onReload) -> loadRecommendations -> triggerAutoRefreshIfStale
+      // microtask/promise chain several times; pre-fix each drain re-fires the
+      // collect, so a multi-iteration drain makes the runaway unmistakable.
+      for (let i = 0; i < 10; i++) {
+        await Promise.resolve();
+      }
+
+      // Even simulated subsequent reloads (filter change, tab re-entry) must
+      // NOT re-arm the auto-collect within the same session.
+      await loadRecommendations();
+      await loadRecommendations();
+      for (let i = 0; i < 10; i++) {
+        await Promise.resolve();
+      }
+
+      // Exactly one paid collect, regardless of how many reloads occurred.
+      expect(recsApi.refreshRecommendations).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/frontend/src/recommendations.ts
+++ b/frontend/src/recommendations.ts
@@ -85,6 +85,22 @@ let lastRecommendationsSummary: RecommendationsSummary | null = null;
 // skips kicking off a second request (and duplicate toasts).
 let autoRefreshInFlight: Promise<void> | null = null;
 
+// Runaway-loop guard: latch so the stale-on-open auto-refresh fires AT MOST
+// once per page session. Without it, triggerAutoRefreshIfStale -> (stale)
+// -> startRecommendationsRefresh -> onReload() (loadRecommendations /
+// loadDashboard) re-enters triggerAutoRefreshIfStale, and when the backend
+// collection never advances last_collected_at (e.g. it fails at a DB error,
+// so freshness stays stale forever) the success path re-fires the collect
+// endlessly — observed at ~4-10 POST /recommendations/refresh per second in
+// production, each a paid Cost Explorer / pricing call once the collector
+// reaches AWS. autoRefreshInFlight only dedups *concurrent* refreshes; it is
+// cleared per cycle, so it cannot stop this sequential re-trigger. The latch
+// is intentionally NOT reset on success/failure: the auto-refresh is a
+// once-per-load convenience, and a hard page reload resets module state.
+// Explicit user actions (lookback change, manual refresh) call
+// startRecommendationsRefresh() directly and so are never gated by this latch.
+let autoRefreshAttempted = false;
+
 /**
  * Freshness budget for auto-refresh (#284). If the last successful collection
  * is older than this threshold (or there has never been one), loadRecommendations
@@ -159,6 +175,7 @@ export function resetExpandedCells(): void {
  */
 export function resetAutoRefreshInFlight(): void {
   autoRefreshInFlight = null;
+  autoRefreshAttempted = false;
 }
 
 /**
@@ -280,6 +297,16 @@ export function setupRecommendationsHandlers(): void {
 export async function triggerAutoRefreshIfStale(
   onReload: () => Promise<void> = loadRecommendations,
 ): Promise<void> {
+  // Runaway-loop guard: the stale-on-open auto-refresh runs at most once per
+  // page session. startRecommendationsRefresh's success path calls onReload()
+  // (loadRecommendations / loadDashboard), which re-enters this function; when
+  // the collector never advances last_collected_at the freshness stays stale
+  // and we would re-fire the (paid) collect endlessly. Latch before the
+  // freshness fetch so neither the GET nor the collect repeats. Explicit user
+  // refreshes bypass this by calling startRecommendationsRefresh() directly.
+  if (autoRefreshAttempted) return;
+  autoRefreshAttempted = true;
+
   let freshness;
   try {
     freshness = await getRecommendationsFreshness();


### PR DESCRIPTION
## Summary

Stops a runaway auto-refresh loop on the Recommendations (Opportunities) and Home (Dashboard) pages that fires the backend recommendation collector continuously. This is a **cost risk**: each collector run is a paid Cost Explorer / pricing API call (~$0.01) once it reaches AWS.

## Repro

1. Open the Recommendations page (or Home) while the recommendations cache is stale (older than 24h, or never collected).
2. `triggerAutoRefreshIfStale` sees stale -> `startRecommendationsRefresh` -> POST `/api/recommendations/refresh` (the collector).
3. The refresh POST returns success (202), so the `.then` path calls `onReload()` (`loadRecommendations` on Opportunities, `loadDashboard` on Home).
4. `onReload` re-runs `triggerAutoRefreshIfStale`. Because the collector never advances `last_collected_at` (currently it fails fast at a DB error, so freshness stays stale forever), the page is *still* stale -> fire the collect again -> reload -> stale -> ... with no terminal condition.

## Evidence

Production logs show the backend collector being hit ~4-10 times **per second**, sustained (~18k calls/hour), accompanied by a repeating "Recommendations refreshed" toast. Today those calls fail fast at a DB error before reaching Cost Explorer, but a DB fix is imminent: once it lands, every loop iteration becomes a continuous paid Cost Explorer / pricing call.

## Root cause

`frontend/src/recommendations.ts`:

- `triggerAutoRefreshIfStale` (the stale-on-open auto-refresh) has no once-per-session guard.
- `startRecommendationsRefresh`'s success path unconditionally calls `onReload()`, which re-enters `triggerAutoRefreshIfStale`.
- The existing `autoRefreshInFlight` guard only dedups **concurrent** refreshes and is cleared in `.finally()` each cycle, so it cannot stop this **sequential** re-trigger.

This is a reactive/effect loop: the refresh's success reload re-evaluates the stale condition that triggered it, and the condition never clears.

## Fix

Add a once-per-page-session latch (`autoRefreshAttempted`) checked at the top of `triggerAutoRefreshIfStale`, before the freshness GET. The stale-on-open auto-refresh now fires **at most once** per page session, regardless of how many times `loadRecommendations` / `loadDashboard` re-run (filter changes, tab re-entry, the post-refresh reload). One change fixes both the Opportunities and Home entry points, since both reload paths funnel through `triggerAutoRefreshIfStale`.

Explicit user actions (lookback change, manual refresh) call `startRecommendationsRefresh` directly and are intentionally **not** gated by the latch. A hard page reload resets module state, re-arming the once-per-load convenience. The fix does not just suppress the toast; it stops the redundant backend calls themselves.

## Test

Added a regression test that reproduces the real scenario (collect POST resolves, freshness stays stale) and asserts the collect endpoint is hit **exactly once** across repeated loads and the post-refresh reload.

- Pre-fix: FAILS (2 collect calls observed; the loop re-fires on reload).
- Post-fix: PASSES (1 collect call).

The latch is reset in the recommendations test `beforeEach` so it cannot leak across tests.

## Verification

- `npx tsc --noEmit`: clean.
- `npx jest` for the touched suites (recommendations, recommendations-permissions, recommendations-enabled-providers, recommendations-lookback, dashboard, navigation, dashboard-ownership-950, settings-accounts): 658 passed, 0 failed.
