### PR TITLE
fix(api/purchases): add scheduled_execution_at to GetPlannedExecutions SELECT

### DIFF
--- a/internal/config/store_postgres.go
+++ b/internal/config/store_postgres.go
@@ -1195,7 +1195,7 @@ func (s *PostgresStore) GetPlannedExecutions(ctx context.Context, statuses []str
 		       created_by_user_id, retry_execution_id, retry_attempt_n,
 		       approval_token_expires_at,
 		       executed_by_user_id, executed_at, pre_approval_skip_reason,
-		       idempotency_key
+		       idempotency_key, scheduled_execution_at
 		FROM purchase_executions
 		WHERE status = ANY($1)
 		ORDER BY scheduled_date ASC NULLS LAST, id ASC

--- a/internal/config/store_postgres_pgxmock_test.go
+++ b/internal/config/store_postgres_pgxmock_test.go
@@ -676,6 +676,7 @@ func TestPGXMock_GetPlannedExecutions_ProjectsAllScanColumns(t *testing.T) {
 		"executed_by_user_id", "executed_at", "pre_approval_skip_reason",
 		"idempotency_key", "scheduled_execution_at",
 	}
+	schedAt := now.Add(2 * time.Hour)
 	rows := pgxmock.NewRows(cols).AddRow(
 		"plan-1", "exec-1", "pending", 1, now,
 		sql.NullTime{}, "tok-123", recsJSON,
@@ -686,6 +687,16 @@ func TestPGXMock_GetPlannedExecutions_ProjectsAllScanColumns(t *testing.T) {
 		nil, sql.NullTime{}, nil,
 		"idem-key-planned",
 		sql.NullTime{}, // scheduled_execution_at (NULL: not on the pre-fire delay path)
+	).AddRow(
+		"plan-1", "exec-2", "pending", 1, now,
+		sql.NullTime{}, "tok-456", recsJSON,
+		100.0, 200.0, sql.NullTime{}, "", sql.NullTime{},
+		nil, "", nil, nil, 100,
+		nil, nil, 0,
+		sql.NullTime{},
+		nil, sql.NullTime{}, nil,
+		"idem-key-delayed",
+		sql.NullTime{Time: schedAt, Valid: true}, // scheduled_execution_at populated (pre-fire delay path)
 	)
 	// Regexp matcher: only matches if the issued SELECT projects both
 	// idempotency_key and scheduled_execution_at. The alternation forces both
@@ -697,11 +708,17 @@ func TestPGXMock_GetPlannedExecutions_ProjectsAllScanColumns(t *testing.T) {
 
 	execs, err := store.GetPlannedExecutions(ctx, []string{"pending"}, 10)
 	require.NoError(t, err)
-	require.Len(t, execs, 1)
+	require.Len(t, execs, 2)
 	assert.Equal(t, "idem-key-planned", execs[0].IdempotencyKey)
 	// NULL scheduled_execution_at must deserialise as nil (*time.Time), not a zero
 	// value; applyNullTimesToExecution only sets the pointer when Valid is true.
 	assert.Nil(t, execs[0].ScheduledExecutionAt, "NULL scheduled_execution_at must be nil, not zero time")
+	// Non-NULL scheduled_execution_at must round-trip into the pointer field. This
+	// is the direct regression guard for the fix: with the column absent from the
+	// SELECT projection the value never reaches ScheduledExecutionAt and every
+	// delayed execution reads back as unscheduled.
+	require.NotNil(t, execs[1].ScheduledExecutionAt, "populated scheduled_execution_at must round-trip, not be dropped")
+	assert.Equal(t, schedAt, *execs[1].ScheduledExecutionAt)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/internal/config/store_postgres_pgxmock_test.go
+++ b/internal/config/store_postgres_pgxmock_test.go
@@ -699,6 +699,9 @@ func TestPGXMock_GetPlannedExecutions_ProjectsAllScanColumns(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, execs, 1)
 	assert.Equal(t, "idem-key-planned", execs[0].IdempotencyKey)
+	// NULL scheduled_execution_at must deserialise as nil (*time.Time), not a zero
+	// value; applyNullTimesToExecution only sets the pointer when Valid is true.
+	assert.Nil(t, execs[0].ScheduledExecutionAt, "NULL scheduled_execution_at must be nil, not zero time")
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/internal/config/store_postgres_pgxmock_test.go
+++ b/internal/config/store_postgres_pgxmock_test.go
@@ -687,8 +687,11 @@ func TestPGXMock_GetPlannedExecutions_ProjectsAllScanColumns(t *testing.T) {
 		"idem-key-planned",
 		sql.NullTime{}, // scheduled_execution_at (NULL: not on the pre-fire delay path)
 	)
-	// Regexp matcher: only matches if the issued SELECT projects idempotency_key.
-	mock.ExpectQuery("idempotency_key").
+	// Regexp matcher: only matches if the issued SELECT projects both
+	// idempotency_key and scheduled_execution_at. The alternation forces both
+	// names to appear; a projection missing either column fails to match, the
+	// mock returns no rows, and the test catches the column-count drift.
+	mock.ExpectQuery(`idempotency_key.*scheduled_execution_at|scheduled_execution_at.*idempotency_key`).
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(rows)
 


### PR DESCRIPTION
Closes #1247

## Symptom

On the Plans page, the "Planned Purchases" section fails to load with "Failed to load planned purchases: Internal server error" (HTTP 500). Reproducible by the Admin user, so this is not a permissions issue.

## Root Cause

`GetPlannedExecutions` in `internal/config/store_postgres.go` projected only 26 columns in its SELECT, omitting `scheduled_execution_at`. The shared `scanExecutionRows` helper scans 27 columns, with `&scheduledExecutionAt` as the final (27th) scan target. Against a real PostgreSQL instance the row Scan fails with "expected 27 destination arguments in Scan, not 26", returning "failed to scan execution" which the handler surfaces as a 500.

This drifted in via PR #804 (revocation-delay feature, commit 8e5f13974) which added `scheduled_execution_at` to `scanExecutionRows` and every other SELECT feeding it (`ListStuckExecutions`, `GetPendingExecutions`, `GetStaleApprovedExecutions`), but skipped `GetPlannedExecutions`.

## Fix

1. Add `scheduled_execution_at` to the `GetPlannedExecutions` SELECT in the correct position (after `idempotency_key`, matching the `scanExecutionRows` scan order and consistent with every sibling query).
2. Tighten the regression test `TestPGXMock_GetPlannedExecutions_ProjectsAllScanColumns`: the mock ExpectQuery regexp now requires both `idempotency_key` AND `scheduled_execution_at` to appear in the issued SQL, so a future column-count drift is caught at test time instead of in production.

### Why the old test was a false positive

The previous matcher (`mock.ExpectQuery("idempotency_key")`) matched any SQL containing `idempotency_key` and returned a 27-column mock result regardless of the actual projection, so it passed even with the bug present. The tightened alternation regexp (`idempotency_key.*scheduled_execution_at|scheduled_execution_at.*idempotency_key`) fails to match a projection missing either column, the mock then returns no rows, and the test fails.

## Testing

- `go build ./...`: pass
- `go test ./internal/config/...`: 585 passed
- Regression test, pre-fix (SELECT change reverted, tightened test active): FAILS with "could not match actual sql" because the issued SELECT does not contain `scheduled_execution_at`.
- Regression test, post-fix (both files in place): PASSES.

## Stacking

Stacked on #1254 (pre-commit repair); retarget to main when #1254 merges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed planned-execution database querying so the scheduled execution timestamp is correctly selected and returned, including proper handling when the timestamp is absent.
* **Tests**
  * Strengthened coverage for planned-execution queries to verify the SQL projection includes the idempotency key and scheduled timestamp, and that null vs. populated timestamp values round-trip as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->