### PR TITLE
fix(ci): cache tflint plugins + retried init to survive GitHub release-API 503s

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -74,6 +74,46 @@ jobs:
             "https://raw.githubusercontent.com/terraform-linters/tflint/${TFLINT_VERSION}/install_linux.sh"
           bash /tmp/tflint-install.sh
 
+      # Cache the tflint ruleset plugins (aws/azurerm/google) that
+      # `tflint --init` downloads from the GitHub Releases API. Without
+      # this cache EVERY run re-downloads all three plugins and is exposed
+      # to transient GitHub release-API 503s — a sustained 503 outrode the
+      # GITHUB_TOKEN auth + 3-attempt pre-commit retry below and reddened
+      # this job repo-wide (blocking every PR). Keyed on .tflint.hcl so a
+      # plugin-version bump re-downloads; restore-keys seeds a warm start.
+      - name: Cache tflint plugins
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.tflint.d/plugins
+          key: tflint-plugins-${{ runner.os }}-${{ hashFiles('.tflint.hcl') }}
+          restore-keys: |
+            tflint-plugins-${{ runner.os }}-
+
+      # Pre-populate the plugin cache with a dedicated, authenticated,
+      # retried `tflint --init` BEFORE pre-commit runs. On a cache hit this
+      # is a fast no-op (tflint skips download when the pinned plugin
+      # versions are already present — no API call, so immune to the 503).
+      # On a cache miss (version bump / cold cache) the retry loop rides
+      # out transient release-API 503s at the init level instead of
+      # re-running every hook via the coarse outer retry. GITHUB_TOKEN
+      # raises the release-API limit above the 60/hr anonymous ceiling.
+      - name: Initialize tflint plugins
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -uo pipefail
+          for attempt in 1 2 3 4 5 6; do
+            if tflint --init --config="${GITHUB_WORKSPACE}/.tflint.hcl"; then
+              echo "tflint --init succeeded (attempt ${attempt})"
+              exit 0
+            fi
+            wait=$((attempt * 20))
+            echo "tflint --init failed (attempt ${attempt}/6); retrying in ${wait}s..." >&2
+            sleep "${wait}"
+          done
+          echo "tflint --init failed after 6 attempts — GitHub release API likely unavailable" >&2
+          exit 1
+
       # Cache the installed tool binaries (gosec, gocyclo). Keyed on the
       # pinned version strings so a tool-version bump still triggers a
       # fresh install. Both binaries land in ~/go/bin which setup-go@v6


### PR DESCRIPTION
## Problem
The `Run pre-commit hooks` CI job has been intermittently failing repo-wide, blocking every PR from merging. Root cause: the `terraform_tflint` hook's `tflint --init` downloads the aws/azurerm/google rulesets from the GitHub Releases API on **every** run — there is a cache for gosec/gocyclo, pre-commit envs, go-build, and npm, but **not** for the tflint plugins. Under a sustained GitHub release-API **503** window this outrode the existing `GITHUB_TOKEN` auth and the 3-attempt outer retry, reddening the job for all PRs.

## Fix
- **Cache `~/.tflint.d/plugins`** keyed on `.tflint.hcl` — on a cache hit `tflint --init` makes no API call (pinned plugin versions already present), so the common case is immune to the 503.
- **Dedicated authenticated + retried `tflint --init` step** before the pre-commit run — on a cache miss (plugin-version bump / cold cache) a 6-attempt backoff loop rides out transient 503s at the init level instead of re-running every hook via the coarse outer retry.

The `GITHUB_TOKEN` was already passed; the missing pieces were the plugin cache and the init-level retry. Since the workflow triggers on `pull_request`, this PR's own pre-commit run uses the new steps and is self-healing on the cold-cache first run.

## Test
YAML validated; local pre-commit hooks pass. CI on this PR exercises the new cache + init path end-to-end (cold cache -> retried download -> cached for subsequent runs).
