### PR TITLE
fix(rbac/plans): let creator manage own scheduled purchase from Plans page (closes #1442)

### DIFF
--- a/frontend/src/__tests__/plans-ownership-950.test.ts
+++ b/frontend/src/__tests__/plans-ownership-950.test.ts
@@ -84,16 +84,30 @@ const legacyPurchase = { ...ownedPurchase, created_by_user_id: undefined as stri
 // A user holding the plan-management verbs + update:purchases (so the #365
 // verb gate passes), optionally update-any:purchases. id identifies the
 // session user for the ownership comparison.
-const setUser = (id: string, opts: { updateAny?: boolean } = {}) => {
-  const effectivePermissions = [
+const setUser = (
+  id: string,
+  opts: { updateAny?: boolean; cancelOwn?: boolean; cancelAny?: boolean; deletePurchases?: boolean } = {},
+) => {
+  const effectivePermissions: Array<{ action: string; resource: string }> = [
     { action: 'update', resource: 'plans' },
     { action: 'delete', resource: 'plans' },
     { action: 'execute', resource: 'purchases' },
     { action: 'update', resource: 'purchases' },
-    { action: 'delete', resource: 'purchases' },
   ];
+  // deletePurchases defaults to true to preserve existing test behaviour
+  // (original setUser always included delete:purchases); callers that
+  // represent Standard users (cancel-own only) must pass deletePurchases: false.
+  if (opts.deletePurchases !== false) {
+    effectivePermissions.push({ action: 'delete', resource: 'purchases' });
+  }
   if (opts.updateAny) {
     effectivePermissions.push({ action: 'update-any', resource: 'purchases' });
+  }
+  if (opts.cancelOwn) {
+    effectivePermissions.push({ action: 'cancel-own', resource: 'purchases' });
+  }
+  if (opts.cancelAny) {
+    effectivePermissions.push({ action: 'cancel-any', resource: 'purchases' });
   }
   (state.getCurrentUser as jest.Mock).mockReturnValue({
     id,
@@ -165,5 +179,62 @@ describe('Scheduled-purchase ownership gating (issue #950)', () => {
     await loadPlans();
     const html = ppHtml();
     ACTIONS.forEach((act) => expect(html).not.toContain(`data-action="${act}"`));
+  });
+});
+
+describe('Plans-page Disable-button cancel-own gating (issue #1442)', () => {
+  // Standard users hold cancel-own:purchases (not delete:purchases) in
+  // DefaultUserPermissions. Before this fix, the canDisablePlan gate required
+  // delete:purchases so the Disable button was hidden even for the creator of
+  // the scheduled purchase. The fix accepts cancel-own:purchases and
+  // cancel-any:purchases in addition to delete:purchases, mirroring the backend
+  // requireDeleteOrCancelPurchasePermission gate introduced by PR #1421.
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setupDom();
+    (api.getPlans as jest.Mock).mockResolvedValue({ plans: [samplePlan] });
+  });
+
+  test('Standard user (cancel-own, no delete:purchases) sees Disable on their own purchase', async () => {
+    // Represents: Plan Author / Standard User role with cancel-own:purchases
+    // but NOT delete:purchases. Creator must see the Disable button.
+    setUser(CREATOR_ID, { deletePurchases: false, cancelOwn: true });
+    (api.getPlannedPurchases as jest.Mock).mockResolvedValue({ purchases: [ownedPurchase] });
+    await loadPlans();
+    expect(ppHtml()).toContain('data-action="disable"');
+  });
+
+  test('Standard user (cancel-own) does NOT see Disable on another user\'s purchase', async () => {
+    // Ownership gate (canManageScheduledPurchase) must block cancel-own users
+    // from managing rows they did not create.
+    setUser(OTHER_ID, { deletePurchases: false, cancelOwn: true });
+    (api.getPlannedPurchases as jest.Mock).mockResolvedValue({ purchases: [ownedPurchase] });
+    await loadPlans();
+    const html = ppHtml();
+    expect(html).not.toContain('data-action="disable"');
+    // The row still renders; only the action button is suppressed.
+    expect(html).toContain('Sample Plan');
+  });
+
+  test('Standard user (cancel-own) sees NO Disable on a legacy NULL-creator row', async () => {
+    // NULL created_by_user_id means ownership cannot be determined.
+    // The button must stay hidden (matches backend: NULL-creator rows are
+    // out of reach for non-full-scope users).
+    setUser(CREATOR_ID, { deletePurchases: false, cancelOwn: true });
+    (api.getPlannedPurchases as jest.Mock).mockResolvedValue({ purchases: [legacyPurchase] });
+    await loadPlans();
+    expect(ppHtml()).not.toContain('data-action="disable"');
+  });
+
+  test('cancel-any holder sees Disable on their own row (full-scope via canManagePurchase)', async () => {
+    // cancel-any:purchases grants operator-scope cancel on the backend.
+    // The UX gate shows Disable when the user is the creator AND holds
+    // cancel-any (canManagePurchase true via creator-match, canDisablePlan
+    // true via cancel-any verb). Full-scope visibility for non-creators
+    // requires update-any, tracked separately.
+    setUser(CREATOR_ID, { deletePurchases: false, cancelAny: true });
+    (api.getPlannedPurchases as jest.Mock).mockResolvedValue({ purchases: [ownedPurchase] });
+    await loadPlans();
+    expect(ppHtml()).toContain('data-action="disable"');
   });
 });

--- a/frontend/src/plans.ts
+++ b/frontend/src/plans.ts
@@ -704,13 +704,25 @@ function renderPlannedPurchaseRow(purchase: PlannedPurchase): string {
   // Issue #950: AND in creator-scope ownership. A non-creator who lacks
   // update-any:purchases (a standard user looking at someone else's row)
   // sees NO action buttons, mirroring the backend ownership gate. This is
-  // a UX gate; the backend authorizeExecutionManagement is the real
+  // a UX gate; the backend authorizePlannedPurchaseCancel is the real
   // boundary.
+  //
+  // Issue #1442: the Disable button (cancel) must be shown to the creator
+  // when they hold cancel-own:purchases or cancel-any:purchases, not only
+  // when they hold delete:purchases. This mirrors the cancel-verb logic in
+  // canCancelUpcomingPurchase (dashboard.ts) and the backend
+  // requireDeleteOrCancelPurchasePermission gate introduced by PR #1421.
+  // canManagePurchase already enforces the ownership check, so accepting
+  // cancel-own here only widens the Disable button for the creator's own row.
   const canManagePurchase = canManageScheduledPurchase(purchase);
   const canRunPurchase = canManagePurchase && canAccess('execute', 'purchases') && canRun;
   const canPauseOrResumePurchase = canManagePurchase && canAccess('update', 'purchases');
   const canEditPlan = canManagePurchase && canAccess('update', 'plans');
-  const canDisablePlan = canManagePurchase && canAccess('delete', 'purchases');
+  const canDisablePlan = canManagePurchase && (
+    canAccess('delete', 'purchases') ||
+    canAccess('cancel-any', 'purchases') ||
+    canAccess('cancel-own', 'purchases')
+  );
 
   return `
     <tr class="planned-purchase-row ${statusClass}">


### PR DESCRIPTION
## Summary

- Standard users with `cancel-own:purchases` could not see the **Disable** button on their own scheduled purchases in the Plans page, even though:
  - The backend `deletePlannedPurchase` already accepts `cancel-own:purchases` (PR #1421)
  - The Home-page widget's `canCancelUpcomingPurchase` already accepts `cancel-own:purchases` (PR #1421)
- The Plans-page `canDisablePlan` gate in `plans.ts` required `delete:purchases` exclusively. Standard users hold `cancel-own:purchases`, not `delete:purchases`, so the button was hidden even for the creator.
- `canManageScheduledPurchase` already enforced the ownership check; only the verb gate in `canDisablePlan` was wrong.

## Changes

**Frontend (`frontend/src/plans.ts`)**
- `canDisablePlan`: extended to accept `cancel-any:purchases` or `cancel-own:purchases` in addition to `delete:purchases`, mirroring the backend `requireDeleteOrCancelPurchasePermission` gate and the dashboard `canCancelUpcomingPurchase` logic introduced by PR #1421.
- Updated comment to reference `authorizePlannedPurchaseCancel` (the current backend function name after #1421, not the old `authorizeExecutionManagement`).

**Tests (`frontend/src/__tests__/plans-ownership-950.test.ts`)**
- Extended `setUser` helper to accept `cancelOwn`, `cancelAny`, and `deletePurchases` opts (backward-compatible: `deletePurchases` defaults to `true`).
- New describe block "Plans-page Disable-button cancel-own gating (issue #1442)" with 4 cases:
  - Creator with `cancel-own` (no `delete:purchases`) sees the Disable button
  - Non-creator with `cancel-own` does NOT see the Disable button (ownership gate holds)
  - Legacy NULL-creator row shows no Disable for a `cancel-own` user
  - `cancel-any` creator also sees Disable (backend supports it)

## Verify-first result

PR #1421 updated the backend and the Home-page widget but did NOT update the Plans-page `canDisablePlan` gate. This is a genuine gap, not a stale re-test.

## Test plan

- [x] Frontend tests: 79 suites, 2641 passed, 0 failures, exit 0
- [x] Frontend typecheck: `tsc --noEmit` exit 0
- [x] Go build: `go build ./...` exit 0
- [x] Go vet: `go vet ./...` exit 0
- [x] Pre-commit hooks: all passed
- [ ] Manual: log in as Standard user, navigate to Plans page, verify Disable button appears on own scheduled purchases and is absent on other users' rows

Closes #1442