### PR TITLE
fix(ci): migrate golangci-lint config to v2 schema and fix count-gated alarm outputs

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,128 +1,110 @@
-# golangci-lint configuration for CUDly
-# https://golangci-lint.run/usage/configuration/
-
+version: "2"
 run:
-  timeout: 5m
-  tests: true
   build-tags:
     - integration
-  skip-dirs:
-    - vendor
-    - testdata
-    - .github
-
-output:
-  format: colored-line-number
-  print-issued-lines: true
-  print-linter-name: true
-  sort-results: true
-
+  tests: true
 linters:
   enable:
-    - errcheck      # Check for unchecked errors
-    - gosimple      # Simplify code
-    - govet         # Reports suspicious constructs
-    - ineffassign   # Detects ineffectual assignments
-    - staticcheck   # Go static analysis
-    - unused        # Checks for unused constants, variables, functions and types
-    - gofmt         # Checks if code is formatted
-    - goimports     # Checks missing or unreferenced package imports
-    - misspell      # Finds commonly misspelled English words
-    - revive        # Fast, configurable, extensible linter
-    - gosec         # Security-focused linter
-    - bodyclose     # Checks HTTP response body is closed
-    - noctx         # Finds http requests without context
-    - errorlint     # Error wrapping issues
-    - exportloopref # Checks for pointers to enclosing loop variables
-    - gocritic      # Provides diagnostics that check for bugs, performance and style issues
-    - gocyclo       # Computes cyclomatic complexity
-    - godot         # Checks if comments end in a period
-    - prealloc      # Finds slice declarations that could potentially be pre-allocated
-    - unconvert     # Removes unnecessary type conversions
-    - unparam       # Reports unused function parameters
-    - whitespace    # Checks for unnecessary newlines
-
-linters-settings:
-  errcheck:
-    check-type-assertions: true
-    check-blank: true
-
-  govet:
-    check-shadowing: true
-    enable-all: true
-
-  gocyclo:
-    min-complexity: 15
-
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - performance
-      - style
-    disabled-checks:
-      - dupImport
-      - ifElseChain
-      - octalLiteral
-      - whyNoLint
-
-  gosec:
-    severity: medium
-    confidence: medium
-    excludes:
-      - G104  # Audit errors not checked (covered by errcheck)
-    config:
-      G101:  # Look for hardcoded credentials
-        pattern: "(?i)passwd|pass|password|pwd|secret|token"
-        ignore_entropy: false
-
-  revive:
+    - bodyclose
+    - errorlint
+    - gocritic
+    - gocyclo
+    - godot
+    - gosec
+    - misspell
+    - noctx
+    - prealloc
+    - revive
+    - unconvert
+    - unparam
+    - whitespace
+  settings:
+    errcheck:
+      check-type-assertions: true
+      check-blank: true
+    gocritic:
+      disabled-checks:
+        - dupImport
+        - ifElseChain
+        - octalLiteral
+        - whyNoLint
+      enabled-tags:
+        - diagnostic
+        - performance
+        - style
+    gocyclo:
+      min-complexity: 15
+    gosec:
+      excludes:
+        - G104
+      severity: medium
+      confidence: medium
+      config:
+        G101:
+          ignore_entropy: false
+          pattern: (?i)passwd|pass|password|pwd|secret|token
+    govet:
+      enable-all: true
+    misspell:
+      locale: US
+    revive:
+      rules:
+        - name: var-naming
+          disabled: false
+        - name: package-comments
+          disabled: true
+        - name: exported
+          disabled: false
+        - name: indent-error-flow
+          disabled: false
+        - name: error-return
+          disabled: false
+        - name: error-naming
+          disabled: false
+        - name: error-strings
+          disabled: false
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
     rules:
-      - name: var-naming
-        disabled: false
-      - name: package-comments
-        disabled: true  # We don't require package comments for internal packages
-      - name: exported
-        disabled: false
-      - name: indent-error-flow
-        disabled: false
-      - name: error-return
-        disabled: false
-      - name: error-naming
-        disabled: false
-      - name: error-strings
-        disabled: false
-
-  misspell:
-    locale: US
-
+      - linters:
+          - errcheck
+          - gocritic
+          - gocyclo
+          - gosec
+        path: _test\.go
+      - linters:
+          - errcheck
+          - gosec
+        path: internal/testutil/
+      - linters:
+          - all
+        path: .*_gen\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 issues:
-  exclude-rules:
-    # Exclude test files from certain linters
-    - path: _test\.go
-      linters:
-        - gocyclo
-        - errcheck
-        - gosec
-        - gocritic
-
-    # Exclude testutil package from certain checks
-    - path: internal/testutil/
-      linters:
-        - errcheck
-        - gosec
-
-    # Exclude generated code
-    - path: .*_gen\.go
-      linters:
-        - all
-
   max-issues-per-linter: 0
   max-same-issues: 0
   new: false
-
 severity:
-  default-severity: warning
+  default: warning
   rules:
     - linters:
         - gosec
       severity: error
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/terraform/modules/compute/aws/lambda/outputs.tf
+++ b/terraform/modules/compute/aws/lambda/outputs.tf
@@ -39,11 +39,11 @@ output "signing_key_id" {
 }
 
 output "migration_failed_alarm_arn" {
-  description = "ARN of the CloudWatch alarm that fires when a database migration fails on cold start"
-  value       = aws_cloudwatch_metric_alarm.migration_failed.arn
+  description = "ARN of the CloudWatch alarm that fires when a database migration fails on cold start (null when var.enable_migration_alarm is false)"
+  value       = one(aws_cloudwatch_metric_alarm.migration_failed[*].arn)
 }
 
 output "migration_failed_metric_filter_name" {
-  description = "Name of the log metric filter counting migration-failure log lines"
-  value       = aws_cloudwatch_log_metric_filter.migration_failed.name
+  description = "Name of the log metric filter counting migration-failure log lines (null when var.enable_migration_alarm is false)"
+  value       = one(aws_cloudwatch_log_metric_filter.migration_failed[*].name)
 }


### PR DESCRIPTION
## What

Fixes two of the failing `CI - Build & Test` jobs at their root cause. Both are config that drifted out of sync with what the rest of the repo already moved to.

### Lint Code (was failing fast, ~6s)
CI pins `golangci-lint` `v2.10.1` (deliberate, see commit `6f6fa3f24` "pin tool versions"), but `.golangci.yml` was still written for the **v1 schema**. The v2 binary rejects it instantly (reproduced locally):

```
can't load config: unsupported version of the configuration: ""
```

Migrated the config to the v2 schema with `golangci-lint migrate` (adds `version: "2"`, moves settings under `linters.settings`, adds the `exclusions`/`formatters` blocks). Default-on linters (`errcheck`, `govet`, `ineffassign`, `staticcheck`, `unused`) are now implicit; `exportloopref` is dropped since v2 removed it (obsolete on Go 1.22+). No linter is disabled to mask findings.

### Validate Terraform (aws) (was failing, ~21s)
PR #1130 added `count = var.enable_migration_alarm ? 1 : 0` to the migration-alarm resources, but the module outputs still referenced them without an index, so `terraform validate` failed:

```
Error: Missing resource instance key
  on .../lambda/outputs.tf line 43, in output "migration_failed_alarm_arn":
  value = aws_cloudwatch_metric_alarm.migration_failed.arn
```

Wrapped both outputs in `one(<resource>[*].<attr>)` so they resolve to the single instance when enabled and `null` when disabled.

## Verification (local)
- `golangci-lint run` now parses the v2 config and lints (no more schema error).
- `terraform -chdir=terraform/environments/aws validate` -> `Success! The configuration is valid.`
- `terraform fmt -check -recursive terraform/` -> clean.

## Out of scope / needs follow-up
- **Security Scanning** fails on **real** `govulncheck` findings: `golang.org/x/net` (GO-2026-5026 / GO-2026-4918) in `providers/azure` + `providers/gcp`, and `google.golang.org/protobuf` GO-2024-2611 in `providers/gcp`. The fix is dependency bumps (`golang.org/x/net` -> v0.55.0, `protobuf` -> v1.33.0+) which require network access to fetch the modules and their go.sum entries (unavailable in the working sandbox). Tracked for a separate PR.
- **E2E Tests** is `continue-on-error: true` (non-blocking); already handled by #1135 (docker compose v2) plus the deliberate non-blocking guard for the not-yet-implemented `Dockerfile.test`. No change made.
- **Lint** will surface pre-existing accumulated findings plus an integration-build-tag compile error (`getMigrationsPath` redeclared and a `*float64` literal mismatch in `internal/analytics/postgres_analytics_*_test.go`) once the schema parses. Those are separate pre-existing problems (the compile error also fails the Integration Tests job) and need their own cleanup.
