### PR TITLE
fix(api): reject NaN/Inf in min-savings query params

### DIFF
--- a/internal/api/validation.go
+++ b/internal/api/validation.go
@@ -4,6 +4,7 @@ package api
 import (
 	"encoding/base64"
 	"fmt"
+	"math"
 	"net/mail"
 	"regexp"
 	"strconv"
@@ -611,9 +612,10 @@ func decodeBase64Password(encoded string) (string, error) {
 
 // parseMinSavingsParam parses a numeric savings-floor query parameter.
 // Returns (0, nil) when the parameter is absent or empty (no floor).
-// Returns 400 when the value is present but not a valid non-negative
-// integer or float. Fractional values are allowed (e.g. "12.5") since
-// savings floors can be sub-dollar amounts.
+// Returns 400 when the value is present but not a finite non-negative
+// integer or float (NaN and +/-Inf are rejected: a NaN floor silently
+// disables or inverts the filter downstream). Fractional values are
+// allowed (e.g. "12.5") since savings floors can be sub-dollar amounts.
 //
 // paramName is included in the error message so callers can distinguish
 // min_savings_usd vs min_savings_pct errors in client logs.
@@ -623,8 +625,8 @@ func parseMinSavingsParam(raw, paramName string) (float64, error) {
 		return 0, nil
 	}
 	v, err := strconv.ParseFloat(raw, 64)
-	if err != nil {
-		return 0, NewClientError(400, fmt.Sprintf("%s must be a non-negative number", paramName))
+	if err != nil || math.IsNaN(v) || math.IsInf(v, 0) {
+		return 0, NewClientError(400, fmt.Sprintf("%s must be a finite non-negative number", paramName))
 	}
 	if v < 0 {
 		return 0, NewClientError(400, fmt.Sprintf("%s must be non-negative", paramName))

--- a/internal/api/validation_test.go
+++ b/internal/api/validation_test.go
@@ -531,6 +531,19 @@ func TestParseMinSavingsParam(t *testing.T) {
 		{"non-numeric word", "thirty", "min_savings_usd", 0, true},
 		{"negative value", "-5", "min_savings_usd", 0, true},
 		{"mixed string", "30abc", "min_savings_usd", 0, true},
+
+		// Non-finite inputs (COR-09 regression, issue #1183):
+		// strconv.ParseFloat accepts these case-insensitively, but a NaN
+		// floor silently excludes all rows in SQL (monthly_savings >= NaN)
+		// or applies no pct floor; +Inf excludes everything. All must 400.
+		{"NaN", "NaN", "min_savings_usd", 0, true},
+		{"lowercase nan", "nan", "min_savings_usd", 0, true},
+		{"positive infinity", "+Inf", "min_savings_usd", 0, true},
+		{"bare infinity", "Inf", "min_savings_usd", 0, true},
+		{"infinity word", "Infinity", "min_savings_usd", 0, true},
+		{"negative infinity", "-Inf", "min_savings_usd", 0, true},
+		{"pct NaN", "NaN", "min_savings_pct", 0, true},
+		{"pct infinity", "Inf", "min_savings_pct", 0, true},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## Problem

`parseMinSavingsParam` (internal/api/validation.go) parses the `min_savings_usd` / `min_savings_pct` query parameters with `strconv.ParseFloat`, which accepts `NaN`, `Inf`, `+Inf` and `Infinity` (case-insensitively). The only guard was `v < 0`, which is false for NaN. Downstream:

- a NaN `min_savings_usd` bound into `monthly_savings >= $n` excludes every row, returning an empty list with HTTP 200 instead of a 400
- a NaN `min_savings_pct` makes `pct < filter.MinSavingsPct` always false, a silently inert floor
- `+Inf` excludes everything

Review finding COR-09 (docs/reviews/codebase-review-2026-06-10.md). Closes #1183.

## Fix

Reject non-finite values at the input boundary: `err != nil || math.IsNaN(v) || math.IsInf(v, 0)` now returns a 400 client error ("must be a finite non-negative number"). Negative finite values keep their existing 400. Docstring updated to state the non-finite rejection.

## Test evidence

Extended `TestParseMinSavingsParam` with table cases for `NaN`, `nan`, `+Inf`, `Inf`, `Infinity`, `-Inf`, and the pct-path (`min_savings_pct`) variants.

- Pre-fix (fix stashed, new tests only): all non-finite cases FAIL with "An error is expected but got nil"
- Post-fix: `go test ./internal/api/ -run TestParseMinSavingsParam` passes (20 subtests)
- Full package: `go test ./internal/api/` passes (1635 tests); `go build ./...` clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for minimum savings parameters to properly reject non-finite numeric values (NaN, Infinity) and provide clearer error messages indicating only finite non-negative numbers are accepted.

* **Tests**
  * Added regression test coverage for invalid non-finite numeric inputs to ensure they are properly rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->