### PR TITLE
refactor(aws): reduce 4 offering-match funcs below gocyclo 10 (closes #1388)

### DIFF
--- a/providers/aws/services/elasticache/client.go
+++ b/providers/aws/services/elasticache/client.go
@@ -290,10 +290,7 @@ func (c *Client) paginateElastiCacheOfferings(ctx context.Context, rec common.Re
 	if err != nil {
 		return "", err
 	}
-	tag := execID
-	if tag == "" {
-		tag = "no-exec"
-	}
+	tag := resolveTag(execID)
 	t0 := time.Now()
 	log.Printf("purchase[%s]: ElastiCache findOfferingID starting (nodeType=%s engine=%s duration=%s payment=%s)",
 		tag, rec.ResourceType, details.Engine, duration, offeringType)
@@ -357,6 +354,17 @@ func scanElastiCacheOfferingPage(offerings []types.ReservedCacheNodesOffering, r
 		return aws.ToString(o.ReservedCacheNodesOfferingId), nil
 	}
 	return "", nil
+}
+
+// resolveTag returns execID when non-empty, or a sentinel "no-exec" string for
+// log correlation when called outside of a purchase flow (e.g. ValidateOffering,
+// GetOfferingDetails). Extracted from paginateElastiCacheOfferings to keep
+// cyclomatic complexity within the pre-commit gocyclo limit (issue #1388).
+func resolveTag(execID string) string {
+	if execID == "" {
+		return "no-exec"
+	}
+	return execID
 }
 
 // ValidateOffering checks if an offering exists without purchasing

--- a/providers/aws/services/memorydb/client.go
+++ b/providers/aws/services/memorydb/client.go
@@ -292,10 +292,7 @@ func (c *Client) findOfferingID(ctx context.Context, rec common.Recommendation, 
 	if err != nil {
 		return "", err
 	}
-	tag := execID
-	if tag == "" {
-		tag = "no-exec"
-	}
+	tag := resolveTag(execID)
 	t0 := time.Now()
 	log.Printf("purchase[%s]: MemoryDB findOfferingID starting (nodeType=%s term=%s payment=%s)",
 		tag, rec.ResourceType, rec.Term, rec.PaymentOption)
@@ -378,6 +375,17 @@ func scanMemoryDBOfferingPage(offerings []types.ReservedNodesOffering, wantOffer
 // Pulled out of findOfferingID to keep that function under the cyclomatic limit.
 func isLastMemoryDBPage(nextToken *string) bool {
 	return nextToken == nil || aws.ToString(nextToken) == ""
+}
+
+// resolveTag returns execID when non-empty, or a sentinel "no-exec" string for
+// log correlation when called outside of a purchase flow (e.g. ValidateOffering,
+// GetOfferingDetails). Extracted from findOfferingID to keep cyclomatic complexity
+// within the pre-commit gocyclo limit (issue #1388).
+func resolveTag(execID string) string {
+	if execID == "" {
+		return "no-exec"
+	}
+	return execID
 }
 
 // getDurationStringForAPI converts the term string to a duration value accepted

--- a/providers/aws/services/opensearch/client.go
+++ b/providers/aws/services/opensearch/client.go
@@ -371,10 +371,7 @@ func (c *Client) findOfferingID(ctx context.Context, rec common.Recommendation, 
 	if err != nil {
 		return "", err
 	}
-	tag := execID
-	if tag == "" {
-		tag = "no-exec"
-	}
+	tag := resolveTag(execID)
 	t0 := time.Now()
 	log.Printf("purchase[%s]: OpenSearch findOfferingID starting (instanceType=%s term=%s payment=%s)",
 		tag, rec.ResourceType, rec.Term, rec.PaymentOption)
@@ -607,4 +604,15 @@ func getTermMonthsFromDuration(duration int32) int {
 		return 36
 	}
 	return 12
+}
+
+// resolveTag returns execID when non-empty, or a sentinel "no-exec" string for
+// log correlation when called outside of a purchase flow (e.g. ValidateOffering,
+// GetOfferingDetails). Extracted from findOfferingID to keep cyclomatic complexity
+// within the pre-commit gocyclo limit (issue #1388).
+func resolveTag(execID string) string {
+	if execID == "" {
+		return "no-exec"
+	}
+	return execID
 }

--- a/providers/aws/services/redshift/client.go
+++ b/providers/aws/services/redshift/client.go
@@ -416,10 +416,7 @@ func (c *Client) findOfferingID(ctx context.Context, rec common.Recommendation, 
 	if err != nil {
 		return "", err
 	}
-	tag := execID
-	if tag == "" {
-		tag = "no-exec"
-	}
+	tag := resolveTag(execID)
 	t0 := time.Now()
 	log.Printf("purchase[%s]: Redshift findOfferingID starting (nodeType=%s term=%s payment=%s)",
 		tag, rec.ResourceType, rec.Term, rec.PaymentOption)
@@ -690,4 +687,15 @@ func getTermMonthsFromDuration(duration int32) int {
 		return 36
 	}
 	return 12
+}
+
+// resolveTag returns execID when non-empty, or a sentinel "no-exec" string for
+// log correlation when called outside of a purchase flow (e.g. ValidateOffering,
+// GetOfferingDetails). Extracted from findOfferingID to keep cyclomatic complexity
+// within the pre-commit gocyclo limit (issue #1388).
+func resolveTag(execID string) string {
+	if execID == "" {
+		return "no-exec"
+	}
+	return execID
 }


### PR DESCRIPTION
## Summary

Reduces cyclomatic complexity of 4 AWS service offering-match functions from 11 to 10, fixing the pre-commit `gocyclo -over 10` hook that currently reddens CI on all-files runs.

## Functions refactored (before -> after complexity)

| Package | Function | Before | After |
|---------|----------|--------|-------|
| `providers/aws/services/redshift` | `(*Client).findOfferingID` | 11 | 10 |
| `providers/aws/services/opensearch` | `(*Client).findOfferingID` | 11 | 10 |
| `providers/aws/services/memorydb` | `(*Client).findOfferingID` | 11 | 10 |
| `providers/aws/services/elasticache` | `(*Client).paginateElastiCacheOfferings` | 11 | 10 |

## Approach

Each package receives a new `resolveTag(execID string) string` helper that returns the execID when non-empty, or `"no-exec"` as a log-correlation sentinel. This replaces the inline `if tag == ""` branch in each function, removing exactly one complexity unit per function.

No control-flow semantics, error handling, or return values were changed.

## No-behavior-change assurance

- All 212 existing tests in the 4 touched packages pass unchanged (zero test modifications).
- `gocyclo -over 10 providers/aws/services/` exits 0 with no violations.
- `go build ./...` and `go vet ./...` exit 0 in both the providers/aws module and the root module.

## Test plan

- [x] `gocyclo -over 10 providers/aws/services/` -> 0 violations, exit 0
- [x] `go build ./...` in providers/aws -> exit 0
- [x] `go vet ./...` in providers/aws -> exit 0
- [x] `go test ./services/redshift/... ./services/opensearch/... ./services/elasticache/... ./services/memorydb/...` -> 212 passed, exit 0
- [x] `go build ./...` in root module -> exit 0
- [x] `go vet ./...` in root module -> exit 0