### PR TITLE
fix(iac/aws): create_before_destroy on OIDC signing key (follow-up to #1480)

### DIFF
--- a/terraform/modules/compute/aws/lambda/signing-key.tf
+++ b/terraform/modules/compute/aws/lambda/signing-key.tf
@@ -15,6 +15,16 @@ resource "aws_kms_key" "signing" {
   tags = merge(var.tags, {
     Name = "${var.stack_name}-oidc-signing"
   })
+
+  # Any change that forces a new CMK (e.g. the RSA_2048 -> ECC_NIST_P256
+  # migration in #1480) must create the replacement key and cut the alias
+  # over to it BEFORE scheduling the old key for deletion. Without this,
+  # Terraform's default destroy-before-create would schedule the live OIDC
+  # signing key for deletion (immediately unusable for kms:Sign) before the
+  # new key exists, briefly breaking client-assertion JWT minting.
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_kms_alias" "signing" {


### PR DESCRIPTION
## Follow-up to #1480

#1480 migrated `aws_kms_key.signing` (OIDC issuer signing key) from `RSA_2048` to `ECC_NIST_P256` (ES256). KMS cannot change a key spec in place, so Terraform must **replace** the key.

Terraform's default **destroy-before-create** would `ScheduleKeyDeletion` on the live signing key (immediately unusable for `kms:Sign`) **before** the new EC key exists — briefly breaking OIDC client-assertion JWT minting (Azure AD federation) on deploy.

## Change
Adds `lifecycle { create_before_destroy = true }` to `aws_kms_key.signing` so the new key is created and the alias cut over **before** the old key is scheduled for deletion. The alias updates in place (no replace), so it needs no change.

Scoped to AWS only: GCP crypto keys are versioned (algorithm change adds a version, no gap) and Azure Key Vault soft-delete keeps the old key recoverable.

`terraform fmt` + `validate` clean.

Refs #1480, #1496.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved signing-key replacement behavior to help prevent temporary interruptions when keys are migrated.
  * Reduced the risk of failures in OIDC client-assertion JWT generation during signing-key updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->