### PR TITLE
fix(ui): enforce future-only planned start date + widen Configure Purchase Term field

### DIFF
--- a/frontend/src/__tests__/plans-range-validation.test.ts
+++ b/frontend/src/__tests__/plans-range-validation.test.ts
@@ -615,3 +615,42 @@ describe('Add Purchases modal: inline range validation (#771)', () => {
     expect(require('../api').createPlannedPurchases).not.toHaveBeenCalled();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Add Purchases modal: start-date picker min attribute (QA 5.6)
+// ---------------------------------------------------------------------------
+
+/**
+ * The start-date input must have its `min` attribute set to today's ISO date
+ * so the browser date-picker blocks past dates while still allowing today.
+ * The default value stays tomorrow (to encourage scheduling ahead), but min
+ * is today so a same-day purchase remains possible.
+ */
+describe('Add Purchases modal: start-date picker enforces future-only dates (QA 5.6)', () => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const plansList = document.createElement('div');
+    plansList.id = 'plans-list';
+    const ppList = document.createElement('div');
+    ppList.id = 'planned-purchases-list';
+    document.body.replaceChildren(plansList, ppList);
+
+    await openAddPurchasesModal('plan-xyz', 'My Test Plan');
+  });
+
+  it('sets min to today on the start-date input after the modal opens', () => {
+    const input = document.getElementById('add-purchases-start-date') as HTMLInputElement;
+    expect(input).not.toBeNull();
+
+    const todayIso = new Date().toISOString().split('T')[0];
+    expect(input.min).toBe(todayIso);
+  });
+
+  it('keeps the default value set to tomorrow, not today', () => {
+    const input = document.getElementById('add-purchases-start-date') as HTMLInputElement;
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    const tomorrowIso = tomorrow.toISOString().split('T')[0];
+    expect(input.value).toBe(tomorrowIso);
+  });
+});

--- a/frontend/src/__tests__/plans-range-validation.test.ts
+++ b/frontend/src/__tests__/plans-range-validation.test.ts
@@ -627,6 +627,17 @@ describe('Add Purchases modal: inline range validation (#771)', () => {
  * is today so a same-day purchase remains possible.
  */
 describe('Add Purchases modal: start-date picker enforces future-only dates (QA 5.6)', () => {
+  // Local-calendar ISO YYYY-MM-DD. Mirrors plans.ts toLocalDateInputValue.
+  // The production code must derive both `value` and `min` from local-time
+  // components (not toISOString, which is UTC) so a user west of UTC at
+  // 6pm local doesn't see "today" greyed out in the picker.
+  function toLocalDateInputValue(d: Date): string {
+    const y = d.getFullYear();
+    const m = String(d.getMonth() + 1).padStart(2, '0');
+    const day = String(d.getDate()).padStart(2, '0');
+    return `${y}-${m}-${day}`;
+  }
+
   beforeEach(async () => {
     jest.clearAllMocks();
     const plansList = document.createElement('div');
@@ -642,15 +653,26 @@ describe('Add Purchases modal: start-date picker enforces future-only dates (QA 
     const input = document.getElementById('add-purchases-start-date') as HTMLInputElement;
     expect(input).not.toBeNull();
 
-    const todayIso = new Date().toISOString().split('T')[0];
-    expect(input.min).toBe(todayIso);
+    expect(input.min).toBe(toLocalDateInputValue(new Date()));
   });
 
   it('keeps the default value set to tomorrow, not today', () => {
     const input = document.getElementById('add-purchases-start-date') as HTMLInputElement;
     const tomorrow = new Date();
     tomorrow.setDate(tomorrow.getDate() + 1);
-    const tomorrowIso = tomorrow.toISOString().split('T')[0];
-    expect(input.value).toBe(tomorrowIso);
+    expect(input.value).toBe(toLocalDateInputValue(tomorrow));
+  });
+
+  it('uses the local calendar day, not UTC, so users west of UTC can still pick today', () => {
+    // Regression check for the UTC-vs-local bug: at 23:00 in (e.g.) Los
+    // Angeles on Dec 31, `new Date().toISOString().split('T')[0]` returns
+    // Jan 1 (UTC), which would make today.min = Jan 1 and reject Dec 31 —
+    // contradicting "today remains selectable". Assert min uses the same
+    // calendar day Date() reports via local getters (the values diverge
+    // only in non-UTC timezones, but the bug shape is the function call).
+    const input = document.getElementById('add-purchases-start-date') as HTMLInputElement;
+    const now = new Date();
+    const localDay = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+    expect(input.min).toBe(localDay);
   });
 });

--- a/frontend/src/plans.ts
+++ b/frontend/src/plans.ts
@@ -916,6 +916,18 @@ function extractPlanInfo(plan: BackendPlan): { provider: string | null; service:
   return { provider: null, service: '—', term: null, coverage: null };
 }
 
+// Format a Date as YYYY-MM-DD in the user's *local* calendar — the format
+// expected by <input type="date"> .value and .min. Built from local
+// year/month/day components so we don't shift by the user's UTC offset
+// (e.g. a US user at 6pm local already crosses into UTC's next day, so
+// toISOString() would return the wrong calendar day for a date-picker).
+function toLocalDateInputValue(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
 // Returns true when the plan's next_execution_date is strictly before today.
 function isPlanOverdue(plan: BackendPlan): boolean {
   if (!plan.next_execution_date) return false;
@@ -2093,12 +2105,19 @@ export async function openAddPurchasesModal(planId: string, planName: string): P
   `;
   document.body.appendChild(modal);
 
-  // Set default start date to tomorrow
+  // Set default start date to tomorrow.
+  //
+  // Date inputs use the user's *local* calendar day, so we must build the
+  // ISO string from local components (toISOString returns UTC). For a user
+  // west of UTC on the evening of day D, `new Date().toISOString()` returns
+  // D+1's calendar date, which would make `min` reject "today" in the
+  // picker and contradict the QA 5.6 promise that same-day purchases stay
+  // selectable. Mirrors isPlanOverdue's local-midnight pattern above.
+  const startDateInput = document.getElementById('add-purchases-start-date') as HTMLInputElement;
   const tomorrow = new Date();
   tomorrow.setDate(tomorrow.getDate() + 1);
-  const startDateInput = document.getElementById('add-purchases-start-date') as HTMLInputElement;
-  startDateInput.value = tomorrow.toISOString().split('T')[0] ?? '';
-  startDateInput.min = new Date().toISOString().split('T')[0] ?? '';
+  startDateInput.value = toLocalDateInputValue(tomorrow);
+  startDateInput.min = toLocalDateInputValue(new Date());
 
   // Add event listeners
   document.getElementById('add-purchases-cancel')?.addEventListener('click', closeAddPurchasesModal);

--- a/frontend/src/plans.ts
+++ b/frontend/src/plans.ts
@@ -2098,6 +2098,7 @@ export async function openAddPurchasesModal(planId: string, planName: string): P
   tomorrow.setDate(tomorrow.getDate() + 1);
   const startDateInput = document.getElementById('add-purchases-start-date') as HTMLInputElement;
   startDateInput.value = tomorrow.toISOString().split('T')[0] ?? '';
+  startDateInput.min = new Date().toISOString().split('T')[0] ?? '';
 
   // Add event listeners
   document.getElementById('add-purchases-cancel')?.addEventListener('click', closeAddPurchasesModal);


### PR DESCRIPTION
## Summary

Two small Purchase-flow UI polish fixes from the QA sheet, shipped together.

### Bug 1 (QA 5.6) - Add Purchases start-date picker allowed past dates

Closes #1249

**Root cause**: the `<input type="date" id="add-purchases-start-date">` in the existing-plan "Add Purchases" modal (`frontend/src/plans.ts`) had no `min` attribute, so the browser date-picker let users select dates in the past, which is contradictory for scheduling future purchases.

**Fix**: after the default value (tomorrow) is assigned, set `startDateInput.min` to today's ISO date. Past dates are now blocked in the picker while today remains selectable (a same-day start is legitimate). The default value stays tomorrow.

### Bug 2 (QA 5.3) - Configure Purchase modal Term field too narrow to read

Closes #1250

**Root cause**: the Term `<select>` in the Configure Purchase modal carries class `.purchase-row-term` (set in `recommendations.ts`), but no CSS rule existed for it anywhere, so the browser rendered it at content width and clipped both the selected value and the dropdown arrow.

**Fix**: add `.purchase-row-term { min-width: 5rem; }` to `frontend/src/styles/modals.css`, next to the sibling `.purchase-modal-*` rules. CSS-only; `recommendations.ts` is untouched (owned by another PR).

## Testing

- **Bug 1**: regression test added in `frontend/src/__tests__/plans-range-validation.test.ts` (new describe block "Add Purchases modal: start-date picker enforces future-only dates (QA 5.6)"). Asserts `input.min === today's ISO date` after the modal opens, plus that the default value stays tomorrow. Confirmed **FAIL pre-fix** (received `""`), **PASS post-fix**. Full file: 44 pass / 0 fail.
- `npx tsc --noEmit`: no errors.
- **Bug 2**: CSS-only, not unit-testable in jsdom - **needs visual verification** in a real browser (Configure Purchase modal Term dropdown should no longer clip the value/arrow).

## Note

Stacked on #1254 (pre-commit repair); retarget to main when #1254 merges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added date validation to the Add Planned Purchases modal, preventing selection of dates before today.
  * Start dates now display using the user’s local calendar date, with tomorrow selected by default.

* **Bug Fixes**
  * Fixed date handling for users in time zones west of UTC, ensuring “today” is recognized correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->