### PR TITLE
fix(api): suppress errorlint on intentionally strict clientError assertion

### DIFF
--- a/internal/api/handler_purchases.go
+++ b/internal/api/handler_purchases.go
@@ -1393,7 +1393,7 @@ func (h *Handler) tryResolveActorEmail(ctx context.Context, req *events.LambdaFu
 // failures into the contact_email gate — exactly the misclassification
 // the propagate-vs-fall-through split is meant to prevent.
 func isPermissionDenied(err error) bool {
-	ce, ok := err.(*clientError)
+	ce, ok := err.(*clientError) //nolint:errorlint // strict (unwrapped) assertion is deliberate; see comment above
 	return ok && ce.code == 403
 }
 


### PR DESCRIPTION
## Summary

- `isPermissionDenied` in `internal/api/handler_purchases.go` uses a deliberate strict (unwrapped) type assertion `err.(*clientError)` that errorlint flags as needing `errors.As`.
- Switching to `errors.As` would change runtime behavior: wrapped backend failures (e.g. `fmt.Errorf("permission check failed: %w", authErr)`) would be misrouted into the contact_email gate instead of being propagated to the caller, defeating the propagate-vs-fall-through split documented in the block comment (added via PR #216 feedback).
- Fix: add `//nolint:errorlint` with a short inline reference to the existing block comment that explains the invariant. No runtime change.

## Test plan

- [x] `go build ./...` passes (exit 0)
- [x] `go test ./internal/api/...` passes (1652 tests, exit 0)
- [x] Pre-commit hooks pass (gofmt, go vet, gosec, cyclo, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Clarified linting intent for permission-denial error handling without changing user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->