### PR TITLE
fix(aws/recommendations): case-insensitive EC2 tenancy so AWS RI recs are not dropped

### DIFF
--- a/providers/aws/recommendations/parser_services.go
+++ b/providers/aws/recommendations/parser_services.go
@@ -82,15 +82,24 @@ func (c *Client) parseElastiCacheDetails(_ context.Context, rec *common.Recommen
 // directly. A nil pointer (CE omitted the field) also maps to default, because
 // CE only populates the field when it is non-default.
 //
+// Matching is case- and whitespace-insensitive: Cost Explorer returns the
+// value title-cased ("Shared", "Dedicated", "Host") even though older docs
+// imply lowercase, so a case-sensitive compare silently rejected every real
+// EC2 RI recommendation and the caller dropped it (no AWS opportunities on the
+// dashboard). Normalising the input keeps the parser robust to AWS varying the
+// casing without re-introducing a silent fallback.
+//
 // Unknown tenancy values (e.g. "host" for Dedicated Hosts, which have no
 // corresponding RI product) return an error so the caller fails loud rather
 // than silently querying for and buying a default-tenancy RI on behalf of a
 // workload that requires a different tenancy class (M5 fix).
 func resolveEC2Tenancy(tenancy *string) (string, error) {
-	if tenancy == nil || *tenancy == "shared" {
+	if tenancy == nil {
 		return string(ec2types.TenancyDefault), nil
 	}
-	switch *tenancy {
+	switch strings.ToLower(strings.TrimSpace(*tenancy)) {
+	case "shared":
+		return string(ec2types.TenancyDefault), nil
 	case "dedicated":
 		return string(ec2types.TenancyDedicated), nil
 	default:

--- a/providers/aws/recommendations/parser_services_test.go
+++ b/providers/aws/recommendations/parser_services_test.go
@@ -345,6 +345,88 @@ func TestParseEC2Details(t *testing.T) {
 			},
 		},
 		{
+			// Regression for "AWS opportunities missing": Cost Explorer
+			// returns Tenancy title-cased as "Shared" (not lowercase
+			// "shared"). The pre-fix case-sensitive compare rejected it,
+			// parseRecommendations swallowed the error and continue'd, and
+			// every EC2 RI recommendation was dropped -> no AWS recs on the
+			// dashboard. This is the exact casing observed in production logs.
+			name: "EC2 CE title-cased Shared tenancy maps to default",
+			details: &types.ReservationPurchaseRecommendationDetail{
+				InstanceDetails: &types.InstanceDetails{
+					EC2InstanceDetails: &types.EC2InstanceDetails{
+						InstanceType: aws.String("m5.large"),
+						Platform:     aws.String("Linux/UNIX"),
+						Region:       aws.String("US East (N. Virginia)"),
+						Tenancy:      aws.String("Shared"),
+					},
+				},
+			},
+			expectError: false,
+			validate: func(t *testing.T, rec *common.Recommendation) {
+				ec2Details, ok := rec.Details.(*common.ComputeDetails)
+				require.True(t, ok)
+				assert.Equal(t, "default", ec2Details.Tenancy)
+			},
+		},
+		{
+			// Same fix for the dedicated case: CE title-cases "Dedicated".
+			name: "EC2 CE title-cased Dedicated tenancy maps to dedicated",
+			details: &types.ReservationPurchaseRecommendationDetail{
+				InstanceDetails: &types.InstanceDetails{
+					EC2InstanceDetails: &types.EC2InstanceDetails{
+						InstanceType: aws.String("r5.xlarge"),
+						Platform:     aws.String("Windows"),
+						Region:       aws.String("eu-central-1"),
+						Tenancy:      aws.String("Dedicated"),
+					},
+				},
+			},
+			expectError: false,
+			validate: func(t *testing.T, rec *common.Recommendation) {
+				ec2Details, ok := rec.Details.(*common.ComputeDetails)
+				require.True(t, ok)
+				assert.Equal(t, "dedicated", ec2Details.Tenancy)
+			},
+		},
+		{
+			// Leading/trailing whitespace must not defeat the mapping either.
+			name: "EC2 tenancy with surrounding whitespace maps to default",
+			details: &types.ReservationPurchaseRecommendationDetail{
+				InstanceDetails: &types.InstanceDetails{
+					EC2InstanceDetails: &types.EC2InstanceDetails{
+						InstanceType: aws.String("m5.large"),
+						Platform:     aws.String("Linux/UNIX"),
+						Region:       aws.String("us-east-1"),
+						Tenancy:      aws.String("  Shared  "),
+					},
+				},
+			},
+			expectError: false,
+			validate: func(t *testing.T, rec *common.Recommendation) {
+				ec2Details, ok := rec.Details.(*common.ComputeDetails)
+				require.True(t, ok)
+				assert.Equal(t, "default", ec2Details.Tenancy)
+			},
+		},
+		{
+			// M5 must still hold under the case-insensitive compare: title-cased
+			// "Host" (Dedicated Hosts, no RI product) must still error rather
+			// than collapse to default.
+			name: "EC2 title-cased Host tenancy still errors",
+			details: &types.ReservationPurchaseRecommendationDetail{
+				InstanceDetails: &types.InstanceDetails{
+					EC2InstanceDetails: &types.EC2InstanceDetails{
+						InstanceType: aws.String("m5.large"),
+						Platform:     aws.String("Linux/UNIX"),
+						Region:       aws.String("us-east-1"),
+						Tenancy:      aws.String("Host"),
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
 			name: "Missing EC2 instance details",
 			details: &types.ReservationPurchaseRecommendationDetail{
 				InstanceDetails: &types.InstanceDetails{


### PR DESCRIPTION
## Problem

On the live GUI, **AWS opportunities/recommendations are missing entirely**. AWS is the primary, most-tested provider, so this is a serious functional regression.

## Root cause

`resolveEC2Tenancy` (`providers/aws/recommendations/parser_services.go`) mapped the Cost Explorer EC2 RI tenancy case-sensitively against lowercase `"shared"` / `"dedicated"`. Cost Explorer actually returns the value **title-cased** (`"Shared"`, `"Dedicated"`, `"Host"`), so every real recommendation fell through to the `default` branch and returned an error. `parseRecommendations` (`parser_ri.go`) catches that error, logs a `Warning: Failed to parse recommendation detail ...` and `continue`s, **silently dropping every EC2 RI recommendation**.

Combined with Savings Plans collection being independently blocked by an IAM `AccessDeniedException` on `ce:GetSavingsPlansPurchaseRecommendation` (a separate permissions issue, not in scope here), AWS produced zero recommendations and the dashboard showed no AWS opportunities.

### Live log evidence (`/aws/lambda/cudly-dev-426fc8af-api`, deployed sha `0c10f1a`)

```
Warning: Failed to parse recommendation detail 0: unrecognised EC2 tenancy "Shared" from Cost Explorer: must be shared (default) or dedicated; host tenancy has no corresponding RI product
```

(repeated on every collection cycle, for every EC2 RI detail)

This is a genuine code bug, **not** the corrupted-DB / `offering_class` situation. The read path (`SELECT payload FROM recommendations` + provider/account WHERE) never references a migration-gap column; the data was missing because nothing was ever stored for AWS.

## Fix

Normalise the tenancy with `strings.ToLower(strings.TrimSpace(...))` before matching, mirroring the existing whitespace-tolerant handling already used on the RDS `DeploymentOption` path. The fail-loud M5 behaviour is preserved: `"host"` (Dedicated Hosts, no RI product) and any unknown value still error rather than collapse to a default-tenancy buy.

## Test

Added a regression test that replicates the exact production casing (`"Shared"` / `"Dedicated"` plus surrounding whitespace). Verified it **fails on the pre-fix parser** (3 new positive cases) and **passes after the fix**; also asserts title-cased `"Host"` still errors. Full package suite: 331 passed; `go build ./...` and `go vet` clean.

## Why the bug shipped despite green tests

The pre-existing `TestParseEC2Details` cases only used lowercase `"shared"`/`"dedicated"`, never the real Cost Explorer casing. The tests exercised a casing the live data does not use, so they stayed green while the feature was broken in production.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)
