### PR TITLE
ci(pre-commit): fetch Trivy installer from pinned release tag

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -151,10 +151,20 @@ jobs:
         # of those tags makes install bail silently after detecting the
         # version. v0.69.3 ships the standard `trivy_<ver>_Linux-64bit.tar.gz`
         # asset.
+        #
+        # The installer itself is fetched from the same pinned release tag
+        # (not the mutable `main` branch) and downloaded to a file before
+        # execution, matching the tflint step above: a malicious or
+        # accidental change to install.sh on main can't silently execute
+        # on this CI runner, and `curl -fsSL` makes transport errors fail
+        # loudly instead of piping an HTML error page into sh.
+        env:
+          TRIVY_VERSION: v0.69.3
         run: |
-          set -eo pipefail
-          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh \
-            | sh -s -- -b /usr/local/bin v0.69.3
+          set -euo pipefail
+          curl -fsSL -o /tmp/trivy-install.sh \
+            "https://raw.githubusercontent.com/aquasecurity/trivy/${TRIVY_VERSION}/contrib/install.sh"
+          sh /tmp/trivy-install.sh -b /usr/local/bin "${TRIVY_VERSION}"
 
       - name: Install git-secrets
         # Pinned to a release tag rather than master HEAD. After install


### PR DESCRIPTION
## Problem

Code-review finding INF-07 (#1187): the `Install Trivy` step in `.github/workflows/pre-commit.yml` fetched `contrib/install.sh` from the mutable `main` branch of aquasecurity/trivy and piped it straight into `sh`:

```
curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.69.3
```

A compromised or accidentally broken `install.sh` on trivy `main` would execute arbitrary code on the CI runner, the exact supply-chain weakness the adjacent tflint step in the same workflow already guards against by pinning its installer to a release tag.

## Fix

- Fetch the installer from the same pinned release tag as the Trivy binary (`v0.69.3`), introduced as a single `TRIVY_VERSION` env var so the pin lives in one place.
- Download the script to a file and execute it from there instead of piping a network stream into `sh`, matching the tflint installer pattern.
- `curl -fsSL` plus `set -euo pipefail` so transport errors fail loudly instead of feeding an HTML error page into the shell.

## Test evidence

- `actionlint .github/workflows/pre-commit.yml` passes.
- Verified `contrib/install.sh` exists at the `v0.69.3` tag and ran the pinned-tag installer end-to-end with the same arguments (`sh install.sh -b <dir> v0.69.3`); it installed a working `trivy` reporting `Version: 0.69.3`.

Closes #1187

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)
