### PR TITLE
docs(claude): fix build/test commands and file layout in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,13 +18,16 @@
 
 ## File Organization
 
-- NEVER save to root folder — use the directories below
-- Use `/src` for source code files
-- Use `/tests` for test files
-- Use `/docs` for documentation and markdown files
-- Use `/config` for configuration files
-- Use `/scripts` for utility scripts
-- Use `/examples` for example code
+- NEVER save working files to the root folder; use the directories below
+- `cmd/`: CLI and server entry points (main packages)
+- `internal/`: backend application code (API, auth, purchase, scheduler, ...)
+- `pkg/`: shared library code (separate Go module, see Go Module Notes)
+- `providers/`: cloud provider integrations (AWS, Azure, GCP)
+- `frontend/`: TypeScript web frontend (webpack + jest)
+- `terraform/`, `cloudformation/`, `arm/`, `iac/`: infrastructure as code
+- `docs/`: documentation and markdown files
+- `scripts/`: utility scripts
+- `tests/`: end-to-end tests (Go unit tests live next to the code they test)
 
 ## Project Architecture
 
@@ -52,15 +55,23 @@
 
 ## Build & Test
 
+The root of the repo is a Go project; the npm scripts live in `frontend/`.
+
 ```bash
-# Build
-npm run build
+# Build (backend, from the repo root)
+go build ./...        # or: make build
 
-# Test
-npm test
+# Test (backend)
+go test ./...         # or: make test-unit
 
-# Lint
-npm run lint
+# Lint (backend)
+make lint             # golangci-lint; also: make vet, make fmt
+
+# Frontend (run from frontend/)
+cd frontend && npm ci
+npm run build         # webpack production build
+npm test              # jest --coverage
+npm run lint          # eslint src/**/*.ts
 ```
 
 - ALWAYS run tests after making code changes


### PR DESCRIPTION
## Problem

CLAUDE.md, the highest-priority instruction file for every agent session, contained two factually wrong sections (review finding HYG-10):

- **Build & Test** instructed `npm run build` / `npm test` / `npm run lint` at the repo root, where no `package.json` exists; the root build is Go.
- **File Organization** mandated `/src`, `/tests` (as generic test dir), `/config`, `/examples` directories that do not exist; the real layout is `cmd/`, `internal/`, `pkg/`, `providers/`, `frontend/`, `terraform/`, etc.

## Fix

Replaced only the factual errors, preserving the rest of the file:

- **Build & Test** now documents the real commands: `go build ./...` / `go test ./...` at the root (with the `make build` / `make test-unit` / `make lint` equivalents), and the npm scripts (`npm run build`, `npm test`, `npm run lint`) under `frontend/`.
- **File Organization** now describes the actual directory map: `cmd/`, `internal/`, `pkg/`, `providers/`, `frontend/`, `terraform/`/`cloudformation/`/`arm/`/`iac/`, `docs/`, `scripts/`, `tests/` (e2e).

No other sections were changed.

## Verification

- Every documented command cross-checked against `Makefile` targets (`build`, `test-unit`, `lint` exist and run go build/go test/golangci-lint) and `frontend/package.json` scripts (`build`, `test`, `lint` exist).
- Directory list cross-checked against the actual repo root and `internal/` contents.
- `go build ./...` run successfully at the repo root of this branch.

Closes #1179
