### PR TITLE
fix(providers/azure): harden Synapse nil HTTP client fallback

### DIFF
--- a/providers/azure/services/synapse/client.go
+++ b/providers/azure/services/synapse/client.go
@@ -64,10 +64,11 @@ func NewClient(cred azcore.TokenCredential, subscriptionID, region string) *Syna
 }
 
 // NewClientWithHTTP creates a new Azure Synapse client with a custom HTTP client (for testing).
-// If httpClient is nil, http.DefaultClient is used.
+// When httpClient is nil, the SSRF-hardened httpclient.New() is used so the nil
+// fallback also blocks IMDS connections.
 func NewClientWithHTTP(cred azcore.TokenCredential, subscriptionID, region string, httpClient HTTPClient) *SynapseClient {
 	if httpClient == nil {
-		httpClient = http.DefaultClient
+		httpClient = httpclient.New()
 	}
 	return &SynapseClient{
 		cred:           cred,

--- a/providers/azure/services/synapse/client.go
+++ b/providers/azure/services/synapse/client.go
@@ -346,7 +346,7 @@ func (c *SynapseClient) GetOfferingDetails(ctx context.Context, rec common.Recom
 		upfrontCost = 0
 		recurringCost = totalCost / (float64(termYears) * 12)
 	default:
-		// Fail loud on an unrecognised payment option rather than silently
+		// Fail loud on an unrecognized payment option rather than silently
 		// billing it as all-upfront (owner policy: no silent fallbacks on
 		// money-affecting fields).
 		return nil, fmt.Errorf("unsupported payment option for Azure Synapse offering details: %q", rec.PaymentOption)

--- a/providers/azure/services/synapse/client_test.go
+++ b/providers/azure/services/synapse/client_test.go
@@ -905,3 +905,21 @@ func TestPurchaseCommitment_canonicalReservedResourceType(t *testing.T) {
 		armreservations.ReservedResourceType(capturedRRT),
 		"reservedResourceType %q must be a member of armreservations.PossibleReservedResourceTypeValues()", capturedRRT)
 }
+
+// ---- nil HTTP client fallback ----------------------------------------------
+
+// TestNewClientWithHTTP_NilFallbackIsHardened is a regression test for the
+// codebase-review finding SEC-03 (issue #1143): when httpClient is nil, the
+// httpClient falls back to httpclient.New() (SSRF-hardened), not
+// http.DefaultClient, so the fallback also rejects IMDS connections.
+func TestNewClientWithHTTP_NilFallbackIsHardened(t *testing.T) {
+	c := NewClientWithHTTP(nil, "sub-123", "eastus", nil)
+	require.NotNil(t, c.httpClient)
+	require.NotEqual(t, http.DefaultClient, c.httpClient,
+		"nil fallback must never be http.DefaultClient")
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://169.254.169.254/metadata/instance", nil)
+	require.NoError(t, err)
+	_, err = c.httpClient.Do(req) //nolint:bodyclose // Do always errors here; no body to close
+	require.Error(t, err, "nil-fallback client must reject IMDS connections")
+	assert.Contains(t, err.Error(), "blocked")
+}

--- a/providers/azure/services/synapse/client_test.go
+++ b/providers/azure/services/synapse/client_test.go
@@ -919,7 +919,10 @@ func TestNewClientWithHTTP_NilFallbackIsHardened(t *testing.T) {
 		"nil fallback must never be http.DefaultClient")
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://169.254.169.254/metadata/instance", nil)
 	require.NoError(t, err)
-	_, err = c.httpClient.Do(req) //nolint:bodyclose // Do always errors here; no body to close
+	resp, err := c.httpClient.Do(req)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	require.Error(t, err, "nil-fallback client must reject IMDS connections")
 	assert.Contains(t, err.Error(), "blocked")
 }


### PR DESCRIPTION
## Problem

Code-review finding SEC-03 (codebase-review-2026-06-10): the Azure Synapse client's `NewClientWithHTTP` constructor was the only one of the Azure `NewClientWithHTTP` constructors that fell back to `http.DefaultClient` on nil injection. `http.DefaultClient` has no IMDS-blocking transport, so a future non-test `NewClientWithHTTP(..., nil)` caller would reopen the SSRF surface the hardened `httpclient.New()` client closes.

## Fix

Replace the nil fallback with `httpclient.New()` (SSRF/IMDS-blocking), matching the production `NewClient` constructor and the established pattern already used by the savingsplans and managedredis clients, and update the doc comment accordingly.

## Test evidence

- Added `TestNewClientWithHTTP_NilFallbackIsHardened`, mirroring the savingsplans regression test: asserts the nil fallback is non-nil, is not `http.DefaultClient`, and that a request to `http://169.254.169.254/metadata/instance` is rejected with a "blocked" error.
- Confirmed the test FAILS on pre-fix code (fallback equals `http.DefaultClient`) and passes post-fix.
- `go build ./...` succeeds in both the root module and the `providers/azure` module; `go test ./services/synapse/ -count=1` passes (44 tests).

Closes #1143


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced HTTP client security in Azure Synapse services with improved request protection.
  * Updated documentation in error handling logic.

* **Tests**
  * Added regression test to validate security hardening of HTTP client behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->