### PR TITLE
refactor(aws): share resolveTag helper across service clients (closes #1390)

### DIFF
--- a/providers/aws/internal/purchasecfg/config.go
+++ b/providers/aws/internal/purchasecfg/config.go
@@ -32,6 +32,16 @@ const (
 	HTTPTimeout = 15 * time.Second
 )
 
+// ResolveTag returns execID when non-empty, or the sentinel string "no-exec"
+// for log correlation when a call occurs outside of a purchase flow (e.g.
+// ValidateOffering, GetOfferingDetails).
+func ResolveTag(execID string) string {
+	if execID == "" {
+		return "no-exec"
+	}
+	return execID
+}
+
 // NewConfig returns a copy of base with purchase-path-appropriate retry and
 // HTTP timeout settings applied. The original base config is not modified.
 //

--- a/providers/aws/services/elasticache/client.go
+++ b/providers/aws/services/elasticache/client.go
@@ -290,7 +290,7 @@ func (c *Client) paginateElastiCacheOfferings(ctx context.Context, rec common.Re
 	if err != nil {
 		return "", err
 	}
-	tag := resolveTag(execID)
+	tag := purchasecfg.ResolveTag(execID)
 	t0 := time.Now()
 	log.Printf("purchase[%s]: ElastiCache findOfferingID starting (nodeType=%s engine=%s duration=%s payment=%s)",
 		tag, rec.ResourceType, details.Engine, duration, offeringType)
@@ -354,17 +354,6 @@ func scanElastiCacheOfferingPage(offerings []types.ReservedCacheNodesOffering, r
 		return aws.ToString(o.ReservedCacheNodesOfferingId), nil
 	}
 	return "", nil
-}
-
-// resolveTag returns execID when non-empty, or a sentinel "no-exec" string for
-// log correlation when called outside of a purchase flow (e.g. ValidateOffering,
-// GetOfferingDetails). Extracted from paginateElastiCacheOfferings to keep
-// cyclomatic complexity within the pre-commit gocyclo limit (issue #1388).
-func resolveTag(execID string) string {
-	if execID == "" {
-		return "no-exec"
-	}
-	return execID
 }
 
 // ValidateOffering checks if an offering exists without purchasing

--- a/providers/aws/services/memorydb/client.go
+++ b/providers/aws/services/memorydb/client.go
@@ -292,7 +292,7 @@ func (c *Client) findOfferingID(ctx context.Context, rec common.Recommendation, 
 	if err != nil {
 		return "", err
 	}
-	tag := resolveTag(execID)
+	tag := purchasecfg.ResolveTag(execID)
 	t0 := time.Now()
 	log.Printf("purchase[%s]: MemoryDB findOfferingID starting (nodeType=%s term=%s payment=%s)",
 		tag, rec.ResourceType, rec.Term, rec.PaymentOption)
@@ -375,17 +375,6 @@ func scanMemoryDBOfferingPage(offerings []types.ReservedNodesOffering, wantOffer
 // Pulled out of findOfferingID to keep that function under the cyclomatic limit.
 func isLastMemoryDBPage(nextToken *string) bool {
 	return nextToken == nil || aws.ToString(nextToken) == ""
-}
-
-// resolveTag returns execID when non-empty, or a sentinel "no-exec" string for
-// log correlation when called outside of a purchase flow (e.g. ValidateOffering,
-// GetOfferingDetails). Extracted from findOfferingID to keep cyclomatic complexity
-// within the pre-commit gocyclo limit (issue #1388).
-func resolveTag(execID string) string {
-	if execID == "" {
-		return "no-exec"
-	}
-	return execID
 }
 
 // getDurationStringForAPI converts the term string to a duration value accepted

--- a/providers/aws/services/opensearch/client.go
+++ b/providers/aws/services/opensearch/client.go
@@ -371,7 +371,7 @@ func (c *Client) findOfferingID(ctx context.Context, rec common.Recommendation, 
 	if err != nil {
 		return "", err
 	}
-	tag := resolveTag(execID)
+	tag := purchasecfg.ResolveTag(execID)
 	t0 := time.Now()
 	log.Printf("purchase[%s]: OpenSearch findOfferingID starting (instanceType=%s term=%s payment=%s)",
 		tag, rec.ResourceType, rec.Term, rec.PaymentOption)
@@ -604,15 +604,4 @@ func getTermMonthsFromDuration(duration int32) int {
 		return 36
 	}
 	return 12
-}
-
-// resolveTag returns execID when non-empty, or a sentinel "no-exec" string for
-// log correlation when called outside of a purchase flow (e.g. ValidateOffering,
-// GetOfferingDetails). Extracted from findOfferingID to keep cyclomatic complexity
-// within the pre-commit gocyclo limit (issue #1388).
-func resolveTag(execID string) string {
-	if execID == "" {
-		return "no-exec"
-	}
-	return execID
 }

--- a/providers/aws/services/redshift/client.go
+++ b/providers/aws/services/redshift/client.go
@@ -416,7 +416,7 @@ func (c *Client) findOfferingID(ctx context.Context, rec common.Recommendation, 
 	if err != nil {
 		return "", err
 	}
-	tag := resolveTag(execID)
+	tag := purchasecfg.ResolveTag(execID)
 	t0 := time.Now()
 	log.Printf("purchase[%s]: Redshift findOfferingID starting (nodeType=%s term=%s payment=%s)",
 		tag, rec.ResourceType, rec.Term, rec.PaymentOption)
@@ -687,15 +687,4 @@ func getTermMonthsFromDuration(duration int32) int {
 		return 36
 	}
 	return 12
-}
-
-// resolveTag returns execID when non-empty, or a sentinel "no-exec" string for
-// log correlation when called outside of a purchase flow (e.g. ValidateOffering,
-// GetOfferingDetails). Extracted from findOfferingID to keep cyclomatic complexity
-// within the pre-commit gocyclo limit (issue #1388).
-func resolveTag(execID string) string {
-	if execID == "" {
-		return "no-exec"
-	}
-	return execID
 }


### PR DESCRIPTION
## Summary

- Removes the 4-way duplication of `resolveTag` that #1389 introduced across `elasticache`, `memorydb`, `opensearch`, and `redshift` service clients
- Moves a single authoritative copy into `purchasecfg.ResolveTag` (the one shared internal package all four already import), so no new import was needed
- Updates the one call site per file to `purchasecfg.ResolveTag(execID)`

No behavior change; all 218 existing tests pass unchanged.

## Test plan

- [x] `git grep -n "func resolveTag"` shows only the shared copy in `purchasecfg`
- [x] `go build ./...` (providers/aws module) -- exit 0
- [x] `go vet ./...` -- exit 0
- [x] `go test ./services/redshift/... ./services/opensearch/... ./services/memorydb/... ./services/elasticache/... ./internal/purchasecfg/...` -- 218 passed, exit 0
- [x] `gocyclo -over 10 services/` -- exit 0
- [x] root `go build ./...` -- exit 0
- [x] pre-commit hooks (gofmt, go vet, cyclomatic complexity) all passed