### PR TITLE
fix(iac/aws): case-insensitive tag match on kms:GetKeyPolicy deploy grant

### DIFF
--- a/terraform/environments/aws/ci-cd-permissions/policy_compute_b.tf
+++ b/terraform/environments/aws/ci-cd-permissions/policy_compute_b.tf
@@ -75,12 +75,24 @@ resource "aws_iam_policy" "compute_b" {
         # prevents the deploy SA from reading key policies of unrelated
         # workloads sharing the account. Split from policy_compute.tf
         # because the 6144-char managed-policy limit was reached.
+        #
+        # Uses StringEqualsIgnoreCase for the same reason as
+        # KMSMutateTaggedOnly in policy_compute.tf (see PR #1496): the
+        # OIDC signing key's Project tag comes from local.common_tags
+        # (Project = var.project_name), which defaults to lowercase
+        # "cudly" and overrides the provider default_tags value "CUDly"
+        # for that resource. The AWS provider reads the key policy
+        # (kms:GetKeyPolicy) on every aws_kms_key refresh, so a
+        # case-sensitive StringEquals against "CUDly" would deny the
+        # deploy role from refreshing/replacing the signing key
+        # (AccessDenied: kms:GetKeyPolicy), blocking the ECC replace this
+        # grant exists to support.
         Sid      = "KMSReadTaggedOnly"
         Effect   = "Allow"
         Action   = ["kms:GetKeyPolicy"]
         Resource = "*"
         Condition = {
-          StringEquals = {
+          StringEqualsIgnoreCase = {
             "aws:ResourceTag/Project" = "CUDly"
           }
         }


### PR DESCRIPTION
## What

Adversarial-review follow-up to #1496 and #1512 (OIDC signing-key RSA->ECC replace). Switches `KMSReadTaggedOnly` in `policy_compute_b.tf` from case-sensitive `StringEquals "CUDly"` to `StringEqualsIgnoreCase`.

## Why

#1496 discovered that the OIDC signing key is tagged `Project=cudly` (lowercase): the tag comes from `local.common_tags` (`Project = var.project_name`, default `"cudly"`), which overrides the provider `default_tags` value `"CUDly"` for that resource. It fixed `KMSMutateTaggedOnly` (kms:ScheduleKeyDeletion etc.) to `StringEqualsIgnoreCase` accordingly.

`KMSReadTaggedOnly` gates the deploy role's **only** grant for `kms:GetKeyPolicy` on the **same** tag, but was left as case-sensitive `StringEquals "CUDly"`, so by the identical reasoning it never matches the signing key. The AWS provider reads the key policy (`kms:GetKeyPolicy`) on every `aws_kms_key` refresh, so once both bootstrap policies are applied the deploy role hits `AccessDenied: kms:GetKeyPolicy` when refreshing/replacing the signing key, blocking the exact ECC replace #1496/#1512 exist to enable.

This was found by adversarially reviewing both merged PRs: the mutate path was fixed but the read path (`GetKeyPolicy`) carries the same latent case mismatch.

## Confidence

- The case mismatch and the single-point `GetKeyPolicy` grant are **confirmed by inspection** (tag chain traced to `local.common_tags` -> `var.project_name = "cudly"`; `GetKeyPolicy` appears only in `KMSReadTaggedOnly`).
- The runtime "blocks the deploy" impact depends on the provider reading + hard-failing on `GetKeyPolicy` during `aws_kms_key` refresh (standard behaviour); precise fatality is best confirmed against live AWS. The fix is safe and internally consistent regardless.

## Scope of the review (other probes)

- `create_before_destroy` on the key only (#1512): **sound** — the alias and IAM role-policy are updated in place (UpdateAlias / PutRolePolicy), not replaced, so no cycle and no need for CBD on them; new key is created and the alias repointed before the old key is scheduled for deletion.
- OIDC/JWKS continuity: the AWS signer caches the public key + `kid` via `sync.Once` with no invalidation, so warm Lambda containers can serve a stale JWKS during any signing-key replacement (transient verification mismatch until recycled). Pre-existing app-code behaviour, not introduced by these PRs, out of scope here.
- Tag-value: confirmed the signing key's `Project` tag is lowercase `cudly`.

## Test

`terraform validate` passes on `ci-cd-permissions`.

Closes nothing; filed as a follow-up fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when validating project tags during signing key policy operations, regardless of capitalization.
  * Added clarification around tag matching and key policy refresh behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->