### PR TITLE
chore: point branch references at main after multicloud->main merge

### DIFF
--- a/.github/workflows/deploy-aws-lambda.yml
+++ b/.github/workflows/deploy-aws-lambda.yml
@@ -15,7 +15,7 @@
 #   - AWS_ROLE_TO_ASSUME: IAM role ARN for OIDC keyless auth
 #
 # Triggered by:
-#   - Pushes to main or feat/multicloud-web-frontend branch
+#   - Pushes to main branch
 #   - Manual workflow dispatch with environment selection
 #   - Release creation (auto-deploy to prod)
 #   - Workflow call from other workflows
@@ -32,7 +32,7 @@ concurrency:
 
 on:
   push:
-    branches: [main, feat/multicloud-web-frontend]
+    branches: [main]
     paths:
       - 'cmd/**'
       - 'internal/**'

--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -16,7 +16,7 @@
 #   - KEY_VAULT_NAME: Azure Key Vault name
 #
 # Triggered by:
-#   - Pushes to main or feat/multicloud-web-frontend branch
+#   - Pushes to main branch
 #   - Manual workflow dispatch
 #   - Workflow call from deploy-all.yml
 
@@ -32,7 +32,7 @@ concurrency:
 
 on:
   push:
-    branches: [main, feat/multicloud-web-frontend]
+    branches: [main]
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -14,7 +14,7 @@
 #   - ARTIFACT_REGISTRY_REPO: Artifact Registry repository name (default: cudly)
 #
 # Triggered by:
-#   - Pushes to main or feat/multicloud-web-frontend branch
+#   - Pushes to main branch
 #   - Manual workflow dispatch
 #   - Workflow call from deploy-all.yml
 
@@ -30,7 +30,7 @@ concurrency:
 
 on:
   push:
-    branches: [main, feat/multicloud-web-frontend]
+    branches: [main]
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -20,7 +20,6 @@ name: Frontend build (PR)
 on:
   pull_request:
     branches:
-      - feat/multicloud-web-frontend
       - main
     paths:
       - "frontend/**"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -2,9 +2,9 @@ name: pre-commit
 
 on:
   pull_request:
-    branches: [main, feat/multicloud-web-frontend]
+    branches: [main]
   push:
-    branches: [main, feat/multicloud-web-frontend]
+    branches: [main]
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -469,8 +469,7 @@ no separate web server process.
 
 ### Capabilities and limitations
 
-The web interface is part of the `feat/multicloud-web-frontend` branch and is
-not yet merged to `main`. The dashboard is operational for AWS workloads; Azure
+The web interface is included in `main`. The dashboard is operational for AWS workloads; Azure
 and GCP support in the web UI follows the same maturity as the CLI providers
 (both are experimental). Specifically:
 

--- a/terraform/environments/azure/ci-cd-permissions/sp.tf
+++ b/terraform/environments/azure/ci-cd-permissions/sp.tf
@@ -48,13 +48,3 @@ resource "azuread_application_federated_identity_credential" "github_pr" {
   subject        = "repo:${var.github_repo}:pull_request"
 }
 
-resource "azuread_application_federated_identity_credential" "github_feat_multicloud" {
-  count = var.github_repo != "" ? 1 : 0
-
-  application_id = azuread_application.cudly_deploy.id
-  display_name   = "github-actions-feat-multicloud"
-  description    = "GitHub Actions OIDC — ${var.github_repo} feat/multicloud-web-frontend branch"
-  audiences      = ["api://AzureADTokenExchange"]
-  issuer         = "https://token.actions.githubusercontent.com"
-  subject        = "repo:${var.github_repo}:ref:refs/heads/feat/multicloud-web-frontend"
-}


### PR DESCRIPTION
## Summary

`feat/multicloud-web-frontend` was merged into `main` via PR #1131 and the branch is now retired. This PR removes all forward-looking/operational references to it so the repo correctly reflects `main` as the sole integration base.

## Files changed

| File | Reference | New value |
|------|-----------|-----------|
| `.github/workflows/deploy-aws-lambda.yml` | `branches: [main, feat/multicloud-web-frontend]` push trigger + comment header | `branches: [main]` / updated comment |
| `.github/workflows/deploy-azure.yml` | `branches: [main, feat/multicloud-web-frontend]` push trigger + comment header | `branches: [main]` / updated comment |
| `.github/workflows/deploy-gcp.yml` | `branches: [main, feat/multicloud-web-frontend]` push trigger + comment header | `branches: [main]` / updated comment |
| `.github/workflows/pre-commit.yml` | `branches: [main, feat/multicloud-web-frontend]` on both `pull_request` and `push` triggers | `branches: [main]` on both |
| `.github/workflows/frontend-build.yml` | `- feat/multicloud-web-frontend` in `pull_request.branches` list | removed (only `main` remains) |
| `terraform/environments/azure/ci-cd-permissions/sp.tf` | `azuread_application_federated_identity_credential.github_feat_multicloud` resource binding OIDC subject `refs/heads/feat/multicloud-web-frontend` | resource removed (branch no longer exists) |
| `README.md` | "part of the `feat/multicloud-web-frontend` branch and is not yet merged to `main`" | "included in `main`" |

## Historical references left in place

These describe past events and were intentionally not changed:

- `frontend/src/recommendations.ts:140` — code comment recording that a verification was performed against `origin/feat/multicloud-web-frontend`
- `specs/migration-resilience.md:161` — records the branch a specific commit was introduced on

## Test plan

- [ ] Confirm `grep -rn "feat/multicloud-web-frontend" . --exclude-dir=.git` returns only the two historical lines listed above
- [ ] All 5 edited workflow YAML files parse without error
- [ ] Deploy workflows now trigger only on `main` pushes
- [ ] pre-commit and frontend-build workflows now filter only `main`
- [ ] Terraform plan for `terraform/environments/azure/ci-cd-permissions/` shows destruction of `azuread_application_federated_identity_credential.github_feat_multicloud[0]` only