### PR TITLE
fix(ci): restrict staging ECR cleanup to cudly-staging repos

### DIFF
--- a/.github/workflows/cleanup-staging.yml
+++ b/.github/workflows/cleanup-staging.yml
@@ -77,8 +77,18 @@ jobs:
       - name: Force-delete all staging ECR repos
         run: |
           for REPO in $(aws ecr describe-repositories \
-            --query "repositories[?starts_with(repositoryName,'cudly-staging') || repositoryName=='cudly'].repositoryName" \
+            --query "repositories[?starts_with(repositoryName,'cudly-staging')].repositoryName" \
             --output text 2>/dev/null); do
+            # Defense in depth: refuse anything outside the staging naming
+            # pattern (in particular the bare 'cudly' prod-adjacent repo)
+            # even if the query filter above is ever loosened.
+            case "$REPO" in
+              cudly-staging*) ;;
+              *)
+                echo "Refusing to delete non-staging ECR repo '$REPO'; staging cleanup only deletes cudly-staging* repos"
+                exit 1
+                ;;
+            esac
             echo "Force-deleting ECR repo $REPO..."
             aws ecr delete-repository --repository-name "$REPO" --force 2>/dev/null \
               || echo "  Failed to delete $REPO (may already be gone)"
@@ -137,8 +147,18 @@ jobs:
       - name: Force-delete all staging ECR repos
         run: |
           for REPO in $(aws ecr describe-repositories \
-            --query "repositories[?starts_with(repositoryName,'cudly-staging') || repositoryName=='cudly'].repositoryName" \
+            --query "repositories[?starts_with(repositoryName,'cudly-staging')].repositoryName" \
             --output text 2>/dev/null); do
+            # Defense in depth: refuse anything outside the staging naming
+            # pattern (in particular the bare 'cudly' prod-adjacent repo)
+            # even if the query filter above is ever loosened.
+            case "$REPO" in
+              cudly-staging*) ;;
+              *)
+                echo "Refusing to delete non-staging ECR repo '$REPO'; staging cleanup only deletes cudly-staging* repos"
+                exit 1
+                ;;
+            esac
             echo "Force-deleting ECR repo $REPO..."
             aws ecr delete-repository --repository-name "$REPO" --force 2>/dev/null \
               || echo "  Failed to delete $REPO (may already be gone)"

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -58,6 +58,8 @@ jobs:
 
       - name: Validate inputs
         id: check
+        env:
+          ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY }}
         run: |
           IS_VALID=true
           IMAGE_URI=""
@@ -71,7 +73,12 @@ jobs:
           # Construct image URI based on cloud provider
           case "${{ inputs.cloud }}" in
             aws-lambda|aws-fargate)
-              IMAGE_URI="${{ vars.AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION || 'us-east-1' }}.amazonaws.com/${{ vars.ECR_REPOSITORY || 'cudly' }}:${{ inputs.image_tag }}"
+              if [ -z "$ECR_REPOSITORY" ]; then
+                echo "❌ ECR_REPOSITORY repository variable is not set; refusing to guess the repo name"
+                IS_VALID=false
+              else
+                IMAGE_URI="${{ vars.AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION || 'us-east-1' }}.amazonaws.com/${ECR_REPOSITORY}:${{ inputs.image_tag }}"
+              fi
               ;;
             gcp)
               IMAGE_URI="${{ vars.GCP_REGION || 'us-central1' }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ vars.ARTIFACT_REGISTRY_REPO || 'cudly' }}/cudly:${{ inputs.image_tag }}"
@@ -127,7 +134,12 @@ jobs:
         if: startsWith(inputs.cloud, 'aws')
         run: |
           IMAGE_TAG="${{ inputs.image_tag }}"
-          REPO="${{ vars.ECR_REPOSITORY || 'cudly' }}"
+          REPO="${{ vars.ECR_REPOSITORY }}"
+
+          if [ -z "$REPO" ]; then
+            echo "❌ ECR_REPOSITORY repository variable is not set"
+            exit 1
+          fi
 
           echo "Checking if image exists: $REPO:$IMAGE_TAG"
 


### PR DESCRIPTION
## Problem

Code review finding INF-05 (P3): the staging cleanup workflow's ECR delete loop matched `starts_with(repositoryName,'cudly-staging') || repositoryName=='cudly'` and then ran `aws ecr delete-repository --force`. The bare `cudly` name is exactly the default production repository used by rollback.yml (`${{ vars.ECR_REPOSITORY || 'cudly' }}`), leaving a hardcoded prod-adjacent name inside a force-delete loop. The `== 'cudly'` clause was a one-off for the legacy pre-suffix repo and has served its purpose; the rollback default is stale relative to the suffixed `cudly-prod-<hex>` Terraform naming scheme.

## Fix

- `.github/workflows/cleanup-staging.yml` (both AWS jobs): drop the `repositoryName=='cudly'` clause so only `cudly-staging*` repos are queried, and add an in-loop `case` guard that refuses (exit 1) any repository name not matching the staging pattern, so a future filter change cannot silently widen the blast radius.
- `.github/workflows/rollback.yml`: remove the silent `|| 'cudly'` fallback for `vars.ECR_REPOSITORY`. The validate job now fails the rollback loudly when the variable is unset instead of guessing a repo name, and the verify-image step double-checks it.

## Test evidence

- `actionlint` passes on both edited workflows.
- Shell simulation of the guard: `cudly` and `cudly-prod-ab12` are REFUSED, `cudly-staging` and `cudly-staging-ab12` are deleted.
- Pre-fix, the JMESPath filter explicitly matched the bare `cudly` repo; post-fix it is excluded by the query and rejected by the guard.

Closes #1185
