### PR TITLE
feat(archera): soft-pitch insurance after CLI purchase + update web signup link

### DIFF
--- a/cmd/multi_service_stats.go
+++ b/cmd/multi_service_stats.go
@@ -167,6 +167,10 @@ func printSuccessRate(success, failed int) {
 	}
 }
 
+// archeraSignupURL is the Archera signup link with CUDly attribution, shared
+// with the web interface (frontend ARCHERA_SIGNUP_URL).
+const archeraSignupURL = "https://www.archera.ai/cudly"
+
 // printFinalMessage prints the final message based on mode and results
 func printFinalMessage(isDryRun bool, riSuccess int) {
 	if isDryRun {
@@ -175,7 +179,23 @@ func printFinalMessage(isDryRun bool, riSuccess int) {
 	} else if riSuccess > 0 {
 		AppLogger.Println("\n🎉 Purchase operations completed!")
 		AppLogger.Println("⏰ Allow up to 15 minutes for RIs to appear in your account")
+		printArcheraPitch()
 	}
+}
+
+// printArcheraPitch prints a soft, non-blocking suggestion to insure the
+// just-purchased commitments through Archera, plus the sponsorship disclosure.
+// Shown only after a successful real purchase. Archera is a third-party service
+// independent of CUDly.
+func printArcheraPitch() {
+	AppLogger.Println("\n🛡️  Want to push your coverage to 100% without the risk that a future")
+	AppLogger.Println("    capacity decrease leaves you paying for commitments you no longer use?")
+	AppLogger.Println("    You can buy underutilization insurance for Reserved Instances and")
+	AppLogger.Println("    Savings Plans from Archera by signing up at:")
+	AppLogger.Printf("      %s\n", archeraSignupURL)
+	AppLogger.Println("    within the first 7 days of the purchase.")
+	AppLogger.Println("\n    For full disclosure, Archera sponsors CUDly's Open Source development")
+	AppLogger.Println("    from a fraction of their insurance premiums.")
 }
 
 // printSavingsPlansSection prints the Savings Plans summary section

--- a/cmd/multi_service_stats.go
+++ b/cmd/multi_service_stats.go
@@ -184,9 +184,14 @@ func printFinalMessage(isDryRun bool, riSuccess int) {
 }
 
 // printArcheraPitch prints a soft, non-blocking suggestion to insure the
-// just-purchased commitments through Archera, plus the sponsorship disclosure.
-// Shown only after a successful real purchase. Archera is a third-party service
-// independent of CUDly.
+// just-purchased commitments through Archera, followed by the two Archera
+// partnership disclosures CUDly commits to keeping visible everywhere the
+// integration is surfaced (see project_archera_partnership memory):
+//  1. Non-gating: CUDly works fully without Archera.
+//  2. Sponsorship: Archera funds part of CUDly's development.
+//
+// Shown only after a successful real purchase. Archera is a third-party
+// service independent of CUDly.
 func printArcheraPitch() {
 	AppLogger.Println("\n🛡️  Want to push your coverage to 100% without the risk that a future")
 	AppLogger.Println("    capacity decrease leaves you paying for commitments you no longer use?")
@@ -194,6 +199,8 @@ func printArcheraPitch() {
 	AppLogger.Println("    Savings Plans from Archera by signing up at:")
 	AppLogger.Printf("      %s\n", archeraSignupURL)
 	AppLogger.Println("    within the first 7 days of the purchase.")
+	AppLogger.Println("\n    This is entirely optional. CUDly's purchase and management features")
+	AppLogger.Println("    work fully without Archera.")
 	AppLogger.Println("\n    For full disclosure, Archera sponsors CUDly's Open Source development")
 	AppLogger.Println("    from a fraction of their insurance premiums.")
 }

--- a/cmd/multi_service_stats_test.go
+++ b/cmd/multi_service_stats_test.go
@@ -526,10 +526,20 @@ func TestPrintFinalMessage(t *testing.T) {
 			notWanted: []string{"Purchase operations completed", "Archera", archeraSignupURL},
 		},
 		{
-			name:       "Successful purchase shows Archera pitch with URL and disclosure",
-			isDryRun:   false,
-			riSuccess:  3,
-			wantOutput: []string{"Purchase operations completed", "underutilization insurance", "https://www.archera.ai/cudly", "first 7 days", "sponsors CUDly's Open Source"},
+			name:      "Successful purchase shows Archera pitch with URL and disclosure",
+			isDryRun:  false,
+			riSuccess: 3,
+			wantOutput: []string{
+				"Purchase operations completed",
+				"underutilization insurance",
+				"https://www.archera.ai/cudly",
+				"first 7 days",
+				// Non-gating partnership disclosure (project_archera_partnership memory).
+				"entirely optional",
+				"work fully without Archera",
+				// Sponsorship partnership disclosure (project_archera_partnership memory).
+				"sponsors CUDly's Open Source",
+			},
 		},
 	}
 

--- a/cmd/multi_service_stats_test.go
+++ b/cmd/multi_service_stats_test.go
@@ -529,7 +529,7 @@ func TestPrintFinalMessage(t *testing.T) {
 			name:       "Successful purchase shows Archera pitch with URL and disclosure",
 			isDryRun:   false,
 			riSuccess:  3,
-			wantOutput: []string{"Purchase operations completed", "underutilization insurance", archeraSignupURL, "first 7 days", "sponsors CUDly's Open Source"},
+			wantOutput: []string{"Purchase operations completed", "underutilization insurance", "https://www.archera.ai/cudly", "first 7 days", "sponsors CUDly's Open Source"},
 		},
 	}
 

--- a/cmd/multi_service_stats_test.go
+++ b/cmd/multi_service_stats_test.go
@@ -504,3 +504,47 @@ func TestPrintComparisonSection(t *testing.T) {
 		})
 	}
 }
+
+func TestPrintFinalMessage(t *testing.T) {
+	tests := []struct {
+		name       string
+		isDryRun   bool
+		riSuccess  int
+		wantOutput []string
+		notWanted  []string
+	}{
+		{
+			name:      "Dry run shows no Archera pitch",
+			isDryRun:  true,
+			riSuccess: 5,
+			notWanted: []string{"Archera", archeraSignupURL},
+		},
+		{
+			name:      "No successful purchases shows no pitch",
+			isDryRun:  false,
+			riSuccess: 0,
+			notWanted: []string{"Purchase operations completed", "Archera", archeraSignupURL},
+		},
+		{
+			name:       "Successful purchase shows Archera pitch with URL and disclosure",
+			isDryRun:   false,
+			riSuccess:  3,
+			wantOutput: []string{"Purchase operations completed", "underutilization insurance", archeraSignupURL, "first 7 days", "sponsors CUDly's Open Source"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output := captureAppOutput(t, func() {
+				printFinalMessage(tt.isDryRun, tt.riSuccess)
+			})
+
+			for _, want := range tt.wantOutput {
+				assert.Contains(t, output, want)
+			}
+			for _, notWant := range tt.notWanted {
+				assert.NotContains(t, output, notWant)
+			}
+		})
+	}
+}

--- a/frontend/src/archera.ts
+++ b/frontend/src/archera.ts
@@ -18,13 +18,13 @@
  * email links).
  *
  * Signup link is carried in both surfaces:
- *   https://archera.ai/signup?mode=cudly
+ *   https://www.archera.ai/cudly
  *
  * No backend, routing, or IaC changes (frontend-only).
  */
 
 /** Canonical Archera signup URL with CUDly attribution. */
-export const ARCHERA_SIGNUP_URL = 'https://archera.ai/signup?mode=cudly';
+export const ARCHERA_SIGNUP_URL = 'https://www.archera.ai/cudly';
 
 /**
  * Frontend URL path for the Archera education page.


### PR DESCRIPTION
## What

Two related Archera changes:

1. **CLI soft pitch after a purchase.** After a successful real Reserved Instance purchase, the CLI now prints a short, non-blocking suggestion to insure commitments to 100% coverage through Archera within the first 7 days, followed by the sponsorship disclosure.
2. **Web interface signup link.** The frontend `ARCHERA_SIGNUP_URL` is updated to the new canonical attribution URL `https://www.archera.ai/cudly`, matching the URL used by the CLI pitch.

## Details

- `cmd/multi_service_stats.go`: new `archeraSignupURL` const + `printArcheraPitch()`. The pitch is gated on `!isDryRun && riSuccess > 0`, so it never appears on dry runs or runs with zero successful purchases.
- `cmd/multi_service_stats_test.go`: `TestPrintFinalMessage` regression test covering all three cases — dry-run (no pitch), zero-success (no pitch), and success (pitch + URL + 7-day window + sponsorship disclosure all visible).
- `frontend/src/archera.ts`: `ARCHERA_SIGNUP_URL` -> `https://www.archera.ai/cudly` (and its docstring). The existing frontend tests assert against the exported const, so they remain green.

## Pitch copy (CLI)

> 🛡️  Want to push your coverage to 100% without the risk that a future capacity decrease leaves you paying for commitments you no longer use? You can buy underutilization insurance for Reserved Instances and Savings Plans from Archera by signing up at https://www.archera.ai/cudly within the first 7 days of the purchase.
>
> For full disclosure, Archera sponsors CUDly's Open Source development from a fraction of their insurance premiums.

## Out of scope / follow-up

The approval/confirmation **email templates** (`internal/email/templates.go`, asserted in `internal/email/template_renderers_test.go`) still reference the prior `https://archera.ai/signup?mode=cudly` URL. This PR is scoped to the web interface + CLI as requested. If the new URL should be canonical everywhere, the email templates and their test should be updated in a follow-up.

## Testing

- `go build ./cmd/...` — success
- `go test ./cmd/ -run TestPrintFinalMessage` — 4 pass
- `npx jest archera` (frontend) — pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an additional post-purchase messaging block after successful reserved instance purchases, including a sponsorship/disclosure note and a signup link (not shown in dry-run mode).
* **Bug Fixes**
  * Updated the signup link to the current canonical Archera website URL so offer and education signups point to the correct destination.
* **Tests**
  * Added coverage to verify the messaging block and signup link behavior across dry-run and purchase-success scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->