### PR TITLE
fix(ci): docker compose v2 + bump terraform-validate to 1.10.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,7 +240,12 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
-          terraform_version: 1.6.0
+          # Must satisfy `required_version = ">= 1.10.0"` declared by every
+          # terraform/environments/*/main.tf -- pinning below 1.10 makes
+          # `terraform init`/`validate` abort with "Unsupported Terraform
+          # Core version". Matches the pin in pre-commit.yml so both
+          # workflows resolve to the same binary.
+          terraform_version: 1.10.5
 
       - name: Terraform Format Check
         run: terraform fmt -check -recursive terraform/
@@ -390,14 +395,14 @@ jobs:
 
       - name: Run E2E tests with docker-compose
         run: |
-          docker-compose -f docker-compose.test.yml up --abort-on-container-exit --exit-code-from test-runner
+          docker compose -f docker-compose.test.yml up --abort-on-container-exit --exit-code-from test-runner
         env:
           COMPOSE_INTERACTIVE_NO_CLI: 1
 
       - name: Cleanup
         if: always()
         run: |
-          docker-compose -f docker-compose.test.yml down -v
+          docker compose -f docker-compose.test.yml down -v
 
   # Assert that the Azure custom-role actions list is identical in the TF module
   # and the ARM onboarding template.  Fast (shell + jq only), so it always runs.

--- a/Makefile
+++ b/Makefile
@@ -229,8 +229,8 @@ cost-estimate:
 # Docker Compose E2E tests
 docker-compose-test:
 	@echo "Running E2E tests with docker-compose..."
-	docker-compose -f docker-compose.test.yml up --abort-on-container-exit --exit-code-from test-runner
-	docker-compose -f docker-compose.test.yml down -v
+	docker compose -f docker-compose.test.yml up --abort-on-container-exit --exit-code-from test-runner
+	docker compose -f docker-compose.test.yml down -v
 
 # Install development dependencies
 install-dev-tools:


### PR DESCRIPTION
## What

Two mechanical CI infrastructure fixes from the failing-CI audit, after the integration branch was promoted to `main` and `ci.yml` started running on all retargeted PRs.

### 1. Docker Compose v2 (`docker compose`)
`ubuntu-24.04` runners dropped the standalone `docker-compose` v1 binary, so the `e2e-tests` job and the `docker-compose-test` Makefile target failed with `docker-compose: command not found`. Switched the four command invocations to the Compose v2 plugin form `docker compose`. The `docker-compose.test.yml` filename is unchanged.

### 2. terraform-validate Terraform version
The `terraform-validate` job pinned `setup-terraform` to `1.6.0`, but every `terraform/environments/*/main.tf` declares `required_version = ">= 1.10.0"`, so `terraform init`/`validate` aborted with **"Unsupported Terraform Core version"** on all three clouds (aws/gcp/azure). Bumped to `1.10.5`, matching the pin already used in `pre-commit.yml`.

## Verification
- `ci.yml` parses as valid YAML.
- `terraform init`/`validate` against `terraform/environments/aws` now passes the version constraint (only the offline sandbox's provider cache fails, which the CI runner downloads normally).

## Scope note
This PR fixes only the unambiguous mechanical CI failures. Other distinct failures found in the audit (real govulncheck CVEs needing a Go toolchain/dep bump, the golangci-lint v2 config-schema migration, and the integration-test compile errors on `main`) require code/dependency decisions and are reported separately, not fixed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated Terraform to version 1.10.5 for infrastructure validation
* Modernized Docker Compose CLI syntax in CI/CD pipeline and build tooling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->