### PR TITLE
fix(terraform/aws): major-only RDS engine_version pin to stop downgrade failures

### DIFF
--- a/terraform/environments/aws/dev.tfvars.example
+++ b/terraform/environments/aws/dev.tfvars.example
@@ -47,7 +47,7 @@ fargate_max_capacity  = 10
 
 database_name            = "cudly"
 database_username        = "cudly"
-database_engine_version  = "16.6"
+database_engine_version  = "16"
 database_backup_retention_days = 7
 database_deletion_protection   = false  # Allow deletion in dev
 database_skip_final_snapshot   = true   # Skip in dev

--- a/terraform/environments/aws/github-dev.tfvars
+++ b/terraform/environments/aws/github-dev.tfvars
@@ -46,7 +46,7 @@ fargate_max_capacity  = 5
 
 database_name                  = "cudly"
 database_username              = "cudly"
-database_engine_version        = "16.6"
+database_engine_version        = "16"
 database_backup_retention_days = 7
 database_deletion_protection   = false
 database_skip_final_snapshot   = true

--- a/terraform/environments/aws/github-prod.tfvars
+++ b/terraform/environments/aws/github-prod.tfvars
@@ -44,7 +44,7 @@ fargate_max_capacity  = 20
 
 database_name                  = "cudly"
 database_username              = "cudly"
-database_engine_version        = "16.6"
+database_engine_version        = "16"
 database_backup_retention_days = 30
 database_deletion_protection   = true
 database_skip_final_snapshot   = false

--- a/terraform/environments/aws/github-staging.tfvars
+++ b/terraform/environments/aws/github-staging.tfvars
@@ -43,7 +43,7 @@ fargate_max_capacity  = 10
 
 database_name                  = "cudly"
 database_username              = "cudly"
-database_engine_version        = "16.6"
+database_engine_version        = "16"
 database_backup_retention_days = 14
 database_deletion_protection   = false
 database_skip_final_snapshot   = true

--- a/terraform/environments/aws/variables.tf
+++ b/terraform/environments/aws/variables.tf
@@ -122,9 +122,9 @@ variable "database_username" {
 }
 
 variable "database_engine_version" {
-  description = "PostgreSQL version"
+  description = "PostgreSQL major engine version (major-only pin, e.g. \"16\"). The AWS provider resolves to the latest minor release and stores it in engine_version_actual, suppressing drift when RDS auto-upgrades the minor version. Pinning a full minor version (e.g. \"16.6\") causes downgrade failures if RDS auto-upgrades beyond it (incident: 2026-07-16, #1372)."
   type        = string
-  default     = "16.6"
+  default     = "16"
 }
 
 variable "database_instance_class" {

--- a/terraform/modules/database/aws/main.tf
+++ b/terraform/modules/database/aws/main.tf
@@ -122,7 +122,12 @@ resource "aws_db_instance" "main" {
   engine     = "postgres"
 
   engine_version = var.engine_version
-  instance_class = var.instance_class
+  # Major-only engine_version pin: the provider stores the real minor in
+  # engine_version_actual and suppresses diff on auto-minor upgrades.
+  # auto_minor_version_upgrade must be explicitly true so the intent is
+  # self-describing (incident: 2026-07-16, #1372).
+  auto_minor_version_upgrade = true
+  instance_class             = var.instance_class
 
   db_name  = var.database_name
   username = var.master_username

--- a/terraform/modules/database/aws/variables.tf
+++ b/terraform/modules/database/aws/variables.tf
@@ -43,9 +43,9 @@ variable "create_password" {
 }
 
 variable "engine_version" {
-  description = "PostgreSQL engine version"
+  description = "PostgreSQL major engine version (major-only pin, e.g. \"16\"). The AWS provider resolves to the latest minor release and stores it in engine_version_actual, suppressing drift when RDS auto-upgrades the minor version. Pinning a full minor version (e.g. \"16.6\") causes downgrade failures if RDS auto-upgrades beyond it (incident: 2026-07-16, #1372)."
   type        = string
-  default     = "16.6"
+  default     = "16"
 }
 
 variable "instance_class" {


### PR DESCRIPTION
## Summary

- RDS auto-minor-upgraded the dev instance from 16.6 to 16.13; Terraform then attempted to downgrade back to 16.6, which RDS rejected: `InvalidParameterCombination: Cannot find upgrade path from 16.13 to 16.6`.
- Root cause: all six `engine_version` pins were set to the exact minor `"16.6"`. Any RDS auto-minor upgrade creates an irreconcilable drift -- Terraform sees a config mismatch and tries a downgrade that the API refuses.
- Fix: change all six pins from `"16.6"` to `"16"` (major-only). The AWS provider v5 (5.100.0, confirmed in lockfile) stores the real minor version in `engine_version_actual` and suppresses diff when the configured value is a major-only prefix, so no downgrade is ever attempted and future auto-minor upgrades remain transparent.
- `auto_minor_version_upgrade = true` is now set explicitly in the module resource with a comment, making the intent self-describing.

## Files changed

- `terraform/modules/database/aws/main.tf` -- added explicit `auto_minor_version_upgrade = true` with explanatory comment
- `terraform/modules/database/aws/variables.tf` -- pin changed to `"16"`, description updated
- `terraform/environments/aws/variables.tf` -- pin changed to `"16"`, description updated
- `terraform/environments/aws/dev.tfvars.example` -- pin changed to `"16"`
- `terraform/environments/aws/github-dev.tfvars` -- pin changed to `"16"`
- `terraform/environments/aws/github-prod.tfvars` -- pin changed to `"16"`
- `terraform/environments/aws/github-staging.tfvars` -- pin changed to `"16"`

## Gate results

- `terraform fmt -check -recursive` on both touched dirs: exit 0
- `terraform init -backend=false && terraform validate` in `terraform/modules/database/aws`: exit 0
- `terraform init -backend=false && terraform validate` in `terraform/environments/aws`: exit 0

## Test plan

- [ ] CI "Validate Terraform (aws)" passes on this PR
- [ ] `terraform plan` in the dev environment shows no engine_version change for the existing 16.13 instance
- [ ] Next deploy does not attempt a downgrade

Addresses the AWS deploy failure in #1372.