### PR TITLE
fix(providers/azure): send canonical reservedResourceType enum values

### DIFF
--- a/providers/azure/services/cache/client.go
+++ b/providers/azure/services/cache/client.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/consumption/armconsumption"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/reservations/armreservations"
 
 	"github.com/LeanerCloud/CUDly/pkg/common"
 	"github.com/LeanerCloud/CUDly/pkg/logging"
@@ -320,7 +321,7 @@ func (c *CacheClient) PurchaseCommitment(ctx context.Context, rec common.Recomme
 		},
 		"location": c.region,
 		"properties": map[string]interface{}{
-			"reservedResourceType": "RedisCache",
+			"reservedResourceType": string(armreservations.ReservedResourceTypeRedisCache),
 			"billingScopeId":       fmt.Sprintf("/subscriptions/%s", c.subscriptionID),
 			"term":                 fmt.Sprintf("P%dY", termYears),
 			"quantity":             rec.Count,

--- a/providers/azure/services/compute/client.go
+++ b/providers/azure/services/compute/client.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/consumption/armconsumption"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/reservations/armreservations"
 
 	"github.com/LeanerCloud/CUDly/pkg/common"
 	"github.com/LeanerCloud/CUDly/pkg/logging"
@@ -427,7 +428,7 @@ func (c *ComputeClient) buildReservationBody(rec common.Recommendation, source, 
 		"sku":      map[string]string{"name": rec.ResourceType},
 		"location": c.region,
 		"properties": map[string]interface{}{
-			"reservedResourceType": "VirtualMachines",
+			"reservedResourceType": string(armreservations.ReservedResourceTypeVirtualMachines),
 			"billingScopeId":       fmt.Sprintf("/subscriptions/%s", c.subscriptionID),
 			"term":                 fmt.Sprintf("P%dY", termYears),
 			"quantity":             rec.Count,

--- a/providers/azure/services/cosmosdb/client.go
+++ b/providers/azure/services/cosmosdb/client.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/consumption/armconsumption"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos/v2"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/reservations/armreservations"
 
 	"github.com/LeanerCloud/CUDly/pkg/common"
 	"github.com/LeanerCloud/CUDly/pkg/logging"
@@ -313,7 +314,7 @@ func (c *CosmosDBClient) PurchaseCommitment(ctx context.Context, rec common.Reco
 		},
 		"location": c.region,
 		"properties": map[string]interface{}{
-			"reservedResourceType": "CosmosDb",
+			"reservedResourceType": string(armreservations.ReservedResourceTypeCosmosDb),
 			"billingScopeId":       fmt.Sprintf("/subscriptions/%s", c.subscriptionID),
 			"term":                 fmt.Sprintf("P%dY", termYears),
 			"quantity":             rec.Count,

--- a/providers/azure/services/database/client.go
+++ b/providers/azure/services/database/client.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/consumption/armconsumption"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/reservations/armreservations"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql"
 
 	"github.com/LeanerCloud/CUDly/pkg/common"
@@ -318,7 +319,7 @@ func (c *DatabaseClient) PurchaseCommitment(ctx context.Context, rec common.Reco
 		},
 		"location": c.region,
 		"properties": map[string]interface{}{
-			"reservedResourceType": "SqlDatabase",
+			"reservedResourceType": string(armreservations.ReservedResourceTypeSQLDatabases),
 			"billingScopeId":       fmt.Sprintf("/subscriptions/%s", c.subscriptionID),
 			"term":                 fmt.Sprintf("P%dY", termYears),
 			"quantity":             rec.Count,

--- a/providers/azure/services/database/client_test.go
+++ b/providers/azure/services/database/client_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/consumption/armconsumption"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/reservations/armreservations"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -1245,4 +1246,55 @@ func TestDatabaseClient_PurchaseCommitment_DisplayNameConformsToAzureAllowlist(t
 	// (see providers/azure/services/internal/reservations/displayname.go).
 	assert.Regexp(t, `^sql-`, capturedDisplayName)
 	assert.Contains(t, capturedDisplayName, "GP_Gen5_2")
+}
+
+// TestDatabaseClient_PurchaseCommitment_CanonicalReservedResourceType guards
+// against regression of issue #1189: the calculatePrice/purchase body must
+// send the canonical SDK enum value "SqlDatabases", not the hand-written
+// "SqlDatabase" Azure rejects as an invalid reservedResourceType.
+func TestDatabaseClient_PurchaseCommitment_CanonicalReservedResourceType(t *testing.T) {
+	ctx := context.Background()
+	mockHTTP := &MockHTTPClient{}
+	mockCred := &MockTokenCredential{token: "test-token"}
+	client := NewClientWithHTTP(mockCred, "test-subscription", "eastus", mockHTTP)
+
+	const orderID = "azure-db-rrt"
+	var capturedRRT string
+	mockHTTP.On("Do", mock.MatchedBy(func(r *http.Request) bool {
+		if r.Method != http.MethodPost || r.URL.Path != "/providers/Microsoft.Capacity/calculatePrice" {
+			return false
+		}
+		if r.Body == nil {
+			return true
+		}
+		bodyBytes, _ := io.ReadAll(r.Body)
+		r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		var body map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &body); err == nil {
+			if props, ok := body["properties"].(map[string]interface{}); ok {
+				if rrt, ok := props["reservedResourceType"].(string); ok {
+					capturedRRT = rrt
+				}
+			}
+		}
+		return true
+	})).Return(createMockHTTPResponse(http.StatusOK, calcPriceRespJSON(orderID)), nil).Once()
+	mockHTTP.On("Do", mock.MatchedBy(func(r *http.Request) bool {
+		return r.Method == http.MethodPost &&
+			r.URL.Path == "/providers/Microsoft.Capacity/reservationOrders/"+orderID+"/purchase"
+	})).Return(createMockHTTPResponse(http.StatusOK, `{}`), nil).Once()
+
+	rec := common.Recommendation{
+		ResourceType:   "GP_Gen5_2",
+		Term:           "1yr",
+		Count:          1,
+		CommitmentCost: 1500.0,
+	}
+	_, err := client.PurchaseCommitment(ctx, rec, common.PurchaseOptions{Source: common.PurchaseSourceCLI})
+	require.NoError(t, err)
+	assert.Equal(t, string(armreservations.ReservedResourceTypeSQLDatabases), capturedRRT)
+	assert.Contains(t, armreservations.PossibleReservedResourceTypeValues(),
+		armreservations.ReservedResourceType(capturedRRT),
+		"reservedResourceType %q must be a member of armreservations.PossibleReservedResourceTypeValues()", capturedRRT)
+	mockHTTP.AssertExpectations(t)
 }

--- a/providers/azure/services/managedredis/client.go
+++ b/providers/azure/services/managedredis/client.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/consumption/armconsumption"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/reservations/armreservations"
 
 	"github.com/LeanerCloud/CUDly/pkg/common"
 	"github.com/LeanerCloud/CUDly/providers/azure/internal/httpclient"
@@ -260,7 +261,7 @@ func (c *ManagedRedisClient) PurchaseCommitment(ctx context.Context, rec common.
 		},
 		"location": c.region,
 		"properties": map[string]interface{}{
-			"reservedResourceType": "RedisCache",
+			"reservedResourceType": string(armreservations.ReservedResourceTypeRedisCache),
 			"billingScopeId":       fmt.Sprintf("/subscriptions/%s", c.subscriptionID),
 			"term":                 fmt.Sprintf("P%dY", termYears),
 			"quantity":             rec.Count,

--- a/providers/azure/services/search/client.go
+++ b/providers/azure/services/search/client.go
@@ -294,6 +294,11 @@ func (c *SearchClient) PurchaseCommitment(ctx context.Context, rec common.Recomm
 		},
 		"location": c.region,
 		"properties": map[string]interface{}{
+			// "SearchService" has no counterpart in the armreservations
+			// ReservedResourceType enum (checked v1.1.0 and v2.0.0), so it
+			// cannot be expressed as an SDK constant like the other service
+			// clients do; the literal is kept until verified against the
+			// live reservation catalog (see issue #1189).
 			"reservedResourceType": "SearchService",
 			"billingScopeId":       fmt.Sprintf("/subscriptions/%s", c.subscriptionID),
 			"term":                 fmt.Sprintf("P%dY", termYears),

--- a/providers/azure/services/synapse/client.go
+++ b/providers/azure/services/synapse/client.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/consumption/armconsumption"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/reservations/armreservations"
 
 	"github.com/LeanerCloud/CUDly/pkg/common"
 	"github.com/LeanerCloud/CUDly/providers/azure/internal/httpclient"
@@ -268,7 +269,7 @@ func (c *SynapseClient) PurchaseCommitment(ctx context.Context, rec common.Recom
 		},
 		"location": c.region,
 		"properties": map[string]interface{}{
-			"reservedResourceType": "SqlDW",
+			"reservedResourceType": string(armreservations.ReservedResourceTypeSQLDataWarehouse),
 			"billingScopeId":       fmt.Sprintf("/subscriptions/%s", c.subscriptionID),
 			"term":                 fmt.Sprintf("P%dY", termYears),
 			"quantity":             rec.Count,

--- a/providers/azure/services/synapse/client_test.go
+++ b/providers/azure/services/synapse/client_test.go
@@ -3,6 +3,7 @@ package synapse
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -12,6 +13,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/consumption/armconsumption"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/reservations/armreservations"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -852,3 +854,54 @@ func TestGetOfferingDetails_noReservationPrice(t *testing.T) {
 // helper's contract is now exercised in providers/azure/services/internal/reservations
 // package tests; the synapse-side coverage is via the executor-level
 // PurchaseCommitment tests above.
+
+// TestPurchaseCommitment_canonicalReservedResourceType guards against
+// regression of issue #1189: the calculatePrice/purchase body must send the
+// canonical SDK enum value "SqlDataWarehouse", not the hand-written "SqlDW"
+// Azure rejects as an invalid reservedResourceType.
+func TestPurchaseCommitment_canonicalReservedResourceType(t *testing.T) {
+	mHTTP := &mockHTTPClient{}
+	t.Cleanup(func() { mHTTP.AssertExpectations(t) })
+
+	const orderID = "syn-order-rrt"
+	var capturedRRT string
+	mHTTP.On("Do", mock.MatchedBy(func(r *http.Request) bool {
+		if r.Method != http.MethodPost || r.URL.Path != "/providers/Microsoft.Capacity/calculatePrice" {
+			return false
+		}
+		if r.Body == nil {
+			return true
+		}
+		bodyBytes, _ := io.ReadAll(r.Body)
+		r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		var body map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &body); err == nil {
+			if props, ok := body["properties"].(map[string]interface{}); ok {
+				if rrt, ok := props["reservedResourceType"].(string); ok {
+					capturedRRT = rrt
+				}
+			}
+		}
+		return true
+	})).Return(newHTTPResponse(http.StatusOK, calcPriceRespJSON(orderID)), nil).Once()
+	mHTTP.On("Do", mock.MatchedBy(func(r *http.Request) bool {
+		return r.Method == http.MethodPost &&
+			r.URL.Path == "/providers/Microsoft.Capacity/reservationOrders/"+orderID+"/purchase"
+	})).Return(newHTTPResponse(http.StatusOK, `{}`), nil).Once()
+
+	cred := &mockTokenCredential{token: "test-token"}
+	c := NewClientWithHTTP(cred, "sub-123", "eastus", mHTTP)
+
+	rec := common.Recommendation{
+		ResourceType:   "DW1000c",
+		Term:           "1yr",
+		Count:          1,
+		CommitmentCost: 5000.0,
+	}
+	_, err := c.PurchaseCommitment(context.Background(), rec, common.PurchaseOptions{Source: common.PurchaseSourceCLI})
+	require.NoError(t, err)
+	assert.Equal(t, string(armreservations.ReservedResourceTypeSQLDataWarehouse), capturedRRT)
+	assert.Contains(t, armreservations.PossibleReservedResourceTypeValues(),
+		armreservations.ReservedResourceType(capturedRRT),
+		"reservedResourceType %q must be a member of armreservations.PossibleReservedResourceTypeValues()", capturedRRT)
+}


### PR DESCRIPTION
## Problem

Closes #1189 (review finding ARCH-01, P2).

The Azure SQL Database and Synapse reservation purchase bodies sent hand-written `reservedResourceType` literals that are not members of the `armreservations.ReservedResourceType` enum:

- `providers/azure/services/database/client.go`: `"SqlDatabase"` (canonical: `"SqlDatabases"`)
- `providers/azure/services/synapse/client.go`: `"SqlDW"` (canonical: `"SqlDataWarehouse"`)

Once the #731 role fix makes non-VM Azure purchases reachable, calculatePrice would reject these values, breaking the purchase path for both services. This repeats the PR #1047 failure mode ("MEMORY_MB" instead of the SDK's "MEMORY").

## Fix

- Replace both bad literals with the SDK constants `string(armreservations.ReservedResourceTypeSQLDatabases)` and `string(armreservations.ReservedResourceTypeSQLDataWarehouse)`.
- Convert the already-correct literals in cache, cosmosdb, compute, and managedredis purchase bodies to their SDK constants (`ReservedResourceTypeRedisCache`, `ReservedResourceTypeCosmosDb`, `ReservedResourceTypeVirtualMachines`), so every expressible purchase body value is a compile-time-checked enum member. Zero behavior change for these four.
- Audit results requested by the finding:
  - managedredis `"RedisCache"`: valid enum member, now uses the SDK constant.
  - search `"SearchService"`: has no counterpart in the armreservations enum in v1.1.0 or v2.0.0 (no search/cognitive-search member exists at all), so it cannot be expressed as an SDK constant; documented in a comment and left for live-catalog verification.
  - The Advisor/Consumption filter literal `resourceType eq 'SqlDatabase'` at `database/client.go:173` is a different API surface (armconsumption reservation recommendations filter, not the Capacity purchase enum) and is intentionally left unchanged here; it needs live verification before touching the read path.

## Tests

New regression tests capture the calculatePrice request body and assert the sent `reservedResourceType` equals the SDK constant AND is a member of `armreservations.PossibleReservedResourceTypeValues()`:

- `TestDatabaseClient_PurchaseCommitment_CanonicalReservedResourceType`
- `TestPurchaseCommitment_canonicalReservedResourceType` (synapse)

Verified both FAIL against the pre-fix code (stash fix, run, unstash): expected `"SqlDatabases"` got `"SqlDatabase"`, expected `"SqlDataWarehouse"` got `"SqlDW"`.

Verification run:
- `go build ./...` (root module and providers/azure module): pass
- `go vet ./providers/azure/...`: clean
- `go test ./services/...` in providers/azure: 495 passed in 9 packages


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated Azure reserved-capacity purchase requests to use Azure SDK-defined reserved resource type constants for Cache, Compute, Cosmos DB, SQL Database, Managed Redis, and Synapse (improves consistency/canonical values).
  * Added a clarifying note for SearchService, which remains hard-coded due to no available SDK enum.
* **Tests**
  * Added/extended regression coverage to verify the canonical `reservedResourceType` values sent in the `calculatePrice` request for SQL Database and Synapse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->