### PR TITLE
fix(test): pin 000086 migration test to version 86, not HEAD

### DIFF
--- a/internal/database/postgres/migrations/000086_remove_approve_own_from_standard_users_test.go
+++ b/internal/database/postgres/migrations/000086_remove_approve_own_from_standard_users_test.go
@@ -59,8 +59,11 @@ func TestMigration_RemoveApproveOwnFromStandardUsers(t *testing.T) {
 		require.True(t, standardUsersHasPurchaseVerb(t, ctx, pool, "retry-own"),
 			"precondition: Standard Users must hold retry-own:purchases at v83")
 
-		// Apply the remaining chain, which includes 000086.
-		require.NoError(t, migrations.RunMigrations(ctx, pool, migrationsPath, "", ""))
+		// Pin at exactly 000086 (the migration under test). Using RunMigrations
+		// (migrate to HEAD) would also run any migrations added on later branches
+		// (e.g. 000087, 000088) whose permission side-effects could mask a regression
+		// in 000086 or cause spurious failures here if they alter the same group.
+		require.NoError(t, migrations.MigrateToVersion(ctx, pool, migrationsPath, 86))
 
 		// Four-eyes (issue #1407): approve-own must be gone.
 		assert.False(t, standardUsersHasPurchaseVerb(t, ctx, pool, "approve-own"),
@@ -79,10 +82,14 @@ func TestMigration_RemoveApproveOwnFromStandardUsers(t *testing.T) {
 		defer container.Cleanup(ctx)
 		pool := container.DB.Pool()
 
-		// Full head has 000086 applied, so approve-own is removed.
-		require.NoError(t, migrations.RunMigrations(ctx, pool, migrationsPath, "", ""))
+		// Pin at exactly 000086 before rolling back. RunMigrations would migrate
+		// to HEAD (which varies by branch), so RollbackMigrations(1) would roll
+		// back whatever the LATEST migration is (000087, 000088, ...) rather than
+		// 000086.down -- leaving approve-own absent and causing a spurious failure.
+		// Pinning to 86 guarantees RollbackMigrations(1) always exercises 000086.down.
+		require.NoError(t, migrations.MigrateToVersion(ctx, pool, migrationsPath, 86))
 		require.False(t, standardUsersHasPurchaseVerb(t, ctx, pool, "approve-own"),
-			"head state: approve-own must be absent after 000086")
+			"post-086 state: approve-own must be absent at version 86")
 
 		// Roll back one step (000086.down) and confirm approve-own is restored.
 		require.NoError(t, migrations.RollbackMigrations(ctx, pool, migrationsPath, 1))


### PR DESCRIPTION
## Summary

`TestMigration_RemoveApproveOwnFromStandardUsers` (added by PR #1422) was failing on the Integration Tests job of PR #808 (`fix/292-wave4`, migration 000087) and PR #1428 (`fix/qa-nonadmin-settings-rbac`, migration 000088).

**Root cause: real cross-migration interaction, not a flake.**

The test has two sub-tests:

1. **"approve-own removed, sibling own-verbs retained"** - migrated from 83 to HEAD, then asserted specific permissions. Passes on both branches (087 and 088 don't touch `purchases` permissions), but is fragile.

2. **"down migration restores approve-own"** - called `RunMigrations` (migrates to HEAD), then `RollbackMigrations(1)`. On a branch where HEAD=087, this rolls back 087.down (marketplace) -- not 000086.down -- leaving approve-own absent and failing the assertion. Same on HEAD=088. **Deterministic failure on both branches.**

**Fix:** Replace both `RunMigrations` calls with `MigrateToVersion(ctx, pool, migrationsPath, 86)` so each sub-test is pinned to exactly the migration it covers. This is the same pattern already used correctly in `000088_grant_view_config_to_nonadmin_groups_test.go` (which pins to 86 before testing 088).

## Verification

```
go test -tags=integration -run TestMigration_RemoveApproveOwnFromStandardUsers ./internal/database/postgres/migrations/ -count=3 -v
```

| Branch context | Migration latest | Result |
|---|---|---|
| `fix/migration-test-pin-version` (main) | 000086 | 9 passed |
| Simulated `fix/292-wave4` (#808) | 000087 | 9 passed |
| Simulated `fix/qa-nonadmin-settings-rbac` (#1428) | 000088 | 9 passed |

Static gates: `go build ./...` clean, `go vet` clean, `golangci-lint` no issues, `gocyclo -over 10` exit 0.

## Test plan

- [ ] CI Integration Tests green on this PR
- [ ] After merge, rebase #808 and #1428 onto main -- their Integration Tests job should now pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved migration integration test reliability by targeting migration version 000086 explicitly.
  * Added deterministic coverage confirming the removal and restoration of the `approve-own:purchases` permission while preserving related permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->