### PR TITLE
fix(cmd): use portable os.Stdin.Fd for password read on Windows (follow-up to #1279)

### DIFF
--- a/cmd/configure_azure.go
+++ b/cmd/configure_azure.go
@@ -12,7 +12,6 @@ import (
 	"os/exec"
 	"regexp"
 	"strings"
-	"syscall"
 
 	"time"
 
@@ -273,7 +272,10 @@ func promptForAzureCredentialFields(reader *bufio.Reader, creds *AzureCredential
 
 	if creds.ClientSecret == "" {
 		fmt.Print("Client Secret (password): ")
-		secret, err := term.ReadPassword(syscall.Stdin)
+		// int(os.Stdin.Fd()) is portable: syscall.Stdin is an int on Unix but a
+		// Handle on Windows, so passing it to term.ReadPassword (which takes an
+		// int) breaks GOOS=windows builds.
+		secret, err := term.ReadPassword(int(os.Stdin.Fd()))
 		if err != nil {
 			return fmt.Errorf("failed to read secret: %w", err)
 		}

--- a/cmd/configure_azure.go
+++ b/cmd/configure_azure.go
@@ -275,7 +275,7 @@ func promptForAzureCredentialFields(reader *bufio.Reader, creds *AzureCredential
 		// int(os.Stdin.Fd()) is portable: syscall.Stdin is an int on Unix but a
 		// Handle on Windows, so passing it to term.ReadPassword (which takes an
 		// int) breaks GOOS=windows builds.
-		secret, err := term.ReadPassword(int(os.Stdin.Fd()))
+		secret, err := term.ReadPassword(int(os.Stdin.Fd())) // #nosec G115 -- OS file descriptors fit in int on every supported platform
 		if err != nil {
 			return fmt.Errorf("failed to read secret: %w", err)
 		}


### PR DESCRIPTION
## Follow-up to #1279 — unaddressed CodeRabbit thread

Part of the adversarial-sweep over recently-merged PRs. #1279 merged with an unresolved CodeRabbit `Major` thread.

`term.ReadPassword` takes an `int`, but `syscall.Stdin` is an `int` only on Unix; on Windows it is a `syscall.Handle` (uintptr), so `cmd/configure_azure.go` failed to compile under `GOOS=windows`. Fix uses `int(os.Stdin.Fd())` (portable) and drops the now-unused `syscall` import.

### Verification
- Confirmed pre-fix: `GOOS=windows go build ./cmd/...` fails with `cannot use syscall.Stdin (variable of uintptr type Handle) as int value`.
- Post-fix: host build + `GOOS=windows GOARCH=amd64` build both pass.