### PR TITLE
fix(admin): only prompt for unsaved changes when settings actually edited (closes #1441)

### DIFF
--- a/frontend/src/__tests__/settings.test.ts
+++ b/frontend/src/__tests__/settings.test.ts
@@ -6,7 +6,8 @@ import {
   saveGlobalSettings,
   resetSettings,
   setupSettingsHandlers,
-  copyToClipboard
+  copyToClipboard,
+  isUnsavedChanges,
 } from '../settings';
 
 // Mock the api module
@@ -1433,6 +1434,79 @@ describe('Settings Module', () => {
       // Must include display name, not raw backend ID.
       expect(bodyText).toMatch(/EC2 Reserved Instances/);
       expect(bodyText).not.toMatch(/^aws$/m);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // isUnsavedChanges -- no false prompt on pristine load or before load
+  // (issue #1441)
+  // -----------------------------------------------------------------------
+  // The navigation guard in navigation.ts calls isUnsavedChanges() whenever
+  // the user leaves the Admin tab. Before the fix, savedSnapshot started as
+  // an empty object ({}), so comparing any live DOM value against undefined
+  // always returned true -- causing the "You have unsaved settings changes.
+  // Leave without saving?" modal to fire even without any edits.
+  describe('isUnsavedChanges -- navigation guard (issue #1441)', () => {
+    const baseConfigResponse = {
+      global: {
+        enabled_providers: ['aws'] as string[],
+        notification_email: '',
+        auto_collect: true,
+        default_term: 3,
+        default_payment: 'all-upfront',
+        default_coverage: 80,
+        notification_days_before: 3,
+        recommendations_cache_stale_hours: 24,
+        recommendations_lookback_days: 7,
+        grace_period_days: { aws: 7, azure: 7, gcp: 7 },
+        laddering_enabled: false,
+      },
+      services: [],
+      credentials: {},
+    };
+
+    test('returns false before settings have been loaded (empty snapshot -- regression for #1441)', () => {
+      // Use a fresh module instance so savedSnapshot starts as the empty object
+      // {} that it is at module initialisation, before any loadGlobalSettings()
+      // call has run snapshotAllFields(). This is the exact state that caused
+      // the bug: the navigation guard fired on every first Admin-tab visit
+      // because `getFieldValue(id) !== undefined` was always true.
+      //
+      // Pre-fix: TRACKED_FIELDS.some(id => getFieldValue(id) !== savedSnapshot[id])
+      //   = TRACKED_FIELDS.some(id => '' !== undefined) = true -> prompt shown (BUG)
+      // Post-fix: Object.keys(savedSnapshot).length === 0 -> return false (CORRECT)
+      let freshIsUnsavedChanges!: () => boolean;
+      jest.isolateModules(() => {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const s = require('../settings') as { isUnsavedChanges: () => boolean };
+        freshIsUnsavedChanges = s.isUnsavedChanges;
+      });
+      expect(freshIsUnsavedChanges()).toBe(false);
+    });
+
+    test('returns false immediately after settings load without any user edits', async () => {
+      // loadGlobalSettings() populates all tracked fields from the API response
+      // and then calls snapshotAllFields() to establish the clean baseline.
+      // A user who navigates away right after load (no edits) must see no prompt.
+      (api.getConfig as jest.Mock).mockResolvedValue(baseConfigResponse);
+      await loadGlobalSettings();
+
+      expect(isUnsavedChanges()).toBe(false);
+    });
+
+    test('returns true after a tracked field is edited post-load', async () => {
+      // After a clean load + snapshot, mutating a tracked field must be detected
+      // so the navigation guard can show the prompt for real unsaved changes.
+      // Verifies the fix does not suppress legitimate dirty-state detection.
+      (api.getConfig as jest.Mock).mockResolvedValue(baseConfigResponse);
+      await loadGlobalSettings();
+
+      // Simulate the user changing the notification email -- a tracked field.
+      const emailInput = document.getElementById('setting-notification-email') as HTMLInputElement;
+      emailInput.value = 'edited@example.com';
+      emailInput.dispatchEvent(new Event('input'));
+
+      expect(isUnsavedChanges()).toBe(true);
     });
   });
 });

--- a/frontend/src/settings.ts
+++ b/frontend/src/settings.ts
@@ -364,8 +364,21 @@ function updateDirtyMarkers(): void {
   reflectDirtyState(anyDirty);
 }
 
-/** Returns true if any tracked field has been changed since the last save/load. */
+/**
+ * Returns true if any tracked field has been changed since the last save/load.
+ *
+ * Returns false when no snapshot has been taken yet (settings are still
+ * loading or have never loaded successfully). Before the first
+ * snapshotAllFields() call, savedSnapshot is an empty object, and comparing
+ * any live DOM value against undefined would always return true -- causing
+ * spurious "unsaved changes" prompts for users who navigate away before the
+ * async settings load completes (issue #1441).
+ */
 export function isUnsavedChanges(): boolean {
+  // savedSnapshot starts as {} and is populated by snapshotAllFields() only
+  // after loadGlobalSettings() resolves. If it is still empty the form is
+  // still loading and no edit could have been made yet.
+  if (Object.keys(savedSnapshot).length === 0) return false;
   return TRACKED_FIELDS.some(id => getFieldValue(id) !== savedSnapshot[id]);
 }
 


### PR DESCRIPTION
## Root cause

`isUnsavedChanges()` in `settings.ts` compared live DOM values against `savedSnapshot`, which starts as an empty object (`{}`) at module initialisation. `loadGlobalSettings()` is async -- it calls `snapshotAllFields()` only after the API response arrives and all fields are populated. During the async window between the navigation-guard being armed and the snapshot being populated, every comparison was `getFieldValue(id) !== undefined` which is always `true`. This caused the "You have unsaved settings changes. Leave without saving?" modal to fire on every Admin-tab navigation, for all roles including read-only viewers who had made no edits.

## Fix

Guard `isUnsavedChanges()` with `Object.keys(savedSnapshot).length === 0 → return false`. When the snapshot is empty the form is still loading and no edit is possible. After `snapshotAllFields()` runs (inside `loadGlobalSettings()` after all fields are populated), the snapshot is non-empty and dirty comparison proceeds normally.

## Tests added (`frontend/src/__tests__/settings.test.ts`)

1. **Empty-snapshot regression test** (via `jest.isolateModules` for a fresh module instance): fails with pre-fix code (`undefined` comparison returns true), passes with fix.
2. **Pristine load + navigate**: `isUnsavedChanges()` returns `false` after `loadGlobalSettings()` with no user edits.
3. **Edit + navigate**: `isUnsavedChanges()` returns `true` after a tracked field is mutated, confirming the fix does not suppress legitimate dirty detection.

## Test plan

- [ ] Run `cd frontend && npx jest --no-coverage --testPathPattern="settings.test.ts"` -- all 75 tests pass.
- [ ] Verify `npm run build` succeeds.
- [ ] Manual: visit Admin tab in browser, navigate away immediately without editing -- no prompt.
- [ ] Manual: visit Admin tab, change a setting, navigate away -- prompt appears.

Closes #1441

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unsaved-changes prompts from appearing before settings finish loading.
  * Navigation warnings now appear only after a loaded setting has been modified.
  * Improved handling of clipboard actions and confirmation dialogs in settings workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->