### PR TITLE
chore(make): drop broken recipes, pin dev tools, add ci to .PHONY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,22 @@
         test-coverage full-test security-scan terraform-validate docker-build \
         fmt vet lint complexity complexity-report security-scan-go security-scan-docker \
         security-scan-terraform terraform-fmt terraform-fmt-check iac-arm docker-test pre-commit \
-        setup-git-secrets security-scan-snyk security-scan-all cost-estimate docker-compose-test \
+        setup-git-secrets security-scan-snyk security-scan-all ci docker-compose-test \
         install-dev-tools
 
 # Variables
 VERSION?=dev
 BUILD_TIME?=$(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
 GIT_SHA?=$(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
+
+# Dev tool versions - keep in sync with the CI pins in
+# .github/workflows/ci.yml, pre-commit.yml and database-migration.yml
+GOLANGCI_LINT_VERSION?=v2.10.1
+GOSEC_VERSION?=v2.22.4
+GOCYCLO_VERSION?=v0.6.0
+MIGRATE_VERSION?=v4.19.1
+# staticcheck has no CI pin; it is used by scripts/security-scan.sh
+STATICCHECK_VERSION?=v0.7.0
 LDFLAGS=-ldflags "-s -w -X main.Version=$(VERSION) -X main.BuildTime=$(BUILD_TIME) -X main.GitSHA=$(GIT_SHA)"
 
 # Default target
@@ -32,7 +41,6 @@ help: ## Display available targets
 	@echo "  security-scan-all  - Run all security scanners including Snyk"
 	@echo "  setup-git-secrets  - Set up git-secrets for preventing credential leaks"
 	@echo "  terraform-validate - Validate Terraform configurations"
-	@echo "  cost-estimate      - Estimate infrastructure costs with Infracost"
 	@echo "  docker-build       - Build Docker image"
 	@echo "  docker-compose-test - Run E2E tests with docker-compose"
 	@echo "  ci                 - Run CI pipeline locally"
@@ -94,7 +102,7 @@ lint:
 	@if command -v golangci-lint > /dev/null; then \
 		golangci-lint run --timeout=5m; \
 	else \
-		echo "golangci-lint not installed. Install: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest"; \
+		echo "golangci-lint not installed. Install: make install-dev-tools"; \
 	fi
 
 # Go vet
@@ -117,7 +125,7 @@ complexity:
 			echo "✅ All functions have acceptable cyclomatic complexity (≤10)"; \
 		fi \
 	else \
-		echo "gocyclo not installed. Install: go install github.com/fzipp/gocyclo/cmd/gocyclo@latest"; \
+		echo "gocyclo not installed. Install: make install-dev-tools"; \
 		exit 1; \
 	fi
 
@@ -129,7 +137,7 @@ complexity-report:
 		echo ""; \
 		echo "📊 Top 20 most complex functions saved to: complexity-report.txt"; \
 	else \
-		echo "gocyclo not installed. Install: go install github.com/fzipp/gocyclo/cmd/gocyclo@latest"; \
+		echo "gocyclo not installed. Install: make install-dev-tools"; \
 	fi
 
 # Security scanning
@@ -141,7 +149,7 @@ security-scan-go:
 		gosec -fmt=json -out=gosec-report.json -exclude=G101,G104,G115,G204,G301,G304,G402,G505 ./...; \
 		echo "✓ Go security scan complete: gosec-report.json"; \
 	else \
-		echo "gosec not installed. Install: go install github.com/securego/gosec/v2/cmd/gosec@latest"; \
+		echo "gosec not installed. Install: make install-dev-tools"; \
 	fi
 
 security-scan-docker:
@@ -221,11 +229,6 @@ security-scan-snyk:
 security-scan-all: security-scan security-scan-snyk
 	@echo "✓ All security scans complete"
 
-# Cost estimation with Infracost
-cost-estimate:
-	@echo "Estimating infrastructure costs..."
-	@bash scripts/cost-estimate.sh
-
 # Docker Compose E2E tests
 docker-compose-test:
 	@echo "Running E2E tests with docker-compose..."
@@ -235,22 +238,21 @@ docker-compose-test:
 # Install development dependencies
 install-dev-tools:
 	@echo "Installing development tools..."
-	@echo "Installing golangci-lint..."
-	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
-	@echo "Installing gosec..."
-	@go install github.com/securego/gosec/v2/cmd/gosec@latest
-	@echo "Installing staticcheck..."
-	@go install honnef.co/go/tools/cmd/staticcheck@latest
-	@echo "Installing gocyclo..."
-	@go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
-	@echo "Installing golang-migrate..."
-	@go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
+	@echo "Installing golangci-lint $(GOLANGCI_LINT_VERSION)..."
+	@go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+	@echo "Installing gosec $(GOSEC_VERSION)..."
+	@go install github.com/securego/gosec/v2/cmd/gosec@$(GOSEC_VERSION)
+	@echo "Installing staticcheck $(STATICCHECK_VERSION)..."
+	@go install honnef.co/go/tools/cmd/staticcheck@$(STATICCHECK_VERSION)
+	@echo "Installing gocyclo $(GOCYCLO_VERSION)..."
+	@go install github.com/fzipp/gocyclo/cmd/gocyclo@$(GOCYCLO_VERSION)
+	@echo "Installing golang-migrate $(MIGRATE_VERSION)..."
+	@go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@$(MIGRATE_VERSION)
 	@echo "✓ Development tools installed"
 	@echo ""
 	@echo "Additional tools to install manually:"
 	@echo "  - trivy: https://aquasecurity.github.io/trivy/"
 	@echo "  - tfsec: https://aquasecurity.github.io/tfsec/"
-	@echo "  - infracost: https://www.infracost.io/docs/"
 	@echo "  - git-secrets: https://github.com/awslabs/git-secrets"
 	@echo "  - snyk: npm install -g snyk"
 	@echo "  - pre-commit: pip install pre-commit"

--- a/Makefile.terraform
+++ b/Makefile.terraform
@@ -1,7 +1,7 @@
 # Terraform Deployment Makefile
 # Simplified commands for common Terraform operations
 
-.PHONY: help deploy plan destroy profile-new profile-list profile-show clean clean-locks \
+.PHONY: help deploy plan destroy profile-list profile-show clean clean-locks \
         output aws-dev aws-prod azure-dev gcp-dev quick-plan aws-dev-plan quick-deploy \
         validate fmt state-list state-show docker-build docker-skip frontend-only frontend-skip
 
@@ -24,7 +24,6 @@ help: ## Show this help message
 	@echo "  make plan PROFILE=prod   # Plan AWS prod deployment"
 	@echo ""
 	@echo "Profile Management:"
-	@echo "  make profile-new         # Create new profile interactively"
 	@echo "  make profile-list        # List all available profiles"
 	@echo "  make profile-show        # Show current profile contents"
 	@echo ""
@@ -53,9 +52,6 @@ destroy: ## Destroy infrastructure (asks for confirmation)
 
 output: ## Show Terraform outputs
 	@./scripts/tf-deploy.sh $(PROVIDER) $(PROFILE) output
-
-profile-new: ## Create new profile interactively
-	@./scripts/generate-profile.sh
 
 profile-list: ## List all available profiles
 	@echo "Available Profiles:"

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -321,7 +321,6 @@ make security-scan-terraform   # tfsec
 make terraform-validate
 make terraform-fmt-check
 make terraform-fmt
-make cost-estimate             # requires infracost
 
 make docker-build              # build Docker image
 make docker-test               # build and test image

--- a/terraform/profiles/README.md
+++ b/terraform/profiles/README.md
@@ -57,7 +57,7 @@ terraform apply -var-file="../../../profiles/aws/prod.tfvars"
 
 ## Creating a New Profile
 
-### Option 1: Copy from Example
+### Copy from Example
 
 ```bash
 # Copy example profile
@@ -68,22 +68,6 @@ vim profiles/aws/my-profile.tfvars
 
 # Use it
 terraform apply -var-file="../../../profiles/aws/my-profile.tfvars"
-```
-
-### Option 2: Use Profile Generator
-
-```bash
-# Generate new profile interactively
-./scripts/generate-profile.sh
-
-# Prompts for:
-# - Cloud provider (aws/azure/gcp)
-# - Environment name
-# - Region
-# - Compute platform
-# - Other settings
-
-# Creates: profiles/{provider}/{name}.tfvars
 ```
 
 ## Profile Contents
@@ -380,32 +364,6 @@ cd "terraform/environments/${PROVIDER}/${PROFILE}"
 
 terraform init
 terraform $ACTION -var-file="../../../../${PROFILE_FILE}"
-```
-
-### generate-profile.sh
-
-```bash
-#!/bin/bash
-# Interactive profile generator
-
-echo "Creating new Terraform profile..."
-read -p "Cloud provider (aws/azure/gcp): " provider
-read -p "Profile name: " profile_name
-read -p "Region: " region
-read -p "Compute platform: " compute_platform
-
-cat > "profiles/${provider}/${profile_name}.tfvars" <<EOF
-# Auto-generated profile
-provider         = "${provider}"
-environment      = "${profile_name}"
-region           = "${region}"
-compute_platform = "${compute_platform}"
-project_name     = "cudly"
-
-# Add more settings as needed
-EOF
-
-echo "✅ Profile created: profiles/${provider}/${profile_name}.tfvars"
 ```
 
 ## Related Documentation


### PR DESCRIPTION
## Problem

Review findings HYG-05 and HYG-11 (docs/reviews/codebase-review-2026-06-10.md):

- `make cost-estimate` (Makefile) and `make -f Makefile.terraform profile-new` invoke `scripts/cost-estimate.sh` and `scripts/generate-profile.sh`, which never existed in repo history (`git log --all` over both paths returns nothing), so both advertised targets fail immediately with "No such file or directory".
- `.PHONY` omits `ci`, so a file named `ci` at the repo root silently masks `make ci`.
- `install-dev-tools` installed golangci-lint/gosec/staticcheck/gocyclo/migrate at `@latest`, contradicting the project's CI pinning practice and causing "passes locally, fails in CI" drift.
- The docker-compose v1 part of HYG-11 was already fixed on main by 5f45f5c09 (ci: use docker compose v2 instead of docker-compose v1); nothing left to do there.

## Fix

- Remove the `cost-estimate` and `profile-new` targets, their `.PHONY` entries and help lines, plus the stale references in `docs/DEVELOPMENT.md` and `terraform/profiles/README.md` (which advertised the nonexistent `generate-profile.sh`, including a fictional source listing).
- Add `ci` to `.PHONY`.
- Pin `install-dev-tools` to the CI versions via overridable Make variables: golangci-lint v2.10.1 (matching `ci.yml`, switched to the `/v2` module path required by v2), gosec v2.22.4 (`pre-commit.yml`), gocyclo v0.6.0 (`ci.yml`/`pre-commit.yml`), golang-migrate v4.19.1 (`ci.yml`/`database-migration.yml`). staticcheck has no CI pin and is only consumed by `scripts/security-scan.sh`; pinned to the latest stable v0.7.0.
- Point the "not installed" hints in `lint`/`complexity`/`complexity-report`/`security-scan-go` at `make install-dev-tools` instead of per-tool `@latest` go install commands, so the pins cannot be bypassed by following the hint.

## Test evidence

- `make -n` passes on every touched/adjacent target: `ci`, `install-dev-tools`, `help`, `lint`, `complexity`, `complexity-report`, `security-scan-go`, `docker-compose-test`, `pre-commit`, and `Makefile.terraform` `help`/`profile-list`/`profile-show`/`deploy`/`plan`.
- Removed targets now fail loudly at make level: `make -n cost-estimate` and `make -f Makefile.terraform -n profile-new` both return "No rule to make target".
- Phony regression check: with a file named `ci` present, `make -n ci` still runs the recipe (pre-fix it would report "up to date").
- Every pinned module version resolves: `go list -m` confirms golangci-lint/v2 v2.10.1, gosec/v2 v2.22.4, gocyclo v0.6.0, migrate/v4 v4.19.1, honnef.co/go/tools v0.7.0.
- No remaining `@latest` in the Makefile; no remaining repo references to `cost-estimate`/`profile-new`/`generate-profile.sh` outside docs/reviews.

Closes #1174, Closes #1181


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Development tools now pinned to specific versions for consistency.
  * Removed obsolete `cost-estimate` and `profile-new` make targets.

* **Documentation**
  * Updated profile creation guidance to use copy-from-example approach instead of automated generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->