### PR TITLE
ci: use docker compose v2 (fixes docker-compose command not found)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -390,14 +390,14 @@ jobs:
 
       - name: Run E2E tests with docker-compose
         run: |
-          docker-compose -f docker-compose.test.yml up --abort-on-container-exit --exit-code-from test-runner
+          docker compose -f docker-compose.test.yml up --abort-on-container-exit --exit-code-from test-runner
         env:
           COMPOSE_INTERACTIVE_NO_CLI: 1
 
       - name: Cleanup
         if: always()
         run: |
-          docker-compose -f docker-compose.test.yml down -v
+          docker compose -f docker-compose.test.yml down -v
 
   # Assert that the Azure custom-role actions list is identical in the TF module
   # and the ARM onboarding template.  Fast (shell + jq only), so it always runs.

--- a/Makefile
+++ b/Makefile
@@ -229,8 +229,8 @@ cost-estimate:
 # Docker Compose E2E tests
 docker-compose-test:
 	@echo "Running E2E tests with docker-compose..."
-	docker-compose -f docker-compose.test.yml up --abort-on-container-exit --exit-code-from test-runner
-	docker-compose -f docker-compose.test.yml down -v
+	docker compose -f docker-compose.test.yml up --abort-on-container-exit --exit-code-from test-runner
+	docker compose -f docker-compose.test.yml down -v
 
 # Install development dependencies
 install-dev-tools:


### PR DESCRIPTION
Fixes the `docker-compose: command not found` CI failure.

ubuntu-24.04 (now `ubuntu-latest`) dropped the standalone `docker-compose` v1 binary. Switched the E2E job (ci.yml) and the Makefile target to `docker compose` (v2, preinstalled on the runners). The `docker-compose.test.yml` filename is unchanged.

Note: the E2E job is `continue-on-error: true` so this was a non-blocking red X; this makes it run correctly when it does run.
