### PR TITLE
fix(server): ladder multi-account skip test + naming/comment follow-ups (closes #1370)

### DIFF
--- a/internal/server/handler_ladder.go
+++ b/internal/server/handler_ladder.go
@@ -253,14 +253,14 @@ func (app *Application) processOneLadderConfig(
 		log.Printf("ladder_run: config %s: LadderCapabilityFactory is nil (not wired), erroring", dbCfg.ID)
 		return outcomeErrored
 	}
-	cap, err := app.LadderCapabilityFactory(ctx, region, cloudAcct.ExternalID)
+	capability, err := app.LadderCapabilityFactory(ctx, region, cloudAcct.ExternalID)
 	if err != nil {
 		log.Printf("ladder_run: config %s: failed to build ladder capability: %v", dbCfg.ID, err)
 		return outcomeErrored
 	}
 
 	// Run the plan engine and persist the result.
-	if err := app.executeLadderRun(ctx, dbCfg, cap, cloudAcct.ExternalID, term, paymentOpt, now); err != nil {
+	if err := app.executeLadderRun(ctx, dbCfg, capability, cloudAcct.ExternalID, term, paymentOpt, now); err != nil {
 		log.Printf("ladder_run: config %s: planning failed: %v", dbCfg.ID, err)
 		return outcomeErrored
 	}
@@ -435,7 +435,8 @@ func ladderWithinCadenceWindow(ctx context.Context, store config.StoreInterface,
 		}
 	default:
 		// Unknown cadence: log but do not block the run. The LadderConfig
-		// validator will surface this as an error during Allocate.
+		// validator surfaces this as an error in ladderConfigToEngine (pre-persist,
+		// fail-loud), so the run will fail before any money action is taken.
 		log.Printf("ladder_run: config %s: unknown cadence=%q, proceeding without cadence gate", dbCfg.ID, dbCfg.Cadence)
 	}
 	return false, "", nil

--- a/internal/server/handler_ladder_test.go
+++ b/internal/server/handler_ladder_test.go
@@ -418,6 +418,65 @@ func TestHandleLadderRun_AllConfigsDisabled(t *testing.T) {
 	assert.Nil(t, store.savedRun)
 }
 
+// TestHandleLadderRun_MultiAccountSkip_CountedAndIsolated verifies that:
+// (a) an enabled ladder config whose cloud account ExternalID does NOT match the
+//
+//	resolved caller account is counted as SkippedMultiAccount (not Errored),
+//
+// (b) nothing is persisted for that config, and
+// (c) a second healthy config present in the same run is not affected -- it still
+//
+//	plans successfully (per-config isolation).
+func TestHandleLadderRun_MultiAccountSkip_CountedAndIsolated(t *testing.T) {
+	ctx := testutil.TestContext(t)
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	const ownAccount = "123456789012"
+	const foreignAccount = "999999999999"
+
+	// cfgForeign: enabled, but its cloud account ExternalID is a different AWS account.
+	cfgForeign := validTestDBConfig("cfg-foreign")
+	cfgForeign.CloudAccountID = "acct-foreign"
+
+	// cfgHealthy: enabled, cloud account matches the caller account.
+	cfgHealthy := validTestDBConfig("cfg-healthy-ma")
+	cfgHealthy.CloudAccountID = "acct-own"
+
+	store := &ladderTestStore{
+		cloudAcctByID: map[string]*config.CloudAccount{
+			"acct-foreign": {
+				ID:         "acct-foreign",
+				Provider:   "aws",
+				ExternalID: foreignAccount,
+				Enabled:    true,
+			},
+			"acct-own": validTestCloudAccount(ownAccount),
+		},
+	}
+	app := &Application{
+		Config: store,
+		LadderCapabilityFactory: func(_ context.Context, _, _ string) (pkgladder.LadderCapability, error) {
+			return &fakeLadderCapability{t: t, baseline: testBaseline(10.0)}, nil
+		},
+	}
+
+	// Put the foreign config first to prove isolation is order-independent.
+	configs := []config.LadderConfigDB{cfgForeign, cfgHealthy}
+	result := app.runLadderConfigs(ctx, configs, ownAccount, "us-east-1", pkgladder.Term1Year, pkgladder.PaymentNoUpfront, now)
+
+	require.NotNil(t, result)
+	// (a) The foreign config must be counted as SkippedMultiAccount.
+	assert.Equal(t, 1, result.SkippedMultiAccount, "foreign-account config must be counted SkippedMultiAccount")
+	assert.Equal(t, 0, result.Errored, "a multi-account skip is not an error")
+	// (b) Nothing persisted for the foreign config; only the healthy config run.
+	require.Len(t, store.savedRuns, 1, "only the healthy config may persist a run")
+	require.NotNil(t, store.savedRuns[0].ConfigID)
+	assert.Equal(t, "cfg-healthy-ma", *store.savedRuns[0].ConfigID, "persisted run must be from the healthy config, not the skipped one")
+	// (c) The healthy config still processes successfully despite the skip.
+	assert.Equal(t, 1, result.Planned, "the healthy config must still be planned")
+	assert.Equal(t, 0, result.SkippedDisabled)
+	assert.Equal(t, 0, result.SkippedCadence)
+}
+
 // ============================================================
 // executeLadderRun: healthy single-config run
 // ============================================================


### PR DESCRIPTION
## What

Closes #1370 (follow-ups from the #1362 pre-merge review):

1. New test `TestHandleLadderRun_MultiAccountSkip_CountedAndIsolated`: a config whose ExternalID does not match the resolved caller account is visibly counted `SkippedMultiAccount==1`, persists nothing, and a healthy config still processes (isolation). Verified the test fails when the account comparison is inverted.
2. Renamed `cap` -> `capability` (builtin shadow).
3. Corrected the unknown-cadence comment (error surfaces in `ladderConfigToEngine`, pre-persist, fail-loud).

Gates all exit 0: build, vet, `go test ./internal/server/...` (402), gocyclo.

Part of #1336. Tracker #1333.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ladder run handling for configurations linked to different cloud accounts.
  * Such configurations are now correctly skipped and counted without preventing eligible configurations from running.
  * Invalid cadence values are surfaced earlier with clearer validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->