### PR TITLE
fix(deploy): forward extra terraform args, drop vestigial targets

### DIFF
--- a/Makefile.terraform
+++ b/Makefile.terraform
@@ -3,7 +3,7 @@
 
 .PHONY: help deploy plan destroy profile-new profile-list profile-show clean clean-locks \
         output aws-dev aws-prod azure-dev gcp-dev quick-plan aws-dev-plan quick-deploy \
-        validate fmt state-list state-show docker-build docker-skip frontend-only frontend-skip
+        validate fmt state-list state-show frontend-only
 
 # Default profile settings
 PROVIDER ?= aws
@@ -123,21 +123,8 @@ state-list: ## List resources in Terraform state
 state-show: ## Show detailed state for a resource
 	@cd terraform/environments/$(PROVIDER)/$(PROFILE) && terraform state show $(RESOURCE)
 
-# Docker operations
-docker-build: ## Build Docker image only
-	@echo "🔨 Building Docker image..."
-	@./scripts/tf-deploy.sh $(PROVIDER) $(PROFILE) apply -var="skip_docker_push=true"
-
-docker-skip: ## Deploy without Docker build
-	@echo "⏭️  Deploying without Docker build..."
-	@./scripts/tf-deploy.sh $(PROVIDER) $(PROFILE) apply -var="skip_docker_build=true"
-
 # Frontend operations
 frontend-only: ## Deploy frontend only
 	@echo "🎨 Deploying frontend..."
 	@cd terraform/environments/$(PROVIDER)/$(PROFILE) && \
 		terraform apply -var-file="../../../profiles/$(PROVIDER)/$(PROFILE).tfvars" -target=module.frontend
-
-frontend-skip: ## Deploy without frontend
-	@echo "⏭️  Deploying without frontend..."
-	@./scripts/tf-deploy.sh $(PROVIDER) $(PROFILE) apply -var="enable_frontend_build=false"

--- a/scripts/tf-deploy.sh
+++ b/scripts/tf-deploy.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 # Terraform Deployment Helper Script
-# Usage: ./scripts/tf-deploy.sh <provider> <profile> [action]
+# Usage: ./scripts/tf-deploy.sh <provider> <profile> [action] [extra terraform args...]
 # Example: ./scripts/tf-deploy.sh aws dev
 # Example: ./scripts/tf-deploy.sh aws prod plan
+# Example: ./scripts/tf-deploy.sh aws dev apply -target=module.frontend
 
 set -euo pipefail
 
@@ -31,12 +32,18 @@ log_error() {
 }
 
 # Parse arguments
-PROVIDER=$1
-PROFILE=$2
+PROVIDER=${1:-}
+PROFILE=${2:-}
 ACTION=${3:-apply}
 
+# Any further arguments are forwarded verbatim to terraform (e.g. -target=...).
+EXTRA_ARGS=()
+if [ "$#" -gt 3 ]; then
+    EXTRA_ARGS=("${@:4}")
+fi
+
 if [ -z "$PROVIDER" ] || [ -z "$PROFILE" ]; then
-    log_error "Usage: $0 <provider> <profile> [action]"
+    log_error "Usage: $0 <provider> <profile> [action] [extra terraform args...]"
     echo ""
     echo "Examples:"
     echo "  $0 aws dev           # Deploy to AWS dev"
@@ -112,34 +119,36 @@ fi
 log_info "Running terraform ${ACTION}..."
 echo ""
 
+# ${EXTRA_ARGS[@]+...} keeps the empty-array expansion safe under set -u
+# on bash 3.2 (macOS default).
 case $ACTION in
     plan)
-        terraform plan -var-file="$PROFILE_FILE"
+        terraform plan -var-file="$PROFILE_FILE" ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}
         ;;
     apply)
-        terraform apply -var-file="$PROFILE_FILE"
+        terraform apply -var-file="$PROFILE_FILE" ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}
         ;;
     destroy)
         log_warning "This will destroy all resources!"
         read -p "Are you sure? (type 'yes' to confirm): " confirm
         if [ "$confirm" = "yes" ]; then
-            terraform destroy -var-file="$PROFILE_FILE"
+            terraform destroy -var-file="$PROFILE_FILE" ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}
         else
             log_info "Destroy cancelled"
             exit 0
         fi
         ;;
     show)
-        terraform show
+        terraform show ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}
         ;;
     refresh)
-        terraform refresh -var-file="$PROFILE_FILE"
+        terraform refresh -var-file="$PROFILE_FILE" ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}
         ;;
     output)
-        terraform output
+        terraform output ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}
         ;;
     *)
-        terraform $ACTION -var-file="$PROFILE_FILE"
+        terraform "$ACTION" -var-file="$PROFILE_FILE" ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}
         ;;
 esac
 


### PR DESCRIPTION
## Problem

Code-review finding HYG-04 (#1172): the `Makefile.terraform` targets `docker-build`, `docker-skip` and `frontend-skip` passed `-var="..."` flags as a 4th argument to `scripts/tf-deploy.sh`, but the script only consumed `$1..$3` and ran a plain `terraform apply -var-file=...`. The flags were silently discarded, so e.g. `make docker-skip` performed a full deploy including the Docker build.

The verifier also found the targets were never functional at all: none of the named variables (`skip_docker_push`, `skip_docker_build`, `enable_frontend_build`) is a declared root-module variable in any of the three cloud environments (they exist only at module level, hardcoded `false` in each root `build.tf`), and nothing in the repo references the targets.

## Fix

- **Delete the three vestigial targets** (and their `.PHONY` entries) rather than plumbing dead variables through three cloud root modules. They now fail loudly with `No rule to make target` instead of silently running a full apply. `frontend-only` (which works via `-target=module.frontend`) is kept.
- **Fix the root cause in `scripts/tf-deploy.sh`**: arguments after `<provider> <profile> <action>` are now forwarded verbatim to terraform (e.g. `-target=...`, `-var=...`), so this class of silent argument drop cannot recur. The empty-array expansion uses the `${EXTRA_ARGS[@]+...}` guard to stay `set -u` safe on bash 3.2 (macOS default).
- **Make the usage check reachable** (also called out in the finding): `PROVIDER=$1` aborted with `unbound variable` under `set -u` before the intended usage message could print; now uses `${1:-}`/`${2:-}` and prints the usage text with exit 1.

## Test evidence

Verified per the finding's guidance with `make -n` dry-runs and a stub `terraform` binary on `PATH` that records its exact invocation:

- Pre-fix: `./scripts/tf-deploy.sh aws <profile> plan -var="skip_docker_build=true"` invoked `terraform plan -var-file=<profile.tfvars>` with the `-var` flag silently dropped; `./scripts/tf-deploy.sh` with no args died with `line 34: $1: unbound variable`.
- Post-fix: the stub records `plan -var-file=<profile.tfvars> -var=skip_docker_build=true -target=module.frontend` (extras forwarded verbatim); a plain invocation renders identically to before (`plan -var-file=<profile.tfvars>`); no-args prints the usage message and exits 1.
- `make -n -f Makefile.terraform docker-build|docker-skip|frontend-skip` now fail with `No rule to make target`; `deploy`, `plan` and `frontend-only` render unchanged.
- `bash -n scripts/tf-deploy.sh` clean.

Closes #1172
