### PR TITLE
fix(auth): scope ladder configs to the caller's allowed accounts

### DIFF
--- a/internal/api/handler_config_test.go
+++ b/internal/api/handler_config_test.go
@@ -1236,6 +1236,7 @@ func TestHandler_updateConfig_RequiresUpdateConfigPermission(t *testing.T) {
 	ctx := context.Background()
 	mockStore := new(MockConfigStore)
 	mockAuth := new(MockAuthService)
+	t.Cleanup(func() { mockStore.AssertExpectations(t); mockAuth.AssertExpectations(t) })
 
 	// A non-admin user who was granted view:config (by migration 000088) but
 	// not update:config. This mirrors the Standard-Users permission set after

--- a/internal/api/handler_ladder.go
+++ b/internal/api/handler_ladder.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/LeanerCloud/CUDly/internal/auth"
 	"github.com/LeanerCloud/CUDly/internal/config"
 	"github.com/aws/aws-lambda-go/events"
 )
@@ -14,10 +15,18 @@ import (
 // LADDER CONFIG HANDLERS
 // ==========================================
 
-// getLadderConfigs returns all per-account ladder configurations.
-// Requires view:config permission.
+// getLadderConfigs returns the ladder configurations for accounts the caller
+// is allowed to see. Requires view:config permission.
+//
+// Migration 000088 granted view:config to the Standard User and Read-Only
+// User groups (previously admin-only), so this handler can no longer return
+// every account's config unconditionally -- a scoped non-admin user would
+// otherwise enumerate other accounts' spend caps and ramp schedules. Filter
+// through filterLadderConfigsByAllowedAccounts before returning, mirroring
+// filterPurchaseHistoryByAllowedAccounts (issue #1030 scoping pattern).
 func (h *Handler) getLadderConfigs(ctx context.Context, req *events.LambdaFunctionURLRequest) (any, error) {
-	if _, err := h.requirePermission(ctx, req, "view", "config"); err != nil {
+	session, err := h.requirePermission(ctx, req, "view", "config")
+	if err != nil {
 		return nil, err
 	}
 
@@ -26,7 +35,34 @@ func (h *Handler) getLadderConfigs(ctx context.Context, req *events.LambdaFuncti
 		return nil, fmt.Errorf("failed to list ladder configs: %w", err)
 	}
 
+	configs, err = h.filterLadderConfigsByAllowedAccounts(ctx, session, configs)
+	if err != nil {
+		return nil, err
+	}
+
 	return map[string]any{"configs": configs}, nil
+}
+
+// filterLadderConfigsByAllowedAccounts drops configs whose CloudAccountID is
+// outside the session's allowed_accounts. Admin/unrestricted sessions pass
+// through unchanged.
+func (h *Handler) filterLadderConfigsByAllowedAccounts(ctx context.Context, session *Session, configs []config.LadderConfigDB) ([]config.LadderConfigDB, error) {
+	allowed, err := h.getAllowedAccounts(ctx, session)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get allowed accounts: %w", err)
+	}
+	if auth.IsUnrestrictedAccess(allowed) {
+		return configs, nil
+	}
+	nameByID := h.resolveAccountNamesByID(ctx)
+	filtered := make([]config.LadderConfigDB, 0, len(configs))
+	for _rvc := range configs {
+		c := configs[_rvc]
+		if auth.MatchesAccount(allowed, c.CloudAccountID, nameByID[c.CloudAccountID]) {
+			filtered = append(filtered, c)
+		}
+	}
+	return filtered, nil
 }
 
 // upsertLadderConfig inserts or updates the per-account ladder configuration

--- a/internal/api/handler_per_account_perms_test.go
+++ b/internal/api/handler_per_account_perms_test.go
@@ -23,6 +23,7 @@ package api
 //  10.  GET /ri-exchange/instances    (getAllowedAccounts scope, issue #1030)
 //  11.  GET /ri-exchange/utilization  (getAllowedAccounts scope, issue #1030)
 //  12.  GET /ri-exchange/reshape      (getAllowedAccounts scope, issue #1030)
+//  13.  GET /ladder/configs           (filterLadderConfigsByAllowedAccounts, issue #1428 follow-up)
 
 import (
 	"context"
@@ -1366,4 +1367,77 @@ func TestPerAccountPerms_GetReshapeRecommendations_AdminSeesAll(t *testing.T) {
 	// We only assert no error and correct type — proving the admin path
 	// proceeded past the scope gate into the actual reshape logic.
 	_ = typed
+}
+
+// ─── 13. GET /ladder/configs ──────────────────────────────────────────────────
+
+// TestPerAccountPerms_GetLadderConfigs_ScopedUserSeesOnlyOwnAccount is the
+// real failing scenario from the cross-account data leak: migration 000088
+// grants view:config to non-admin groups, but getLadderConfigs previously
+// returned every account's LadderConfigDB (spend caps, ramp schedules)
+// unconditionally. A scoped user (allowed_accounts: [permsAccA]) must see
+// only permsAccA's config when configs exist for both accounts.
+//
+// Regression: without filterLadderConfigsByAllowedAccounts, this test fails
+// because the account-B config is included in the response.
+func TestPerAccountPerms_GetLadderConfigs_ScopedUserSeesOnlyOwnAccount(t *testing.T) {
+	ctx := context.Background()
+
+	cfgA := config.LadderConfigDB{ID: "cfg-a", CloudAccountID: permsAccA, Provider: "aws"}
+	cfgB := config.LadderConfigDB{ID: "cfg-b", CloudAccountID: permsAccB, Provider: "aws"}
+
+	mockStore := new(MockConfigStore)
+	mockStore.On("GetLadderConfigs", ctx).Return([]config.LadderConfigDB{cfgA, cfgB}, nil)
+	mockStore.ListCloudAccountsFn = func(_ context.Context, _ config.CloudAccountFilter) ([]config.CloudAccount, error) {
+		return permsAccountList(), nil
+	}
+
+	handler := &Handler{
+		auth:   scopedAuthMock(ctx),
+		config: mockStore,
+	}
+
+	resp, err := handler.getLadderConfigs(ctx, scopedReq())
+	require.NoError(t, err)
+	body, ok := resp.(map[string]any)
+	require.True(t, ok, "expected map[string]any, got %T", resp)
+	configs, ok := body["configs"].([]config.LadderConfigDB)
+	require.True(t, ok, "expected []config.LadderConfigDB, got %T", body["configs"])
+
+	ids := make([]string, len(configs))
+	for i, c := range configs {
+		ids[i] = c.ID
+	}
+	assert.ElementsMatch(t, []string{"cfg-a"}, ids,
+		"scoped user must see only account-A's ladder config; account-B config must be filtered out")
+}
+
+// TestPerAccountPerms_GetLadderConfigs_AdminSeesAll verifies that an admin
+// (unrestricted) session bypasses the allowed_accounts gate and receives
+// every account's ladder config.
+func TestPerAccountPerms_GetLadderConfigs_AdminSeesAll(t *testing.T) {
+	ctx := context.Background()
+
+	cfgA := config.LadderConfigDB{ID: "cfg-a", CloudAccountID: permsAccA, Provider: "aws"}
+	cfgB := config.LadderConfigDB{ID: "cfg-b", CloudAccountID: permsAccB, Provider: "aws"}
+
+	mockStore := new(MockConfigStore)
+	mockStore.On("GetLadderConfigs", ctx).Return([]config.LadderConfigDB{cfgA, cfgB}, nil)
+
+	mockAuth, req := adminDashboardReq(ctx)
+	handler := &Handler{auth: mockAuth, config: mockStore}
+
+	resp, err := handler.getLadderConfigs(ctx, req)
+	require.NoError(t, err)
+	body, ok := resp.(map[string]any)
+	require.True(t, ok, "expected map[string]any, got %T", resp)
+	configs, ok := body["configs"].([]config.LadderConfigDB)
+	require.True(t, ok, "expected []config.LadderConfigDB, got %T", body["configs"])
+
+	ids := make([]string, len(configs))
+	for i, c := range configs {
+		ids[i] = c.ID
+	}
+	assert.ElementsMatch(t, []string{"cfg-a", "cfg-b"}, ids,
+		"admin must see every account's ladder config")
 }

--- a/internal/api/handler_per_account_perms_test.go
+++ b/internal/api/handler_per_account_perms_test.go
@@ -28,6 +28,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
@@ -1410,6 +1411,40 @@ func TestPerAccountPerms_GetLadderConfigs_ScopedUserSeesOnlyOwnAccount(t *testin
 	}
 	assert.ElementsMatch(t, []string{"cfg-a"}, ids,
 		"scoped user must see only account-A's ladder config; account-B config must be filtered out")
+}
+
+// TestPerAccountPerms_GetLadderConfigs_AllowedAccountsLookupError verifies
+// that when GetAllowedAccountsAPI returns an error, getLadderConfigs fails
+// closed (returns the error, not unfiltered configs).
+func TestPerAccountPerms_GetLadderConfigs_AllowedAccountsLookupError(t *testing.T) {
+	ctx := context.Background()
+
+	cfgA := config.LadderConfigDB{ID: "cfg-a", CloudAccountID: permsAccA, Provider: "aws"}
+	cfgB := config.LadderConfigDB{ID: "cfg-b", CloudAccountID: permsAccB, Provider: "aws"}
+
+	mockStore := new(MockConfigStore)
+	mockStore.On("GetLadderConfigs", ctx).Return([]config.LadderConfigDB{cfgA, cfgB}, nil)
+
+	// Scoped auth mock, but GetAllowedAccountsAPI fails
+	mockAuth := new(MockAuthService)
+	mockAuth.On("ValidateSession", ctx, permsScopedToken).Return(&Session{
+		UserID: permsScopedUserID,
+		Email:  "scoped@example.com",
+	}, nil)
+	mockAuth.On("HasPermissionAPI", ctx, permsScopedUserID, mock.Anything, mock.Anything).Return(true, nil)
+	injectedErr := errors.New("allowed accounts lookup failed")
+	mockAuth.On("GetAllowedAccountsAPI", ctx, permsScopedUserID).Return(nil, injectedErr)
+
+	handler := &Handler{
+		auth:   mockAuth,
+		config: mockStore,
+	}
+
+	resp, err := handler.getLadderConfigs(ctx, scopedReq())
+	require.Error(t, err, "expected getLadderConfigs to return an error when allowed-accounts lookup fails")
+	assert.ErrorContains(t, err, "failed to get allowed accounts",
+		"error should wrap the allowed-accounts lookup failure")
+	assert.Nil(t, resp, "response must be nil when allowed-accounts lookup fails (fail-closed)")
 }
 
 // TestPerAccountPerms_GetLadderConfigs_AdminSeesAll verifies that an admin


### PR DESCRIPTION
## Summary

Fixes a cross-account data leak in `getLadderConfigs` (`GET /ladder/configs`), found via adversarial review of #1428.

- Migration 000088 (part of #1428) granted `view:config` permission to the Standard-User and Read-Only-User groups, which previously only admins held.
- `getLadderConfigs` in `internal/api/handler_ladder.go` was never updated to account for that: it returned every account's `LadderConfigDB` (spend caps, ramp schedules) unconditionally, regardless of the caller's `allowed_accounts` scope.
- Result: any scoped non-admin user could enumerate other accounts' spend caps and ramp schedules simply by having been granted `view:config`.

## Root cause

`getLadderConfigs` called `h.config.GetLadderConfigs(ctx)` and returned the result unfiltered. There was no scoping step, unlike the analogous purchase-history endpoint which already went through `filterPurchaseHistoryByAllowedAccounts` (added for issue #1030).

## Fix

- `getLadderConfigs` now captures the `session` from `requirePermission` and filters the result through a new `filterLadderConfigsByAllowedAccounts` method, mirroring the existing `filterPurchaseHistoryByAllowedAccounts` pattern.
- Admin / unrestricted sessions (`auth.IsUnrestrictedAccess`) pass through unfiltered.
- Scoped sessions are filtered via `auth.MatchesAccount(allowed, c.CloudAccountID, nameByID[c.CloudAccountID])`.
- Fails closed: if `getAllowedAccounts` errors, the whole request errors out rather than falling through to unfiltered data.

## Tests

Two new regression tests in `internal/api/handler_per_account_perms_test.go`:
- `TestPerAccountPerms_GetLadderConfigs_ScopedUserSeesOnlyOwnAccount`: the real failing scenario. A scoped user with `allowed_accounts: [accA]` must not see account B's config when the store returns configs for both accounts. Verified this fails on the pre-fix code (account-B config leaks through) and passes post-fix.
- `TestPerAccountPerms_GetLadderConfigs_AdminSeesAll`: an admin/unrestricted session still receives every account's config.

Also added `t.Cleanup(mockStore/mockAuth.AssertExpectations)` to an existing test in `handler_config_test.go` per this repo's mock-assertion convention.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/api/...` (full package, all green)
- [x] `golangci-lint run` (pinned v2.10.1, matching CI) — 0 issues
- [x] `gocyclo -over 10` on changed files — clean
- [x] Manually reverted the filter call and confirmed the new regression test fails pre-fix, then confirmed it passes after restoring the fix

Context only: #1428 (already merged; this is a fix-forward PR for a scoping gap it introduced, not a fix to #1428 itself).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ladder configuration results are now restricted to the accounts permitted for the signed-in user.
  * Users with unrestricted access continue to see ladder configurations across all accounts.
* **Tests**
  * Added coverage to verify account-level filtering and unrestricted access behavior.
  * Improved automatic validation of mocked service expectations in configuration update tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->