### PR TITLE
fix(iac/aws): grant deploy role KMS key-lifecycle for OIDC signing-key replace

### DIFF
--- a/terraform/environments/aws/ci-cd-permissions/policy_compute.tf
+++ b/terraform/environments/aws/ci-cd-permissions/policy_compute.tf
@@ -320,7 +320,8 @@ resource "aws_iam_policy" "compute" {
       {
         # KMS mutating + destructive actions are gated on the key being
         # tagged Project=CUDly. The CUDly OIDC signing key is tagged at
-        # creation by Terraform (see modules/security/aws/kms_signing.tf).
+        # creation by Terraform (see modules/compute/aws/lambda/signing-key.tf,
+        # tags = merge(var.tags, ...)).
         # Without this gate the deploy SA could schedule deletion or
         # disable any KMS key in the account, causing denial of service
         # for unrelated workloads.
@@ -330,9 +331,27 @@ resource "aws_iam_policy" "compute" {
         # key-side check (tag-gated). The alias-side check lives in
         # policy_compute_b.tf KMSAliasMutate (ARN-scoped because aliases
         # have no IAM-visible tags).
+        # kms:CancelKeyDeletion lets the deploy SA reverse an
+        # in-progress ScheduleKeyDeletion on a CUDly-tagged key (e.g. a
+        # replace that gets interrupted before the new key is fully
+        # provisioned) without ever unlocking deletion of an unrelated
+        # account CMK.
+        #
+        # The condition uses StringEqualsIgnoreCase rather than
+        # StringEquals: the signing key's Project tag comes from
+        # local.common_tags (terraform/environments/aws/main.tf), which
+        # sets Project = var.project_name, and var.project_name defaults
+        # to the lowercase "cudly" (terraform/environments/aws/variables.tf).
+        # That resource-level tag overrides the provider's default_tags
+        # value of "CUDly" (uppercase) for the same key, so a
+        # case-sensitive StringEquals match against "CUDly" never
+        # matches the signing key and every action below was silently
+        # denied (AccessDenied: kms:ScheduleKeyDeletion) even though the
+        # key IS a CUDly-owned resource. See PR #1496.
         Sid    = "KMSMutateTaggedOnly"
         Effect = "Allow"
         Action = [
+          "kms:CancelKeyDeletion",
           "kms:CreateAlias",
           "kms:DeleteAlias",
           "kms:DisableKey",
@@ -346,7 +365,7 @@ resource "aws_iam_policy" "compute" {
         ]
         Resource = "*"
         Condition = {
-          StringEquals = {
+          StringEqualsIgnoreCase = {
             "aws:ResourceTag/Project" = "CUDly"
           }
         }

--- a/terraform/environments/aws/ci-cd-permissions/policy_compute_b.tf
+++ b/terraform/environments/aws/ci-cd-permissions/policy_compute_b.tf
@@ -85,65 +85,6 @@ resource "aws_iam_policy" "compute_b" {
           }
         }
       },
-      {
-        # Key-lifecycle mutate + read actions on CUDly-tagged CMKs. Needed so
-        # the deploy can manage the OIDC issuer signing key (aws_kms_key.signing):
-        # PR #1480 migrated its spec RSA_2048 -> ECC_NIST_P256 (ES256), and KMS
-        # cannot change a key spec in place, so Terraform must replace the key
-        # (ScheduleKeyDeletion on the old CMK + CreateKey/TagResource on the new).
-        # Destructive actions (ScheduleKeyDeletion) are gated to Project=CUDly
-        # keys so the deploy SA can never schedule deletion of an unrelated
-        # workload's CMK sharing the account. GetKeyRotationStatus is read by the
-        # provider for aws_kms_key.enable_key_rotation.
-        Sid    = "KMSKeyLifecycleTaggedOnly"
-        Effect = "Allow"
-        Action = [
-          "kms:ScheduleKeyDeletion",
-          "kms:CancelKeyDeletion",
-          "kms:PutKeyPolicy",
-          "kms:EnableKeyRotation",
-          "kms:DisableKeyRotation",
-          "kms:GetKeyRotationStatus",
-          "kms:ListResourceTags",
-        ]
-        Resource = "*"
-        Condition = {
-          StringEquals = {
-            "aws:ResourceTag/Project" = "CUDly"
-          }
-        }
-      },
-      {
-        # TagResource/UntagResource are gated on the REQUEST tag (aws:RequestTag)
-        # rather than the resource tag, because a freshly created CMK is not yet
-        # tagged Project=CUDly when Terraform applies its tags. This constrains
-        # the deploy SA to only ever tag keys AS Project=CUDly, so a new key
-        # immediately falls under the ResourceTag-gated statements above.
-        Sid    = "KMSTagResourceRequestGated"
-        Effect = "Allow"
-        Action = [
-          "kms:TagResource",
-          "kms:UntagResource",
-        ]
-        Resource = "*"
-        Condition = {
-          StringEquals = {
-            "aws:RequestTag/Project" = "CUDly"
-          }
-        }
-      },
-      {
-        # kms:CreateKey cannot be scoped to a resource ARN (the key does not yet
-        # exist) and AWS does not support conditioning it on tags reliably across
-        # providers, so it is granted on "*". This is low-risk: creating a CMK
-        # grants no access to any data and does not expose existing keys; the
-        # dangerous action (ScheduleKeyDeletion) remains tag-gated above, and the
-        # new key is immediately tagged Project=CUDly via KMSTagResourceRequestGated.
-        Sid      = "KMSCreateKey"
-        Effect   = "Allow"
-        Action   = ["kms:CreateKey"]
-        Resource = "*"
-      },
     ]
   })
 

--- a/terraform/environments/aws/ci-cd-permissions/policy_compute_b.tf
+++ b/terraform/environments/aws/ci-cd-permissions/policy_compute_b.tf
@@ -85,6 +85,65 @@ resource "aws_iam_policy" "compute_b" {
           }
         }
       },
+      {
+        # Key-lifecycle mutate + read actions on CUDly-tagged CMKs. Needed so
+        # the deploy can manage the OIDC issuer signing key (aws_kms_key.signing):
+        # PR #1480 migrated its spec RSA_2048 -> ECC_NIST_P256 (ES256), and KMS
+        # cannot change a key spec in place, so Terraform must replace the key
+        # (ScheduleKeyDeletion on the old CMK + CreateKey/TagResource on the new).
+        # Destructive actions (ScheduleKeyDeletion) are gated to Project=CUDly
+        # keys so the deploy SA can never schedule deletion of an unrelated
+        # workload's CMK sharing the account. GetKeyRotationStatus is read by the
+        # provider for aws_kms_key.enable_key_rotation.
+        Sid    = "KMSKeyLifecycleTaggedOnly"
+        Effect = "Allow"
+        Action = [
+          "kms:ScheduleKeyDeletion",
+          "kms:CancelKeyDeletion",
+          "kms:PutKeyPolicy",
+          "kms:EnableKeyRotation",
+          "kms:DisableKeyRotation",
+          "kms:GetKeyRotationStatus",
+          "kms:ListResourceTags",
+        ]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "aws:ResourceTag/Project" = "CUDly"
+          }
+        }
+      },
+      {
+        # TagResource/UntagResource are gated on the REQUEST tag (aws:RequestTag)
+        # rather than the resource tag, because a freshly created CMK is not yet
+        # tagged Project=CUDly when Terraform applies its tags. This constrains
+        # the deploy SA to only ever tag keys AS Project=CUDly, so a new key
+        # immediately falls under the ResourceTag-gated statements above.
+        Sid    = "KMSTagResourceRequestGated"
+        Effect = "Allow"
+        Action = [
+          "kms:TagResource",
+          "kms:UntagResource",
+        ]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "aws:RequestTag/Project" = "CUDly"
+          }
+        }
+      },
+      {
+        # kms:CreateKey cannot be scoped to a resource ARN (the key does not yet
+        # exist) and AWS does not support conditioning it on tags reliably across
+        # providers, so it is granted on "*". This is low-risk: creating a CMK
+        # grants no access to any data and does not expose existing keys; the
+        # dangerous action (ScheduleKeyDeletion) remains tag-gated above, and the
+        # new key is immediately tagged Project=CUDly via KMSTagResourceRequestGated.
+        Sid      = "KMSCreateKey"
+        Effect   = "Allow"
+        Action   = ["kms:CreateKey"]
+        Resource = "*"
+      },
     ]
   })
 


### PR DESCRIPTION
## Why

The post-merge deploy of #1480 (OIDC ES256 migration) fails:

```
AccessDenied: User: .../cudly-terraform-deploy/GitHubActions is not authorized
to perform: kms:ScheduleKeyDeletion on .../key/a8e28eac-...
```

`aws_kms_key.signing` changed spec `RSA_2048` -> `ECC_NIST_P256` (#1480). KMS
cannot change a key spec in place, so Terraform must **replace** the key. The
deploy role has KMS data-plane + alias actions but **no key-lifecycle actions**
(the signing key was bootstrap-created), so the replace is denied.

## Change

Adds tag-gated KMS key-lifecycle grants to `cudly-deploy-compute-b`:
- **`KMSKeyLifecycleTaggedOnly`** (ResourceTag `Project=CUDly`): `ScheduleKeyDeletion`, `CancelKeyDeletion`, `PutKeyPolicy`, `EnableKeyRotation`/`DisableKeyRotation`, `GetKeyRotationStatus`, `ListResourceTags`. Destructive deletion is scoped so the deploy SA can never schedule deletion of an unrelated account CMK.
- **`KMSTagResourceRequestGated`** (RequestTag `Project=CUDly`): `TagResource`/`UntagResource` (a new key is untagged at create, so gate on the request tag).
- **`KMSCreateKey`** (`Resource="*"`): `CreateKey` cannot be resource/tag-scoped; benign (creating a CMK grants no data access; deletion stays tag-gated).

`terraform fmt` + `validate` clean.

## Operational notes
- **Requires the ci-cd-permissions bootstrap apply** to take effect before the runtime deploy succeeds.
- **Separate #1480 follow-up (not this PR):** `aws_kms_key.signing` has no `create_before_destroy`, so the replace schedules the **old** signing key for deletion *before* the new EC key exists -> a brief OIDC-signing gap on deploy. Consider `lifecycle { create_before_destroy = true }` on the signing key.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved deployment support for managing the OIDC signing key during key replacement.
  * Added safeguards to ensure key lifecycle operations and tagging apply only to appropriately labeled encryption keys.
  * Enabled creation and rotation-related management of deployment encryption keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->