### PR TITLE
fix(frontend): call toBeDefined() matcher to clear eslint no-unused-expressions

### DIFF
--- a/frontend/src/__tests__/users.test.ts
+++ b/frontend/src/__tests__/users.test.ts
@@ -1858,7 +1858,7 @@ describe('users/handlers', () => {
       userHandlers.setupUserHandlers();
 
       const form = document.getElementById('user-form');
-      expect(form?.onsubmit || form?.getAttribute('data-handler')).toBeDefined;
+      expect(form?.onsubmit || form?.getAttribute('data-handler')).toBeDefined();
     });
 
     it('should set up search input handler', () => {

--- a/frontend/src/__tests__/users.test.ts
+++ b/frontend/src/__tests__/users.test.ts
@@ -1855,10 +1855,18 @@ describe('users/handlers', () => {
     });
 
     it('should set up form submit handler', () => {
+      // saveUser is wired via addEventListener('submit', ...), so form.onsubmit
+      // stays null. Prove the listener is actually attached by spying on saveUser
+      // and dispatching a real submit event, then asserting the observable call.
+      const saveUserSpy = jest.spyOn(userModals, 'saveUser').mockResolvedValue(undefined);
+
       userHandlers.setupUserHandlers();
 
-      const form = document.getElementById('user-form');
-      expect(form?.onsubmit || form?.getAttribute('data-handler')).toBeDefined();
+      const form = document.getElementById('user-form') as HTMLFormElement;
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+
+      expect(saveUserSpy).toHaveBeenCalledTimes(1);
+      saveUserSpy.mockRestore();
     });
 
     it('should set up search input handler', () => {


### PR DESCRIPTION
## Summary

- `frontend/src/__tests__/users.test.ts` line 1861 was missing call parentheses on `.toBeDefined`, causing `eslint @typescript-eslint/no-unused-expressions` to report 1 error and fail the **Build-frontend CI job on every open PR** in the repo.
- The missing parentheses also meant the assertion never actually ran, so the test was silently not checking anything.
- This is the sole error in `npm run lint` (the other ~89 findings are non-blocking `no-explicit-any` warnings).

## Verification

- `npm run lint` before: **1 error**, exit 1
- `npm run lint` after: **0 errors**, 89 warnings, exit 0
- `npx jest users.test`: **207 tests pass**, 0 failures

## Impact

Unblocks the Build-frontend CI check for all currently open PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Corrected a test assertion so it now properly verifies that the user form has a submit handler configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->