### PR TITLE
fix(ci): repair main pre-commit (gocyclo recEffectiveSavingsPct #1222 + Dockerfile.test non-root)

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -7,9 +7,18 @@
 # keep the digest in sync with the builder stage there.
 FROM golang:1.25.4-alpine3.21@sha256:3289aac2aac769e031d644313d094dbda745f28af81cd7a94137e73eefd58b33
 
+# Run the suite as a non-root user (trivy DS-0002). tests/e2e is a stdlib-only
+# module so no module downloads are needed; GOCACHE lives in the user's home,
+# which it owns and can write to during both the pre-compile below and the
+# runtime CMD.
+RUN adduser -D -u 10001 e2e
+ENV GOCACHE=/home/e2e/.cache/go-build
+
 WORKDIR /e2e
 
-COPY tests/e2e/ ./
+COPY --chown=e2e:e2e tests/e2e/ ./
+
+USER e2e
 
 # Pre-compile the test binary so `docker compose up` failures are runtime
 # failures, not compile errors discovered after the stack is already up.

--- a/internal/config/store_postgres_recommendations.go
+++ b/internal/config/store_postgres_recommendations.go
@@ -325,24 +325,33 @@ func recEffectiveSavingsPct(rec *RecommendationRecord) (float64, bool) {
 	if rec.Term == 0 {
 		return 0, false
 	}
-	hasOnDemand := rec.OnDemandCost != nil && *rec.OnDemandCost > 0
-	if !hasOnDemand && rec.MonthlyCost == nil {
-		return 0, false
-	}
-	if rec.Provider == providerAWS && !hasOnDemand {
-		return 0, false
-	}
-	var onDemand float64
-	if hasOnDemand {
-		onDemand = *rec.OnDemandCost
-	} else {
-		amortized := rec.UpfrontCost / float64(rec.Term*12)
-		onDemand = *rec.MonthlyCost + rec.Savings + amortized
-	}
-	if onDemand == 0 {
+	onDemand, ok := recOnDemandBaseline(rec)
+	if !ok || onDemand == 0 {
 		return 0, false
 	}
 	return (rec.Savings / onDemand) * 100, true
+}
+
+// recOnDemandBaseline returns the monthly on-demand baseline used as the
+// denominator in recEffectiveSavingsPct, and whether one could be determined.
+// It prefers the provider-reported OnDemandCost; otherwise it reconstructs the
+// baseline as monthly_cost + net savings + amortized upfront. It returns
+// ok=false when no baseline can be derived: no explicit on-demand and no
+// monthly_cost, or an AWS row without an explicit on-demand baseline (the
+// reconstruction diverges from Cost Explorer's true baseline -- the frontend's
+// #323 guard). Callers must ensure rec.Term != 0 before calling.
+func recOnDemandBaseline(rec *RecommendationRecord) (float64, bool) {
+	if rec.OnDemandCost != nil && *rec.OnDemandCost > 0 {
+		return *rec.OnDemandCost, true
+	}
+	if rec.MonthlyCost == nil {
+		return 0, false
+	}
+	if rec.Provider == providerAWS {
+		return 0, false
+	}
+	amortized := rec.UpfrontCost / float64(rec.Term*12)
+	return *rec.MonthlyCost + rec.Savings + amortized, true
 }
 
 // ListStoredRecommendations reads recommendations matching the filter.


### PR DESCRIPTION
## Summary

Repairs two pre-commit failures on `main` that block every PR.

### 1. gocyclo (closes #1222) — the CI blocker
`recEffectiveSavingsPct` had cyclomatic complexity 12, above the pre-commit `gocyclo -over 10` threshold, so the "Run pre-commit hooks" CI job failed on **every** PR regardless of what it touched (the hook scans all non-test `.go` files). Extracted the on-demand baseline derivation into a new helper `recOnDemandBaseline`, bringing both functions under the threshold.

Behavior is identical — the helper returns the same `(baseline, ok)` for every input branch (explicit `OnDemandCost`, `monthly_cost` reconstruction, the AWS-without-baseline and no-`monthly_cost` guards), so the net-savings semantics from #1103/#1148 are unchanged.

### 2. trivy DS-0002 on `Dockerfile.test`
Newer trivy (>=0.70.0) flags `Dockerfile.test` (the ephemeral docker-compose E2E test-runner) for running as root; CI pins trivy v0.69.3 which doesn't report it, so the hook was clean on CI but failed for contributors on a newer local trivy. Rather than suppress the finding, the test image now runs as a dedicated non-root `e2e` user, with `GOCACHE` in its home so both the build-time pre-compile and the runtime `go test` run unprivileged. `tests/e2e` is stdlib-only, so no module downloads are needed.

## Testing
- `gocyclo -over 10 internal/config/store_postgres_recommendations.go` -> clean
- `trivy config --severity HIGH,CRITICAL --exit-code 1 ... .` -> exit 0
- `go build ./...` -> ok; `go test ./internal/config/` -> ok
- `docker build -f Dockerfile.test .` -> `go vet` + `go test` run cleanly as non-root `e2e`

Unblocks the QA-sheet fix PRs (#1247, #1248, #1251, #1249/#1250, #1252) which stack on this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test container security by configuring tests to run with non-root user privileges.

* **Refactor**
  * Improved internal recommendation cost calculation logic for better code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->