### PR TITLE
fix(frontend/deps): resolve fast-uri and svgo high-severity advisories

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5510,9 +5510,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {
@@ -10584,9 +10584,9 @@
       }
     },
     "node_modules/svgo": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
-      "integrity": "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
+      "integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

Clears the two newly-published high-severity npm advisories that are currently failing **Security Scanning** on `main` HEAD, which blocks every open PR in the repo.

| Advisory | Package | Affected | Fixed | Path (transitive) |
|---|---|---|---|---|
| [GHSA-v2hh-gcrm-f6hx](https://github.com/advisories/GHSA-v2hh-gcrm-f6hx) | `fast-uri` | 3.0.0-3.1.3 | **3.1.4** | via `ajv` (ajv-formats / schema-utils, webpack tooling) |
| [GHSA-2p49-hgcm-8545](https://github.com/advisories/GHSA-2p49-hgcm-8545) | `svgo` | 4.0.0-4.0.1 | **4.0.2** | via `postcss-svgo` (css-minimizer-webpack-plugin / cssnano) |

## Fix method

Both are transitive dev-dependencies. The fixed patch versions already satisfy the existing semver ranges (`^3.0.1`, `^4.0.1`), so `npm audit fix` bumps only `package-lock.json` (6 lines). No `package.json` change or `overrides` block was needed, no downgrades, no breaking major bumps.

`npm audit` now reports **0 vulnerabilities**.

## Verification

- `npm audit`: 0 vulnerabilities (both target advisories gone)
- `npm ci`: exit 0
- `npm run build` (webpack): success
- `npm test` (jest): 2714 passed, 1 skipped
- `tsc --noEmit`: clean
- `eslint`: 0 errors

## Impact

This unblocks Security Scanning across `main` and all currently-open PRs, so it is high-priority to merge.
