### PR TITLE
test(cmd): funnel goroutine results to test goroutine in alias test

### DIFF
--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"math"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -168,19 +169,25 @@ func TestGetAccountAliasConcurrency(t *testing.T) {
 
 	cache := NewAccountAliasCacheWithClient(mockOrg)
 
-	// Test concurrent access to ensure proper locking
-	done := make(chan bool, 10)
-	for i := 0; i < 10; i++ {
+	// Test concurrent access to ensure proper locking. Worker goroutines must
+	// not call assert/require directly; funnel results back and assert on the
+	// test goroutine after wg.Wait().
+	const numGoroutines = 10
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+	results := make(chan string, numGoroutines)
+	for i := 0; i < numGoroutines; i++ {
 		go func() {
-			result := cache.GetAccountAlias(ctx, "123456789012")
-			assert.Equal(t, "Test Account", result)
-			done <- true
+			defer wg.Done()
+			results <- cache.GetAccountAlias(ctx, "123456789012")
 		}()
 	}
 
-	// Wait for all goroutines to complete
-	for i := 0; i < 10; i++ {
-		<-done
+	// Wait for all goroutines to complete, then assert on the test goroutine.
+	wg.Wait()
+	close(results)
+	for result := range results {
+		assert.Equal(t, "Test Account", result)
 	}
 
 	// Mock should only be called once due to double-checked locking in GetAccountAlias


### PR DESCRIPTION
## Problem

Code-review finding TEST-06 (P3, issue #1159): in `TestGetAccountAliasConcurrency` (`cmd/helpers_test.go`), 10 worker goroutines each called `assert.Equal(t, ...)` directly. Only the test goroutine may call assert/require; the current join via a `done` channel prevents a post-completion race today, but the pattern is fragile: upgrading `assert` to `require` inside a goroutine, or removing the join, turns failures into lost reports or post-test panics.

## Fix

Workers now send their `GetAccountAlias` results over a buffered `results` channel and only the test goroutine asserts, after `wg.Wait()` and `close(results)`. This matches the established errCh pattern used in `internal/server/scheduledauth/validator_test.go` and `internal/auth/service_user_test.go`. The goroutine count is a named constant (`numGoroutines`) instead of a repeated literal.

## Test evidence

- `go build ./...` passes
- `go test -race -run TestGetAccountAlias ./cmd/` passes (6 tests)
- `go test -race ./cmd/` passes (733 tests)

This is a test-hygiene refactor of an existing test; the mock single-call invariant (`mockOrg.AssertExpectations`) and the double-checked-locking coverage are unchanged.

Closes #1159
