### PR TITLE
sec(iac/aws): require OIDC subject claim in aws-target CloudFormation

### DIFF
--- a/iac/federation/aws-target/cloudformation/template.yaml
+++ b/iac/federation/aws-target/cloudformation/template.yaml
@@ -39,10 +39,10 @@ Parameters:
       literal string sts.amazonaws.com, so only tokens carrying exactly that
       audience are accepted.
     Default: ""
-    AllowedPattern: "^$|^[^\\s*$]$|^[^\\s*$][^*$]*[^\\s*$]$"
+    AllowedPattern: "^$|^[^\\s*$]+$"
     ConstraintDescription: >
-      OIDCAudience must be empty, or a non-whitespace string with no
-      leading/trailing whitespace and containing no '$' or '*'.
+      OIDCAudience must be empty, or a string containing no whitespace, '$'
+      or '*' anywhere.
       '$' is rejected because the trust policy is an IAM policy document and
       IAM expands ${...} policy variables inside Condition values: an audience
       of ${accounts.google.com:aud} would expand to the presented token's own
@@ -69,17 +69,19 @@ Parameters:
       so any tenant of that issuer could assume this role and place
       irreversible multi-year commitment purchases in this account.
       Azure AD managed identity: the object ID of the managed identity.
-      GCP service account: the service account's 21-digit numeric unique ID.
-      That is the sub claim accounts.google.com actually issues; it is not the
-      service account email. The system:serviceaccount:<namespace>:<name> form
-      is the Kubernetes subject format and belongs to a cluster OIDC issuer,
-      not to accounts.google.com.
+      GCP service account: the service account's numeric unique ID (typically
+      21 digits; Google documents it as a numeric string without guaranteeing
+      a length). That is the sub claim accounts.google.com actually issues; it
+      is not the service account email.
+      The system:serviceaccount:<namespace>:<name> form is the Kubernetes
+      subject format and belongs to a cluster OIDC issuer, not to
+      accounts.google.com.
       Mirrors the required oidc_subject_claim variable in the Terraform module.
     MinLength: 1
-    AllowedPattern: "^[^\\s*$]$|^[^\\s*$][^*$]*[^\\s*$]$"
+    AllowedPattern: "^[^\\s*$]+$"
     ConstraintDescription: >
-      OIDCSubjectClaim is required and must be a non-empty string with no
-      leading/trailing whitespace and containing no '$' or '*'.
+      OIDCSubjectClaim is required and must be a non-empty string containing
+      no whitespace, '$' or '*' anywhere.
       '$' is rejected because the trust policy below is an IAM policy document
       (Version 2012-10-17) and IAM expands ${...} policy variables inside
       Condition values. A subject of ${accounts.google.com:sub} would expand

--- a/iac/federation/aws-target/cloudformation/template.yaml
+++ b/iac/federation/aws-target/cloudformation/template.yaml
@@ -52,9 +52,22 @@ Parameters:
   OIDCSubjectClaim:
     Type: String
     Description: >
-      Optional subject (sub) claim to restrict which identity can assume the role.
-      Leave empty to allow any authenticated subject from this issuer.
-    Default: ""
+      REQUIRED. Subject (sub) claim identifying the single workload allowed to
+      assume this role. There is deliberately no default: without a :sub
+      condition the trust policy accepts EVERY identity the issuer can mint,
+      so any tenant of that issuer could assume this role and place
+      irreversible multi-year commitment purchases in this account.
+      Azure AD managed identity: the object ID of the managed identity.
+      GCP service account: the service account unique ID, or the form
+      system:serviceaccount:<project>:<sa-email>.
+      Mirrors the required oidc_subject_claim variable in the Terraform module.
+    MinLength: 1
+    AllowedPattern: "^[^\\s*]$|^[^\\s*][^*]*[^\\s*]$"
+    ConstraintDescription: >
+      OIDCSubjectClaim is required and must be a non-empty string with no
+      leading/trailing whitespace and no '*'. The trust policy matches the
+      subject with StringEquals, so a '*' is compared literally rather than
+      as a wildcard and would silently produce a role nobody can assume.
 
   RoleName:
     Type: String
@@ -63,7 +76,6 @@ Parameters:
 
 Conditions:
   HasAudience: !Not [!Equals [!Ref OIDCAudience, ""]]
-  HasSubject: !Not [!Equals [!Ref OIDCSubjectClaim, ""]]
 
 Resources:
   OIDCProvider:
@@ -156,26 +168,19 @@ Resources:
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
-          # Use Fn::If to conditionally include :sub restriction alongside :aud
-          - !If
-            - HasSubject
-            - Effect: Allow
-              Principal:
-                Federated: !GetAtt OIDCProvider.Arn
-              Action: sts:AssumeRoleWithWebIdentity
-              Condition:
-                StringEquals:
-                  !Sub "${OIDCIssuerHost}:aud":
-                    !If [HasAudience, !Ref OIDCAudience, sts.amazonaws.com]
-                  !Sub "${OIDCIssuerHost}:sub": !Ref OIDCSubjectClaim
-            - Effect: Allow
-              Principal:
-                Federated: !GetAtt OIDCProvider.Arn
-              Action: sts:AssumeRoleWithWebIdentity
-              Condition:
-                StringEquals:
-                  !Sub "${OIDCIssuerHost}:aud":
-                    !If [HasAudience, !Ref OIDCAudience, sts.amazonaws.com]
+          # Both :aud and :sub are always enforced. There is intentionally no
+          # subject-less variant of this statement: omitting :sub would trust
+          # every identity the issuer can mint. OIDCSubjectClaim is a required
+          # parameter, so this condition can never collapse to an empty match.
+          - Effect: Allow
+            Principal:
+              Federated: !GetAtt OIDCProvider.Arn
+            Action: sts:AssumeRoleWithWebIdentity
+            Condition:
+              StringEquals:
+                !Sub "${OIDCIssuerHost}:aud":
+                  !If [HasAudience, !Ref OIDCAudience, sts.amazonaws.com]
+                !Sub "${OIDCIssuerHost}:sub": !Ref OIDCSubjectClaim
       ManagedPolicyArns:
         - !Ref CUDlyPolicy
 

--- a/iac/federation/aws-target/cloudformation/template.yaml
+++ b/iac/federation/aws-target/cloudformation/template.yaml
@@ -34,10 +34,21 @@ Parameters:
       Expected audience (aud) in the incoming OIDC token.
       Azure: api://<client_id>  or  <client_id>
       GCP:   https://iam.googleapis.com/projects/<project_number>/locations/global/workloadIdentityPools/<pool_id>/providers/<provider_id>
-      Leave empty to skip audience matching, or supply a non-whitespace string.
+      Leaving this empty does NOT skip audience matching. Both the trust
+      policy condition and the OIDC provider ClientIdList fall back to the
+      literal string sts.amazonaws.com, so only tokens carrying exactly that
+      audience are accepted.
     Default: ""
-    AllowedPattern: "^$|^\\S$|^\\S.*\\S$"
-    ConstraintDescription: "OIDCAudience must be either empty or a non-whitespace string (no leading/trailing whitespace)."
+    AllowedPattern: "^$|^[^\\s*$]$|^[^\\s*$][^*$]*[^\\s*$]$"
+    ConstraintDescription: >
+      OIDCAudience must be empty, or a non-whitespace string with no
+      leading/trailing whitespace and containing no '$' or '*'.
+      '$' is rejected because the trust policy is an IAM policy document and
+      IAM expands ${...} policy variables inside Condition values: an audience
+      of ${accounts.google.com:aud} would expand to the presented token's own
+      aud claim and therefore match every token.
+      '*' is rejected because StringEquals compares it literally rather than
+      as a wildcard, silently producing a role nobody can assume.
 
   OIDCThumbprint:
     Type: String
@@ -58,16 +69,26 @@ Parameters:
       so any tenant of that issuer could assume this role and place
       irreversible multi-year commitment purchases in this account.
       Azure AD managed identity: the object ID of the managed identity.
-      GCP service account: the service account unique ID, or the form
-      system:serviceaccount:<project>:<sa-email>.
+      GCP service account: the service account's 21-digit numeric unique ID.
+      That is the sub claim accounts.google.com actually issues; it is not the
+      service account email. The system:serviceaccount:<namespace>:<name> form
+      is the Kubernetes subject format and belongs to a cluster OIDC issuer,
+      not to accounts.google.com.
       Mirrors the required oidc_subject_claim variable in the Terraform module.
     MinLength: 1
-    AllowedPattern: "^[^\\s*]$|^[^\\s*][^*]*[^\\s*]$"
+    AllowedPattern: "^[^\\s*$]$|^[^\\s*$][^*$]*[^\\s*$]$"
     ConstraintDescription: >
       OIDCSubjectClaim is required and must be a non-empty string with no
-      leading/trailing whitespace and no '*'. The trust policy matches the
-      subject with StringEquals, so a '*' is compared literally rather than
-      as a wildcard and would silently produce a role nobody can assume.
+      leading/trailing whitespace and containing no '$' or '*'.
+      '$' is rejected because the trust policy below is an IAM policy document
+      (Version 2012-10-17) and IAM expands ${...} policy variables inside
+      Condition values. A subject of ${accounts.google.com:sub} would expand
+      to the presented token's own sub claim, making the condition a tautology
+      that matches EVERY identity the issuer can mint. That is exactly the
+      hole this parameter exists to close, so it is rejected at submission
+      time rather than deployed.
+      '*' is rejected because StringEquals compares it literally rather than
+      as a wildcard, silently producing a role nobody can assume.
 
   RoleName:
     Type: String

--- a/iac/federation/aws-target/terraform/variables.tf
+++ b/iac/federation/aws-target/terraform/variables.tf
@@ -29,10 +29,14 @@ variable "oidc_audience" {
   # Same IAM policy-variable expansion hazard as oidc_subject_claim: an
   # audience of ${accounts.google.com:aud} expands to the token's own aud
   # claim and matches every token. Audience is the only other control on this
-  # trust policy, so it gets the same guard.
+  # trust policy, so it gets the same guard, including the whitespace
+  # rejection that keeps it equivalent to the CloudFormation AllowedPattern
+  # ^$|^[^\s*$]+$. An empty audience still passes (it contains none of the
+  # rejected characters) and falls back to sts.amazonaws.com, matching that
+  # pattern's ^$ branch without needing an explicit empty-string clause.
   validation {
-    condition     = !can(regex("[*$]", var.oidc_audience))
-    error_message = "oidc_audience must not contain '$' or '*'. IAM expands $${...} policy variables inside Condition values, so a value such as $${accounts.google.com:aud} would expand to the token's own aud claim and match every token. '*' is compared literally by StringEquals."
+    condition     = !can(regex("[\\s*$]", var.oidc_audience))
+    error_message = "oidc_audience must not contain whitespace, '$' or '*'. IAM expands $${...} policy variables inside Condition values, so a value such as $${accounts.google.com:aud} would expand to the token's own aud claim and match every token. '*' is compared literally by StringEquals."
   }
 }
 
@@ -40,8 +44,10 @@ variable "oidc_subject_claim" {
   description = <<-EOT
     Subject (sub) claim used to restrict OIDC trust to a specific identity.
     Azure AD managed identity: the object ID of the managed identity.
-    GCP service account:       the service account's 21-digit numeric unique
-                               ID. That is the sub claim accounts.google.com
+    GCP service account:       the service account's numeric unique ID
+                               (typically 21 digits; Google documents it as a
+                               numeric string without guaranteeing a length).
+                               That is the sub claim accounts.google.com
                                actually issues; it is not the SA email. The
                                system:serviceaccount:<namespace>:<name> form
                                is the Kubernetes subject format and belongs to
@@ -61,9 +67,14 @@ variable "oidc_subject_claim" {
   # expands to the presented token's own sub claim, making the condition a
   # tautology that matches every identity the issuer can mint. Reject '$'
   # outright rather than emit a trust policy that only looks restricted.
+  # Whitespace is rejected in the same expression so this stays byte-for-byte
+  # equivalent to the CloudFormation AllowedPattern ^[^\s*$]+$ that the
+  # template's ConstraintDescription claims to mirror. No real OIDC subject
+  # (GCP numeric IDs, Azure GUIDs, system:serviceaccount:, GitHub, GitLab,
+  # SPIFFE, Auth0, Bitbucket) contains whitespace.
   validation {
-    condition     = !can(regex("[*$]", var.oidc_subject_claim))
-    error_message = "oidc_subject_claim must not contain '$' or '*'. IAM expands $${...} policy variables inside Condition values, so a value such as $${accounts.google.com:sub} would expand to the token's own sub claim and match every identity the issuer can mint. '*' is compared literally by StringEquals and would silently produce a role nobody can assume."
+    condition     = !can(regex("[\\s*$]", var.oidc_subject_claim))
+    error_message = "oidc_subject_claim must not contain whitespace, '$' or '*'. IAM expands $${...} policy variables inside Condition values, so a value such as $${accounts.google.com:sub} would expand to the token's own sub claim and match every identity the issuer can mint. '*' is compared literally by StringEquals and would silently produce a role nobody can assume."
   }
 }
 

--- a/iac/federation/aws-target/terraform/variables.tf
+++ b/iac/federation/aws-target/terraform/variables.tf
@@ -19,18 +19,33 @@ variable "oidc_audience" {
     Expected audience (aud) in the OIDC token.
     Azure: api://<client_id>  or  <client_id>
     GCP:   https://iam.googleapis.com/projects/.../providers/...
-    Defaults to sts.amazonaws.com when empty.
+    Leaving this empty does not skip audience matching: both the trust policy
+    condition and the OIDC provider client ID list fall back to the literal
+    string sts.amazonaws.com.
   EOT
   type        = string
   default     = ""
+
+  # Same IAM policy-variable expansion hazard as oidc_subject_claim: an
+  # audience of ${accounts.google.com:aud} expands to the token's own aud
+  # claim and matches every token. Audience is the only other control on this
+  # trust policy, so it gets the same guard.
+  validation {
+    condition     = !can(regex("[*$]", var.oidc_audience))
+    error_message = "oidc_audience must not contain '$' or '*'. IAM expands $${...} policy variables inside Condition values, so a value such as $${accounts.google.com:aud} would expand to the token's own aud claim and match every token. '*' is compared literally by StringEquals."
+  }
 }
 
 variable "oidc_subject_claim" {
   description = <<-EOT
     Subject (sub) claim used to restrict OIDC trust to a specific identity.
     Azure AD managed identity: the object ID of the managed identity.
-    GCP service account:       the service account email in the form
-                               system:serviceaccount:<project>:<sa-email>.
+    GCP service account:       the service account's 21-digit numeric unique
+                               ID. That is the sub claim accounts.google.com
+                               actually issues; it is not the SA email. The
+                               system:serviceaccount:<namespace>:<name> form
+                               is the Kubernetes subject format and belongs to
+                               a cluster OIDC issuer, not accounts.google.com.
     This variable is required and must not be empty. An empty value would
     allow any principal in the same OIDC provider tenant to assume this role.
   EOT
@@ -39,6 +54,16 @@ variable "oidc_subject_claim" {
   validation {
     condition     = var.oidc_subject_claim != null && length(trimspace(var.oidc_subject_claim)) > 0
     error_message = "oidc_subject_claim must be set to a non-empty subject claim. Leaving it empty would allow any principal in the OIDC provider tenant to assume this role."
+  }
+
+  # assume_role_policy is an IAM policy document, and IAM expands ${...} policy
+  # variables inside Condition values. A subject of ${accounts.google.com:sub}
+  # expands to the presented token's own sub claim, making the condition a
+  # tautology that matches every identity the issuer can mint. Reject '$'
+  # outright rather than emit a trust policy that only looks restricted.
+  validation {
+    condition     = !can(regex("[*$]", var.oidc_subject_claim))
+    error_message = "oidc_subject_claim must not contain '$' or '*'. IAM expands $${...} policy variables inside Condition values, so a value such as $${accounts.google.com:sub} would expand to the token's own sub claim and match every identity the issuer can mint. '*' is compared literally by StringEquals and would silently produce a role nobody can assume."
   }
 }
 

--- a/known_issues/13_iac_aws_target.md
+++ b/known_issues/13_iac_aws_target.md
@@ -1,6 +1,48 @@
 # Known Issues: IaC AWS Target Federation
 
-> **Audit status (2026-04-20):** `0 still valid · 7 resolved · 0 partially fixed · 0 moved · 0 needs triage`
+> **Audit status (2026-07-28):** `1 still valid · 8 resolved · 0 partially fixed · 0 moved · 0 needs triage`
+
+## CRITICAL: federation bundle generator never emits `OIDCSubjectClaim`
+
+**File**: `internal/api/handler_federation.go` (`buildCFParamsJSON`), `internal/iacfiles/templates/aws-wif-cf-params.json.tmpl`, `internal/iacfiles/templates/aws-wif-cli.sh.tmpl`
+**Description**: The customer-facing onboarding bundle writes CloudFormation
+parameter overrides for `OIDCIssuerURL`, `OIDCIssuerHost`, `OIDCAudience` and
+`RoleName`, but never `OIDCSubjectClaim`. `aws-wif-cli.sh.tmpl` has the same
+shape: it documents `OIDC_SUBJECT_CLAIM` as "Optional" and builds a trust
+policy with no `:sub` condition when the variable is unset. Both paths
+therefore produce the unrestricted trust policy that issue #1543 removed from
+the template itself.
+**Impact**: Now that `OIDCSubjectClaim` is a required template parameter, the
+generated CloudFormation bundle fails at change-set creation with
+`Parameters: [OIDCSubjectClaim] must have values` — fail-closed, but the
+onboarding flow is broken until the generator is taught to emit the subject.
+The `aws-wif-cli.sh.tmpl` path does not go through CloudFormation and still
+creates a subject-less role.
+**Status:** ⚠️ Still valid — tracked as a follow-up to #1543, and not fixed in
+that PR because `internal/` was owned by concurrent in-flight branches.
+
+## ~~CRITICAL: CloudFormation `:sub` restriction is optional and defaults to trusting every issuer identity~~ — RESOLVED
+
+**File**: `iac/federation/aws-target/cloudformation/template.yaml:52-57`, `:64-66`, `:171-178`
+**Description**: `OIDCSubjectClaim` defaulted to `""` and a `HasSubject`
+condition selected a trust statement that omitted the `:sub` condition
+entirely, gating only on `<issuer>:aud`. With `OIDCAudience` also left at its
+default the audience collapsed to the literal `sts.amazonaws.com`, so any
+identity the issuer could mint — for the documented `accounts.google.com`
+issuer, any Google service account anywhere — could call
+`sts:AssumeRoleWithWebIdentity` and obtain `ec2:PurchaseReservedInstancesOffering`,
+`savingsplans:CreateSavingsPlan` and `rds:PurchaseReservedDBInstancesOffering`
+in the customer's account.
+**Impact**: Unauthenticated-in-practice takeover of the commitment-purchasing
+role in every customer account deployed with the default parameters. The
+purchases are irreversible multi-year spend.
+**Status:** ✔️ Resolved
+
+**Resolved by:** #1543 — removes the `HasSubject` condition and the
+subject-less trust statement, and makes `OIDCSubjectClaim` a required
+parameter (no `Default`, `MinLength: 1`, `AllowedPattern` rejecting
+whitespace-only and `*` values), mirroring the Terraform module's
+`oidc_subject_claim` validation.
 
 ## ~~CRITICAL: Terraform trust policy silently drops `:aud` condition when `oidc_subject_claim` is set~~ — RESOLVED
 
@@ -19,6 +61,11 @@
 **Status:** ✔️ Resolved
 
 **Resolved by:** `a96fc719f` — adds an `OIDCSubjectClaim` parameter and conditional `:sub` `StringEquals` alongside the existing `:aud` check.
+
+> **Follow-up:** the *conditional* form this entry describes was itself the
+> CRITICAL hole filed as #1543 — the parameter defaulted to `""` and the
+> condition then selected a subject-less trust statement. The `:sub` check is
+> now unconditional; see the #1543 entry above.
 
 ## ~~HIGH: `OIDCThumbprint` parameter has no format validation in CloudFormation~~ — RESOLVED
 

--- a/known_issues/13_iac_aws_target.md
+++ b/known_issues/13_iac_aws_target.md
@@ -4,22 +4,41 @@
 
 ## CRITICAL: federation bundle generator never emits `OIDCSubjectClaim`
 
-**File**: `internal/api/handler_federation.go` (`buildCFParamsJSON`), `internal/iacfiles/templates/aws-wif-cf-params.json.tmpl`, `internal/iacfiles/templates/aws-wif-cli.sh.tmpl`
+**File**:
+
+- `internal/api/handler_federation.go` (`buildCFParamsJSON`, and the
+  `format=cli` bundle selector at `:401`/`:415`)
+- `internal/iacfiles/templates/aws-wif-cf-params.json.tmpl`
+- `internal/iacfiles/templates/aws-wif-cli.sh.tmpl:17` (documents
+  `OIDC_SUBJECT_CLAIM` as Optional) and `:57-70` (else branch builds the role
+  with only the `:aud` condition and no `:sub`)
+- `internal/iacfiles/templates/aws-cfn-deploy.sh.tmpl:34-38`, the
+  `--parameter-overrides` list in the script that deploys the CloudFormation
+  bundle; it does not pass `OIDCSubjectClaim`
+- `internal/iacfiles/templates/aws-wif.tfvars.tmpl:14-15`, which emits
+  `# oidc_subject_claim = ""` labelled Optional, contradicting the REQUIRED
+  `oidc_subject_claim` variable in `terraform/variables.tf:28-42`
+
 **Description**: The customer-facing onboarding bundle writes CloudFormation
 parameter overrides for `OIDCIssuerURL`, `OIDCIssuerHost`, `OIDCAudience` and
 `RoleName`, but never `OIDCSubjectClaim`. `aws-wif-cli.sh.tmpl` has the same
 shape: it documents `OIDC_SUBJECT_CLAIM` as "Optional" and builds a trust
 policy with no `:sub` condition when the variable is unset. Both paths
 therefore produce the unrestricted trust policy that issue #1543 removed from
-the template itself.
+the template itself. The tfvars template repeats the claim that the subject is
+optional, and the deploy script never forwards the parameter.
 **Impact**: Now that `OIDCSubjectClaim` is a required template parameter, the
 generated CloudFormation bundle fails at change-set creation with
 `Parameters: [OIDCSubjectClaim] must have values` — fail-closed, but the
-onboarding flow is broken until the generator is taught to emit the subject.
-The `aws-wif-cli.sh.tmpl` path does not go through CloudFormation and still
-creates a subject-less role.
-**Status:** ⚠️ Still valid — tracked as a follow-up to #1543, and not fixed in
-that PR because `internal/` was owned by concurrent in-flight branches.
+onboarding flow is broken until the generator and `aws-cfn-deploy.sh.tmpl` are
+taught to emit the subject. The `aws-wif-cli.sh.tmpl` path does not go through
+CloudFormation at all: `format=cli` is a first-class user-selectable download,
+so a customer choosing the CLI bundle still gets exactly the subject-less
+role #1543 describes. The tfvars path is fail-closed (Terraform's variable
+validation rejects the omission) but misleads the operator first.
+**Status:** ⚠️ Still valid — tracked as a follow-up to #1543 in #1640, and not
+fixed in that PR because `internal/` was owned by concurrent in-flight
+branches.
 
 ## ~~CRITICAL: CloudFormation `:sub` restriction is optional and defaults to trusting every issuer identity~~ — RESOLVED
 
@@ -41,8 +60,20 @@ purchases are irreversible multi-year spend.
 **Resolved by:** #1543 — removes the `HasSubject` condition and the
 subject-less trust statement, and makes `OIDCSubjectClaim` a required
 parameter (no `Default`, `MinLength: 1`, `AllowedPattern` rejecting
-whitespace-only and `*` values), mirroring the Terraform module's
+whitespace-only values and any `*` or `$`), mirroring the Terraform module's
 `oidc_subject_claim` validation.
+
+`$` is rejected because `AssumeRolePolicyDocument` is an IAM policy document
+and IAM expands `${...}` policy variables inside `Condition` values. A subject
+of `${accounts.google.com:sub}` (a documented web-identity policy variable for
+the `accounts.google.com` issuer this template targets) expands to the
+presented token's own `sub` claim, making the condition a tautology that
+matches every identity the issuer can mint. An operator could reach that value
+by copy-pasting a placeholder or by running a templating layer that failed to
+interpolate, reconstructing the #1543 hole through the guard added to close
+it. The same guard is applied to `OIDCAudience` and to the Terraform
+`oidc_subject_claim` / `oidc_audience` variables, since audience is the only
+other control on this trust policy.
 
 ## ~~CRITICAL: Terraform trust policy silently drops `:aud` condition when `oidc_subject_claim` is set~~ — RESOLVED
 
@@ -135,7 +166,7 @@ whitespace-only and `*` values), mirroring the Terraform module's
 **Description**: A whitespace-only audience value previously created a trust policy that no token matches.
 **Status:** ✔️ Resolved
 
-**Resolved by:** Added `AllowedPattern: "^$|^\\S$|^\\S.*\\S$"` and `ConstraintDescription` to the `OIDCAudience` parameter. Empty strings remain allowed (HasAudience stays false); whitespace-only and leading/trailing-whitespace values are now rejected at change-set creation time.
+**Resolved by:** Added `AllowedPattern` and `ConstraintDescription` to the `OIDCAudience` parameter. Empty strings remain allowed (HasAudience stays false); whitespace-only and leading/trailing-whitespace values are now rejected at change-set creation time. #1543 tightened the pattern to `^$|^[^\\s*$]$|^[^\\s*$][^*$]*[^\\s*$]$`, additionally rejecting `*` and `$` for the IAM policy-variable-expansion reason described in the #1543 entry above.
 
 ### Original implementation plan
 

--- a/known_issues/13_iac_aws_target.md
+++ b/known_issues/13_iac_aws_target.md
@@ -34,8 +34,13 @@ onboarding flow is broken until the generator and `aws-cfn-deploy.sh.tmpl` are
 taught to emit the subject. The `aws-wif-cli.sh.tmpl` path does not go through
 CloudFormation at all: `format=cli` is a first-class user-selectable download,
 so a customer choosing the CLI bundle still gets exactly the subject-less
-role #1543 describes. The tfvars path is fail-closed (Terraform's variable
-validation rejects the omission) but misleads the operator first.
+role #1543 describes. The tfvars path is fail-closed, but not for the reason
+one might assume: with `oidc_subject_claim` commented out there is no value
+for a `validation` block to inspect, so the validations never fire. What makes
+it fail-closed is the **absent default** on the variable, which makes
+Terraform prompt for the value interactively or hard-error under
+`-input=false`. The validations only apply once a value exists. The security
+property holds; the operator is still misled by the "Optional" label first.
 **Status:** ⚠️ Still valid — tracked as a follow-up to #1543 in #1640, and not
 fixed in that PR because `internal/` was owned by concurrent in-flight
 branches.
@@ -60,7 +65,7 @@ purchases are irreversible multi-year spend.
 **Resolved by:** #1543 — removes the `HasSubject` condition and the
 subject-less trust statement, and makes `OIDCSubjectClaim` a required
 parameter (no `Default`, `MinLength: 1`, `AllowedPattern` rejecting
-whitespace-only values and any `*` or `$`), mirroring the Terraform module's
+any whitespace, `*` or `$`), mirroring the Terraform module's
 `oidc_subject_claim` validation.
 
 `$` is rejected because `AssumeRolePolicyDocument` is an IAM policy document
@@ -166,7 +171,7 @@ other control on this trust policy.
 **Description**: A whitespace-only audience value previously created a trust policy that no token matches.
 **Status:** ✔️ Resolved
 
-**Resolved by:** Added `AllowedPattern` and `ConstraintDescription` to the `OIDCAudience` parameter. Empty strings remain allowed (HasAudience stays false); whitespace-only and leading/trailing-whitespace values are now rejected at change-set creation time. #1543 tightened the pattern to `^$|^[^\\s*$]$|^[^\\s*$][^*$]*[^\\s*$]$`, additionally rejecting `*` and `$` for the IAM policy-variable-expansion reason described in the #1543 entry above.
+**Resolved by:** Added `AllowedPattern` and `ConstraintDescription` to the `OIDCAudience` parameter. Empty strings remain allowed (HasAudience stays false); whitespace-only and leading/trailing-whitespace values are now rejected at change-set creation time. #1543 tightened the pattern to `^$|^[^\\s*$]+$`, additionally rejecting `*`, `$` and interior whitespace for the IAM policy-variable-expansion reason described in the #1543 entry above.
 
 ### Original implementation plan
 


### PR DESCRIPTION
Refs #1543. Follow-up for the remaining attack surface: #1640.

> **Scope.** This PR closes the **CloudFormation and Terraform bundles**. It does **not** close the **CLI bundle**, so #1543 stays open until #1640 lands. See [Attack surface](#attack-surface-closed-vs-still-open) below.

`iac/federation/aws-target/cloudformation/template.yaml` made the OIDC subject restriction optional: `OIDCSubjectClaim` defaulted to `""`, and a `HasSubject` condition selected a trust statement that omitted the `<issuer>:sub` condition entirely, gating only on `<issuer>:aud`. With `OIDCAudience` also left at its default, the audience collapsed to the literal `sts.amazonaws.com`.

Customers deploy this template into **their own AWS accounts**. With the documented `accounts.google.com` issuer and the default parameters, any Google service account anywhere could mint an ID token with `audience=sts.amazonaws.com`, present it to `sts:AssumeRoleWithWebIdentity`, and land in the customer account holding `ec2:PurchaseReservedInstancesOffering`, `savingsplans:CreateSavingsPlan` and `rds:PurchaseReservedDBInstancesOffering`. Those are irreversible multi-year spend commitments, reachable by anyone who could read the role ARN.

The Terraform sibling already refuses this (`oidc_subject_claim` has no default and validates against empty values); this brings the CloudFormation path to parity.

## Changes

- Drop the `HasSubject` condition and the subject-less trust statement, so the `:sub` condition is always present.
- Make `OIDCSubjectClaim` required: no `Default`, `MinLength: 1`, and an `AllowedPattern` rejecting whitespace-only values and any `*` or `$`.
- Apply the same `$` / `*` rejection to `OIDCAudience`, and to the Terraform `oidc_subject_claim` and `oidc_audience` variables.
- Correct two documentation errors (GCP subject format, and the false "leave empty to skip audience matching" claim).
- Record the finding and the still-open bundle-generator gap in `known_issues/13_iac_aws_target.md`.

### Why `$` had to be rejected: the guard was fail-open

The first version of the `AllowedPattern` rejected whitespace and `*` but still admitted `$`. An adversarial review found that left the guard **fail-open**.

`AssumeRolePolicyDocument` is an IAM policy document (`Version: 2012-10-17`), and IAM expands `${...}` policy variables inside Condition **values**, not only in resource ARNs. AWS documents `${accounts.google.com:sub}` and `${accounts.google.com:aud}` as valid web-identity policy variables, for exactly the `accounts.google.com` issuer this template documents. So an operator who sets:

```
OIDCSubjectClaim=${accounts.google.com:sub}
```

renders the condition:

```json
"accounts.google.com:sub": "${accounts.google.com:sub}"
```

IAM expands that to the presented token's own `sub` claim. The condition compares every subject **to itself**: it is a tautology satisfied by every token the issuer can mint. That is the #1543 hole reconstructed through the very parameter added to close it. The value is reachable by copy-pasting a placeholder, by a templating layer that failed to interpolate, or by a generator emitting an unresolved variable.

Contrast with `*`, which `StringEquals` compares **literally** and which therefore only produces a dead role that nobody can assume. `*` fails closed; `$` fails **open**. Both are now rejected at submission time.

Audience is hardened in the same pass because, with the subject now pinned, `aud` is the only other control on this trust policy.

### Verified pattern behaviour

Final patterns, both a single anchored character class:

```
OIDCSubjectClaim  ^[^\s*$]+$
OIDCAudience   ^$|^[^\s*$]+$
```

Both were parsed back **out of the committed YAML** (not retyped) and checked as an anchored full match over 43 inputs, 0 mismatches. Every legitimate format passes; every whitespace, `$` and `*` form is rejected.

**Legitimate formats, all PASS both patterns** (18 checked): GCP service-account numeric unique IDs (21- and 20-digit), Azure object-ID GUIDs, Azure `api://<guid>`, Kubernetes `system:serviceaccount:ns:name`, GitHub Actions `repo:org/repo:ref:refs/heads/main` and `repo:org/repo:environment:production`, GitLab `project_path:group/project:ref_type:branch:ref:main`, SPIFFE `spiffe://cluster.local/ns/default/sa/my-app`, Auth0 `auth0|5f7c...` and `google-oauth2|1034...`, Bitbucket `{f7c8ec7c-...}`, the GCP workload-identity-pool provider URL, `sts.amazonaws.com`, LDAP-style DNs, URNs, and a single character.

**All REJECTED by both patterns** (22 checked): `" "`, `"   "`, tab, newline, leading and trailing whitespace, **interior space**, **interior newline**, **interior tab**, `*`, `a*b`, `*abc`, `abc*`, `$`, `$$`, `abc$def`, `${accounts.google.com:sub}`, `${accounts.google.com:aud}`, `${aws:userid}`, `${aws:PrincipalTag/x}`, `x${accounts.google.com:sub}`, `${accounts.google.com:sub}x`.

Empty string: subject FAILS (required), audience PASSES (falls back to `sts.amazonaws.com`).

The simplified `^[^\s*$]+$` is **provably identical** to the three-branch form it replaces (`^[^\s*$]$|^[^\s*$][^\s*$]*[^\s*$]$`) once the middle class matches the edge classes. The verification asserts that equivalence across the whole corpus rather than assuming it, so the simplification is not a second behaviour change.

**Interior whitespace was tightened, not left.** Two independent reviews noted that the earlier middle class `[^*$]` still admitted `a b` and `ab\ncd`. Neither called it a finding, correctly: such a value carries no `$` or `*`, so no policy-variable expansion; CloudFormation JSON-escapes it, so no injection; and no real `sub`/`aud` claim contains whitespace, so the result is a subject nothing equals, i.e. a dead role. Fail-closed. It is tightened here only because a push was happening anyway, and none of the 18 real formats above contains whitespace.

**One recorded engine divergence, fail-closed.** Java's `\s` is ASCII-only while Python's is Unicode-aware, so a value containing a non-breaking space (U+00A0) or em space (U+2003) is rejected by the local verification but would be **accepted** by CloudFormation's Java engine. This is not claimed as blocked. It remains fail-closed for the same reason as above: no `$` or `*` means no policy-variable expansion, and no real claim contains those characters. This is a documentation-accuracy point, not a hole.

**One uncited claim, flagged rather than dressed up.** The parameter documentation now says the GCP service-account subject is a "numeric unique ID (typically 21 digits; Google documents it as a numeric string without guaranteeing a length)". The *no-guaranteed-length* part was not sourced against Google's published documentation by anyone in this review chain. The wording is deliberately weaker than the "21-digit" assertion it replaces, so it holds whether or not a length guarantee exists somewhere, but it should not be read as a verified citation.

## Attack surface: closed vs. still open

**Closed by this PR:**

- The checked-in **CloudFormation** template (`iac/federation/aws-target/cloudformation/`). The `:sub` condition is unconditional and the parameter cannot hold a tautology.
- The checked-in **Terraform** module (`iac/federation/aws-target/terraform/`), which gains the same `$` / `*` rejection on both `oidc_subject_claim` and `oidc_audience`.

**Why Terraform is fixed in the same PR rather than deferred.** The Terraform sibling had the *identical* fail-open: `oidc_subject_claim` validated only non-emptiness, and `oidc_audience` had no validation at all. The CloudFormation `ConstraintDescription` explicitly claims parity with it ("Mirrors the required `oidc_subject_claim` variable in the Terraform module"). Fixing only the CloudFormation path would leave the same tautology exploitable through Terraform *while the docs assert the two are equivalent*, which is worse than fixing either both or neither, because a reader is actively misled about coverage. That is the same "sibling instance" shape that already bit this PR once: the CLI bundle still ships the vulnerable policy, which is exactly why the trailer is now `Refs` rather than `Closes`. Fixing one instance of a defect class while a named-as-equivalent sibling keeps it is the pattern to avoid. Blast radius is contained: `iac/federation/aws-target/` has no other open PR touching it.

**Still open, tracked in #1640:**

- The **CLI bundle** is exploitable. `internal/iacfiles/templates/aws-wif-cli.sh.tmpl:17` still treats `OIDC_SUBJECT_CLAIM` as optional, and its else branch (`:57-70`) creates the role with only the `:aud` condition and no `:sub`. `format=cli` is a first-class user-selectable download (`internal/api/handler_federation.go:401,415`), so a customer choosing the CLI bundle still gets exactly the role #1543 describes. This path never goes through CloudFormation, so nothing rejects it.
- `internal/iacfiles/templates/aws-cfn-deploy.sh.tmpl:34-38` does not forward `OIDCSubjectClaim`, so the CloudFormation onboarding flow is now **broken** (fail-closed) until the script is updated.
- `internal/iacfiles/templates/aws-wif.tfvars.tmpl:14-15` labels `oidc_subject_claim` Optional, contradicting the required Terraform variable (fail-closed, but misleading).

`internal/` is owned by concurrent in-flight branches, so it is deliberately untouched here. **The trailer is `Refs #1543`, not `Closes`**, so merging this does not auto-close a p0/CRITICAL whose exploit is still reachable through the CLI bundle.

## Breaking change

Stacks deployed with the blank default now **fail to update** until `OIDCSubjectClaim` is supplied. That is deliberate; the alternative is leaving an open trust policy in place. The rendered trust policy for stacks that already set a subject is byte-identical.

**Existing deployments remain vulnerable until they redeploy with a subject claim set.**

**Second breaking surface: the audience and the Terraform variables.** The `OIDCAudience` `AllowedPattern` was tightened in the same pass, and the Terraform module gained validations on `oidc_subject_claim` and `oidc_audience`. So an existing stack, or an existing `.tfvars`, carrying whitespace, `$` or `*` in **either** value will now fail at change-set creation or at `terraform plan` rather than applying. Realistically no such deployment exists (none of the 18 real subject/audience formats contains any of those characters, and a `$` value would have been a live tautology), but it is a second way this PR can break an existing deployment and it should not go unmentioned.

## Verification

| Gate | Result |
|---|---|
| Both `AllowedPattern`s re-parsed from the committed YAML and checked against 43 inputs (18 legitimate formats, 22 rejections, empty-string asymmetry) | exit 0, 0 mismatches |
| Simplified vs three-branch pattern equivalence proven over the full corpus | identical on all 43 |
| CFN-tag-aware YAML parse (trust policy pins both `:aud` and `:sub`; `HasSubject` gone; subject has no `Default`, `MinLength: 1`) | exit 0 |
| `terraform validate` / `terraform fmt -check` / `tflint` | exit 0 |
| Terraform validations exercised with `terraform plan`, both variables | tautology, `*` and interior whitespace rejected; real GCP subject, `system:serviceaccount:`, `sts.amazonaws.com` and empty audience accepted |
| CI on the previous commit `c945995d0` (all 4 runs) | `CI - Build & Test`, `pre-commit`, AWS Sanity, Azure Sanity: all success |
| `markdownlint` (repo config) | exit 0 |
| pre-commit hooks over the commit range (markdownlint, terraform_fmt/validate/tflint, trailing-whitespace, end-of-file-fixer, git-secrets, detect-private-key) | all Passed, exit 0 |

**Do not read the `CodeRabbit` check on this commit either way.** For `c945995d0` it reports `state=success` with `description="Review rate limited"` (updated `19:05:00Z`), while a genuine full-range CodeRabbit review *did* run and posted at `19:04:55Z`. The status is unreliable in both directions here: green does not mean a review happened, and the "rate limited" text does not mean one did not. The truth lives only in the comment stream. This is the hazard documented in #1530.

`cfn-lint` **cannot** lint this template: it exits **2** with `E0000 Unhashable type "{'Fn::Sub': '${OIDCIssuerHost}:aud'}"`. That is a known cfn-lint limitation with intrinsics in mapping-**key** position, it is pre-existing since `bf19197ea` (identical exit 2 on the parent commit's template), and it is why `.pre-commit-config.yaml` excludes `iac/.*/cloudformation/.*` from `check-yaml`. It is a tool limitation, not a template defect, and is **not** recorded as a passing gate. There is no `cfn-lint` or `validate-template` step anywhere in CI, so no automated check guards this file.

## Provenance

The original fix was authored and pushed but its PR was never opened, because the authoring session hit an account-level limit immediately afterwards. Recovered from the pushed branch rather than re-implemented. The `$` fail-open gap was found by a subsequent independent adversarial review of that commit.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Federation configuration now always requires a non-empty OIDC subject claim.
  - Empty OIDC audiences now default to `sts.amazonaws.com` instead of disabling audience matching.
  - Trust policies consistently enforce subject and audience restrictions.

- **Bug Fixes**
  - Added validation to reject whitespace and unsafe characters in OIDC audience and subject values.
  - Improved protection against malformed or overly permissive trust policies.

- **Documentation**
  - Updated known-issue tracking and documented a limitation affecting federation bundle generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
