### PR TITLE
fix(cmd): respect LifecycleSupportEndDate in extended-support check

### DIFF
--- a/cmd/multi_service_coverage_test.go
+++ b/cmd/multi_service_coverage_test.go
@@ -246,7 +246,7 @@ func TestIsInExtendedSupport_EdgeCases(t *testing.T) {
 			MajorEngineVersion: "5.7",
 			SupportedEngineLifecycles: []EngineLifecycleInfo{
 				{
-					LifecycleSupportName:      "open-source-rds-extended-support",
+					LifecycleSupportName:      string(rdstypes.LifecycleSupportNameOpenSourceRdsExtendedSupport),
 					LifecycleSupportStartDate: pastDate,
 					LifecycleSupportEndDate:   futureDate,
 				},
@@ -257,7 +257,7 @@ func TestIsInExtendedSupport_EdgeCases(t *testing.T) {
 			MajorEngineVersion: "8.0",
 			SupportedEngineLifecycles: []EngineLifecycleInfo{
 				{
-					LifecycleSupportName:      "open-source-rds-standard-support",
+					LifecycleSupportName:      string(rdstypes.LifecycleSupportNameOpenSourceRdsStandardSupport),
 					LifecycleSupportStartDate: now.AddDate(-2, 0, 0),
 					LifecycleSupportEndDate:   futureDate,
 				},
@@ -318,7 +318,7 @@ func TestAdjustRecommendationForExcludedVersions_AdditionalCases(t *testing.T) {
 			MajorEngineVersion: "5.7",
 			SupportedEngineLifecycles: []EngineLifecycleInfo{
 				{
-					LifecycleSupportName:      "open-source-rds-extended-support",
+					LifecycleSupportName:      string(rdstypes.LifecycleSupportNameOpenSourceRdsExtendedSupport),
 					LifecycleSupportStartDate: pastDate,
 					LifecycleSupportEndDate:   futureDate,
 				},

--- a/cmd/multi_service_engine_versions.go
+++ b/cmd/multi_service_engine_versions.go
@@ -399,11 +399,17 @@ func isInExtendedSupport(engine, fullVersion string, versionInfo map[string]Majo
 	// Check if current date falls within extended support period
 	now := time.Now()
 	for _, lifecycle := range info.SupportedEngineLifecycles {
-		if lifecycle.LifecycleSupportName == "open-source-rds-extended-support" {
-			// Check if we're past the start date of extended support
-			if now.After(lifecycle.LifecycleSupportStartDate) || now.Equal(lifecycle.LifecycleSupportStartDate) {
-				return true
-			}
+		if lifecycle.LifecycleSupportName != string(rdstypes.LifecycleSupportNameOpenSourceRdsExtendedSupport) {
+			continue
+		}
+		// Not in extended support before its start date
+		if now.Before(lifecycle.LifecycleSupportStartDate) {
+			continue
+		}
+		// Past the end date means extended support is over; a zero end date
+		// is open-ended (issue #1182)
+		if lifecycle.LifecycleSupportEndDate.IsZero() || now.Before(lifecycle.LifecycleSupportEndDate) {
+			return true
 		}
 	}
 

--- a/cmd/multi_service_engine_versions_paginate_test.go
+++ b/cmd/multi_service_engine_versions_paginate_test.go
@@ -51,7 +51,7 @@ func rdsMajorVersion(engine, major string) rdstypes.DBMajorEngineVersion { //nol
 		MajorEngineVersion: aws.String(major),
 		SupportedEngineLifecycles: []rdstypes.SupportedEngineLifecycle{
 			{
-				LifecycleSupportName:      "open-source-rds-extended-support",
+				LifecycleSupportName:      rdstypes.LifecycleSupportNameOpenSourceRdsExtendedSupport,
 				LifecycleSupportStartDate: aws.Time(time.Now().AddDate(-1, 0, 0)),
 				LifecycleSupportEndDate:   aws.Time(time.Now().AddDate(2, 0, 0)),
 			},

--- a/cmd/multi_service_engine_versions_test.go
+++ b/cmd/multi_service_engine_versions_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/LeanerCloud/CUDly/pkg/common"
+	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -134,7 +135,7 @@ func TestAdjustRecommendationForExcludedVersions(t *testing.T) {
 					MajorEngineVersion: "5.7",
 					SupportedEngineLifecycles: []EngineLifecycleInfo{
 						{
-							LifecycleSupportName:      "open-source-rds-extended-support",
+							LifecycleSupportName:      string(rdstypes.LifecycleSupportNameOpenSourceRdsExtendedSupport),
 							LifecycleSupportStartDate: time.Now().AddDate(0, -6, 0),
 							LifecycleSupportEndDate:   time.Now().AddDate(3, 0, 0),
 						},
@@ -213,7 +214,7 @@ func TestAdjustRecommendationForExcludedVersions_MultipleVersionsInExtendedSuppo
 			MajorEngineVersion: "5.6",
 			SupportedEngineLifecycles: []EngineLifecycleInfo{
 				{
-					LifecycleSupportName:      "open-source-rds-extended-support",
+					LifecycleSupportName:      string(rdstypes.LifecycleSupportNameOpenSourceRdsExtendedSupport),
 					LifecycleSupportStartDate: time.Now().AddDate(0, -12, 0),
 					LifecycleSupportEndDate:   time.Now().AddDate(2, 0, 0),
 				},
@@ -224,7 +225,7 @@ func TestAdjustRecommendationForExcludedVersions_MultipleVersionsInExtendedSuppo
 			MajorEngineVersion: "5.7",
 			SupportedEngineLifecycles: []EngineLifecycleInfo{
 				{
-					LifecycleSupportName:      "open-source-rds-extended-support",
+					LifecycleSupportName:      string(rdstypes.LifecycleSupportNameOpenSourceRdsExtendedSupport),
 					LifecycleSupportStartDate: time.Now().AddDate(0, -6, 0),
 					LifecycleSupportEndDate:   time.Now().AddDate(3, 0, 0),
 				},
@@ -518,7 +519,7 @@ func TestIsInExtendedSupport(t *testing.T) {
 					MajorEngineVersion: "5.7",
 					SupportedEngineLifecycles: []EngineLifecycleInfo{
 						{
-							LifecycleSupportName:      "open-source-rds-extended-support",
+							LifecycleSupportName:      string(rdstypes.LifecycleSupportNameOpenSourceRdsExtendedSupport),
 							LifecycleSupportStartDate: pastDate,
 							LifecycleSupportEndDate:   futureDate,
 						},
@@ -537,7 +538,7 @@ func TestIsInExtendedSupport(t *testing.T) {
 					MajorEngineVersion: "8.0",
 					SupportedEngineLifecycles: []EngineLifecycleInfo{
 						{
-							LifecycleSupportName:      "open-source-rds-standard-support",
+							LifecycleSupportName:      string(rdstypes.LifecycleSupportNameOpenSourceRdsStandardSupport),
 							LifecycleSupportStartDate: now.AddDate(-2, 0, 0),
 							LifecycleSupportEndDate:   futureDate,
 						},
@@ -575,7 +576,7 @@ func TestIsInExtendedSupport(t *testing.T) {
 					MajorEngineVersion: "5.7",
 					SupportedEngineLifecycles: []EngineLifecycleInfo{
 						{
-							LifecycleSupportName:      "open-source-rds-extended-support",
+							LifecycleSupportName:      string(rdstypes.LifecycleSupportNameOpenSourceRdsExtendedSupport),
 							LifecycleSupportStartDate: futureDate,
 							LifecycleSupportEndDate:   futureDate.AddDate(1, 0, 0),
 						},
@@ -594,7 +595,7 @@ func TestIsInExtendedSupport(t *testing.T) {
 					MajorEngineVersion: "11.19",
 					SupportedEngineLifecycles: []EngineLifecycleInfo{
 						{
-							LifecycleSupportName:      "open-source-rds-extended-support",
+							LifecycleSupportName:      string(rdstypes.LifecycleSupportNameOpenSourceRdsExtendedSupport),
 							LifecycleSupportStartDate: now,
 							LifecycleSupportEndDate:   futureDate,
 						},
@@ -613,7 +614,7 @@ func TestIsInExtendedSupport(t *testing.T) {
 					MajorEngineVersion: "5.7",
 					SupportedEngineLifecycles: []EngineLifecycleInfo{
 						{
-							LifecycleSupportName:      "open-source-rds-extended-support",
+							LifecycleSupportName:      string(rdstypes.LifecycleSupportNameOpenSourceRdsExtendedSupport),
 							LifecycleSupportStartDate: now.AddDate(-3, 0, 0),
 							LifecycleSupportEndDate:   pastDate,
 						},
@@ -632,7 +633,7 @@ func TestIsInExtendedSupport(t *testing.T) {
 					MajorEngineVersion: "5.7",
 					SupportedEngineLifecycles: []EngineLifecycleInfo{
 						{
-							LifecycleSupportName:      "open-source-rds-extended-support",
+							LifecycleSupportName:      string(rdstypes.LifecycleSupportNameOpenSourceRdsExtendedSupport),
 							LifecycleSupportStartDate: pastDate,
 						},
 					},
@@ -650,7 +651,7 @@ func TestIsInExtendedSupport(t *testing.T) {
 					MajorEngineVersion: "5.7",
 					SupportedEngineLifecycles: []EngineLifecycleInfo{
 						{
-							LifecycleSupportName:      "open-source-rds-extended-support",
+							LifecycleSupportName:      string(rdstypes.LifecycleSupportNameOpenSourceRdsExtendedSupport),
 							LifecycleSupportStartDate: pastDate,
 							LifecycleSupportEndDate:   futureDate,
 						},

--- a/cmd/multi_service_engine_versions_test.go
+++ b/cmd/multi_service_engine_versions_test.go
@@ -604,6 +604,43 @@ func TestIsInExtendedSupport(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:    "Extended support already ended",
+			engine:  "mysql",
+			version: "5.7.44",
+			versionInfo: map[string]MajorEngineVersionInfo{
+				"mysql:5.7": {
+					Engine:             "mysql",
+					MajorEngineVersion: "5.7",
+					SupportedEngineLifecycles: []EngineLifecycleInfo{
+						{
+							LifecycleSupportName:      "open-source-rds-extended-support",
+							LifecycleSupportStartDate: now.AddDate(-3, 0, 0),
+							LifecycleSupportEndDate:   pastDate,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name:    "Zero end date treated as open-ended",
+			engine:  "mysql",
+			version: "5.7.44",
+			versionInfo: map[string]MajorEngineVersionInfo{
+				"mysql:5.7": {
+					Engine:             "mysql",
+					MajorEngineVersion: "5.7",
+					SupportedEngineLifecycles: []EngineLifecycleInfo{
+						{
+							LifecycleSupportName:      "open-source-rds-extended-support",
+							LifecycleSupportStartDate: pastDate,
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
 			name:    "Engine name normalization with spaces",
 			engine:  "Aurora MySQL",
 			version: "5.7.mysql_aurora.2.11.1",

--- a/cmd/multi_service_test.go
+++ b/cmd/multi_service_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/LeanerCloud/CUDly/pkg/common"
 	"github.com/aws/aws-sdk-go-v2/aws"
+	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -1828,12 +1829,12 @@ func createTestVersionInfo() map[string]MajorEngineVersionInfo {
 			MajorEngineVersion: "5.7",
 			SupportedEngineLifecycles: []EngineLifecycleInfo{
 				{
-					LifecycleSupportName:      "open-source-rds-standard-support",
+					LifecycleSupportName:      string(rdstypes.LifecycleSupportNameOpenSourceRdsStandardSupport),
 					LifecycleSupportStartDate: now.AddDate(-5, 0, 0),
 					LifecycleSupportEndDate:   pastDate,
 				},
 				{
-					LifecycleSupportName:      "open-source-rds-extended-support",
+					LifecycleSupportName:      string(rdstypes.LifecycleSupportNameOpenSourceRdsExtendedSupport),
 					LifecycleSupportStartDate: pastDate,
 					LifecycleSupportEndDate:   futureDate,
 				},
@@ -1844,7 +1845,7 @@ func createTestVersionInfo() map[string]MajorEngineVersionInfo {
 			MajorEngineVersion: "8.0",
 			SupportedEngineLifecycles: []EngineLifecycleInfo{
 				{
-					LifecycleSupportName:      "open-source-rds-standard-support",
+					LifecycleSupportName:      string(rdstypes.LifecycleSupportNameOpenSourceRdsStandardSupport),
 					LifecycleSupportStartDate: now.AddDate(-2, 0, 0),
 					LifecycleSupportEndDate:   futureDate,
 				},


### PR DESCRIPTION
## Problem

`isInExtendedSupport` (cmd/multi_service_engine_versions.go) parsed both `LifecycleSupportStartDate` and `LifecycleSupportEndDate` from the RDS `DescribeDBMajorEngineVersions` response, but only ever compared the start date. Any engine version whose extended-support window had already ended was still classified as in-extended-support, so `adjustRecommendationForExcludedVersions` kept decrementing `rec.Count` for those instances, systematically under-sizing RI purchases for the affected instance types. (COR-08 from docs/reviews/codebase-review-2026-06-10.md)

## Fix

A version is now in extended support only when `now` is on or after the lifecycle start date AND before the end date; a zero end date is treated as open-ended (field absent in the API response). The bare `"open-source-rds-extended-support"` string literal is also replaced with the SDK enum constant `rdstypes.LifecycleSupportNameOpenSourceRdsExtendedSupport` per the project's typed-enum convention.

## Test evidence

Added two table cases to `TestIsInExtendedSupport`:

- "Extended support already ended" (start 3y ago, end 6mo ago, expect `false`): confirmed FAILING pre-fix (`expected: false, actual: true`) and passing post-fix.
- "Zero end date treated as open-ended" (expect `true`): guards the open-ended semantics.

Verification: `go build ./...` clean; `go test ./cmd/...` 752 passed in 7 packages.

Closes #1182
