### PR TITLE
fix(iac/aws): gate migration-failure alarm to unblock deploys

### DIFF
--- a/terraform/modules/compute/aws/lambda/migration-alarm.tf
+++ b/terraform/modules/compute/aws/lambda/migration-alarm.tf
@@ -22,6 +22,13 @@
 # inventing new SNS notification infrastructure here.
 
 resource "aws_cloudwatch_log_metric_filter" "migration_failed" {
+  # Gated off by default. Creating a metric filter needs logs:PutMetricFilter,
+  # which the CI deploy SA does not hold until the ci-cd-permissions bootstrap
+  # grants it (root CLAUDE.md "CI/CD IAM" bootstrap-vs-runtime split). Leaving
+  # this ungated 403s every terraform apply and blocks all deploys. Set
+  # enable_migration_alarm=true only after re-applying the bootstrap.
+  count = var.enable_migration_alarm ? 1 : 0
+
   name           = "${var.stack_name}-migration-failed"
   log_group_name = aws_cloudwatch_log_group.lambda.name
 
@@ -38,11 +45,13 @@ resource "aws_cloudwatch_log_metric_filter" "migration_failed" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "migration_failed" {
+  count = var.enable_migration_alarm ? 1 : 0
+
   alarm_name          = "${var.stack_name}-migration-failed"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 1
-  metric_name         = aws_cloudwatch_log_metric_filter.migration_failed.metric_transformation[0].name
-  namespace           = aws_cloudwatch_log_metric_filter.migration_failed.metric_transformation[0].namespace
+  metric_name         = aws_cloudwatch_log_metric_filter.migration_failed[0].metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.migration_failed[0].metric_transformation[0].namespace
   period              = 300
   statistic           = "Sum"
   threshold           = 0

--- a/terraform/modules/compute/aws/lambda/variables.tf
+++ b/terraform/modules/compute/aws/lambda/variables.tf
@@ -3,6 +3,12 @@ variable "stack_name" {
   type        = string
 }
 
+variable "enable_migration_alarm" {
+  description = "Create the migration-failure CloudWatch metric filter + alarm. Defaults to false because the metric filter requires logs:PutMetricFilter on the deploy SA, which is granted via the ci-cd-permissions bootstrap (root CLAUDE.md CI/CD IAM split). Leaving it false keeps deploys unblocked when that permission is absent; set true only after re-applying the bootstrap so the deploy role can manage the filter."
+  type        = bool
+  default     = false
+}
+
 variable "environment" {
   description = "Environment name (dev/staging/prod)"
   type        = string


### PR DESCRIPTION
## Problem
#1124's migration-failure CloudWatch metric filter (`terraform/modules/compute/aws/lambda/migration-alarm.tf`) needs `logs:PutMetricFilter`, which the CI deploy SA (`cudly-terraform-deploy/GitHubActions`) does not hold. Every `terraform apply` now 403s at that resource and **all deploys fail** (the Lambda code updates first, so the app looks deployed while the pipeline is red).

## Fix
Gate the metric filter + alarm behind a new `enable_migration_alarm` variable (default **false**), so deploys succeed without the permission. This is the bootstrap-vs-runtime IAM split from CLAUDE.md.

## To enable the alarm later
Grant `logs:PutMetricFilter/DeleteMetricFilter/DescribeMetricFilters` to the deploy SA in `terraform/environments/aws/ci-cd-permissions/`, re-apply that bootstrap (privileged human), then set `enable_migration_alarm=true`. (Follow-up.)

Verified: `terraform fmt` clean; pre-commit hooks pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added optional migration alarm monitoring to track and alert on migration failures
- Users can now enable CloudWatch metric filtering and alerting for migration events through a new configuration option
- Migration failure monitoring can be controlled per deployment environment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->