### PR TITLE
refactor(oidc): inject Azure Key Vault client factory

### DIFF
--- a/internal/oidc/azure_factory_test.go
+++ b/internal/oidc/azure_factory_test.go
@@ -181,3 +181,39 @@ func TestNewSignerFromEnv_AzureHalfConfigured(t *testing.T) {
 		})
 	}
 }
+
+// ---------------------------------------------------------------------------
+// #1464 -- Azure factory branch fully configured (both env vars set)
+// ---------------------------------------------------------------------------
+
+// TestNewSignerFromEnv_AzureFullyConfigured verifies that NewSignerFromEnv
+// reaches NewAzureKeyVaultSigner's client-construction path when both Azure
+// env vars are set. It overrides the package-level newAzureKeyVaultClient
+// factory hook with a fake so the test never spawns the real
+// azidentity.NewDefaultAzureCredential chain (az/pwsh, macOS keychain
+// prompts) that made this branch untestable before #1464.
+func TestNewSignerFromEnv_AzureFullyConfigured(t *testing.T) {
+	t.Setenv(envSourceCloud, "azure")
+	t.Setenv(envAWSSigningKeyID, "")
+	t.Setenv(envGCPKeyResource, "")
+
+	const wantVaultURL = "https://my-vault.vault.azure.net/"
+	t.Setenv(envAzureVaultURL, wantVaultURL)
+	t.Setenv(envAzureKeyName, "my-key")
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	var gotVaultURL string
+	origFactory := newAzureKeyVaultClient
+	newAzureKeyVaultClient = func(vaultURL string) (AzureKeyVaultClient, error) {
+		gotVaultURL = vaultURL
+		return &fakeAzureKeyVaultClient{key: &key.PublicKey}, nil
+	}
+	t.Cleanup(func() { newAzureKeyVaultClient = origFactory })
+
+	signer, err := NewSignerFromEnv(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, signer)
+	assert.Equal(t, wantVaultURL, gotVaultURL, "factory must receive the configured vault URL")
+}

--- a/internal/oidc/azure_signer.go
+++ b/internal/oidc/azure_signer.go
@@ -31,6 +31,23 @@ type AzureKeyVaultSigner struct {
 	once       sync.Once
 }
 
+// newAzureKeyVaultClient builds the real AzureKeyVaultClient using the
+// standard azidentity default credential chain. It is a package-level var
+// (rather than a call baked into NewAzureKeyVaultSigner) so tests can
+// override it with a fake and exercise the fully-configured factory branch
+// without spawning the live credential chain (az/pwsh, macOS keychain, etc).
+var newAzureKeyVaultClient = func(vaultURL string) (AzureKeyVaultClient, error) {
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		return nil, fmt.Errorf("oidc: azure default credential: %w", err)
+	}
+	client, err := azkeys.NewClient(vaultURL, cred, nil)
+	if err != nil {
+		return nil, fmt.Errorf("oidc: azkeys client: %w", err)
+	}
+	return client, nil
+}
+
 // NewAzureKeyVaultSigner constructs a signer against a Key Vault using
 // the standard azidentity default credential chain. vaultURL is the
 // full vault URL (e.g. https://cudly-vault.vault.azure.net/); keyName
@@ -39,13 +56,9 @@ func NewAzureKeyVaultSigner(ctx context.Context, vaultURL, keyName string) (*Azu
 	if vaultURL == "" || keyName == "" {
 		return nil, fmt.Errorf("oidc: azure key vault signer requires vaultURL + keyName")
 	}
-	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	client, err := newAzureKeyVaultClient(vaultURL)
 	if err != nil {
-		return nil, fmt.Errorf("oidc: azure default credential: %w", err)
-	}
-	client, err := azkeys.NewClient(vaultURL, cred, nil)
-	if err != nil {
-		return nil, fmt.Errorf("oidc: azkeys client: %w", err)
+		return nil, err
 	}
 	return NewAzureKeyVaultSignerFromClient(client, keyName, ""), nil
 }


### PR DESCRIPTION
Closes #1464

## Problem

`NewAzureKeyVaultSigner` in `internal/oidc/azure_signer.go` called
`azidentity.NewDefaultAzureCredential(nil)` and `azkeys.NewClient(...)`
inline, with no injection seam. Existing tests only exercised
`NewAzureKeyVaultSignerFromClient` with a fake `AzureKeyVaultClient`. In
`internal/oidc/factory.go`, the Azure branch of `NewSignerFromEnv` calls
`NewAzureKeyVaultSigner` when both `CUDLY_SIGNING_KEY_VAULT_URL` and
`CUDLY_SIGNING_KEY_NAME` are set, and that branch was untested: any test
reaching it would build the live `DefaultAzureCredential` chain, risking
`az`/`pwsh` process spawns and macOS keychain prompts.

## Fix

- Added a package-level `newAzureKeyVaultClient` factory hook in
  `azure_signer.go` that holds the credential + client construction.
  `NewAzureKeyVaultSigner` now calls the hook instead of inlining the
  construction. Zero production behavior change (same error wrapping,
  same call sequence).
- This mirrors the `AzureSPProber.NewClient` injected-factory pattern in
  `internal/commitmentopts/probe_azure.go`, adapted to this package's
  package-level-var style since `AzureKeyVaultSigner` construction is a
  free function rather than a method on a struct with an overridable
  field.
- Added `TestNewSignerFromEnv_AzureFullyConfigured` in
  `internal/oidc/azure_factory_test.go`, which overrides the hook with
  the existing `fakeAzureKeyVaultClient`, calls `NewSignerFromEnv` with
  both Azure env vars set, and asserts a non-nil signer, no error, and
  that the hook received the configured vault URL.
- Checked the other test in the file
  (`TestNewSignerFromEnv_AzureHalfConfigured`) - it only exercises the
  half-configured and both-empty cases, which return before reaching the
  hook, so no further protection was needed.

## Verification

- `gofmt -l internal/` - clean
- `go vet ./internal/oidc/` - clean
- `go test ./internal/oidc/ -count=1` - all tests pass (28 tests,
  including the new one)
- `go build ./...` - clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
