### PR TITLE
fix(db): add missing offering columns to GetActivePurchaseHistory SELECT (production-down)

### DIFF
--- a/internal/config/store_postgres.go
+++ b/internal/config/store_postgres.go
@@ -1810,11 +1810,17 @@ func (s *PostgresStore) GetActivePurchaseHistory(ctx context.Context, asOf time.
 	args := []any{asOf}
 	conds, args = appendAccountPredicate(conds, args, accountIDs, externalIDsByProvider)
 
+	// The column list MUST match scanPurchaseHistoryRow's scan destinations
+	// exactly (pgx errors on a field/destination count mismatch). #808 added
+	// offering_class, listing_id, listing_state to the scanner and every other
+	// purchase-history SELECT but missed this one, which broke every real-Postgres
+	// call here (dashboard KPIs, /api/inventory/*, analytics collector).
 	query := fmt.Sprintf(`
 		SELECT account_id, purchase_id, timestamp, provider, service, region,
 		       resource_type, count, term, payment, upfront_cost, monthly_cost,
 		       estimated_savings, plan_id, plan_name, ramp_step, cloud_account_id,
-		       revocation_window_closes_at, revoked_at, revoked_via, support_case_id
+		       revocation_window_closes_at, revoked_at, revoked_via, support_case_id,
+		       offering_class, listing_id, listing_state
 		FROM purchase_history
 		WHERE %s
 		ORDER BY timestamp DESC

--- a/internal/config/store_postgres_pgxmock_test.go
+++ b/internal/config/store_postgres_pgxmock_test.go
@@ -1046,7 +1046,7 @@ func TestPGXMock_GetActivePurchaseHistory_Unscoped(t *testing.T) {
 	now := time.Now().Truncate(time.Second)
 	rows := pgxmock.NewRows(purchaseHistoryCols).AddRow(purchaseHistoryRow(now, "aws", "acct-1")...)
 	mock.ExpectQuery(
-		`SELECT account_id, purchase_id, .*revocation_window_closes_at, revoked_at, revoked_via, support_case_id FROM purchase_history WHERE term > 0 AND timestamp \+ make_interval\(hours => term \* 8760\) >= \$1 AND revoked_at IS NULL ORDER BY timestamp DESC$`,
+		`SELECT account_id, purchase_id, .*revocation_window_closes_at, revoked_at, revoked_via, support_case_id, offering_class, listing_id, listing_state FROM purchase_history WHERE term > 0 AND timestamp \+ make_interval\(hours => term \* 8760\) >= \$1 AND revoked_at IS NULL ORDER BY timestamp DESC$`,
 	).WithArgs(now).WillReturnRows(rows)
 
 	records, err := store.GetActivePurchaseHistory(ctx, now, nil, nil)


### PR DESCRIPTION
## CRITICAL — dashboard KPIs, inventory endpoints, and analytics collector broken on real Postgres

Found by the adversarial (Fable) review sweep of recently-merged PRs.

`GetActivePurchaseHistory` SELECTed **21** columns but shares `scanPurchaseHistoryRow`, which scans **24** destinations (`offering_class, listing_id, listing_state` were added by #808). pgx/v5 `Rows.Scan` requires field count == destination count, so **every real-Postgres call to this query fails**:
`number of field descriptions must equal number of destinations, got 21 and 24`.

### Impact
- Dashboard commitment KPIs render **0 active commitments / $0 committed monthly / $0 YTD** (`fetchCommitmentPurchases` swallows the error → fabricated $0 on a money path).
- `GET /api/inventory/commitments` and `/api/inventory/coverage` return errors.
- The analytics collector's `Collect` fails every run.

### Root cause
#808 (marketplace, closes #292) added the three columns to the scanner and to `GetPurchaseHistory` / `GetAllPurchaseHistory` / `GetPurchaseHistoryFiltered` but **missed `GetActivePurchaseHistory`**. Same defect class as #1221 (17-vs-21).

### Fix
Append `offering_class, listing_id, listing_state` so the column list is **identical** to the other purchase-history queries and matches the scanner (verified: 24 == 24, identical to `GetAllPurchaseHistory`). Updated the pgxmock regex to pin the corrected list.

### Verification
- Column lists of `GetActivePurchaseHistory` and `GetAllPurchaseHistory` are now identical (24 each).
- `go build`, `go vet`, full `internal/config` suite green.
- Note: pgxmock fabricates result columns so it can't reproduce the field-count mismatch; a shared "emitted SELECT columns == purchaseHistoryCols" assertion across all purchase-history queries is a worthwhile follow-up (filed mentally as test-infra debt).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed purchase history retrieval failures caused by missing marketplace details in query results.
  * Dashboard and analytics views now correctly load purchase records with offering class, listing ID, and listing status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->