### PR TITLE
test(providers/azure): reuse shared mocks in synapse/managedredis

### DIFF
--- a/providers/azure/services/managedredis/client_test.go
+++ b/providers/azure/services/managedredis/client_test.go
@@ -77,23 +77,8 @@ func (m *mockRedisPager) NextPage(_ context.Context) (armredis.ClientListBySubsc
 	return p, nil
 }
 
-type mockHTTPClient struct{ mock.Mock }
-
-func (m *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
-	args := m.Called(req)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(*http.Response), args.Error(1)
-}
-
-func fakeHTTPResp(status int, body string) *http.Response {
-	return &http.Response{
-		StatusCode: status,
-		Body:       io.NopCloser(bytes.NewBufferString(body)),
-		Header:     make(http.Header),
-	}
-}
+// The mock HTTP client and response helper live in the shared
+// providers/azure/mocks package (mocks.MockHTTPClient, mocks.CreateMockHTTPResponse).
 
 func samplePricingJSON() string {
 	return `{
@@ -191,7 +176,7 @@ func TestNewClientWithHTTP_NilFallbackIsHardened(t *testing.T) {
 // returns an error rather than fabricating a price from a hardcoded multiplier
 // (issue #1020 H4). Pre-fix this would have returned a fabricated price silently.
 func TestGetOfferingDetails_NoReservationPricing(t *testing.T) {
-	h := &mockHTTPClient{}
+	h := &mocks.MockHTTPClient{}
 	t.Cleanup(func() { h.AssertExpectations(t) })
 	onDemandOnly := `{
 		"Items": [
@@ -209,7 +194,7 @@ func TestGetOfferingDetails_NoReservationPricing(t *testing.T) {
 		"NextPageLink": "",
 		"Count": 1
 	}`
-	h.On("Do", mock.Anything).Return(fakeHTTPResp(http.StatusOK, onDemandOnly), nil)
+	h.On("Do", mock.Anything).Return(mocks.CreateMockHTTPResponse(http.StatusOK, onDemandOnly), nil)
 	c := NewClientWithHTTP(nil, "sub", "eastus", h)
 	_, err := c.GetOfferingDetails(context.Background(), common.Recommendation{
 		ResourceType: "Premium_P1", Term: "1yr",
@@ -219,7 +204,7 @@ func TestGetOfferingDetails_NoReservationPricing(t *testing.T) {
 }
 
 func TestNewClientWithHTTP(t *testing.T) {
-	h := &mockHTTPClient{}
+	h := &mocks.MockHTTPClient{}
 	c := NewClientWithHTTP(nil, "sub-123", "eastus", h)
 	require.NotNil(t, c)
 	assert.Equal(t, h, c.httpClient)
@@ -445,9 +430,9 @@ func TestGetExistingCommitments_PagerError(t *testing.T) {
 // -- GetOfferingDetails --
 
 func TestGetOfferingDetails_1yr(t *testing.T) {
-	h := &mockHTTPClient{}
+	h := &mocks.MockHTTPClient{}
 	t.Cleanup(func() { h.AssertExpectations(t) })
-	h.On("Do", mock.Anything).Return(fakeHTTPResp(http.StatusOK, samplePricingJSON()), nil)
+	h.On("Do", mock.Anything).Return(mocks.CreateMockHTTPResponse(http.StatusOK, samplePricingJSON()), nil)
 	c := NewClientWithHTTP(nil, "sub", "eastus", h)
 	details, err := c.GetOfferingDetails(context.Background(), common.Recommendation{
 		ResourceType: "Premium_P1", Term: "1yr", PaymentOption: "upfront",
@@ -461,9 +446,9 @@ func TestGetOfferingDetails_1yr(t *testing.T) {
 }
 
 func TestGetOfferingDetails_3yr(t *testing.T) {
-	h := &mockHTTPClient{}
+	h := &mocks.MockHTTPClient{}
 	t.Cleanup(func() { h.AssertExpectations(t) })
-	h.On("Do", mock.Anything).Return(fakeHTTPResp(http.StatusOK, samplePricingJSON()), nil)
+	h.On("Do", mock.Anything).Return(mocks.CreateMockHTTPResponse(http.StatusOK, samplePricingJSON()), nil)
 	c := NewClientWithHTTP(nil, "sub", "eastus", h)
 	details, err := c.GetOfferingDetails(context.Background(), common.Recommendation{
 		ResourceType: "Premium_P1", Term: "3yr", PaymentOption: "monthly",
@@ -479,9 +464,9 @@ func TestGetOfferingDetails_3yr(t *testing.T) {
 }
 
 func TestGetOfferingDetails_NoUpfront(t *testing.T) {
-	h := &mockHTTPClient{}
+	h := &mocks.MockHTTPClient{}
 	t.Cleanup(func() { h.AssertExpectations(t) })
-	h.On("Do", mock.Anything).Return(fakeHTTPResp(http.StatusOK, samplePricingJSON()), nil)
+	h.On("Do", mock.Anything).Return(mocks.CreateMockHTTPResponse(http.StatusOK, samplePricingJSON()), nil)
 	c := NewClientWithHTTP(nil, "sub", "eastus", h)
 	details, err := c.GetOfferingDetails(context.Background(), common.Recommendation{
 		ResourceType: "Premium_P1", Term: "1yr", PaymentOption: "no-upfront",
@@ -492,9 +477,9 @@ func TestGetOfferingDetails_NoUpfront(t *testing.T) {
 }
 
 func TestGetOfferingDetails_APIError(t *testing.T) {
-	h := &mockHTTPClient{}
+	h := &mocks.MockHTTPClient{}
 	t.Cleanup(func() { h.AssertExpectations(t) })
-	h.On("Do", mock.Anything).Return(fakeHTTPResp(http.StatusInternalServerError, "Internal Server Error"), nil)
+	h.On("Do", mock.Anything).Return(mocks.CreateMockHTTPResponse(http.StatusInternalServerError, "Internal Server Error"), nil)
 	c := NewClientWithHTTP(nil, "sub", "eastus", h)
 	_, err := c.GetOfferingDetails(context.Background(), common.Recommendation{ResourceType: "Premium_P1", Term: "1yr"})
 	require.Error(t, err)
@@ -502,9 +487,9 @@ func TestGetOfferingDetails_APIError(t *testing.T) {
 }
 
 func TestGetOfferingDetails_NoPricing(t *testing.T) {
-	h := &mockHTTPClient{}
+	h := &mocks.MockHTTPClient{}
 	t.Cleanup(func() { h.AssertExpectations(t) })
-	h.On("Do", mock.Anything).Return(fakeHTTPResp(http.StatusOK, `{"Items": []}`), nil)
+	h.On("Do", mock.Anything).Return(mocks.CreateMockHTTPResponse(http.StatusOK, `{"Items": []}`), nil)
 	c := NewClientWithHTTP(nil, "sub", "eastus", h)
 	_, err := c.GetOfferingDetails(context.Background(), common.Recommendation{ResourceType: "Premium_P1", Term: "1yr"})
 	require.Error(t, err)
@@ -548,9 +533,9 @@ func TestGetOfferingDetails_Paginated(t *testing.T) {
 		"NextPageLink": "",
 		"Count": 1
 	}`
-	h := &mockHTTPClient{}
-	h.On("Do", mock.Anything).Return(fakeHTTPResp(http.StatusOK, page1), nil).Once()
-	h.On("Do", mock.Anything).Return(fakeHTTPResp(http.StatusOK, page2), nil).Once()
+	h := &mocks.MockHTTPClient{}
+	h.On("Do", mock.Anything).Return(mocks.CreateMockHTTPResponse(http.StatusOK, page1), nil).Once()
+	h.On("Do", mock.Anything).Return(mocks.CreateMockHTTPResponse(http.StatusOK, page2), nil).Once()
 	c := NewClientWithHTTP(nil, "sub", "eastus", h)
 	details, err := c.GetOfferingDetails(context.Background(), common.Recommendation{
 		ResourceType: "Premium_P1", Term: "1yr", PaymentOption: "upfront",
@@ -570,14 +555,14 @@ func calcPriceRespJSON(orderID string) string {
 }
 
 func TestPurchaseCommitment_Success(t *testing.T) {
-	h := &mockHTTPClient{}
+	h := &mocks.MockHTTPClient{}
 	t.Cleanup(func() { h.AssertExpectations(t) })
 	h.On("Do", mock.MatchedBy(func(r *http.Request) bool {
 		return r.URL.Path == "/providers/Microsoft.Capacity/calculatePrice"
-	})).Return(fakeHTTPResp(http.StatusOK, calcPriceRespJSON("mr-order-001")), nil).Once()
+	})).Return(mocks.CreateMockHTTPResponse(http.StatusOK, calcPriceRespJSON("mr-order-001")), nil).Once()
 	h.On("Do", mock.MatchedBy(func(r *http.Request) bool {
 		return r.URL.Path == "/providers/Microsoft.Capacity/reservationOrders/mr-order-001/purchase"
-	})).Return(fakeHTTPResp(http.StatusOK, `{}`), nil).Once()
+	})).Return(mocks.CreateMockHTTPResponse(http.StatusOK, `{}`), nil).Once()
 	cred := &mockTokenCredential{token: "tok"}
 	c := NewClientWithHTTP(cred, "sub", "eastus", h)
 	result, err := c.PurchaseCommitment(context.Background(), common.Recommendation{
@@ -590,14 +575,14 @@ func TestPurchaseCommitment_Success(t *testing.T) {
 }
 
 func TestPurchaseCommitment_3yr(t *testing.T) {
-	h := &mockHTTPClient{}
+	h := &mocks.MockHTTPClient{}
 	t.Cleanup(func() { h.AssertExpectations(t) })
 	h.On("Do", mock.MatchedBy(func(r *http.Request) bool {
 		return r.URL.Path == "/providers/Microsoft.Capacity/calculatePrice"
-	})).Return(fakeHTTPResp(http.StatusOK, calcPriceRespJSON("mr-order-3yr")), nil).Once()
+	})).Return(mocks.CreateMockHTTPResponse(http.StatusOK, calcPriceRespJSON("mr-order-3yr")), nil).Once()
 	h.On("Do", mock.MatchedBy(func(r *http.Request) bool {
 		return r.URL.Path == "/providers/Microsoft.Capacity/reservationOrders/mr-order-3yr/purchase"
-	})).Return(fakeHTTPResp(http.StatusCreated, `{}`), nil).Once()
+	})).Return(mocks.CreateMockHTTPResponse(http.StatusCreated, `{}`), nil).Once()
 	cred := &mockTokenCredential{token: "tok"}
 	c := NewClientWithHTTP(cred, "sub", "eastus", h)
 	result, err := c.PurchaseCommitment(context.Background(), common.Recommendation{
@@ -609,14 +594,14 @@ func TestPurchaseCommitment_3yr(t *testing.T) {
 }
 
 func TestPurchaseCommitment_Accepted(t *testing.T) {
-	h := &mockHTTPClient{}
+	h := &mocks.MockHTTPClient{}
 	t.Cleanup(func() { h.AssertExpectations(t) })
 	h.On("Do", mock.MatchedBy(func(r *http.Request) bool {
 		return r.URL.Path == "/providers/Microsoft.Capacity/calculatePrice"
-	})).Return(fakeHTTPResp(http.StatusOK, calcPriceRespJSON("mr-order-202")), nil).Once()
+	})).Return(mocks.CreateMockHTTPResponse(http.StatusOK, calcPriceRespJSON("mr-order-202")), nil).Once()
 	h.On("Do", mock.MatchedBy(func(r *http.Request) bool {
 		return r.URL.Path == "/providers/Microsoft.Capacity/reservationOrders/mr-order-202/purchase"
-	})).Return(fakeHTTPResp(http.StatusAccepted, `{}`), nil).Once()
+	})).Return(mocks.CreateMockHTTPResponse(http.StatusAccepted, `{}`), nil).Once()
 	cred := &mockTokenCredential{token: "tok"}
 	c := NewClientWithHTTP(cred, "sub", "eastus", h)
 	result, err := c.PurchaseCommitment(context.Background(), common.Recommendation{
@@ -627,7 +612,7 @@ func TestPurchaseCommitment_Accepted(t *testing.T) {
 }
 
 func TestPurchaseCommitment_TokenError(t *testing.T) {
-	h := &mockHTTPClient{}
+	h := &mocks.MockHTTPClient{}
 	t.Cleanup(func() { h.AssertExpectations(t) })
 	cred := &mockTokenCredential{err: errors.New("token error")}
 	c := NewClientWithHTTP(cred, "sub", "eastus", h)
@@ -640,7 +625,7 @@ func TestPurchaseCommitment_TokenError(t *testing.T) {
 }
 
 func TestPurchaseCommitment_HTTPError(t *testing.T) {
-	h := &mockHTTPClient{}
+	h := &mocks.MockHTTPClient{}
 	t.Cleanup(func() { h.AssertExpectations(t) })
 	h.On("Do", mock.MatchedBy(func(r *http.Request) bool {
 		return r.URL.Path == "/providers/Microsoft.Capacity/calculatePrice"
@@ -656,14 +641,14 @@ func TestPurchaseCommitment_HTTPError(t *testing.T) {
 }
 
 func TestPurchaseCommitment_BadStatus(t *testing.T) {
-	h := &mockHTTPClient{}
+	h := &mocks.MockHTTPClient{}
 	t.Cleanup(func() { h.AssertExpectations(t) })
 	h.On("Do", mock.MatchedBy(func(r *http.Request) bool {
 		return r.URL.Path == "/providers/Microsoft.Capacity/calculatePrice"
-	})).Return(fakeHTTPResp(http.StatusOK, calcPriceRespJSON("mr-order-bad")), nil).Once()
+	})).Return(mocks.CreateMockHTTPResponse(http.StatusOK, calcPriceRespJSON("mr-order-bad")), nil).Once()
 	h.On("Do", mock.MatchedBy(func(r *http.Request) bool {
 		return r.URL.Path == "/providers/Microsoft.Capacity/reservationOrders/mr-order-bad/purchase"
-	})).Return(fakeHTTPResp(http.StatusBadRequest, `{"error":"bad"}`), nil).Once()
+	})).Return(mocks.CreateMockHTTPResponse(http.StatusBadRequest, `{"error":"bad"}`), nil).Once()
 	cred := &mockTokenCredential{token: "tok"}
 	c := NewClientWithHTTP(cred, "sub", "eastus", h)
 	result, err := c.PurchaseCommitment(context.Background(), common.Recommendation{
@@ -675,7 +660,7 @@ func TestPurchaseCommitment_BadStatus(t *testing.T) {
 }
 
 func TestPurchaseCommitment_InvalidTerm(t *testing.T) {
-	h := &mockHTTPClient{}
+	h := &mocks.MockHTTPClient{}
 	t.Cleanup(func() { h.AssertExpectations(t) })
 	c := NewClientWithHTTP(nil, "sub", "eastus", h)
 	result, err := c.PurchaseCommitment(context.Background(), common.Recommendation{
@@ -693,7 +678,7 @@ func TestPurchaseCommitment_InvalidTerm(t *testing.T) {
 // signal CUDly controls -- proceeding without it would allow a re-driven
 // purchase to create a duplicate reservation.
 func TestPurchaseCommitment_RequiresSource(t *testing.T) {
-	h := &mockHTTPClient{}
+	h := &mocks.MockHTTPClient{}
 	t.Cleanup(func() { h.AssertExpectations(t) })
 	cred := &mockTokenCredential{token: "tok"}
 	c := NewClientWithHTTP(cred, "sub", "eastus", h)
@@ -707,7 +692,7 @@ func TestPurchaseCommitment_RequiresSource(t *testing.T) {
 }
 
 func TestGetOfferingDetails_InvalidTerm(t *testing.T) {
-	h := &mockHTTPClient{}
+	h := &mocks.MockHTTPClient{}
 	t.Cleanup(func() { h.AssertExpectations(t) })
 	c := NewClientWithHTTP(nil, "sub", "eastus", h)
 	_, err := c.GetOfferingDetails(context.Background(), common.Recommendation{
@@ -803,14 +788,14 @@ func TestPurchaseCommitment_TagInjection(t *testing.T) {
 	const orderID = "mr-tag-test-order"
 	const source = "cudly-web"
 
-	h := &mockHTTPClient{}
+	h := &mocks.MockHTTPClient{}
 	t.Cleanup(func() { h.AssertExpectations(t) })
 	cred := &mockTokenCredential{token: "tok"}
 	c := NewClientWithHTTP(cred, "sub", "eastus", h)
 
 	h.On("Do", mock.MatchedBy(func(r *http.Request) bool {
 		return r.URL.Path == "/providers/Microsoft.Capacity/calculatePrice"
-	})).Return(fakeHTTPResp(http.StatusOK, calcPriceRespJSON(orderID)), nil).Once()
+	})).Return(mocks.CreateMockHTTPResponse(http.StatusOK, calcPriceRespJSON(orderID)), nil).Once()
 
 	var capturedBody []byte
 	h.On("Do", mock.MatchedBy(func(r *http.Request) bool {
@@ -820,7 +805,7 @@ func TestPurchaseCommitment_TagInjection(t *testing.T) {
 		capturedBody, _ = io.ReadAll(r.Body)
 		r.Body = io.NopCloser(bytes.NewReader(capturedBody))
 		return true
-	})).Return(fakeHTTPResp(http.StatusOK, `{}`), nil).Once()
+	})).Return(mocks.CreateMockHTTPResponse(http.StatusOK, `{}`), nil).Once()
 
 	result, err := c.PurchaseCommitment(context.Background(), common.Recommendation{
 		ResourceType: "Premium_P1", Term: "1yr", Count: 1, CommitmentCost: 500.0,
@@ -841,7 +826,7 @@ func TestPurchaseCommitment_TagInjection(t *testing.T) {
 // this guard a zero-quantity purchase would reach the Azure API and produce a
 // confusing 400.
 func TestPurchaseCommitment_ZeroCountRejected(t *testing.T) {
-	h := &mockHTTPClient{}
+	h := &mocks.MockHTTPClient{}
 	t.Cleanup(func() { h.AssertExpectations(t) })
 	cred := &mockTokenCredential{token: "tok"}
 	c := NewClientWithHTTP(cred, "sub", "eastus", h)

--- a/providers/azure/services/synapse/client_test.go
+++ b/providers/azure/services/synapse/client_test.go
@@ -41,26 +41,9 @@ func (m *mockTokenCredential) GetToken(_ context.Context, _ policy.TokenRequestO
 }
 
 // ---- HTTP client mock -------------------------------------------------------
-
-type mockHTTPClient struct {
-	mock.Mock
-}
-
-func (m *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
-	args := m.Called(req)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(*http.Response), args.Error(1)
-}
-
-func newHTTPResponse(statusCode int, body string) *http.Response {
-	return &http.Response{
-		StatusCode: statusCode,
-		Body:       io.NopCloser(bytes.NewBufferString(body)),
-		Header:     make(http.Header),
-	}
-}
+//
+// The mock HTTP client and response helper live in the shared
+// providers/azure/mocks package (mocks.MockHTTPClient, mocks.CreateMockHTTPResponse).
 
 // captureHTTPClient captures the request body on each call.
 type captureHTTPClient struct {
@@ -454,8 +437,8 @@ const sampleSynapsePricingJSON = `{
 }`
 
 func TestGetOfferingDetails_upfront(t *testing.T) {
-	mHTTP := &mockHTTPClient{}
-	mHTTP.On("Do", mock.Anything).Return(newHTTPResponse(http.StatusOK, sampleSynapsePricingJSON), nil)
+	mHTTP := &mocks.MockHTTPClient{}
+	mHTTP.On("Do", mock.Anything).Return(mocks.CreateMockHTTPResponse(http.StatusOK, sampleSynapsePricingJSON), nil)
 
 	c := &SynapseClient{subscriptionID: "sub-123", region: "eastus", httpClient: mHTTP}
 
@@ -470,8 +453,8 @@ func TestGetOfferingDetails_upfront(t *testing.T) {
 }
 
 func TestGetOfferingDetails_monthly(t *testing.T) {
-	mHTTP := &mockHTTPClient{}
-	mHTTP.On("Do", mock.Anything).Return(newHTTPResponse(http.StatusOK, sampleSynapsePricingJSON), nil)
+	mHTTP := &mocks.MockHTTPClient{}
+	mHTTP.On("Do", mock.Anything).Return(mocks.CreateMockHTTPResponse(http.StatusOK, sampleSynapsePricingJSON), nil)
 
 	c := &SynapseClient{subscriptionID: "sub-123", region: "eastus", httpClient: mHTTP}
 
@@ -483,7 +466,7 @@ func TestGetOfferingDetails_monthly(t *testing.T) {
 }
 
 func TestGetOfferingDetails_httpError(t *testing.T) {
-	mHTTP := &mockHTTPClient{}
+	mHTTP := &mocks.MockHTTPClient{}
 	mHTTP.On("Do", mock.Anything).Return(nil, errors.New("network error"))
 
 	c := &SynapseClient{subscriptionID: "sub-123", region: "eastus", httpClient: mHTTP}
@@ -502,14 +485,14 @@ func calcPriceRespJSON(orderID string) string {
 // ---- PurchaseCommitment ---------------------------------------------------
 
 func TestPurchaseCommitment_success(t *testing.T) {
-	mHTTP := &mockHTTPClient{}
+	mHTTP := &mocks.MockHTTPClient{}
 	t.Cleanup(func() { mHTTP.AssertExpectations(t) })
 	mHTTP.On("Do", mock.MatchedBy(func(r *http.Request) bool {
 		return r.URL.Path == "/providers/Microsoft.Capacity/calculatePrice"
-	})).Return(newHTTPResponse(http.StatusOK, calcPriceRespJSON("syn-order-001")), nil).Once()
+	})).Return(mocks.CreateMockHTTPResponse(http.StatusOK, calcPriceRespJSON("syn-order-001")), nil).Once()
 	mHTTP.On("Do", mock.MatchedBy(func(r *http.Request) bool {
 		return r.URL.Path == "/providers/Microsoft.Capacity/reservationOrders/syn-order-001/purchase"
-	})).Return(newHTTPResponse(http.StatusOK, `{}`), nil).Once()
+	})).Return(mocks.CreateMockHTTPResponse(http.StatusOK, `{}`), nil).Once()
 
 	cred := &mockTokenCredential{token: "test-token"}
 	c := NewClientWithHTTP(cred, "sub-123", "eastus", mHTTP)
@@ -528,14 +511,14 @@ func TestPurchaseCommitment_success(t *testing.T) {
 }
 
 func TestPurchaseCommitment_3yrTerm(t *testing.T) {
-	mHTTP := &mockHTTPClient{}
+	mHTTP := &mocks.MockHTTPClient{}
 	t.Cleanup(func() { mHTTP.AssertExpectations(t) })
 	mHTTP.On("Do", mock.MatchedBy(func(r *http.Request) bool {
 		return r.URL.Path == "/providers/Microsoft.Capacity/calculatePrice"
-	})).Return(newHTTPResponse(http.StatusOK, calcPriceRespJSON("syn-order-3yr")), nil).Once()
+	})).Return(mocks.CreateMockHTTPResponse(http.StatusOK, calcPriceRespJSON("syn-order-3yr")), nil).Once()
 	mHTTP.On("Do", mock.MatchedBy(func(r *http.Request) bool {
 		return r.URL.Path == "/providers/Microsoft.Capacity/reservationOrders/syn-order-3yr/purchase"
-	})).Return(newHTTPResponse(http.StatusAccepted, `{}`), nil).Once()
+	})).Return(mocks.CreateMockHTTPResponse(http.StatusAccepted, `{}`), nil).Once()
 
 	cred := &mockTokenCredential{token: "test-token"}
 	c := NewClientWithHTTP(cred, "sub-123", "eastus", mHTTP)
@@ -549,7 +532,7 @@ func TestPurchaseCommitment_3yrTerm(t *testing.T) {
 func TestPurchaseCommitment_withSource(t *testing.T) {
 	// Capture the body sent to calculatePrice to verify the automation tag is present.
 	var capturedBody []byte
-	mHTTP := &mockHTTPClient{}
+	mHTTP := &mocks.MockHTTPClient{}
 	t.Cleanup(func() { mHTTP.AssertExpectations(t) })
 	mHTTP.On("Do", mock.MatchedBy(func(r *http.Request) bool {
 		return r.URL.Path == "/providers/Microsoft.Capacity/calculatePrice"
@@ -559,10 +542,10 @@ func TestPurchaseCommitment_withSource(t *testing.T) {
 			capturedBody, _ = io.ReadAll(req.Body)
 			req.Body = io.NopCloser(bytes.NewReader(capturedBody))
 		}
-	}).Return(newHTTPResponse(http.StatusOK, calcPriceRespJSON("syn-order-src")), nil).Once()
+	}).Return(mocks.CreateMockHTTPResponse(http.StatusOK, calcPriceRespJSON("syn-order-src")), nil).Once()
 	mHTTP.On("Do", mock.MatchedBy(func(r *http.Request) bool {
 		return r.URL.Path == "/providers/Microsoft.Capacity/reservationOrders/syn-order-src/purchase"
-	})).Return(newHTTPResponse(http.StatusCreated, `{}`), nil).Once()
+	})).Return(mocks.CreateMockHTTPResponse(http.StatusCreated, `{}`), nil).Once()
 
 	cred := &mockTokenCredential{token: "test-token"}
 	c := NewClientWithHTTP(cred, "sub-123", "eastus", mHTTP)
@@ -576,14 +559,14 @@ func TestPurchaseCommitment_withSource(t *testing.T) {
 
 func TestPurchaseCommitment_apiError(t *testing.T) {
 	// calculatePrice succeeds; purchase fails with a non-timeout 400.
-	mHTTP := &mockHTTPClient{}
+	mHTTP := &mocks.MockHTTPClient{}
 	t.Cleanup(func() { mHTTP.AssertExpectations(t) })
 	mHTTP.On("Do", mock.MatchedBy(func(r *http.Request) bool {
 		return r.URL.Path == "/providers/Microsoft.Capacity/calculatePrice"
-	})).Return(newHTTPResponse(http.StatusOK, calcPriceRespJSON("syn-order-err")), nil).Once()
+	})).Return(mocks.CreateMockHTTPResponse(http.StatusOK, calcPriceRespJSON("syn-order-err")), nil).Once()
 	mHTTP.On("Do", mock.MatchedBy(func(r *http.Request) bool {
 		return r.URL.Path == "/providers/Microsoft.Capacity/reservationOrders/syn-order-err/purchase"
-	})).Return(newHTTPResponse(http.StatusBadRequest, `{"error":"bad request"}`), nil).Once()
+	})).Return(mocks.CreateMockHTTPResponse(http.StatusBadRequest, `{"error":"bad request"}`), nil).Once()
 
 	cred := &mockTokenCredential{token: "test-token"}
 	c := NewClientWithHTTP(cred, "sub-123", "eastus", mHTTP)
@@ -596,7 +579,7 @@ func TestPurchaseCommitment_apiError(t *testing.T) {
 
 func TestPurchaseCommitment_httpError(t *testing.T) {
 	// calculatePrice network failure.
-	mHTTP := &mockHTTPClient{}
+	mHTTP := &mocks.MockHTTPClient{}
 	t.Cleanup(func() { mHTTP.AssertExpectations(t) })
 	mHTTP.On("Do", mock.MatchedBy(func(r *http.Request) bool {
 		return r.URL.Path == "/providers/Microsoft.Capacity/calculatePrice"
@@ -808,7 +791,7 @@ func TestPurchaseCommitment_unsupportedTerm(t *testing.T) {
 // signal CUDly controls -- proceeding without it would allow a re-driven
 // purchase to create a duplicate reservation.
 func TestPurchaseCommitment_requiresSource(t *testing.T) {
-	mHTTP := &mockHTTPClient{}
+	mHTTP := &mocks.MockHTTPClient{}
 	t.Cleanup(func() { mHTTP.AssertExpectations(t) })
 	cred := &mockTokenCredential{token: "tok"}
 	c := NewClientWithHTTP(cred, "sub-123", "eastus", mHTTP)
@@ -837,8 +820,8 @@ func TestGetOfferingDetails_noReservationPrice(t *testing.T) {
 		"NextPageLink": "",
 		"Count": 1
 	}`
-	mHTTP := &mockHTTPClient{}
-	mHTTP.On("Do", mock.Anything).Return(newHTTPResponse(http.StatusOK, onDemandOnlyJSON), nil)
+	mHTTP := &mocks.MockHTTPClient{}
+	mHTTP.On("Do", mock.Anything).Return(mocks.CreateMockHTTPResponse(http.StatusOK, onDemandOnlyJSON), nil)
 	c := &SynapseClient{subscriptionID: "sub-123", region: "eastus", httpClient: mHTTP}
 	rec := common.Recommendation{ResourceType: "DW100c", Term: "1yr"}
 	_, err := c.GetOfferingDetails(context.Background(), rec)
@@ -860,7 +843,7 @@ func TestGetOfferingDetails_noReservationPrice(t *testing.T) {
 // canonical SDK enum value "SqlDataWarehouse", not the hand-written "SqlDW"
 // Azure rejects as an invalid reservedResourceType.
 func TestPurchaseCommitment_canonicalReservedResourceType(t *testing.T) {
-	mHTTP := &mockHTTPClient{}
+	mHTTP := &mocks.MockHTTPClient{}
 	t.Cleanup(func() { mHTTP.AssertExpectations(t) })
 
 	const orderID = "syn-order-rrt"
@@ -883,11 +866,11 @@ func TestPurchaseCommitment_canonicalReservedResourceType(t *testing.T) {
 			}
 		}
 		return true
-	})).Return(newHTTPResponse(http.StatusOK, calcPriceRespJSON(orderID)), nil).Once()
+	})).Return(mocks.CreateMockHTTPResponse(http.StatusOK, calcPriceRespJSON(orderID)), nil).Once()
 	mHTTP.On("Do", mock.MatchedBy(func(r *http.Request) bool {
 		return r.Method == http.MethodPost &&
 			r.URL.Path == "/providers/Microsoft.Capacity/reservationOrders/"+orderID+"/purchase"
-	})).Return(newHTTPResponse(http.StatusOK, `{}`), nil).Once()
+	})).Return(mocks.CreateMockHTTPResponse(http.StatusOK, `{}`), nil).Once()
 
 	cred := &mockTokenCredential{token: "test-token"}
 	c := NewClientWithHTTP(cred, "sub-123", "eastus", mHTTP)


### PR DESCRIPTION
Closes #1466

## Summary
- Removes the local `mockHTTPClient` struct and mock HTTP response helper from `providers/azure/services/synapse/client_test.go` and `providers/azure/services/managedredis/client_test.go`.
- Both were functionally identical to `mocks.MockHTTPClient` and `mocks.CreateMockHTTPResponse` in the shared `providers/azure/mocks` package, already used by compute, database, cache, cosmosdb, and search test suites.
- No test behavior, assertions, or pass/fail semantics changed; this is a pure deduplication.

## Test plan
- [x] `gofmt -l .` clean from `providers/azure/`
- [x] `go vet ./...` clean from `providers/azure/`
- [x] `go test ./... -count=1` green across the module
- [x] synapse: 46 tests before and after, identical names/results
- [x] managedredis: 43 tests before and after, identical names/results

🤖 Generated with [Claude Code](https://claude.com/claude-code)
