### PR TITLE
fix(terraform/aws): grant OpenSearch RI actions instead of legacy es names

### DIFF
--- a/terraform/modules/compute/aws/fargate/main.tf
+++ b/terraform/modules/compute/aws/fargate/main.tf
@@ -313,9 +313,9 @@ resource "aws_iam_role_policy" "ri_exchange" {
           "elasticache:DescribeReservedCacheNodesOfferings",
           "elasticache:PurchaseReservedCacheNodesOffering",
           # OpenSearch reserved instances
-          "es:DescribeReservedElasticsearchInstances",
-          "es:DescribeReservedElasticsearchInstanceOfferings",
-          "es:PurchaseReservedElasticsearchInstanceOffering",
+          "es:DescribeReservedInstances",
+          "es:DescribeReservedInstanceOfferings",
+          "es:PurchaseReservedInstanceOffering",
           # Redshift reserved nodes
           "redshift:DescribeReservedNodes",
           "redshift:DescribeReservedNodeOfferings",

--- a/terraform/modules/compute/aws/iam_actions_test.go
+++ b/terraform/modules/compute/aws/iam_actions_test.go
@@ -1,0 +1,62 @@
+// Package aws_test guards the AWS runtime IAM action lists in the lambda and
+// fargate Terraform modules against drift from the actions the application
+// code actually calls.
+//
+// Regression test for issue #1149 (INF-01): both runtime modules granted the
+// legacy Elasticsearch-era reserved-instance actions
+// (es:DescribeReservedElasticsearchInstances, ...) while the application uses
+// the OpenSearch SDK (opensearch.NewFromConfig), whose operations
+// DescribeReservedInstances / DescribeReservedInstanceOfferings /
+// PurchaseReservedInstanceOffering authorize against the distinct new-style
+// es:* action names. The mismatch made every host-account OpenSearch RI call
+// return AccessDenied on Terraform deployments.
+package aws_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// runtimeModuleFiles are the Terraform runtime modules that define the IAM
+// policy for the deployed application identity.
+var runtimeModuleFiles = []string{
+	filepath.Join("lambda", "main.tf"),
+	filepath.Join("fargate", "main.tf"),
+}
+
+// requiredOpenSearchActions are the IAM actions required by the OpenSearch
+// API operations invoked in providers/aws/services/opensearch/client.go.
+var requiredOpenSearchActions = []string{
+	"es:DescribeReservedInstances",
+	"es:DescribeReservedInstanceOfferings",
+	"es:PurchaseReservedInstanceOffering",
+}
+
+// legacyElasticsearchActionPattern matches the pre-OpenSearch action names
+// (e.g. es:DescribeReservedElasticsearchInstances) that no code path uses.
+var legacyElasticsearchActionPattern = regexp.MustCompile(`es:\w*ReservedElasticsearch\w*`)
+
+func TestRuntimeModulesGrantOpenSearchActions(t *testing.T) {
+	for _, rel := range runtimeModuleFiles {
+		t.Run(rel, func(t *testing.T) {
+			data, err := os.ReadFile(rel)
+			if err != nil {
+				t.Fatalf("reading %s: %v", rel, err)
+			}
+			content := string(data)
+
+			if legacy := legacyElasticsearchActionPattern.FindAllString(content, -1); len(legacy) > 0 {
+				t.Errorf("%s grants legacy Elasticsearch-era actions %v; the code calls the OpenSearch API, which authorizes against the new-style es:* action names", rel, legacy)
+			}
+
+			for _, action := range requiredOpenSearchActions {
+				if !strings.Contains(content, `"`+action+`"`) {
+					t.Errorf("%s is missing required OpenSearch action %q (called by providers/aws/services/opensearch/client.go)", rel, action)
+				}
+			}
+		})
+	}
+}

--- a/terraform/modules/compute/aws/lambda/main.tf
+++ b/terraform/modules/compute/aws/lambda/main.tf
@@ -363,9 +363,9 @@ resource "aws_iam_role_policy" "ri_exchange" {
           "elasticache:DescribeReservedCacheNodesOfferings",
           "elasticache:PurchaseReservedCacheNodesOffering",
           # OpenSearch reserved instances
-          "es:DescribeReservedElasticsearchInstances",
-          "es:DescribeReservedElasticsearchInstanceOfferings",
-          "es:PurchaseReservedElasticsearchInstanceOffering",
+          "es:DescribeReservedInstances",
+          "es:DescribeReservedInstanceOfferings",
+          "es:PurchaseReservedInstanceOffering",
           # Redshift reserved nodes
           "redshift:DescribeReservedNodes",
           "redshift:DescribeReservedNodeOfferings",


### PR DESCRIPTION
## Problem

Closes #1149 (review finding INF-01, P2).

Both AWS runtime Terraform modules (`terraform/modules/compute/aws/lambda/main.tf`, `terraform/modules/compute/aws/fargate/main.tf`) granted only the legacy Elasticsearch-era reserved-instance actions:

- `es:DescribeReservedElasticsearchInstances`
- `es:DescribeReservedElasticsearchInstanceOfferings`
- `es:PurchaseReservedElasticsearchInstanceOffering`

The application uses the OpenSearch SDK (`opensearch.NewFromConfig` in `providers/aws/services/opensearch/client.go`), whose `DescribeReservedInstances`, `DescribeReservedInstanceOfferings` and `PurchaseReservedInstanceOffering` operations authorize against the distinct new-style action names. On any Terraform-deployed Lambda or Fargate runtime, host-account OpenSearch RI describe/offering/purchase calls returned AccessDenied. The parallel CloudFormation stack already grants the correct actions, confirming TF drift.

## Fix

Replace the three legacy actions with the new-style ones in both runtime modules, matching the CloudFormation stack:

- `es:DescribeReservedInstances`
- `es:DescribeReservedInstanceOfferings`
- `es:PurchaseReservedInstanceOffering`

Added a regression test (`terraform/modules/compute/aws/iam_actions_test.go`) that reads both runtime module files and fails if any legacy `es:*ReservedElasticsearch*` action is granted or any of the three required OpenSearch actions is missing.

Out of scope, tracked separately: `es:AddTags` for post-purchase tagging (INF-10) and the broader CFN/TF parity gate (INF-02).

## Test evidence

- Regression test confirmed to FAIL against pre-fix code (both modules flagged for legacy actions and missing new-style actions), then PASS after the fix: `go test ./terraform/modules/compute/aws/` -> 3 passed.
- `go build ./...` -> success; `go vet ./terraform/...` -> no issues.
- `terraform fmt -check -recursive terraform/` -> clean.
- `cd terraform/environments/aws && terraform init -backend=false && terraform validate` -> "The configuration is valid."
