### PR TITLE
refactor(common): make DatabaseDetails/CacheDetails pointer-only

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -693,7 +693,12 @@ func adjustSingleRecommendation(rec common.Recommendation, existingMap map[strin
 // DatabaseDetails/CacheDetails are always pointers (every producer -- AWS,
 // Azure, the CSV loader, and the JSON codec -- constructs them that way); see
 // pkg/common/service_details_codec.go's package doc for the pointer
-// invariant.
+// invariant. The nil-pointer guards are not dead code: `rec.Details == nil`
+// only catches an untyped nil, so a typed nil (a (*common.DatabaseDetails)(nil)
+// stored in the interface) reaches the switch and would panic on the field
+// read. Returning blank matches the sibling helpers (extractDeployment and
+// extractEngine in multi_service_csv.go, rdsEngineDeploymentFromRec in the
+// AWS coverage package), which already guard the same way.
 func getEngineFromRecommendation(rec common.Recommendation) string {
 	if rec.Details == nil {
 		return ""
@@ -701,8 +706,14 @@ func getEngineFromRecommendation(rec common.Recommendation) string {
 	var engine string
 	switch details := rec.Details.(type) {
 	case *common.DatabaseDetails:
+		if details == nil {
+			return ""
+		}
 		engine = details.Engine
 	case *common.CacheDetails:
+		if details == nil {
+			return ""
+		}
 		engine = details.Engine
 	default:
 		return ""

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -690,17 +690,17 @@ func adjustSingleRecommendation(rec common.Recommendation, existingMap map[strin
 }
 
 // getEngineFromRecommendation extracts the engine from recommendation details.
+// DatabaseDetails/CacheDetails are always pointers (every producer -- AWS,
+// Azure, the CSV loader, and the JSON codec -- constructs them that way); see
+// pkg/common/service_details_codec.go's package doc for the pointer
+// invariant.
 func getEngineFromRecommendation(rec common.Recommendation) string {
 	if rec.Details == nil {
 		return ""
 	}
 	var engine string
 	switch details := rec.Details.(type) {
-	case common.DatabaseDetails:
-		engine = details.Engine
 	case *common.DatabaseDetails:
-		engine = details.Engine
-	case common.CacheDetails:
 		engine = details.Engine
 	case *common.CacheDetails:
 		engine = details.Engine

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -628,6 +628,23 @@ func TestGetEngineFromRecommendation(t *testing.T) {
 			},
 			expected: "",
 		},
+		// Typed nils: rec.Details != nil (the interface holds a type) but the
+		// pointer inside is nil, so the `rec.Details == nil` guard does not
+		// catch it and the field read would panic without the per-case check.
+		{
+			name: "typed nil *DatabaseDetails - returns empty, no panic",
+			rec: common.Recommendation{
+				Details: (*common.DatabaseDetails)(nil),
+			},
+			expected: "",
+		},
+		{
+			name: "typed nil *CacheDetails - returns empty, no panic",
+			rec: common.Recommendation{
+				Details: (*common.CacheDetails)(nil),
+			},
+			expected: "",
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -589,6 +589,11 @@ func TestNormalizeEngineName(t *testing.T) {
 	}
 }
 
+// TestGetEngineFromRecommendation only exercises pointer-typed
+// DatabaseDetails/CacheDetails: every producer (AWS, Azure, the CSV
+// loader, and the JSON codec) constructs them that way, so there is no
+// value-typed case to cover -- see
+// pkg/common/service_details_codec.go's package doc for the invariant.
 func TestGetEngineFromRecommendation(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -596,25 +601,11 @@ func TestGetEngineFromRecommendation(t *testing.T) {
 		rec      common.Recommendation
 	}{
 		{
-			name: "DatabaseDetails value type",
-			rec: common.Recommendation{
-				Details: common.DatabaseDetails{Engine: "mysql"},
-			},
-			expected: "mysql",
-		},
-		{
 			name: "DatabaseDetails pointer type",
 			rec: common.Recommendation{
 				Details: &common.DatabaseDetails{Engine: "postgresql"},
 			},
 			expected: "postgresql",
-		},
-		{
-			name: "CacheDetails value type",
-			rec: common.Recommendation{
-				Details: common.CacheDetails{Engine: "redis"},
-			},
-			expected: "redis",
 		},
 		{
 			name: "CacheDetails pointer type",

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -283,8 +283,9 @@ func effectiveSizingPct(cfg Config) float64 {
 // polymorphic Details field. DatabaseDetails/CacheDetails are always
 // pointers (every producer constructs them that way; see
 // pkg/common/service_details_codec.go's package doc for the pointer
-// invariant). ComputeDetails is still accepted as a value because the GCP
-// compute-engine client constructs it that way.
+// invariant). ComputeDetails is still accepted as a value because the
+// Azure compute client and the GCP compute-engine client both construct
+// it that way.
 func extractEngineLabel(details interface{}) string {
 	switch d := details.(type) {
 	case *common.DatabaseDetails:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -279,20 +279,18 @@ func effectiveSizingPct(cfg Config) float64 {
 	return cfg.Coverage
 }
 
-// extractEngineLabel returns the engine or platform string from the polymorphic
-// Details field, handling both value and pointer forms. The live parser and the
-// CSV loader store pointers (*DatabaseDetails is required by findOfferingID),
-// while some test callers construct values directly.
+// extractEngineLabel returns the engine or platform string from the
+// polymorphic Details field. DatabaseDetails/CacheDetails are always
+// pointers (every producer constructs them that way; see
+// pkg/common/service_details_codec.go's package doc for the pointer
+// invariant). ComputeDetails is still accepted as a value because the GCP
+// compute-engine client constructs it that way.
 func extractEngineLabel(details interface{}) string {
 	switch d := details.(type) {
-	case common.DatabaseDetails:
-		return d.Engine
 	case *common.DatabaseDetails:
 		if d != nil {
 			return d.Engine
 		}
-	case common.CacheDetails:
-		return d.Engine
 	case *common.CacheDetails:
 		if d != nil {
 			return d.Engine

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -111,7 +111,7 @@ func TestGeneratePurchaseID(t *testing.T) {
 				Service:      common.ServiceRDS,
 				ResourceType: "db.t3.micro",
 				Count:        2,
-				Details: common.DatabaseDetails{
+				Details: &common.DatabaseDetails{
 					Engine:   "mysql",
 					AZConfig: "single-az",
 				},
@@ -141,7 +141,7 @@ func TestGeneratePurchaseID(t *testing.T) {
 				Service:      common.ServiceElastiCache,
 				ResourceType: "cache.r5.large",
 				Count:        1,
-				Details: common.CacheDetails{
+				Details: &common.CacheDetails{
 					Engine: "redis",
 				},
 			},
@@ -157,7 +157,7 @@ func TestGeneratePurchaseID(t *testing.T) {
 				Service:      common.ServiceRDS,
 				ResourceType: "db.m5.xlarge",
 				Count:        3,
-				Details: common.DatabaseDetails{
+				Details: &common.DatabaseDetails{
 					Engine:   "postgres",
 					AZConfig: "multi-az",
 				},
@@ -373,7 +373,7 @@ func TestGeneratePurchaseIDEdgeCases(t *testing.T) {
 		Service:      common.ServiceRDS,
 		ResourceType: "db.r5b.2xlarge",
 		Count:        10,
-		Details: common.DatabaseDetails{
+		Details: &common.DatabaseDetails{
 			Engine:   "MySQL 8.0",
 			AZConfig: "single-az",
 		},
@@ -414,7 +414,7 @@ func TestGeneratePurchaseIDComprehensive(t *testing.T) {
 				ResourceType: "db.r5.large",
 				Count:        3,
 				AccountName:  "Production Account",
-				Details: common.DatabaseDetails{
+				Details: &common.DatabaseDetails{
 					Engine: "PostgreSQL",
 				},
 			},
@@ -431,7 +431,7 @@ func TestGeneratePurchaseIDComprehensive(t *testing.T) {
 				Service:      common.ServiceElastiCache,
 				ResourceType: "cache.r5.xlarge",
 				Count:        5,
-				Details: common.CacheDetails{
+				Details: &common.CacheDetails{
 					Engine: "Redis",
 				},
 			},
@@ -465,7 +465,7 @@ func TestGeneratePurchaseIDComprehensive(t *testing.T) {
 				Service:      common.ServiceMemoryDB,
 				ResourceType: "db.r6g.large",
 				Count:        2,
-				Details:      common.CacheDetails{Engine: "redis"},
+				Details:      &common.CacheDetails{Engine: "redis"},
 			},
 			region:   "us-east-1",
 			isDryRun: false,
@@ -523,7 +523,7 @@ func TestGeneratePurchaseIDComprehensive(t *testing.T) {
 				ResourceType: "db.r6g.xlarge",
 				Count:        15,
 				AccountName:  "Staging",
-				Details: common.DatabaseDetails{
+				Details: &common.DatabaseDetails{
 					Engine:   "aurora-mysql",
 					AZConfig: "multi-az",
 				},
@@ -541,7 +541,7 @@ func TestGeneratePurchaseIDComprehensive(t *testing.T) {
 				Service:      common.ServiceElastiCache,
 				ResourceType: "cache.m5.large",
 				Count:        1,
-				Details: common.CacheDetails{
+				Details: &common.CacheDetails{
 					Engine: "redis",
 				},
 			},
@@ -558,7 +558,7 @@ func TestGeneratePurchaseIDComprehensive(t *testing.T) {
 				Service:      common.ServiceRDS,
 				ResourceType: "db.t3.micro",
 				Count:        20,
-				Details: common.DatabaseDetails{
+				Details: &common.DatabaseDetails{
 					Engine: "MySQL_8.0_Community",
 				},
 			},
@@ -610,7 +610,7 @@ func TestGeneratePurchaseIDCoverageVariations(t *testing.T) {
 		Service:      common.ServiceRDS,
 		ResourceType: "db.t3.small",
 		Count:        1,
-		Details: common.DatabaseDetails{
+		Details: &common.DatabaseDetails{
 			Engine: "mysql",
 		},
 	}

--- a/cmd/multi_service_coverage_test.go
+++ b/cmd/multi_service_coverage_test.go
@@ -339,7 +339,7 @@ func TestAdjustRecommendationForExcludedVersions_AdditionalCases(t *testing.T) {
 				ResourceType: "db.t3.small",
 				Count:        10,
 				Region:       "us-east-1",
-				Details: common.DatabaseDetails{
+				Details: &common.DatabaseDetails{
 					Engine: "mysql",
 				},
 			},
@@ -352,7 +352,7 @@ func TestAdjustRecommendationForExcludedVersions_AdditionalCases(t *testing.T) {
 				ResourceType: "db.t3.small",
 				Count:        10,
 				Region:       "us-east-1",
-				Details: common.DatabaseDetails{
+				Details: &common.DatabaseDetails{
 					Engine: "mysql",
 				},
 			},
@@ -380,7 +380,7 @@ func TestAdjustRecommendationForExcludedVersions_AdditionalCases(t *testing.T) {
 				ResourceType: "db.t3.small",
 				Count:        10,
 				Region:       "us-east-1",
-				Details: common.DatabaseDetails{
+				Details: &common.DatabaseDetails{
 					Engine: "mysql",
 				},
 			},
@@ -739,7 +739,7 @@ func TestFilterAndAdjustRecommendations_WithEngineVersionFiltering(t *testing.T)
 			ResourceType: "db.t3.small",
 			Count:        5,
 			Region:       "us-east-1",
-			Details: common.DatabaseDetails{
+			Details: &common.DatabaseDetails{
 				Engine: "mysql",
 			},
 		},

--- a/cmd/multi_service_csv.go
+++ b/cmd/multi_service_csv.go
@@ -385,15 +385,12 @@ func formatNormalizedUnitsOrBlank(rec common.Recommendation) string {
 // operators need to see the deployment alongside the upfront figure to
 // confirm a $X upfront row is for the deployment they expect.
 //
-// Both value and pointer Details are accepted to mirror extractEngine
-// (parser path stores pointers; CSV-loader path constructs values).
+// DatabaseDetails is always a pointer: every producer (AWS, Azure, the CSV
+// loader, and the JSON codec used on the purchase-execution round trip)
+// constructs it that way -- see pkg/common/service_details_codec.go's
+// package doc for the invariant.
 func extractDeployment(rec common.Recommendation) string {
-	switch details := rec.Details.(type) {
-	case *common.DatabaseDetails:
-		if details != nil {
-			return details.AZConfig
-		}
-	case common.DatabaseDetails:
+	if details, ok := rec.Details.(*common.DatabaseDetails); ok && details != nil {
 		return details.AZConfig
 	}
 	return ""
@@ -404,25 +401,20 @@ func extractDeployment(rec common.Recommendation) string {
 // CacheDetails), Platform for EC2 (ComputeDetails), empty for SP and other
 // commitment types that don't carry an engine field.
 //
-// Both value and pointer Details are accepted because the parser stores
-// *DatabaseDetails / *CacheDetails / *ComputeDetails while the CSV-loader
-// path constructs the value forms; the dispatch in generatePurchaseID does
-// the same trick. Without the pointer cases the column silently blanks
-// every row coming from the live parser path.
+// DatabaseDetails/CacheDetails are always pointers (see extractDeployment's
+// godoc for the invariant). ComputeDetails is still accepted as a value
+// because the GCP compute-engine client constructs it that way; without that
+// case the column silently blanks every GCP compute row.
 func extractEngine(rec common.Recommendation) string {
 	switch details := rec.Details.(type) {
 	case *common.DatabaseDetails:
 		if details != nil {
 			return details.Engine
 		}
-	case common.DatabaseDetails:
-		return details.Engine
 	case *common.CacheDetails:
 		if details != nil {
 			return details.Engine
 		}
-	case common.CacheDetails:
-		return details.Engine
 	case *common.ComputeDetails:
 		if details != nil {
 			return details.Platform

--- a/cmd/multi_service_csv.go
+++ b/cmd/multi_service_csv.go
@@ -403,8 +403,9 @@ func extractDeployment(rec common.Recommendation) string {
 //
 // DatabaseDetails/CacheDetails are always pointers (see extractDeployment's
 // godoc for the invariant). ComputeDetails is still accepted as a value
-// because the GCP compute-engine client constructs it that way; without that
-// case the column silently blanks every GCP compute row.
+// because the Azure compute client and the GCP compute-engine client both
+// construct it that way; without that case the column silently blanks every
+// Azure VM and GCP compute row.
 func extractEngine(rec common.Recommendation) string {
 	switch details := rec.Details.(type) {
 	case *common.DatabaseDetails:

--- a/cmd/multi_service_csv_test.go
+++ b/cmd/multi_service_csv_test.go
@@ -86,7 +86,7 @@ func TestWriteMultiServiceCSVReport(t *testing.T) {
 						EstimatedSavings:  100,
 						SavingsPercentage: 30,
 						Timestamp:         time.Now(),
-						Details: common.DatabaseDetails{
+						Details: &common.DatabaseDetails{
 							Engine:   "mysql",
 							AZConfig: "multi-az",
 						},
@@ -109,7 +109,7 @@ func TestWriteMultiServiceCSVReport(t *testing.T) {
 						ResourceType: "cache.t3.micro",
 						Count:        1,
 						Term:         "1yr",
-						Details: common.CacheDetails{
+						Details: &common.CacheDetails{
 							Engine:   "redis",
 							NodeType: "cache.t3.micro",
 						},
@@ -495,8 +495,9 @@ func TestFormatNormalizedUnitsOrBlank(t *testing.T) {
 // TestExtractDeployment covers the deployment-extraction helper used by
 // the RDS row in the CSV. Single-AZ / Multi-AZ is critical context for
 // pricing verification (Multi-AZ list price is ~2x Single-AZ) so the
-// column should land for every RDS rec regardless of which Details form
-// the upstream path used.
+// column should land for every RDS rec. DatabaseDetails is always a
+// pointer (every producer constructs it that way); no value-typed case
+// is needed.
 func TestExtractDeployment(t *testing.T) {
 	tests := []struct {
 		name string
@@ -505,7 +506,6 @@ func TestExtractDeployment(t *testing.T) {
 	}{
 		{"*DatabaseDetails Single-AZ", common.Recommendation{Details: &common.DatabaseDetails{AZConfig: "single-az"}}, "single-az"},
 		{"*DatabaseDetails Multi-AZ", common.Recommendation{Details: &common.DatabaseDetails{AZConfig: "multi-az"}}, "multi-az"},
-		{"DatabaseDetails (value) Multi-AZ", common.Recommendation{Details: common.DatabaseDetails{AZConfig: "multi-az"}}, "multi-az"},
 		{"DatabaseDetails empty AZConfig", common.Recommendation{Details: &common.DatabaseDetails{Engine: "mysql"}}, ""},
 		// Non-RDS Details → blank (column is RDS-only data).
 		{"CacheDetails -> empty", common.Recommendation{Details: &common.CacheDetails{Engine: "redis"}}, ""},
@@ -523,19 +523,20 @@ func TestExtractDeployment(t *testing.T) {
 // TestExtractEngine covers the four cases the helper dispatches on:
 // DatabaseDetails (RDS engine), CacheDetails (ElastiCache engine),
 // ComputeDetails (EC2 platform), and unset/other Details (blank).
+// DatabaseDetails/CacheDetails are always pointers (every producer
+// constructs them that way); ComputeDetails still accepts a value because
+// the GCP compute-engine client constructs it that way.
 func TestExtractEngine(t *testing.T) {
 	tests := []struct {
 		name string
 		rec  common.Recommendation
 		want string
 	}{
-		// Pointer forms — what the live parser actually emits.
 		{"*DatabaseDetails -> Engine", common.Recommendation{Details: &common.DatabaseDetails{Engine: "aurora-postgresql"}}, "aurora-postgresql"},
 		{"*CacheDetails -> Engine", common.Recommendation{Details: &common.CacheDetails{Engine: "redis"}}, "redis"},
 		{"*ComputeDetails -> Platform", common.Recommendation{Details: &common.ComputeDetails{Platform: "Linux/UNIX"}}, "Linux/UNIX"},
-		// Value forms — what the CSV-loader path constructs.
-		{"DatabaseDetails (value) -> Engine", common.Recommendation{Details: common.DatabaseDetails{Engine: "mysql"}}, "mysql"},
-		{"CacheDetails (value) -> Engine", common.Recommendation{Details: common.CacheDetails{Engine: "memcached"}}, "memcached"},
+		// GCP's compute-engine client still constructs ComputeDetails as a
+		// value; keep coverage for that form.
 		{"ComputeDetails (value) -> Platform", common.Recommendation{Details: common.ComputeDetails{Platform: "Windows"}}, "Windows"},
 		// Fallbacks.
 		{"nil Details -> empty", common.Recommendation{}, ""},

--- a/cmd/multi_service_csv_test.go
+++ b/cmd/multi_service_csv_test.go
@@ -525,7 +525,8 @@ func TestExtractDeployment(t *testing.T) {
 // ComputeDetails (EC2 platform), and unset/other Details (blank).
 // DatabaseDetails/CacheDetails are always pointers (every producer
 // constructs them that way); ComputeDetails still accepts a value because
-// the GCP compute-engine client constructs it that way.
+// the Azure compute client and the GCP compute-engine client both construct
+// it that way.
 func TestExtractEngine(t *testing.T) {
 	tests := []struct {
 		name string
@@ -535,8 +536,9 @@ func TestExtractEngine(t *testing.T) {
 		{"*DatabaseDetails -> Engine", common.Recommendation{Details: &common.DatabaseDetails{Engine: "aurora-postgresql"}}, "aurora-postgresql"},
 		{"*CacheDetails -> Engine", common.Recommendation{Details: &common.CacheDetails{Engine: "redis"}}, "redis"},
 		{"*ComputeDetails -> Platform", common.Recommendation{Details: &common.ComputeDetails{Platform: "Linux/UNIX"}}, "Linux/UNIX"},
-		// GCP's compute-engine client still constructs ComputeDetails as a
-		// value; keep coverage for that form.
+		// The Azure compute client and GCP's compute-engine client both
+		// still construct ComputeDetails as a value; keep coverage for
+		// that form.
 		{"ComputeDetails (value) -> Platform", common.Recommendation{Details: common.ComputeDetails{Platform: "Windows"}}, "Windows"},
 		// Fallbacks.
 		{"nil Details -> empty", common.Recommendation{}, ""},

--- a/cmd/multi_service_engine_versions.go
+++ b/cmd/multi_service_engine_versions.go
@@ -426,11 +426,11 @@ func adjustRecommendationForExcludedVersions(rec common.Recommendation, instance
 		return rec
 	}
 
-	// Get the engine name from the recommendation
+	// Get the engine name from the recommendation. DatabaseDetails is
+	// always a pointer (every producer constructs it that way; see
+	// pkg/common/service_details_codec.go's package doc).
 	var recEngine string
 	switch details := rec.Details.(type) {
-	case common.DatabaseDetails:
-		recEngine = details.Engine
 	case *common.DatabaseDetails:
 		recEngine = details.Engine
 	default:

--- a/cmd/multi_service_engine_versions.go
+++ b/cmd/multi_service_engine_versions.go
@@ -428,10 +428,15 @@ func adjustRecommendationForExcludedVersions(rec common.Recommendation, instance
 
 	// Get the engine name from the recommendation. DatabaseDetails is
 	// always a pointer (every producer constructs it that way; see
-	// pkg/common/service_details_codec.go's package doc).
+	// pkg/common/service_details_codec.go's package doc). A typed nil
+	// pointer is treated like a non-RDS rec rather than panicking on the
+	// field read.
 	var recEngine string
 	switch details := rec.Details.(type) {
 	case *common.DatabaseDetails:
+		if details == nil {
+			return rec
+		}
 		recEngine = details.Engine
 	default:
 		return rec // Not RDS, no engine version filtering

--- a/cmd/multi_service_engine_versions_test.go
+++ b/cmd/multi_service_engine_versions_test.go
@@ -255,6 +255,34 @@ func TestAdjustRecommendationForExcludedVersions_NonRDSService(t *testing.T) {
 	assert.Equal(t, 5, result.Count, "Non-RDS services should not be adjusted")
 }
 
+// TestAdjustRecommendationForExcludedVersions_TypedNilDetails pins the typed-nil
+// guard on the *common.DatabaseDetails case. A nil interface is caught by the
+// caller's own nil checks, but a (*common.DatabaseDetails)(nil) stored in the
+// interface reaches the type switch, and reading details.Engine there panics.
+// instanceVersions must contain an entry for the rec's ResourceType so the
+// function gets past its early "no running instances" return and actually
+// reaches the switch.
+func TestAdjustRecommendationForExcludedVersions_TypedNilDetails(t *testing.T) {
+	recommendation := common.Recommendation{
+		Service:      common.ServiceRDS,
+		Region:       "us-east-1",
+		ResourceType: "db.r5.large",
+		Count:        7,
+		Details:      (*common.DatabaseDetails)(nil),
+	}
+
+	instanceVersions := map[string][]InstanceEngineVersion{
+		"db.r5.large": {
+			{Engine: "aurora-mysql", EngineVersion: "5.7.mysql_aurora.2.11.1", InstanceClass: "db.r5.large", Region: "us-east-1"},
+		},
+	}
+
+	assert.NotPanics(t, func() {
+		result := adjustRecommendationForExcludedVersions(recommendation, instanceVersions, createTestVersionInfo())
+		assert.Equal(t, 7, result.Count, "typed-nil Details must pass through unadjusted")
+	})
+}
+
 func TestExtractMajorVersion_Additional(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/cmd/multi_service_test.go
+++ b/cmd/multi_service_test.go
@@ -895,9 +895,9 @@ func TestApplyFilters_EngineFiltering(t *testing.T) {
 		{
 			name: "Include specific engines",
 			recs: []common.Recommendation{
-				{Region: "us-east-1", ResourceType: "db.t3.small", Count: 1, Service: common.ServiceRDS, Details: common.DatabaseDetails{Engine: "postgresql"}},
-				{Region: "us-east-1", ResourceType: "db.t3.medium", Count: 2, Service: common.ServiceRDS, Details: common.DatabaseDetails{Engine: "mysql"}},
-				{Region: "us-east-1", ResourceType: "cache.t3.small", Count: 3, Service: common.ServiceElastiCache, Details: common.CacheDetails{Engine: "redis"}},
+				{Region: "us-east-1", ResourceType: "db.t3.small", Count: 1, Service: common.ServiceRDS, Details: &common.DatabaseDetails{Engine: "postgresql"}},
+				{Region: "us-east-1", ResourceType: "db.t3.medium", Count: 2, Service: common.ServiceRDS, Details: &common.DatabaseDetails{Engine: "mysql"}},
+				{Region: "us-east-1", ResourceType: "cache.t3.small", Count: 3, Service: common.ServiceElastiCache, Details: &common.CacheDetails{Engine: "redis"}},
 			},
 			includeEngines: []string{"postgresql", "mysql"},
 			excludeEngines: []string{},
@@ -906,9 +906,9 @@ func TestApplyFilters_EngineFiltering(t *testing.T) {
 		{
 			name: "Exclude specific engines",
 			recs: []common.Recommendation{
-				{Region: "us-east-1", ResourceType: "db.t3.small", Count: 1, Service: common.ServiceRDS, Details: common.DatabaseDetails{Engine: "postgresql"}},
-				{Region: "us-east-1", ResourceType: "db.t3.medium", Count: 2, Service: common.ServiceRDS, Details: common.DatabaseDetails{Engine: "mysql"}},
-				{Region: "us-east-1", ResourceType: "cache.t3.small", Count: 3, Service: common.ServiceElastiCache, Details: common.CacheDetails{Engine: "redis"}},
+				{Region: "us-east-1", ResourceType: "db.t3.small", Count: 1, Service: common.ServiceRDS, Details: &common.DatabaseDetails{Engine: "postgresql"}},
+				{Region: "us-east-1", ResourceType: "db.t3.medium", Count: 2, Service: common.ServiceRDS, Details: &common.DatabaseDetails{Engine: "mysql"}},
+				{Region: "us-east-1", ResourceType: "cache.t3.small", Count: 3, Service: common.ServiceElastiCache, Details: &common.CacheDetails{Engine: "redis"}},
 			},
 			includeEngines: []string{},
 			excludeEngines: []string{"redis"},
@@ -917,8 +917,8 @@ func TestApplyFilters_EngineFiltering(t *testing.T) {
 		{
 			name: "Case insensitive engine matching",
 			recs: []common.Recommendation{
-				{Region: "us-east-1", ResourceType: "db.t3.small", Count: 1, Service: common.ServiceRDS, Details: common.DatabaseDetails{Engine: "PostgreSQL"}},
-				{Region: "us-east-1", ResourceType: "db.t3.medium", Count: 2, Service: common.ServiceRDS, Details: common.DatabaseDetails{Engine: "MySQL"}},
+				{Region: "us-east-1", ResourceType: "db.t3.small", Count: 1, Service: common.ServiceRDS, Details: &common.DatabaseDetails{Engine: "PostgreSQL"}},
+				{Region: "us-east-1", ResourceType: "db.t3.medium", Count: 2, Service: common.ServiceRDS, Details: &common.DatabaseDetails{Engine: "MySQL"}},
 			},
 			includeEngines: []string{"postgresql", "mysql"},
 			excludeEngines: []string{},
@@ -928,7 +928,7 @@ func TestApplyFilters_EngineFiltering(t *testing.T) {
 			name: "No engine details - with include list",
 			recs: []common.Recommendation{
 				{Region: "us-east-1", ResourceType: "db.t3.small", Count: 1, Service: common.ServiceRDS},
-				{Region: "us-east-1", ResourceType: "db.t3.medium", Count: 2, Service: common.ServiceRDS, Details: common.DatabaseDetails{Engine: "mysql"}},
+				{Region: "us-east-1", ResourceType: "db.t3.medium", Count: 2, Service: common.ServiceRDS, Details: &common.DatabaseDetails{Engine: "mysql"}},
 			},
 			includeEngines: []string{"mysql"},
 			excludeEngines: []string{},
@@ -1025,10 +1025,10 @@ func TestApplyFilters_AccountFiltering(t *testing.T) {
 
 func TestApplyFilters_CombinedFilters(t *testing.T) {
 	recs := []common.Recommendation{
-		{Region: "us-east-1", ResourceType: "db.t3.small", Count: 1, Service: common.ServiceRDS, Details: common.DatabaseDetails{Engine: "postgresql"}, AccountName: "prod-account"},
-		{Region: "us-west-2", ResourceType: "db.t3.medium", Count: 2, Service: common.ServiceRDS, Details: common.DatabaseDetails{Engine: "mysql"}, AccountName: "dev-account"},
-		{Region: "us-east-1", ResourceType: "db.r5.large", Count: 3, Service: common.ServiceRDS, Details: common.DatabaseDetails{Engine: "postgresql"}, AccountName: "staging-account"},
-		{Region: "eu-west-1", ResourceType: "cache.t3.small", Count: 4, Service: common.ServiceElastiCache, Details: common.CacheDetails{Engine: "redis"}, AccountName: "prod-account"},
+		{Region: "us-east-1", ResourceType: "db.t3.small", Count: 1, Service: common.ServiceRDS, Details: &common.DatabaseDetails{Engine: "postgresql"}, AccountName: "prod-account"},
+		{Region: "us-west-2", ResourceType: "db.t3.medium", Count: 2, Service: common.ServiceRDS, Details: &common.DatabaseDetails{Engine: "mysql"}, AccountName: "dev-account"},
+		{Region: "us-east-1", ResourceType: "db.r5.large", Count: 3, Service: common.ServiceRDS, Details: &common.DatabaseDetails{Engine: "postgresql"}, AccountName: "staging-account"},
+		{Region: "eu-west-1", ResourceType: "cache.t3.small", Count: 4, Service: common.ServiceElastiCache, Details: &common.CacheDetails{Engine: "redis"}, AccountName: "prod-account"},
 	}
 
 	cfg := Config{

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -1244,21 +1244,18 @@ func nonZeroPtr(v float64) *float64 {
 }
 
 // extractEngine pulls the engine string out of a polymorphic
-// common.ServiceDetails value when one is present, supporting both value
-// and pointer receivers as the provider parsers historically used either
-// shape. Returns "" for any other Details type (or nil). Extracted from
-// convertRecommendations to keep that function under the gocyclo budget
-// (min-complexity: 10 in .pre-commit-config.yaml).
+// common.ServiceDetails value when one is present. DatabaseDetails/
+// CacheDetails are always pointers (every producer constructs them that
+// way; see pkg/common/service_details_codec.go's package doc for the
+// invariant). Returns "" for any other Details type (or nil). Extracted
+// from convertRecommendations to keep that function under the gocyclo
+// budget (min-complexity: 10 in .pre-commit-config.yaml).
 func extractEngine(details common.ServiceDetails) string {
 	if details == nil {
 		return ""
 	}
 	switch d := details.(type) {
-	case common.DatabaseDetails:
-		return d.Engine
 	case *common.DatabaseDetails:
-		return d.Engine
-	case common.CacheDetails:
 		return d.Engine
 	case *common.CacheDetails:
 		return d.Engine

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -1247,17 +1247,26 @@ func nonZeroPtr(v float64) *float64 {
 // common.ServiceDetails value when one is present. DatabaseDetails/
 // CacheDetails are always pointers (every producer constructs them that
 // way; see pkg/common/service_details_codec.go's package doc for the
-// invariant). Returns "" for any other Details type (or nil). Extracted
-// from convertRecommendations to keep that function under the gocyclo
-// budget (min-complexity: 10 in .pre-commit-config.yaml).
+// invariant). Returns "" for any other Details type (or nil). The
+// nil-pointer guards are not dead code: the `details == nil` check above
+// only catches an untyped nil, so a typed nil reaches the switch and would
+// panic on the field read. Extracted from convertRecommendations to keep
+// that function under the gocyclo budget (min-complexity: 10 in
+// .pre-commit-config.yaml).
 func extractEngine(details common.ServiceDetails) string {
 	if details == nil {
 		return ""
 	}
 	switch d := details.(type) {
 	case *common.DatabaseDetails:
+		if d == nil {
+			return ""
+		}
 		return d.Engine
 	case *common.CacheDetails:
+		if d == nil {
+			return ""
+		}
 		return d.Engine
 	}
 	return ""

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -2343,3 +2343,38 @@ func TestScheduler_ResolveAmbientAccountID_StoreError(t *testing.T) {
 	got := sched.resolveAmbientAccountID(context.Background(), "gcp", "some-project")
 	assert.Empty(t, got, "store error must collapse to empty (don't fail the collection)")
 }
+
+// TestExtractEngine covers the pointer-only dispatch documented in
+// pkg/common/service_details_codec.go's package doc, plus the typed-nil
+// guard. The typed-nil cases are the regression bar: the `details == nil`
+// check only catches an untyped nil, so a (*common.DatabaseDetails)(nil)
+// stored in the interface reaches the type switch and the field read
+// panics without the per-case guard. extractEngine feeds the persisted
+// engine column and the scheduler recommendation ID, so a panic here
+// aborts an entire collection run.
+func TestExtractEngine(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		details common.ServiceDetails
+		name    string
+		want    string
+	}{
+		{name: "nil interface", details: nil, want: ""},
+		{name: "*DatabaseDetails", details: &common.DatabaseDetails{Engine: "mysql"}, want: "mysql"},
+		{name: "*CacheDetails", details: &common.CacheDetails{Engine: "redis"}, want: "redis"},
+		{name: "*ComputeDetails carries no engine", details: &common.ComputeDetails{Platform: "Linux/UNIX"}, want: ""},
+		{name: "typed nil *DatabaseDetails", details: (*common.DatabaseDetails)(nil), want: ""},
+		{name: "typed nil *CacheDetails", details: (*common.CacheDetails)(nil), want: ""},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.NotPanics(t, func() {
+				assert.Equal(t, tt.want, extractEngine(tt.details))
+			})
+		})
+	}
+}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1200,7 +1200,7 @@ func TestScheduler_ConvertRecommendations(t *testing.T) {
 			PaymentOption:    "partial-upfront",
 			CommitmentCost:   500.0,
 			EstimatedSavings: 200.0,
-			Details: common.DatabaseDetails{
+			Details: &common.DatabaseDetails{
 				Engine: "mysql",
 			},
 		},
@@ -1463,9 +1463,9 @@ func TestScheduler_ConvertRecommendations_IDUniqueness(t *testing.T) {
 				rdsBase := base
 				rdsBase.Service = common.ServiceRDS
 				rdsBase.ResourceType = "db.m5.large"
-				rdsBase.Details = common.DatabaseDetails{Engine: "mysql"}
+				rdsBase.Details = &common.DatabaseDetails{Engine: "mysql"}
 				rdsTwin := rdsBase
-				rdsTwin.Details = common.DatabaseDetails{Engine: "postgres"}
+				rdsTwin.Details = &common.DatabaseDetails{Engine: "postgres"}
 				return rdsBase, rdsTwin
 			},
 		},

--- a/pkg/common/engine.go
+++ b/pkg/common/engine.go
@@ -44,7 +44,9 @@ func NormalizeEngineName(engine string) string {
 // recommendation details. Returns an empty string for non-database/cache
 // service types. DatabaseDetails/CacheDetails are always pointers (every
 // producer constructs them that way; see service_details_codec.go's
-// package doc for the invariant).
+// package doc for the invariant). The nil-pointer guards are not dead
+// code: the `details == nil` check above only catches an untyped nil, so a
+// typed nil reaches the switch and would panic on the field read.
 func EngineFromDetails(details ServiceDetails) string {
 	if details == nil {
 		return ""
@@ -52,8 +54,14 @@ func EngineFromDetails(details ServiceDetails) string {
 	var engine string
 	switch d := details.(type) {
 	case *DatabaseDetails:
+		if d == nil {
+			return ""
+		}
 		engine = d.Engine
 	case *CacheDetails:
+		if d == nil {
+			return ""
+		}
 		engine = d.Engine
 	default:
 		return ""

--- a/pkg/common/engine.go
+++ b/pkg/common/engine.go
@@ -40,19 +40,18 @@ func NormalizeEngineName(engine string) string {
 	return strings.ToLower(engine)
 }
 
-// EngineFromDetails extracts and normalizes the engine name from recommendation details.
-// Returns an empty string for non-database/cache service types.
+// EngineFromDetails extracts and normalizes the engine name from
+// recommendation details. Returns an empty string for non-database/cache
+// service types. DatabaseDetails/CacheDetails are always pointers (every
+// producer constructs them that way; see service_details_codec.go's
+// package doc for the invariant).
 func EngineFromDetails(details ServiceDetails) string {
 	if details == nil {
 		return ""
 	}
 	var engine string
 	switch d := details.(type) {
-	case DatabaseDetails:
-		engine = d.Engine
 	case *DatabaseDetails:
-		engine = d.Engine
-	case CacheDetails:
 		engine = d.Engine
 	case *CacheDetails:
 		engine = d.Engine

--- a/pkg/common/engine_test.go
+++ b/pkg/common/engine_test.go
@@ -1,0 +1,44 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestEngineFromDetails covers the pointer-only dispatch documented in
+// service_details_codec.go's package doc, plus the typed-nil guard.
+//
+// The typed-nil cases are the regression bar: a (*DatabaseDetails)(nil)
+// stored in the ServiceDetails interface is NOT caught by the
+// `details == nil` check (the interface itself is non-nil once it carries a
+// type), so it reaches the type switch and the field read panics without the
+// per-case guard. Matches() calls EngineFromDetails on every
+// recommendation/commitment pair, so a panic here takes down coverage
+// matching for the whole run rather than skipping one row.
+func TestEngineFromDetails(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		details ServiceDetails
+		name    string
+		want    string
+	}{
+		{name: "nil interface", details: nil, want: ""},
+		{name: "*DatabaseDetails", details: &DatabaseDetails{Engine: "PostgreSQL"}, want: "postgresql"},
+		{name: "*CacheDetails", details: &CacheDetails{Engine: "Redis"}, want: "redis"},
+		{name: "*ComputeDetails is not a DB/cache type", details: &ComputeDetails{Platform: "Linux/UNIX"}, want: ""},
+		{name: "typed nil *DatabaseDetails", details: (*DatabaseDetails)(nil), want: ""},
+		{name: "typed nil *CacheDetails", details: (*CacheDetails)(nil), want: ""},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.NotPanics(t, func() {
+				assert.Equal(t, tt.want, EngineFromDetails(tt.details))
+			})
+		})
+	}
+}

--- a/pkg/common/service_details_codec.go
+++ b/pkg/common/service_details_codec.go
@@ -18,6 +18,15 @@
 // type definitions (ComputeDetails / DatabaseDetails / …). internal/config
 // (where RecommendationRecord lives) is deliberately kept free of
 // pkg/common imports so the dependency graph stays a strict DAG.
+//
+// Pointer invariant: this codec always reconstructs *DatabaseDetails /
+// *CacheDetails, and every other producer (AWS, Azure, the CSV loader)
+// constructs them as pointers too, so Recommendation.Details never holds a
+// bare DatabaseDetails / CacheDetails value anywhere in the codebase.
+// Consumers that type-switch on Details only need the pointer case for
+// these two types. ComputeDetails is the one remaining exception: the GCP
+// compute-engine client still constructs it as a value, so consumers that
+// handle ComputeDetails must keep accepting both forms.
 package common
 
 import (

--- a/pkg/common/service_details_codec.go
+++ b/pkg/common/service_details_codec.go
@@ -24,9 +24,12 @@
 // constructs them as pointers too, so Recommendation.Details never holds a
 // bare DatabaseDetails / CacheDetails value anywhere in the codebase.
 // Consumers that type-switch on Details only need the pointer case for
-// these two types. ComputeDetails is the one remaining exception: the GCP
-// compute-engine client still constructs it as a value, so consumers that
-// handle ComputeDetails must keep accepting both forms.
+// these two types. ComputeDetails is the one remaining exception: the
+// Azure compute client (providers/azure/services/compute) and the GCP
+// compute-engine client (providers/gcp/services/computeengine) both still
+// construct it as a value, so consumers that handle ComputeDetails must
+// keep accepting both forms. Dropping the value case would silently blank
+// every Azure VM and GCP compute row instead of failing to compile.
 package common
 
 import (

--- a/providers/aws/recommendations/coverage.go
+++ b/providers/aws/recommendations/coverage.go
@@ -469,16 +469,11 @@ func lookupPoolKey(rec common.Recommendation) string {
 
 // rdsEngineDeploymentFromRec extracts the RDS engine and deployment
 // strings from a recommendation's polymorphic Details, returning ("", "")
-// when the rec isn't an RDS rec. Handles both pointer and value forms of
-// DatabaseDetails because the live parser uses pointers and the CSV
-// loader uses values.
+// when the rec isn't an RDS rec. DatabaseDetails is always a pointer
+// (every producer constructs it that way; see
+// pkg/common/service_details_codec.go's package doc for the invariant).
 func rdsEngineDeploymentFromRec(rec common.Recommendation) (engine, deployment string) {
-	switch details := rec.Details.(type) {
-	case *common.DatabaseDetails:
-		if details != nil {
-			return details.Engine, details.AZConfig
-		}
-	case common.DatabaseDetails:
+	if details, ok := rec.Details.(*common.DatabaseDetails); ok && details != nil {
 		return details.Engine, details.AZConfig
 	}
 	return "", ""

--- a/providers/aws/services/memorydb/client_test.go
+++ b/providers/aws/services/memorydb/client_test.go
@@ -203,7 +203,7 @@ func TestClient_ValidateOffering(t *testing.T) {
 		ResourceType:  "db.r6gd.xlarge",
 		PaymentOption: "partial-upfront",
 		Term:          "1yr",
-		Details: common.CacheDetails{
+		Details: &common.CacheDetails{
 			Engine:   "redis",
 			NodeType: "db.r6gd.xlarge",
 		},
@@ -239,7 +239,7 @@ func TestClient_PurchaseCommitment(t *testing.T) {
 		Count:         3,
 		PaymentOption: "all-upfront",
 		Term:          "3yr",
-		Details: common.CacheDetails{
+		Details: &common.CacheDetails{
 			Engine:   "redis",
 			NodeType: "db.r6gd.2xlarge",
 		},
@@ -458,7 +458,7 @@ func TestClient_GetOfferingDetails(t *testing.T) {
 		ResourceType:  "db.r6gd.xlarge",
 		PaymentOption: "partial-upfront",
 		Term:          "1yr",
-		Details: common.CacheDetails{
+		Details: &common.CacheDetails{
 			Engine:   "redis",
 			NodeType: "db.r6gd.xlarge",
 		},
@@ -507,7 +507,7 @@ func TestClient_GetOfferingDetails_NotFound(t *testing.T) {
 		ResourceType:  "db.r6gd.xlarge",
 		PaymentOption: "partial-upfront",
 		Term:          "1yr",
-		Details: common.CacheDetails{
+		Details: &common.CacheDetails{
 			Engine:   "redis",
 			NodeType: "db.r6gd.xlarge",
 		},
@@ -552,7 +552,7 @@ func TestClient_GetOfferingDetails_APIError(t *testing.T) {
 		ResourceType:  "db.r6gd.xlarge",
 		PaymentOption: "partial-upfront",
 		Term:          "1yr",
-		Details: common.CacheDetails{
+		Details: &common.CacheDetails{
 			Engine:   "redis",
 			NodeType: "db.r6gd.xlarge",
 		},
@@ -595,7 +595,7 @@ func TestClient_PurchaseCommitment_OfferingNotFound(t *testing.T) {
 		ResourceType:  "db.r6gd.xlarge",
 		PaymentOption: "partial-upfront",
 		Term:          "1yr",
-		Details: common.CacheDetails{
+		Details: &common.CacheDetails{
 			Engine:   "redis",
 			NodeType: "db.r6gd.xlarge",
 		},
@@ -627,7 +627,7 @@ func TestClient_PurchaseCommitment_PurchaseError(t *testing.T) {
 		Count:         1,
 		PaymentOption: "partial-upfront",
 		Term:          "1yr",
-		Details: common.CacheDetails{
+		Details: &common.CacheDetails{
 			Engine:   "redis",
 			NodeType: "db.r6gd.xlarge",
 		},
@@ -669,7 +669,7 @@ func TestClient_PurchaseCommitment_EmptyResponse(t *testing.T) {
 		Count:         1,
 		PaymentOption: "partial-upfront",
 		Term:          "1yr",
-		Details: common.CacheDetails{
+		Details: &common.CacheDetails{
 			Engine:   "redis",
 			NodeType: "db.r6gd.xlarge",
 		},
@@ -774,7 +774,7 @@ func mdbIdemRec() common.Recommendation {
 		Count:         1,
 		PaymentOption: "all-upfront",
 		Term:          "1yr",
-		Details:       common.CacheDetails{Engine: "redis", NodeType: "db.r6gd.large"},
+		Details:       &common.CacheDetails{Engine: "redis", NodeType: "db.r6gd.large"},
 	}
 }
 
@@ -910,7 +910,7 @@ func TestClient_PurchaseCommitment_NoToken_RichReservationName(t *testing.T) {
 		Count:         3,
 		PaymentOption: "all-upfront", // must match expectMDBOffering's OfferingType
 		Term:          "1yr",
-		Details:       common.CacheDetails{Engine: "redis", NodeType: "db.r6gd.large"},
+		Details:       &common.CacheDetails{Engine: "redis", NodeType: "db.r6gd.large"},
 	}
 
 	expectMDBOffering(mockMDB)

--- a/providers/azure/services/cache/client.go
+++ b/providers/azure/services/cache/client.go
@@ -624,7 +624,7 @@ func (c *CacheClient) convertAzureRedisRecommendation(ctx context.Context, azure
 	if f == nil {
 		return nil
 	}
-	details := common.CacheDetails{
+	details := &common.CacheDetails{
 		Engine:   "redis",
 		NodeType: f.ResourceType,
 	}

--- a/providers/azure/services/cache/client_test.go
+++ b/providers/azure/services/cache/client_test.go
@@ -842,8 +842,8 @@ func TestCacheClient_ConvertAzureRedisRecommendation_PopulatesAllFields(t *testi
 	// stays 0 when no cache instance matches in the subscription (the
 	// catalogue's only signal source for shard counts).
 	require.NotNil(t, out.Details)
-	details, ok := out.Details.(common.CacheDetails)
-	require.True(t, ok, "Details must be a common.CacheDetails value")
+	details, ok := out.Details.(*common.CacheDetails)
+	require.True(t, ok, "Details must be a *common.CacheDetails pointer")
 	assert.Equal(t, "redis", details.Engine)
 	assert.Equal(t, "Premium_P3", details.NodeType)
 	assert.Equal(t, 0, details.Shards, "Shards is 0 when no matching cache exists in the subscription")
@@ -892,7 +892,7 @@ func TestCacheClient_ConvertAzureRedisRecommendation_PopulatesShardsFromSKUCache
 	)
 	out := client.convertAzureRedisRecommendation(context.Background(), rec)
 	require.NotNil(t, out)
-	details, ok := out.Details.(common.CacheDetails)
+	details, ok := out.Details.(*common.CacheDetails)
 	require.True(t, ok)
 	assert.Equal(t, "redis", details.Engine)
 	assert.Equal(t, "Premium_P3", details.NodeType)
@@ -918,7 +918,7 @@ func TestCacheClient_ConvertAzureRedisRecommendation_PagerErrorFallsBack(t *test
 	)
 	out := client.convertAzureRedisRecommendation(context.Background(), rec)
 	require.NotNil(t, out, "conversion must NOT fail on catalogue-fetch error")
-	details, ok := out.Details.(common.CacheDetails)
+	details, ok := out.Details.(*common.CacheDetails)
 	require.True(t, ok)
 	assert.Equal(t, "redis", details.Engine)
 	assert.Equal(t, "Premium_P3", details.NodeType)

--- a/providers/azure/services/database/client.go
+++ b/providers/azure/services/database/client.go
@@ -900,11 +900,10 @@ func (c *DatabaseClient) createServersPager() (SQLServersPager, error) {
 // Engine is always "sqlserver". EngineVersion, AZConfig, and Deployment
 // are enriched by the lazy subscription-wide cached lookups in
 // convertAzureSQLRecommendation; they are left empty here.
-func detailsFromSQLSKU(sku string) common.DatabaseDetails {
+func detailsFromSQLSKU(sku string) *common.DatabaseDetails {
 	// Engine is always SQL Server for an Azure SQL Database reservation.
-	d := common.DatabaseDetails{
+	return &common.DatabaseDetails{
 		Engine:        "sqlserver",
 		InstanceClass: sku,
 	}
-	return d
 }

--- a/providers/azure/services/database/client.go
+++ b/providers/azure/services/database/client.go
@@ -890,7 +890,7 @@ func (c *DatabaseClient) createServersPager() (SQLServersPager, error) {
 }
 
 // detailsFromSQLSKU parses an Azure SQL SKU string into a
-// common.DatabaseDetails value. The Azure Reservation Recommendations
+// *common.DatabaseDetails. The Azure Reservation Recommendations
 // API returns SKU strings like "GeneralPurpose_Gen5_2" (edition, compute
 // generation, vcore count) or "BusinessCritical_Gen5_4". The parser is
 // permissive: unknown formats populate InstanceClass and leave the rest

--- a/providers/azure/services/database/client_test.go
+++ b/providers/azure/services/database/client_test.go
@@ -754,8 +754,8 @@ func TestDatabaseClient_ConvertAzureSQLRecommendation_PopulatesAllFields(t *test
 	// matching SKU (no signal); AZConfig/Deployment still need a
 	// per-server lookup and remain deferred.
 	require.NotNil(t, out.Details)
-	details, ok := out.Details.(common.DatabaseDetails)
-	require.True(t, ok, "Details must be a common.DatabaseDetails value")
+	details, ok := out.Details.(*common.DatabaseDetails)
+	require.True(t, ok, "Details must be a *common.DatabaseDetails pointer")
 	assert.Equal(t, "sqlserver", details.Engine)
 	assert.Equal(t, "GeneralPurpose_Gen5_2", details.InstanceClass)
 	assert.Empty(t, details.EngineVersion, "EngineVersion empty when no matching SKU in catalogue")
@@ -800,7 +800,7 @@ func TestDatabaseClient_ConvertAzureSQLRecommendation_PopulatesEngineVersion(t *
 	)
 	out := client.convertAzureSQLRecommendation(context.Background(), rec)
 	require.NotNil(t, out)
-	details, ok := out.Details.(common.DatabaseDetails)
+	details, ok := out.Details.(*common.DatabaseDetails)
 	require.True(t, ok)
 	assert.Equal(t, "sqlserver", details.Engine)
 	assert.Equal(t, skuName, details.InstanceClass)
@@ -822,7 +822,7 @@ func TestDatabaseClient_ConvertAzureSQLRecommendation_CapabilitiesErrorFallsBack
 	)
 	out := client.convertAzureSQLRecommendation(context.Background(), rec)
 	require.NotNil(t, out, "conversion must NOT fail on capabilities-fetch error")
-	details, ok := out.Details.(common.DatabaseDetails)
+	details, ok := out.Details.(*common.DatabaseDetails)
 	require.True(t, ok)
 	assert.Equal(t, "sqlserver", details.Engine)
 	assert.Equal(t, "GeneralPurpose_Gen5_2", details.InstanceClass)
@@ -1408,7 +1408,7 @@ func TestDatabaseClient_ConvertAzureSQLRecommendation_PopulatesAZConfig(t *testi
 	)
 	out := client.convertAzureSQLRecommendation(context.Background(), rec)
 	require.NotNil(t, out)
-	details, ok := out.Details.(common.DatabaseDetails)
+	details, ok := out.Details.(*common.DatabaseDetails)
 	require.True(t, ok)
 	assert.Equal(t, "zoneRedundant", details.AZConfig)
 }
@@ -1429,7 +1429,7 @@ func TestDatabaseClient_ConvertAzureSQLRecommendation_AmbiguousAZConfig(t *testi
 	)
 	out := client.convertAzureSQLRecommendation(context.Background(), rec)
 	require.NotNil(t, out)
-	details, ok := out.Details.(common.DatabaseDetails)
+	details, ok := out.Details.(*common.DatabaseDetails)
 	require.True(t, ok)
 	assert.Empty(t, details.AZConfig, "ambiguous zone-redundancy must leave AZConfig empty")
 }
@@ -1451,7 +1451,7 @@ func TestDatabaseClient_ConvertAzureSQLRecommendation_AZConfigPagerErrorFallsBac
 	)
 	out := client.convertAzureSQLRecommendation(context.Background(), rec)
 	require.NotNil(t, out, "conversion must NOT fail on pager error")
-	details, ok := out.Details.(common.DatabaseDetails)
+	details, ok := out.Details.(*common.DatabaseDetails)
 	require.True(t, ok)
 	assert.Empty(t, details.AZConfig, "AZConfig empty on pager error")
 }
@@ -1480,7 +1480,7 @@ func TestDatabaseClient_ConvertAzureSQLRecommendation_PopulatesDeployment(t *tes
 	)
 	out := client.convertAzureSQLRecommendation(context.Background(), rec)
 	require.NotNil(t, out)
-	details, ok := out.Details.(common.DatabaseDetails)
+	details, ok := out.Details.(*common.DatabaseDetails)
 	require.True(t, ok)
 	assert.Equal(t, "managed", details.Deployment)
 }
@@ -1502,7 +1502,7 @@ func TestDatabaseClient_ConvertAzureSQLRecommendation_DeploymentSingle(t *testin
 	)
 	out := client.convertAzureSQLRecommendation(context.Background(), rec)
 	require.NotNil(t, out)
-	details, ok := out.Details.(common.DatabaseDetails)
+	details, ok := out.Details.(*common.DatabaseDetails)
 	require.True(t, ok)
 	assert.Equal(t, "single", details.Deployment)
 }
@@ -1524,7 +1524,7 @@ func TestDatabaseClient_ConvertAzureSQLRecommendation_DeploymentPagerErrorFallsB
 	)
 	out := client.convertAzureSQLRecommendation(context.Background(), rec)
 	require.NotNil(t, out, "conversion must NOT fail on servers pager error")
-	details, ok := out.Details.(common.DatabaseDetails)
+	details, ok := out.Details.(*common.DatabaseDetails)
 	require.True(t, ok)
 	assert.Empty(t, details.Deployment, "Deployment empty on pager error")
 }


### PR DESCRIPTION
## Summary

Revives the valuable part of a stale, unshipped refactor found in worktree `agent-a2b3490bc2d3f0c08` (~1 month old, never landed). That worktree bundled three ideas; after assessing each against current `main`, only one turned out to be a genuine win. This PR implements only that part, built fresh against current `main` (not built from the stale diff).

**What's in scope**: `common.DatabaseDetails` / `common.CacheDetails` were the only `ServiceDetails` producers in the codebase constructed inconsistently -- Azure's SQL/Redis reservation converters built them as plain values, while AWS, the CSV loader, and the JSON codec (used on the purchase-execution DB round trip) always built pointers. That inconsistency forced 8 separate consumer functions (in `cmd/`, `internal/scheduler`, `providers/aws/recommendations`, `pkg/common`) to defensively type-switch on *both* `T` and `*T` for the same two types.

- Commit 1: fix the root cause -- Azure's SQL/Redis converters now construct `*DatabaseDetails`/`*CacheDetails`.
- Commit 2: simplify the 8 consumer type switches down to the pointer-only case now that the value form is unreachable; also corrects a couple of stale comments claiming "the CSV loader constructs values" (it has constructed pointers for a while -- the real source was Azure).
- Commit 3: update test fixtures to match, dropping the "value type" test cases that existed solely to cover the now-removed branches.

`ComputeDetails` is intentionally untouched -- GCP's compute-engine client still constructs it as a value, so its dual-handling stays.

## What was in the stale worktree but is NOT in this PR (assessed as not worth reviving)

- **`provider.ProviderConfig` -> `provider.Config` rename**: real (revive stutter) finding, but ~96 occurrences across 18 files for a purely cosmetic rename. Also discovered while assessing this: `golangci-lint` in CI only lints the root Go module -- `pkg/`, `providers/aws`, `providers/azure`, `providers/gcp` (separate `go.work` modules) are never scanned by the "Lint Code" job, so this stutter finding isn't even CI-enforced today. High blast radius for a change with no functional or CI-visible payoff; declined.
- **`WriteAuditRecord(record AuditRecord)` -> `(record *AuditRecord)`**: `AuditRecord` is ~280 bytes, well under the project's deliberate 1024-byte `gocritic` `hugeParam` threshold (see `.golangci.yml` comment). No lint fires on it today and passing it by value is idiomatic Go at that size. Declined as zero-value churn.

## Follow-ups surfaced but out of scope here (not fixed, flagging per project convention)

- The exact same value/pointer inconsistency exists for `ComputeDetails` (GCP constructs a value; everyone else a pointer), with the same 2-branch dual-handling in `cmd/multi_service_csv.go` and `cmd/main.go`. Could be collapsed the same way in a follow-up.
- `cmd/helpers.go`'s `getEngineFromRecommendation`/`normalizeEngineName` is a near-duplicate of `pkg/common/engine.go`'s `EngineFromDetails`/`NormalizeEngineName` (independent of this refactor).
- CI's `golangci-lint` step only covers the root module; `pkg/`, `providers/aws`, `providers/azure`, `providers/gcp` carry real pre-existing lint debt (godot, misspell, a couple of `revive` stutter findings, gosec is separately covered) that's currently invisible to the "Lint Code" job.

## Test plan

- [x] `go build ./...` clean in root, `pkg/`, `providers/aws`, `providers/azure`, `providers/gcp` modules
- [x] `go vet ./...` clean in all of the above
- [x] `go test ./...` green at the repo root (includes `cmd`, `internal/scheduler`, `internal/purchase`, etc.)
- [x] `go test ./...` green in `pkg/`, `providers/aws`, `providers/azure`
- [x] `golangci-lint run --timeout=10m` (pinned to CI's `v2.10.1`) clean at repo root, matching the exact CI invocation
- [x] `gofmt -l` clean on all touched files
- [x] `.golangci.yml` unchanged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recommendation processing to safely handle missing or nil service details without panics.
  * Standardized database and cache recommendation details for more reliable engine, deployment, filtering, and reporting results.
  * Preserved compute recommendation handling across supported detail formats.

* **Tests**
  * Added coverage for nil and typed-nil recommendation details across engine extraction, scheduling, filtering, and version processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->