### PR TITLE
fix(db): renumber audit_actor_stamps migration to clear 000074 collision

### DIFF
--- a/internal/database/postgres/migrations/000077_audit_actor_stamps.down.sql
+++ b/internal/database/postgres/migrations/000077_audit_actor_stamps.down.sql
@@ -1,4 +1,4 @@
--- Rollback migration 000074: remove audit actor stamp columns.
+-- Rollback migration 000077: remove audit actor stamp columns.
 -- The FK constraint on transitioned_by is dropped automatically with the column.
 
 ALTER TABLE purchase_executions

--- a/internal/database/postgres/migrations/000077_audit_actor_stamps.up.sql
+++ b/internal/database/postgres/migrations/000077_audit_actor_stamps.up.sql
@@ -1,4 +1,4 @@
--- Migration 000074: audit actor stamps on state transitions
+-- Migration 000077: audit actor stamps on state transitions
 -- Adds transitioned_by + transitioned_at to the three financial state machines:
 -- purchase_executions, ri_exchanges (ri_exchange_history), account_registrations.
 -- Idempotent: uses ADD COLUMN IF NOT EXISTS throughout.


### PR DESCRIPTION
## Root cause

PR #1011 added `000074_audit_actor_stamps` while prod already has `000074_repair_partial_migration_058_067` applied and recorded in `schema_migrations`. The duplicate migration number caused the "CI - Build & Test / Integration Tests" job to fail at "Run database migrations" with:

```
duplicate migration file: 000074_repair_partial_migration_058_067.down.sql
```

## Fix

- Keep `000074_repair_partial_migration_058_067` at its existing number (prod-applied; recorded in `schema_migrations` as version 74).
- Renumber `000074_audit_actor_stamps` -> `000077_audit_actor_stamps` (next free slot after 000076).
- Update SQL comment headers in both `.up.sql` and `.down.sql` to reflect 000077.
- No SQL DDL changes.

## Verification

- `dups=$(ls internal/database/postgres/migrations/*.up.sql | cut -c-6 | sort | uniq -d)` returns empty (pre-commit collision check passes).
- `go build ./...` succeeds.
- Exactly one `000074` entry (the repair) and one `000077` entry (audit stamps) in the migrations directory.
- No other references to `000074_audit_actor_stamps` anywhere in the codebase (grep clean).

## Safety check

`000074_audit_actor_stamps` was merged today via PR #1011 and is NOT yet applied to any environment. Safe to renumber.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced audit trail support with user and timestamp tracking for transaction state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->