### PR TITLE
fix(ci): scope trivy config scan to skip gitignored .terraform cache dirs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -131,7 +131,14 @@ repos:
         # installs trivy v0.69.3 via the workflow step in
         # .github/workflows/pre-commit.yml, so PRs are always scanned
         # regardless of a developer's local setup.
-        entry: bash -c 'trivy config --severity HIGH,CRITICAL --exit-code 1 --skip-dirs terraform/environments/aws --skip-dirs .claude .'
+        #
+        # `**/.terraform` is skipped because it is a gitignored, generated
+        # local cache (downloaded provider schemas + cached plan snapshots
+        # from `terraform init`) — never committed and never present in CI
+        # (which checks out from git), so findings there are local-only
+        # false positives on third-party provider cache, not on our source.
+        # The actual terraform module source files are still fully scanned.
+        entry: bash -c 'trivy config --severity HIGH,CRITICAL --exit-code 1 --skip-dirs terraform/environments/aws --skip-dirs "**/.terraform" --skip-dirs .claude .'
         language: system
         pass_filenames: false
 


### PR DESCRIPTION
## Problem
The `trivy-config` pre-commit hook scans the whole repo (`.`), including gitignored local `.terraform/` directories — downloaded provider schemas + cached plan snapshots created by `terraform init`. Those cached artifacts carry HIGH/CRITICAL findings and block local commits (they surface once any terraform file is staged). They are **never committed** and **never present in CI** (which checks out from git), so the findings are local-only false positives on third-party provider cache, not on our source.

## Fix
Add `**/.terraform` to trivy's `--skip-dirs` (alongside the existing `terraform/environments/aws` and `.claude` skips). The actual terraform **module source files** remain fully scanned — this is scan-scope correctness for a gitignored generated cache, not suppression of real findings in committed code.

Self-healing: the commit's own pre-commit run reads the edited config, so trivy skips `.terraform/` and the commit passes.
