### PR TITLE
fix(exchange): fail closed on unparseable PaymentDue in daily-cap check

### DIFF
--- a/pkg/exchange/auto.go
+++ b/pkg/exchange/auto.go
@@ -230,6 +230,9 @@ func processRecommendation(ctx context.Context, params RunAutoExchangeParams, re
 		return
 	}
 
+	// A nil PaymentDueUSD documents a zero-cost exchange (no payment due),
+	// distinct from a parse failure: processAutoExchange fails closed on any
+	// string that does not parse as a decimal.
 	paymentDueStr := "0"
 	if quote.PaymentDueUSD != nil {
 		paymentDueStr = quote.PaymentDueUSD.FloatString(6)
@@ -444,12 +447,17 @@ func processAutoExchange(ctx context.Context, params RunAutoExchangeParams, rec 
 		return outcome
 	}
 
+	// paymentDueStr is always a decimal here: processRecommendation sets it to
+	// "0" when the quote has no PaymentDueUSD (the documented nil-means-zero
+	// case) and to FloatString(6) otherwise. A parse failure therefore means a
+	// caller passed garbage; fail closed instead of counting $0 toward the
+	// daily cap, mirroring the dailySpent branch above.
 	paymentDue, err := ParseDecimalRat(paymentDueStr)
 	if err != nil {
-		logging.Warnf("failed to parse payment due %q: %v, using zero", paymentDueStr, err)
-	}
-	if paymentDue == nil {
-		paymentDue = new(big.Rat)
+		logging.Errorf("failed to parse payment due %q for %s: %v", paymentDueStr, rec.SourceRIID, err)
+		outcome.Error = fmt.Sprintf("failed to parse payment due %q: %v", paymentDueStr, err)
+		saveFailedRecord(ctx, params, rec, offeringID, paymentDueStr, outcome.Error, ExchangeModeAuto)
+		return outcome
 	}
 
 	newTotal := new(big.Rat).Add(dailySpent, paymentDue)

--- a/pkg/exchange/auto_test.go
+++ b/pkg/exchange/auto_test.go
@@ -3,6 +3,7 @@ package exchange
 import (
 	"context"
 	"fmt"
+	"math/big"
 	"testing"
 	"time"
 
@@ -112,6 +113,7 @@ type mockExchangeClient struct {
 	quoteErr      error
 	executeResult string
 	executeErr    error
+	executeCalls  int
 }
 
 func (m *mockExchangeClient) GetQuote(_ context.Context, _ ExchangeQuoteRequest) (*ExchangeQuoteSummary, error) {
@@ -119,6 +121,7 @@ func (m *mockExchangeClient) GetQuote(_ context.Context, _ ExchangeQuoteRequest)
 }
 
 func (m *mockExchangeClient) Execute(_ context.Context, _ ExchangeExecuteRequest) (string, *ExchangeQuoteSummary, error) {
+	m.executeCalls++
 	return m.executeResult, m.quoteResult, m.executeErr
 }
 
@@ -313,6 +316,46 @@ func TestRunAutoExchange_AutoMode_DailySpendDBError_FailsClosed(t *testing.T) {
 
 	assert.Len(t, result.Failed, 1)
 	assert.Contains(t, result.Failed[0].Error, "daily cap check failed")
+}
+
+// TestProcessAutoExchange_UnparseablePaymentDue_FailsClosed is the regression
+// test for COR-04: an unparseable or empty paymentDueStr must abort the
+// exchange and persist a failed record, never count as $0 toward the
+// MaxPaymentDailyUSD cap. RunAutoExchange always builds a parseable string
+// today, so processAutoExchange is exercised directly with the bad inputs.
+func TestProcessAutoExchange_UnparseablePaymentDue_FailsClosed(t *testing.T) {
+	t.Parallel()
+	for _, paymentDueStr := range []string{"not-a-number", ""} {
+		t.Run(fmt.Sprintf("paymentDue=%q", paymentDueStr), func(t *testing.T) {
+			t.Parallel()
+			store := &mockExchangeStore{dailySpend: "0"}
+			client := &mockExchangeClient{executeResult: "exch-should-not-happen"}
+			params := defaultParams(store, client)
+			params.Config.Mode = "auto"
+
+			rec := ReshapeRecommendation{
+				SourceRIID:         "ri-001",
+				SourceInstanceType: "m5.xlarge",
+				TargetInstanceType: "m5.large",
+				SourceCount:        1,
+				TargetCount:        2,
+				UtilizationPercent: 50.0,
+			}
+			perExchangeCap := new(big.Rat).SetFloat64(params.Config.MaxPaymentPerExchangeUSD)
+
+			outcome := processAutoExchange(context.Background(), params, rec, "offering-123", paymentDueStr, perExchangeCap)
+
+			assert.Contains(t, outcome.Error, "failed to parse payment due")
+			assert.Empty(t, outcome.ExchangeID)
+			assert.Zero(t, client.executeCalls, "exchange must not execute on unparseable payment due")
+
+			// A failed record must be persisted for the audit trail,
+			// mirroring the dailySpent parse-failure branch.
+			require.Len(t, store.savedRecords, 1)
+			assert.Equal(t, "failed", store.savedRecords[0].Status)
+			assert.Contains(t, store.savedRecords[0].Error, "failed to parse payment due")
+		})
+	}
 }
 
 func TestRunAutoExchange_AutoMode_ExecutionFails(t *testing.T) {


### PR DESCRIPTION
## Problem

COR-04 (docs/reviews/codebase-review-2026-06-10.md): in `processAutoExchange` (`pkg/exchange/auto.go`), a `PaymentDue` parse failure only logged a warning and coerced the value to $0 before adding it to the `MaxPaymentDailyUSD` daily-cap check. This is a silent fallback on a money path and is inconsistent with the `dailySpent` parse failure five lines above, which aborts the exchange and persists a failed record. Latent today (current callers always produce a parseable decimal), but any future path producing a non-decimal `paymentDueStr` would silently undercount the daily guardrail.

## Fix

- The `PaymentDue` parse failure now mirrors the `dailySpent` branch: log at error level, set `outcome.Error`, persist a failed record via `saveFailedRecord`, and return without executing the exchange.
- The documented nil-means-zero-cost quote case stays explicit and separate: `processRecommendation` maps a nil `quote.PaymentDueUSD` to the literal `"0"` string before the parse, now with a comment distinguishing it from parse errors.

## Test evidence

New regression test `TestProcessAutoExchange_UnparseablePaymentDue_FailsClosed` exercises `processAutoExchange` directly with `"not-a-number"` and `""` (the public `RunAutoExchange` path always builds a parseable string, which is why the bug was latent). It asserts the outcome errors, `Execute` is never called (new mock call counter), and a `failed` record is persisted.

- Pre-fix (fix stashed): both subtests FAIL - `outcome.Error` empty, exchange executed with $0 counted toward the cap.
- Post-fix: `go test ./exchange/` from `pkg/` - 97 passed.
- `go build ./...` succeeds in both the root module and the `pkg/` module.

Closes #1166
