### PR TITLE
test(providers/azure): make IsConfigured guards deterministic

### DIFF
--- a/providers/azure/provider_test.go
+++ b/providers/azure/provider_test.go
@@ -300,14 +300,20 @@ func TestAzureProvider_IsConfigured(t *testing.T) {
 }
 
 func TestAzureProvider_GetCredentials_NotConfigured(t *testing.T) {
-	// Test GetCredentials when Azure is not configured
+	// Test GetCredentials when Azure is not configured. Inject a mock
+	// credential provider that fails so IsConfigured() deterministically
+	// returns false, instead of falling through to the real
+	// DefaultAzureCredential lookup.
 	p := &AzureProvider{}
-	// If IsConfigured returns false, GetCredentials should return error
-	if !p.IsConfigured() {
-		_, err := p.GetCredentials()
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "azure provider is not configured")
-	}
+	p.SetCredentialProvider(&mockCredentialProvider{
+		cred: nil,
+		err:  errors.New("no credentials"),
+	})
+	require.False(t, p.IsConfigured())
+
+	_, err := p.GetCredentials()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "azure provider is not configured")
 }
 
 func TestAzureProvider_ValidateCredentials(t *testing.T) {
@@ -375,13 +381,20 @@ func TestAzureProvider_ValidateCredentials(t *testing.T) {
 }
 
 func TestAzureProvider_GetServiceClient_NotConfigured(t *testing.T) {
-	// Test GetServiceClient when Azure is not configured
+	// Test GetServiceClient when Azure is not configured. Inject a mock
+	// credential provider that fails so IsConfigured() deterministically
+	// returns false, instead of falling through to the real
+	// DefaultAzureCredential lookup.
 	p := &AzureProvider{}
-	if !p.IsConfigured() {
-		_, err := p.GetServiceClient(context.Background(), common.ServiceCompute, "eastus")
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "azure provider is not configured")
-	}
+	p.SetCredentialProvider(&mockCredentialProvider{
+		cred: nil,
+		err:  errors.New("no credentials"),
+	})
+	require.False(t, p.IsConfigured())
+
+	_, err := p.GetServiceClient(context.Background(), common.ServiceCompute, "eastus")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "azure provider is not configured")
 }
 
 func TestAzureProvider_GetServiceClient_UnsupportedService(t *testing.T) {
@@ -429,13 +442,20 @@ func TestAzureProvider_GetServiceClient_AllServiceTypes(t *testing.T) {
 }
 
 func TestAzureProvider_GetRecommendationsClient_NotConfigured(t *testing.T) {
-	// Test GetRecommendationsClient when Azure is not configured
+	// Test GetRecommendationsClient when Azure is not configured. Inject a
+	// mock credential provider that fails so IsConfigured() deterministically
+	// returns false, instead of falling through to the real
+	// DefaultAzureCredential lookup.
 	p := &AzureProvider{}
-	if !p.IsConfigured() {
-		_, err := p.GetRecommendationsClient(context.Background())
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "azure provider is not configured")
-	}
+	p.SetCredentialProvider(&mockCredentialProvider{
+		cred: nil,
+		err:  errors.New("no credentials"),
+	})
+	require.False(t, p.IsConfigured())
+
+	_, err := p.GetRecommendationsClient(context.Background())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "azure provider is not configured")
 }
 
 func TestAzureProvider_GetRecommendationsClient(t *testing.T) {


### PR DESCRIPTION
Closes #1465

## Summary

- `providers/azure/provider_test.go` had three tests (`TestAzureProvider_GetCredentials_NotConfigured`, `TestAzureProvider_GetServiceClient_NotConfigured`, `TestAzureProvider_GetRecommendationsClient_NotConfigured`) that wrapped their assertions in `if !p.IsConfigured() { ... }` on a bare `&AzureProvider{}`.
- With no `credProvider` injected, `IsConfigured()` fell through to the real `realCredentialProvider{}.NewDefaultAzureCredential()`. Construction succeeds on virtually any machine, so the guarded "not configured" assertions silently never ran, and the pattern normalized real-credential construction in tests.
- Each test now injects the existing `mockCredentialProvider` configured to fail (`SetCredentialProvider`), asserts `IsConfigured()` is false unconditionally, and runs the negative-path assertion unconditionally instead of behind an `if`.
- Grepped the file for other `IsConfigured()` guards or hazardous bare `&AzureProvider{}` constructions; no other instances found. The remaining bare `&AzureProvider{}` uses either don't touch `IsConfigured()`/credentials (`Name()`, `DisplayName()`, `GetDefaultRegion()`, `GetSupportedServices()`) or already inject a mock credential provider immediately after construction.

## Test plan

- [x] `gofmt -l .` clean (from `providers/azure/`)
- [x] `go vet ./...` clean (from `providers/azure/`)
- [x] `go test ./... -count=1` green, 710 tests passed across 14 packages (from `providers/azure/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved Azure provider tests to reliably verify behavior when credentials are unavailable.
  * Added explicit checks that the provider reports itself as unconfigured and returns the expected error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->