### PR TITLE
fix(arm): pin GCP WIF attribute condition and narrow SA grant

### DIFF
--- a/arm/CUDly-CrossSubscription/setup-gcp-wif.sh
+++ b/arm/CUDly-CrossSubscription/setup-gcp-wif.sh
@@ -4,6 +4,11 @@
 # account key file.  Outputs the external-account credential config JSON that
 # should be stored as gcp_workload_identity_config in CUDly.
 #
+# SECURITY: the provider is always created with an --attribute-condition and the
+# service account impersonation grant is always scoped to a single principal.
+# Both require an explicit identity to pin (--aws-role-name / --oidc-subject);
+# there is no permissive default, and the script exits nonzero if one is missing.
+#
 # Prerequisites:
 #   gcloud auth login (with roles/iam.workloadIdentityPoolAdmin + roles/iam.serviceAccountAdmin
 #   on the target project, and roles/iam.serviceAccountTokenCreator on the SA)
@@ -15,6 +20,7 @@
 #       --provider-id cudly-aws \
 #       --provider-type aws \
 #       --aws-account-id 123456789012 \
+#       --aws-role-name CUDly-Execution \
 #       --sa-email cudly@my-gcp-project.iam.gserviceaccount.com
 #
 # Usage (OIDC provider):
@@ -24,7 +30,15 @@
 #       --provider-id cudly-oidc \
 #       --provider-type oidc \
 #       --issuer-uri https://token.actions.githubusercontent.com \
+#       --oidc-subject 'repo:my-org/my-repo:ref:refs/heads/main' \
 #       --sa-email cudly@my-gcp-project.iam.gserviceaccount.com
+#
+# Upgrading from an earlier run: versions of this script before the
+# --aws-role-name / --oidc-subject requirement granted
+# roles/iam.workloadIdentityUser to every identity in the pool
+# (principalSet://.../workloadIdentityPools/<pool>/*). Re-running this script
+# detects that binding and refuses to report success while it exists; pass
+# --remove-legacy-pool-binding to delete it once the narrow grant is in place.
 
 set -euo pipefail
 
@@ -34,11 +48,12 @@ PROVIDER_ID="cudly-provider"
 PROVIDER_TYPE=""   # "aws" or "oidc"
 SA_EMAIL=""
 AWS_ACCOUNT_ID=""
+AWS_ROLE_NAME=""
 ISSUER_URI=""
-# Optional: restrict which OIDC subject (sub claim) may impersonate the SA.
-# Example: "assertion.sub=='repo:my-org/my-repo:ref:refs/heads/main'" (GitHub Actions)
-# STRONGLY RECOMMENDED for public issuers to prevent privilege escalation.
-SUBJECT_CONDITION=""
+OIDC_SUBJECT=""
+REMOVE_LEGACY_POOL_BINDING="false"
+
+die() { echo "Error: $*" >&2; exit 1; }
 
 # ── Argument parsing ───────────────────────────────────────────────────────────
 while [[ $# -gt 0 ]]; do
@@ -49,35 +64,89 @@ while [[ $# -gt 0 ]]; do
     --provider-type)     PROVIDER_TYPE="$2";     shift 2 ;;
     --sa-email)          SA_EMAIL="$2";          shift 2 ;;
     --aws-account-id)    AWS_ACCOUNT_ID="$2";    shift 2 ;;
+    --aws-role-name)     AWS_ROLE_NAME="$2";     shift 2 ;;
     --issuer-uri)        ISSUER_URI="$2";        shift 2 ;;
-    --subject-condition) SUBJECT_CONDITION="$2"; shift 2 ;;
-    *) echo "Unknown argument: $1" >&2; exit 1 ;;
+    --oidc-subject)      OIDC_SUBJECT="$2";      shift 2 ;;
+    --remove-legacy-pool-binding) REMOVE_LEGACY_POOL_BINDING="true"; shift ;;
+    # Removed on purpose: --subject-condition took a raw CEL expression, so a
+    # value such as "true" or "assertion.sub != ''" looked like a restriction
+    # while admitting every subject from the issuer. --oidc-subject takes the
+    # subject itself and this script builds the equality condition around it.
+    --subject-condition)
+      die "--subject-condition has been removed; pass --oidc-subject '<exact sub claim>' instead (this script builds the attribute condition, so a hand-written CEL expression can no longer silently admit every subject)" ;;
+    *) die "Unknown argument: $1" ;;
   esac
 done
 
-# ── Validate required args ─────────────────────────────────────────────────────
+# ── Value validation ───────────────────────────────────────────────────────────
+# Every value below is interpolated into either the provider's CEL
+# --attribute-condition or the IAM principal identifier of the impersonation
+# grant. Reject the forms that fail OPEN there rather than merely looking wrong:
+#   '*'      would widen an IAM principal identifier to match every identity;
+#   '$'      catches pasted ${...} placeholders, which IAM does not expand here
+#            (they yield a binding that matches nothing, or in a context that
+#            does expand them, one that matches everything);
+#   ' " \ `  would terminate the CEL string literal in --attribute-condition and
+#            let the rest of the value rewrite the condition (e.g. "|| true").
+validate_principal_value() {
+  local flag="$1" value="$2" pattern="$3"
+  [[ -n "$value" ]] || die "$flag must not be empty"
+  case "$value" in
+    *'*'*) die "$flag must not contain '*' (got: $value): a wildcard would match every identity and defeat the restriction this flag exists to apply" ;;
+    *'$'*) die "$flag must not contain '\$' (got: $value): it looks like an unexpanded \${...} placeholder, which is not substituted here" ;;
+    *\'*|*\"*|*\\*|*'`'*) die "$flag must not contain quotes or backslashes (got: $value): they would break out of the CEL string literal in the provider's attribute condition" ;;
+  esac
+  [[ "$value" =~ $pattern ]] || die "$flag has an unexpected format (got: $value)"
+}
+
 if [[ -z "$PROJECT" || -z "$SA_EMAIL" || -z "$PROVIDER_TYPE" ]]; then
-  echo "Error: --project, --sa-email, and --provider-type are required" >&2
-  exit 1
-fi
-if [[ "$PROVIDER_TYPE" == "aws" && -z "$AWS_ACCOUNT_ID" ]]; then
-  echo "Error: --aws-account-id is required for --provider-type aws" >&2
-  exit 1
-fi
-if [[ "$PROVIDER_TYPE" == "oidc" && -z "$ISSUER_URI" ]]; then
-  echo "Error: --issuer-uri is required for --provider-type oidc" >&2
-  exit 1
+  die "--project, --sa-email, and --provider-type are required"
 fi
 if [[ "$PROVIDER_TYPE" != "aws" && "$PROVIDER_TYPE" != "oidc" ]]; then
-  echo "Error: --provider-type must be 'aws' or 'oidc'" >&2
-  exit 1
+  die "--provider-type must be 'aws' or 'oidc'"
+fi
+
+validate_principal_value "--project"     "$PROJECT"     '^[a-z][-a-z0-9]{4,28}[a-z0-9]$'
+validate_principal_value "--pool-id"     "$POOL_ID"     '^[a-z0-9][-a-z0-9]{2,30}[a-z0-9]$'
+validate_principal_value "--provider-id" "$PROVIDER_ID" '^[a-z0-9][-a-z0-9]{2,30}[a-z0-9]$'
+validate_principal_value "--sa-email"    "$SA_EMAIL"    '^[a-zA-Z0-9][-a-zA-Z0-9._]*@[a-z0-9.-]+\.gserviceaccount\.com$'
+
+if [[ "$PROVIDER_TYPE" == "aws" ]]; then
+  [[ -n "$AWS_ACCOUNT_ID" ]] || die "--aws-account-id is required for --provider-type aws"
+  # Mandatory: without a role to pin, the provider has no attribute condition and
+  # every IAM principal in the AWS account can federate as the service account.
+  [[ -n "$AWS_ROLE_NAME" ]] || die "--aws-role-name is required for --provider-type aws. Without it the provider has no attribute condition and any IAM role in account ${AWS_ACCOUNT_ID} can federate as ${SA_EMAIL}."
+  validate_principal_value "--aws-account-id" "$AWS_ACCOUNT_ID" '^[0-9]{12}$'
+  validate_principal_value "--aws-role-name"  "$AWS_ROLE_NAME"  '^[A-Za-z0-9_+=.@-]{1,64}$'
+  # Standard AWS partition. A GovCloud or China-partition caller presents a
+  # different ARN prefix, so the condition below simply would not match: the
+  # token exchange is refused rather than admitted on a partition mismatch.
+  AWS_ROLE_ARN="arn:aws:sts::${AWS_ACCOUNT_ID}:assumed-role/${AWS_ROLE_NAME}"
+else
+  [[ -n "$ISSUER_URI" ]] || die "--issuer-uri is required for --provider-type oidc"
+  # Mandatory: public issuers such as token.actions.githubusercontent.com will
+  # mint a token for any workload on the platform, so without a pinned subject
+  # any repository in the world can federate as the service account.
+  [[ -n "$OIDC_SUBJECT" ]] || die "--oidc-subject is required for --provider-type oidc. Without it the provider has no attribute condition and any subject issued by ${ISSUER_URI} can federate as ${SA_EMAIL}."
+  validate_principal_value "--issuer-uri"   "$ISSUER_URI"   '^https://[a-zA-Z0-9.-]+(:[0-9]+)?(/[-a-zA-Z0-9._~/]*)?$'
+  validate_principal_value "--oidc-subject" "$OIDC_SUBJECT" '^[A-Za-z0-9][-A-Za-z0-9._:/@=+~]*$'
+  # google.subject is capped at 127 characters by GCP; a longer value would be
+  # rejected at token-exchange time, long after this script reported success.
+  [[ ${#OIDC_SUBJECT} -le 127 ]] || die "--oidc-subject must be at most 127 characters (google.subject limit); got ${#OIDC_SUBJECT}"
 fi
 
 PROJECT_NUMBER=$(gcloud projects describe "$PROJECT" --format='value(projectNumber)')
+[[ "$PROJECT_NUMBER" =~ ^[0-9]+$ ]] || die "could not resolve a numeric project number for '$PROJECT' (got: '$PROJECT_NUMBER')"
+
 echo "Project       : $PROJECT (number: $PROJECT_NUMBER)"
 echo "Pool          : $POOL_ID"
 echo "Provider      : $PROVIDER_ID ($PROVIDER_TYPE)"
 echo "Service Acct  : $SA_EMAIL"
+if [[ "$PROVIDER_TYPE" == "aws" ]]; then
+  echo "Trusted role  : $AWS_ROLE_ARN"
+else
+  echo "Trusted subj  : $OIDC_SUBJECT (issuer: $ISSUER_URI)"
+fi
 echo ""
 
 # ── Idempotent pool creation ───────────────────────────────────────────────────
@@ -89,6 +158,14 @@ if ! gcloud iam workload-identity-pools describe "$POOL_ID" \
     --display-name="CUDly WIF pool" --quiet
 else
   echo "Reusing existing pool '${POOL_ID}'"
+  # GCP principal identifiers are pool-scoped, not provider-scoped: the grant
+  # below names an attribute value, and any provider in this pool that can mint
+  # that attribute satisfies it. A pool dedicated to this provider keeps the
+  # trust boundary equal to the attribute condition set below.
+  echo "Note: principal identifiers are pool-scoped, not provider-scoped. Another" >&2
+  echo "      provider in this pool that maps the same attribute value would also" >&2
+  echo "      satisfy the grant below. Use a pool dedicated to CUDly (--pool-id)" >&2
+  echo "      unless you intend to share it." >&2
 fi
 
 # ── Idempotent provider creation ───────────────────────────────────────────────
@@ -97,49 +174,92 @@ if ! gcloud iam workload-identity-pools providers describe "$PROVIDER_ID" \
      --workload-identity-pool="$POOL_ID" &>/dev/null; then
   echo "Creating ${PROVIDER_TYPE} provider '${PROVIDER_ID}'..."
   if [[ "$PROVIDER_TYPE" == "aws" ]]; then
+    # attribute.aws_role normalises the session ARN
+    # (arn:aws:sts::<acct>:assumed-role/<role>/<session>) down to the role ARN,
+    # so both the condition below and the IAM grant can match it exactly instead
+    # of relying on a substring test.
     gcloud iam workload-identity-pools providers create-aws "$PROVIDER_ID" \
       --project="$PROJECT" --location=global \
       --workload-identity-pool="$POOL_ID" \
-      --account-id="$AWS_ACCOUNT_ID" --quiet
+      --account-id="$AWS_ACCOUNT_ID" \
+      --attribute-mapping="google.subject=assertion.arn,attribute.aws_role=assertion.arn.contains('assumed-role') ? assertion.arn.extract('{account_arn}assumed-role/') + 'assumed-role/' + assertion.arn.extract('assumed-role/{role_name}/') : assertion.arn" \
+      --attribute-condition="attribute.aws_role == '${AWS_ROLE_ARN}'" \
+      --quiet
   else
     # --attribute-mapping is required; without it no subject claims are mapped and
-    # all token exchanges will be rejected at runtime despite successful pool setup.
-    # --attribute-condition restricts which OIDC subjects can impersonate the SA.
-    # For public issuers (GitHub Actions, etc.) omitting --attribute-condition allows
-    # ANY token from the issuer to impersonate — pass --subject-condition to scope it.
-    if [[ -z "$SUBJECT_CONDITION" ]]; then
-      echo "WARNING: --subject-condition not set. Any OIDC token from '${ISSUER_URI}'" >&2
-      echo "         will be able to impersonate ${SA_EMAIL}." >&2
-      echo "         For public issuers pass e.g. --subject-condition \"assertion.sub=='<your-subject>'\"" >&2
-    fi
-    OIDC_ARGS=(
-      "$PROVIDER_ID"
-      --project="$PROJECT" --location=global
-      --workload-identity-pool="$POOL_ID"
-      --issuer-uri="$ISSUER_URI"
-      --attribute-mapping="google.subject=assertion.sub"
+    # all token exchanges are rejected at runtime despite a successful setup.
+    # --attribute-condition is built here from --oidc-subject so that only that
+    # exact subject is admitted to the pool.
+    gcloud iam workload-identity-pools providers create-oidc "$PROVIDER_ID" \
+      --project="$PROJECT" --location=global \
+      --workload-identity-pool="$POOL_ID" \
+      --issuer-uri="$ISSUER_URI" \
+      --attribute-mapping="google.subject=assertion.sub" \
+      --attribute-condition="google.subject == '${OIDC_SUBJECT}'" \
       --quiet
-    )
-    if [[ -n "$SUBJECT_CONDITION" ]]; then
-      OIDC_ARGS+=(--attribute-condition="$SUBJECT_CONDITION")
-    fi
-    gcloud iam workload-identity-pools providers create-oidc "${OIDC_ARGS[@]}"
   fi
 else
-  echo "Reusing existing provider '${PROVIDER_ID}'"
+  # An existing provider keeps whatever attribute condition it was created with,
+  # including none at all. Do not report success over a provider this script
+  # cannot vouch for.
+  EXISTING_CONDITION=$(gcloud iam workload-identity-pools providers describe "$PROVIDER_ID" \
+    --project="$PROJECT" --location=global \
+    --workload-identity-pool="$POOL_ID" \
+    --format='value(attributeCondition)')
+  if [[ -z "$EXISTING_CONDITION" ]]; then
+    die "provider '${PROVIDER_ID}' already exists with no attribute condition, so every identity it accepts can enter pool '${POOL_ID}'. Delete it and re-run:
+  gcloud iam workload-identity-pools providers delete ${PROVIDER_ID} --project=${PROJECT} --location=global --workload-identity-pool=${POOL_ID}"
+  fi
+  echo "Reusing existing provider '${PROVIDER_ID}' (attribute condition: ${EXISTING_CONDITION})"
 fi
 
-# ── Grant service account impersonation to the pool ───────────────────────────
-POOL_PRINCIPAL="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL_ID}/*"
-echo "Granting roles/iam.workloadIdentityUser to pool members on ${SA_EMAIL}..."
+# ── Grant service account impersonation to one principal ──────────────────────
+POOL_RESOURCE="projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL_ID}"
+if [[ "$PROVIDER_TYPE" == "aws" ]]; then
+  # Session ARNs carry a per-session suffix, so the grant names the normalised
+  # role attribute rather than an exact subject.
+  MEMBER="principalSet://iam.googleapis.com/${POOL_RESOURCE}/attribute.aws_role/${AWS_ROLE_ARN}"
+else
+  MEMBER="principal://iam.googleapis.com/${POOL_RESOURCE}/subject/${OIDC_SUBJECT}"
+fi
+echo "Granting roles/iam.workloadIdentityUser on ${SA_EMAIL} to:"
+echo "  ${MEMBER}"
 gcloud iam service-accounts add-iam-policy-binding "$SA_EMAIL" \
   --role=roles/iam.workloadIdentityUser \
-  --member="$POOL_PRINCIPAL" \
+  --member="$MEMBER" \
   --project="$PROJECT" \
   --quiet
 
+# ── Retire the pool-wide grant left by earlier versions of this script ────────
+LEGACY_MEMBER="principalSet://iam.googleapis.com/${POOL_RESOURCE}/*"
+# Fetched into a variable first: a pipeline straight into grep would let a failed
+# get-iam-policy read as "no legacy binding found" and report success over one.
+SA_POLICY=$(gcloud iam service-accounts get-iam-policy "$SA_EMAIL" \
+  --project="$PROJECT" --format=json)
+if grep -qF -- "$LEGACY_MEMBER" <<<"$SA_POLICY"; then
+  if [[ "$REMOVE_LEGACY_POOL_BINDING" == "true" ]]; then
+    echo "Removing legacy pool-wide impersonation grant..."
+    gcloud iam service-accounts remove-iam-policy-binding "$SA_EMAIL" \
+      --role=roles/iam.workloadIdentityUser \
+      --member="$LEGACY_MEMBER" \
+      --project="$PROJECT" \
+      --quiet
+  else
+    die "${SA_EMAIL} still grants roles/iam.workloadIdentityUser to every identity in pool '${POOL_ID}':
+  ${LEGACY_MEMBER}
+That grant was created by an earlier version of this script and makes the narrow
+grant added above irrelevant: anything admitted to the pool can still impersonate
+the service account. Re-run this command with --remove-legacy-pool-binding, or
+remove it yourself with:
+  gcloud iam service-accounts remove-iam-policy-binding ${SA_EMAIL} \\
+    --role=roles/iam.workloadIdentityUser \\
+    --member='${LEGACY_MEMBER}' \\
+    --project=${PROJECT}"
+  fi
+fi
+
 # ── Generate external account credential config (no secrets) ──────────────────
-PROVIDER_RESOURCE="projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL_ID}/providers/${PROVIDER_ID}"
+PROVIDER_RESOURCE="${POOL_RESOURCE}/providers/${PROVIDER_ID}"
 echo ""
 echo "══════════════════════════════════════════════════════════════"
 echo "  External account credential config (store in CUDly as"

--- a/arm/CUDly-CrossSubscription/setup-gcp-wif.sh
+++ b/arm/CUDly-CrossSubscription/setup-gcp-wif.sh
@@ -127,10 +127,12 @@ if [[ "$PROVIDER_TYPE" == "aws" ]]; then
   AWS_ROLE_ARN="arn:aws:sts::${AWS_ACCOUNT_ID}:assumed-role/${AWS_ROLE_NAME}"
   EXPECTED_CONDITION="attribute.aws_role == '${AWS_ROLE_ARN}'"
   # google.subject is the full session ARN here and GCP caps it at 127 chars.
-  # "arn:aws:sts::<12 digits>:assumed-role/<role>/<session>" leaves
-  # 127 - 38 - len(role) - 1 for the session name, which AWS allows up to 64.
-  if [[ $((127 - 38 - ${#AWS_ROLE_NAME} - 1)) -lt 64 ]]; then
-    echo "Note: role name '${AWS_ROLE_NAME}' leaves only $((127 - 38 - ${#AWS_ROLE_NAME} - 1)) characters" >&2
+  # "arn:aws:sts::<12 digits>:assumed-role/" is 39 characters, and the session
+  # name is preceded by a "/", so the role name leaves 127 - 39 - len(role) - 1
+  # for a session name that AWS allows to reach 64.
+  AWS_SESSION_BUDGET=$((127 - 39 - ${#AWS_ROLE_NAME} - 1))
+  if [[ $AWS_SESSION_BUDGET -lt 64 ]]; then
+    echo "Note: role name '${AWS_ROLE_NAME}' leaves only ${AWS_SESSION_BUDGET} characters" >&2
     echo "      for the session name before google.subject exceeds GCP's 127-character" >&2
     echo "      limit. Longer session names will be rejected at token-exchange time." >&2
   fi
@@ -174,15 +176,21 @@ if ! gcloud iam workload-identity-pools describe "$POOL_ID" \
     --display-name="CUDly WIF pool" --quiet
 else
   echo "Reusing existing pool '${POOL_ID}'"
-  # GCP principal identifiers are pool-scoped, not provider-scoped: the grant
-  # below names an attribute value, and any provider in this pool that can mint
-  # that attribute satisfies it. A pool dedicated to this provider keeps the
-  # trust boundary equal to the attribute condition set below.
-  echo "Note: principal identifiers are pool-scoped, not provider-scoped. Another" >&2
-  echo "      provider in this pool that maps the same attribute value would also" >&2
-  echo "      satisfy the grant below. Use a pool dedicated to CUDly (--pool-id)" >&2
-  echo "      unless you intend to share it." >&2
 fi
+
+# GCP principal identifiers are pool-scoped, not provider-scoped: the grant below
+# names an attribute value, and any provider in this pool that can mint that
+# attribute satisfies it. A pool dedicated to this provider keeps the trust
+# boundary equal to the attribute condition set below.
+#
+# Printed unconditionally, not only when reusing a pool: a pool this run creates
+# fresh is equally exposed the moment a second provider is added to it later, and
+# that operator would otherwise never have seen the warning. No script can close
+# this - GCP has no provider-scoped principal form - so a notice is the ceiling.
+echo "Note: principal identifiers are pool-scoped, not provider-scoped. Another" >&2
+echo "      provider in pool '${POOL_ID}' that maps the same attribute value would" >&2
+echo "      also satisfy the grant below. Keep this pool dedicated to CUDly" >&2
+echo "      (--pool-id) unless you intend to share it." >&2
 
 # ── Idempotent provider creation ───────────────────────────────────────────────
 if ! gcloud iam workload-identity-pools providers describe "$PROVIDER_ID" \
@@ -326,8 +334,13 @@ fi
 # Narrow grants for identities other than this run's are not removed (they may
 # belong to a second legitimate CUDly account), but they are surfaced: a re-run
 # with a corrected role or subject otherwise leaves the previous one impersonating.
-OTHER_GRANTS=$(grep -F "iam.googleapis.com/${POOL_RESOURCE}/" <<<"$SA_BINDINGS" \
-  | grep -vF -- "$MEMBER" || true)
+# The member is compared as a whole field, not with `grep -vF`. A substring
+# exclusion drops every line CONTAINING this run's member, so a sibling grant
+# whose member merely starts with it is suppressed: pinning CUDly-Execution would
+# hide an existing grant to CUDly-Execution-Admin, in exactly the "re-ran with a
+# corrected role" case this notice exists to surface.
+OTHER_GRANTS=$(awk -F'\t' -v pool="iam.googleapis.com/${POOL_RESOURCE}/" -v m="$MEMBER" \
+  'index($2, pool) && $2 != m' <<<"$SA_BINDINGS" || true)
 if [[ -n "$OTHER_GRANTS" ]]; then
   echo "Note: ${SA_EMAIL} is also impersonable by other identities in pool '${POOL_ID}':" >&2
   while IFS= read -r grant_line; do

--- a/arm/CUDly-CrossSubscription/setup-gcp-wif.sh
+++ b/arm/CUDly-CrossSubscription/setup-gcp-wif.sh
@@ -117,11 +117,23 @@ if [[ "$PROVIDER_TYPE" == "aws" ]]; then
   # every IAM principal in the AWS account can federate as the service account.
   [[ -n "$AWS_ROLE_NAME" ]] || die "--aws-role-name is required for --provider-type aws. Without it the provider has no attribute condition and any IAM role in account ${AWS_ACCOUNT_ID} can federate as ${SA_EMAIL}."
   validate_principal_value "--aws-account-id" "$AWS_ACCOUNT_ID" '^[0-9]{12}$'
-  validate_principal_value "--aws-role-name"  "$AWS_ROLE_NAME"  '^[A-Za-z0-9_+=.@-]{1,64}$'
+  # Matches AWS's own role-name charset [\w+=,.@-]{1,64}. The comma is safe here:
+  # the role name reaches --attribute-condition (a plain string flag), never the
+  # comma-delimited --attribute-mapping dict.
+  validate_principal_value "--aws-role-name"  "$AWS_ROLE_NAME"  '^[A-Za-z0-9_+=,.@-]{1,64}$'
   # Standard AWS partition. A GovCloud or China-partition caller presents a
   # different ARN prefix, so the condition below simply would not match: the
   # token exchange is refused rather than admitted on a partition mismatch.
   AWS_ROLE_ARN="arn:aws:sts::${AWS_ACCOUNT_ID}:assumed-role/${AWS_ROLE_NAME}"
+  EXPECTED_CONDITION="attribute.aws_role == '${AWS_ROLE_ARN}'"
+  # google.subject is the full session ARN here and GCP caps it at 127 chars.
+  # "arn:aws:sts::<12 digits>:assumed-role/<role>/<session>" leaves
+  # 127 - 38 - len(role) - 1 for the session name, which AWS allows up to 64.
+  if [[ $((127 - 38 - ${#AWS_ROLE_NAME} - 1)) -lt 64 ]]; then
+    echo "Note: role name '${AWS_ROLE_NAME}' leaves only $((127 - 38 - ${#AWS_ROLE_NAME} - 1)) characters" >&2
+    echo "      for the session name before google.subject exceeds GCP's 127-character" >&2
+    echo "      limit. Longer session names will be rejected at token-exchange time." >&2
+  fi
 else
   [[ -n "$ISSUER_URI" ]] || die "--issuer-uri is required for --provider-type oidc"
   # Mandatory: public issuers such as token.actions.githubusercontent.com will
@@ -129,10 +141,14 @@ else
   # any repository in the world can federate as the service account.
   [[ -n "$OIDC_SUBJECT" ]] || die "--oidc-subject is required for --provider-type oidc. Without it the provider has no attribute condition and any subject issued by ${ISSUER_URI} can federate as ${SA_EMAIL}."
   validate_principal_value "--issuer-uri"   "$ISSUER_URI"   '^https://[a-zA-Z0-9.-]+(:[0-9]+)?(/[-a-zA-Z0-9._~/]*)?$'
-  validate_principal_value "--oidc-subject" "$OIDC_SUBJECT" '^[A-Za-z0-9][-A-Za-z0-9._:/@=+~]*$'
+  # '|' is permitted because Auth0/Okta-style subjects use it (google-oauth2|123).
+  # It is inert in both destinations: quotes are rejected above, so it cannot
+  # escape the CEL string literal, and it carries no meaning in a principal path.
+  validate_principal_value "--oidc-subject" "$OIDC_SUBJECT" '^[A-Za-z0-9][-A-Za-z0-9._:/@=+~|]*$'
   # google.subject is capped at 127 characters by GCP; a longer value would be
   # rejected at token-exchange time, long after this script reported success.
   [[ ${#OIDC_SUBJECT} -le 127 ]] || die "--oidc-subject must be at most 127 characters (google.subject limit); got ${#OIDC_SUBJECT}"
+  EXPECTED_CONDITION="google.subject == '${OIDC_SUBJECT}'"
 fi
 
 PROJECT_NUMBER=$(gcloud projects describe "$PROJECT" --format='value(projectNumber)')
@@ -183,7 +199,7 @@ if ! gcloud iam workload-identity-pools providers describe "$PROVIDER_ID" \
       --workload-identity-pool="$POOL_ID" \
       --account-id="$AWS_ACCOUNT_ID" \
       --attribute-mapping="google.subject=assertion.arn,attribute.aws_role=assertion.arn.contains('assumed-role') ? assertion.arn.extract('{account_arn}assumed-role/') + 'assumed-role/' + assertion.arn.extract('assumed-role/{role_name}/') : assertion.arn" \
-      --attribute-condition="attribute.aws_role == '${AWS_ROLE_ARN}'" \
+      --attribute-condition="$EXPECTED_CONDITION" \
       --quiet
   else
     # --attribute-mapping is required; without it no subject claims are mapped and
@@ -195,22 +211,44 @@ if ! gcloud iam workload-identity-pools providers describe "$PROVIDER_ID" \
       --workload-identity-pool="$POOL_ID" \
       --issuer-uri="$ISSUER_URI" \
       --attribute-mapping="google.subject=assertion.sub" \
-      --attribute-condition="google.subject == '${OIDC_SUBJECT}'" \
+      --attribute-condition="$EXPECTED_CONDITION" \
       --quiet
   fi
 else
-  # An existing provider keeps whatever attribute condition it was created with,
-  # including none at all. Do not report success over a provider this script
-  # cannot vouch for.
+  # An existing provider keeps whatever attribute condition it was created with.
+  # Checking only that the condition is non-empty would grandfather exactly the
+  # values --subject-condition was removed to prevent: "true", or
+  # "assertion.sub != ''", both non-empty and both admitting every identity. The
+  # condition is therefore compared to the one this script would have written.
+  DELETE_HINT="  gcloud iam workload-identity-pools providers delete ${PROVIDER_ID} --project=${PROJECT} --location=global --workload-identity-pool=${POOL_ID}"
   EXISTING_CONDITION=$(gcloud iam workload-identity-pools providers describe "$PROVIDER_ID" \
     --project="$PROJECT" --location=global \
     --workload-identity-pool="$POOL_ID" \
     --format='value(attributeCondition)')
-  if [[ -z "$EXISTING_CONDITION" ]]; then
-    die "provider '${PROVIDER_ID}' already exists with no attribute condition, so every identity it accepts can enter pool '${POOL_ID}'. Delete it and re-run:
-  gcloud iam workload-identity-pools providers delete ${PROVIDER_ID} --project=${PROJECT} --location=global --workload-identity-pool=${POOL_ID}"
+  # A provider of the other type would emit a credential config that does not
+  # match it and mint an attribute the grant below never names.
+  EXISTING_TYPE=$(gcloud iam workload-identity-pools providers describe "$PROVIDER_ID" \
+    --project="$PROJECT" --location=global \
+    --workload-identity-pool="$POOL_ID" \
+    --format='value(aws.accountId,oidc.issuerUri)')
+  if [[ "$PROVIDER_TYPE" == "aws" && "$EXISTING_TYPE" != "${AWS_ACCOUNT_ID}"* ]]; then
+    die "provider '${PROVIDER_ID}' already exists but is not an AWS provider for account ${AWS_ACCOUNT_ID} (describe reports: ${EXISTING_TYPE}). Delete it and re-run:
+${DELETE_HINT}"
   fi
-  echo "Reusing existing provider '${PROVIDER_ID}' (attribute condition: ${EXISTING_CONDITION})"
+  if [[ "$PROVIDER_TYPE" == "oidc" && "$EXISTING_TYPE" != *"${ISSUER_URI}" ]]; then
+    die "provider '${PROVIDER_ID}' already exists but is not an OIDC provider for issuer ${ISSUER_URI} (describe reports: ${EXISTING_TYPE}). Delete it and re-run:
+${DELETE_HINT}"
+  fi
+  if [[ "$EXISTING_CONDITION" != "$EXPECTED_CONDITION" ]]; then
+    die "provider '${PROVIDER_ID}' already exists with a different attribute condition, so this script cannot vouch for which identities enter pool '${POOL_ID}'.
+  found   : ${EXISTING_CONDITION:-(none)}
+  expected: ${EXPECTED_CONDITION}
+A condition that is merely non-empty is not a restriction: 'true' and
+\"assertion.sub != ''\" both admit every identity the issuer will vouch for.
+Delete the provider and re-run:
+${DELETE_HINT}"
+  fi
+  echo "Reusing existing provider '${PROVIDER_ID}' (attribute condition matches: ${EXISTING_CONDITION})"
 fi
 
 # ── Grant service account impersonation to one principal ──────────────────────
@@ -230,32 +268,72 @@ gcloud iam service-accounts add-iam-policy-binding "$SA_EMAIL" \
   --project="$PROJECT" \
   --quiet
 
-# ── Retire the pool-wide grant left by earlier versions of this script ────────
-LEGACY_MEMBER="principalSet://iam.googleapis.com/${POOL_RESOURCE}/*"
-# Fetched into a variable first: a pipeline straight into grep would let a failed
-# get-iam-policy read as "no legacy binding found" and report success over one.
-SA_POLICY=$(gcloud iam service-accounts get-iam-policy "$SA_EMAIL" \
-  --project="$PROJECT" --format=json)
-if grep -qF -- "$LEGACY_MEMBER" <<<"$SA_POLICY"; then
+# ── Retire pool-wide grants left by earlier versions of this script ───────────
+# Scanned across every pool and every role, not just this run's --pool-id and
+# roles/iam.workloadIdentityUser. Scoping the scan to the current pool would let
+# a customer hide the original grant simply by re-running with a different
+# --pool-id (which the pool-reuse note above actively recommends), and scoping it
+# to one role would miss the same wildcard under roles/iam.serviceAccountTokenCreator,
+# which confers the same impersonation power via generateAccessToken.
+#
+# Emitted one "role<TAB>member" line per member so the role owning each wildcard
+# is known; a bare policy grep cannot tell which role to remove it from.
+#
+# The fetch is deliberately kept out of the grep pipeline. Piping gcloud straight
+# into `grep ... || true` would let a failed get-iam-policy produce empty output
+# and read as "no wildcard grants found", reporting success over the very grant
+# this check exists to catch. As a plain assignment it aborts under `set -e`.
+sa_bindings() {
+  gcloud iam service-accounts get-iam-policy "$SA_EMAIL" \
+    --project="$PROJECT" --flatten="bindings[].members" \
+    --format="value(bindings.role,bindings.members)"
+}
+pool_wide_grants() {
+  grep -E $'\t''principalSet://iam\.googleapis\.com/projects/[0-9]+/locations/[^/]+/workloadIdentityPools/[^/]+/\*$' <<<"$1" || true
+}
+
+SA_BINDINGS=$(sa_bindings)
+LEGACY_GRANTS=$(pool_wide_grants "$SA_BINDINGS")
+if [[ -n "$LEGACY_GRANTS" ]]; then
   if [[ "$REMOVE_LEGACY_POOL_BINDING" == "true" ]]; then
-    echo "Removing legacy pool-wide impersonation grant..."
-    gcloud iam service-accounts remove-iam-policy-binding "$SA_EMAIL" \
-      --role=roles/iam.workloadIdentityUser \
-      --member="$LEGACY_MEMBER" \
-      --project="$PROJECT" \
-      --quiet
+    while IFS=$'\t' read -r legacy_role legacy_member; do
+      [[ -n "$legacy_member" ]] || continue
+      echo "Removing pool-wide grant: ${legacy_role} -> ${legacy_member}"
+      gcloud iam service-accounts remove-iam-policy-binding "$SA_EMAIL" \
+        --role="$legacy_role" \
+        --member="$legacy_member" \
+        --project="$PROJECT" \
+        --quiet
+    done <<<"$LEGACY_GRANTS"
+    # Re-read the policy: removing one role's wildcard says nothing about the
+    # others, and reporting success here is the whole point of the check.
+    SA_BINDINGS=$(sa_bindings)
+    REMAINING=$(pool_wide_grants "$SA_BINDINGS")
+    [[ -z "$REMAINING" ]] || die "pool-wide grants survived removal on ${SA_EMAIL}:
+${REMAINING}"
   else
-    die "${SA_EMAIL} still grants roles/iam.workloadIdentityUser to every identity in pool '${POOL_ID}':
-  ${LEGACY_MEMBER}
-That grant was created by an earlier version of this script and makes the narrow
-grant added above irrelevant: anything admitted to the pool can still impersonate
-the service account. Re-run this command with --remove-legacy-pool-binding, or
-remove it yourself with:
+    die "${SA_EMAIL} still grants impersonation to every identity in a workload identity pool:
+${LEGACY_GRANTS}
+Grants of this shape were created by earlier versions of this script and make the
+narrow grant added above irrelevant: anything admitted to that pool can still
+impersonate the service account. Re-run with --remove-legacy-pool-binding, or
+remove each one yourself with:
   gcloud iam service-accounts remove-iam-policy-binding ${SA_EMAIL} \\
-    --role=roles/iam.workloadIdentityUser \\
-    --member='${LEGACY_MEMBER}' \\
-    --project=${PROJECT}"
+    --role='<role>' --member='<member>' --project=${PROJECT}"
   fi
+fi
+
+# Narrow grants for identities other than this run's are not removed (they may
+# belong to a second legitimate CUDly account), but they are surfaced: a re-run
+# with a corrected role or subject otherwise leaves the previous one impersonating.
+OTHER_GRANTS=$(grep -F "iam.googleapis.com/${POOL_RESOURCE}/" <<<"$SA_BINDINGS" \
+  | grep -vF -- "$MEMBER" || true)
+if [[ -n "$OTHER_GRANTS" ]]; then
+  echo "Note: ${SA_EMAIL} is also impersonable by other identities in pool '${POOL_ID}':" >&2
+  while IFS= read -r grant_line; do
+    echo "      ${grant_line}" >&2
+  done <<<"$OTHER_GRANTS"
+  echo "      Remove any that are no longer expected." >&2
 fi
 
 # ── Generate external account credential config (no secrets) ──────────────────


### PR DESCRIPTION
Closes #1544

`arm/CUDly-CrossSubscription/setup-gcp-wif.sh` is run by customers against **their own** GCP projects. Both defects filed in #1544 were still live on `main` at 887d51fd6 (re-verified, not just at the filed commit be11bdcb5).

## What was wrong

**A. No attribute condition on the provider.** AWS mode called `providers create-aws` with only `--account-id`. OIDC mode printed a stderr warning when `--subject-condition` was empty and then created the provider anyway, and the header's copy-paste example used `https://token.actions.githubusercontent.com` without the flag.

**B. Pool-wide impersonation.** `roles/iam.workloadIdentityUser` was bound to `principalSet://.../workloadIdentityPools/<pool>/*`, so anything admitted to the pool could impersonate the service account regardless of how the provider was configured.

The Terraform sibling `iac/federation/gcp-target/terraform/main.tf` already forbids the condition-less state with `lifecycle` preconditions. The shell path for the same onboarding job did not.

### Before / after

Provider creation, AWS mode:

```diff
-gcloud iam workload-identity-pools providers create-aws "$PROVIDER_ID" \
-  --project="$PROJECT" --location=global \
-  --workload-identity-pool="$POOL_ID" \
-  --account-id="$AWS_ACCOUNT_ID" --quiet
+gcloud iam workload-identity-pools providers create-aws "$PROVIDER_ID" \
+  --project="$PROJECT" --location=global \
+  --workload-identity-pool="$POOL_ID" \
+  --account-id="$AWS_ACCOUNT_ID" \
+  --attribute-mapping="google.subject=assertion.arn,attribute.aws_role=assertion.arn.contains('assumed-role') ? assertion.arn.extract('{account_arn}assumed-role/') + 'assumed-role/' + assertion.arn.extract('assumed-role/{role_name}/') : assertion.arn" \
+  --attribute-condition="attribute.aws_role == 'arn:aws:sts::123456789012:assumed-role/CUDly-Execution'" \
+  --quiet
```

Provider creation, OIDC mode (the `--attribute-condition` line was previously appended only when `--subject-condition` happened to be non-empty):

```diff
-OIDC_ARGS=( ... --attribute-mapping="google.subject=assertion.sub" --quiet )
-if [[ -n "$SUBJECT_CONDITION" ]]; then
-  OIDC_ARGS+=(--attribute-condition="$SUBJECT_CONDITION")
-fi
-gcloud iam workload-identity-pools providers create-oidc "${OIDC_ARGS[@]}"
+gcloud iam workload-identity-pools providers create-oidc "$PROVIDER_ID" \
+  --project="$PROJECT" --location=global \
+  --workload-identity-pool="$POOL_ID" \
+  --issuer-uri="$ISSUER_URI" \
+  --attribute-mapping="google.subject=assertion.sub" \
+  --attribute-condition="google.subject == 'repo:my-org/my-repo:ref:refs/heads/main'" \
+  --quiet
```

Impersonation grant:

```diff
-POOL_PRINCIPAL="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL_ID}/*"
 gcloud iam service-accounts add-iam-policy-binding "$SA_EMAIL" \
   --role=roles/iam.workloadIdentityUser \
-  --member="$POOL_PRINCIPAL" \
+  --member="principalSet://iam.googleapis.com/${POOL_RESOURCE}/attribute.aws_role/arn:aws:sts::123456789012:assumed-role/CUDly-Execution" \
+  # (OIDC: principal://iam.googleapis.com/${POOL_RESOURCE}/subject/<exact sub>)
   --project="$PROJECT" --quiet
```

AWS keeps a `principalSet` on the normalised role attribute because session ARNs carry a per-session suffix; the attribute mapping normalises `arn:aws:sts::<acct>:assumed-role/<role>/<session>` down to the role ARN so the grant matches it exactly rather than by substring. That mapping is verbatim Google's documented AWS default.

### Attacker's view

**Before:** in OIDC mode with the documented command, the identity that could federate was *any GitHub Actions job in any repository on GitHub* - `token.actions.githubusercontent.com` mints a token for every workflow on the platform, the pool had no condition to reject them, and the pool-wide grant let anything admitted impersonate the SA. In AWS mode it was *any IAM principal in the referenced AWS account* that can call `sts:GetCallerIdentity`: a sandbox role, a CI runner, an EC2 instance profile on a compromised host. Either way the attacker lands on a service account holding `compute.commitments.create/update`, i.e. spend authority on the customer's project, with no CUDly involvement.

**After:** the provider's attribute condition rejects the token at STS exchange time unless `google.subject` equals the one pinned subject (OIDC) or the normalised role ARN equals the one pinned role (AWS), so a workflow in `attacker/repo` or a different role in the same AWS account never enters the pool. The grant is a second, independent gate: it names one principal, so even an identity that did enter the pool is not a member of the binding. Neither gate can be skipped, because the script exits nonzero without a value to pin.

## Fail-closed, and the fail-*open* validation forms

`--aws-role-name` (aws) and `--oidc-subject` (oidc) are now required; missing either exits 1 before any `gcloud` call.

`--subject-condition` is **removed**, not made mandatory. It took a raw CEL expression, so `--subject-condition true` or `--subject-condition "assertion.sub != ''"` satisfied a non-empty check while admitting every subject from the issuer - a mandatory-but-unvalidated flag would have reproduced the bug it was meant to close. `--oidc-subject` takes the subject itself and the script builds the equality condition.

Validation targets the forms that fail **open**, not the merely ugly ones:

- `'` `"` `\` `` ` `` are rejected because they terminate the CEL string literal in `--attribute-condition`. `--oidc-subject "x' || true || '"` would otherwise render `google.subject == 'x' || true || ''`, a condition that is always true. This is the direct analogue of the `${...}` expansion trap on #1602: the guard being added is what gets rewritten.
- `*` is rejected because it widens an IAM principal identifier rather than being compared literally.
- `$` is rejected to catch a pasted `${...}` placeholder. Checked explicitly: GCP IAM principal identifiers and CEL attribute conditions have **no** policy-variable expansion (unlike AWS IAM's `${aws:...}`), so a `${...}` here is literal and fails closed rather than open - but it still silently produces a binding that matches nothing, so it is refused rather than accepted.
- The script never `eval`s and quotes every interpolation, so the shell itself performs no second expansion.

Also enforced: `--issuer-uri` must be `https://`, `--aws-account-id` must be 12 digits, and pool/provider/project/SA values are format-checked. Two characters real identities legitimately use are permitted: `,` in AWS role names (AWS's own charset allows it, and role names never reach the comma-delimited attribute mapping) and `|` in OIDC subjects (Auth0/Okta style). Both are inert because quotes remain rejected.

## Second commit: fail-open gaps on the re-run path

An adversarial review of the first commit found four ways the hardening could still be bypassed against an already-provisioned project. All four are fixed in 21af9ccdd:

1. **The legacy-grant scan was scoped to the current `--pool-id`.** The script's own pool-reuse note recommends moving to a dedicated pool, and doing so rebuilt the search string for the *new* pool, so the original wildcard grant went unseen and the script exited 0 - the p0 surviving via a path the script recommends. The scan is now pool-agnostic.
2. **Removal was hardcoded to `roles/iam.workloadIdentityUser`** while the detection scanned the whole policy. A wildcard under `roles/iam.serviceAccountTokenCreator` (same impersonation power via `generateAccessToken`) matched the check but survived the removal, and nothing re-verified. Removal now uses the role each member is actually bound to, and the policy is re-read afterwards so a partial removal cannot pass.
3. **The existing-provider gate only asserted the condition was non-empty**, grandfathering exactly the values `--subject-condition` was removed to prevent. It now compares against the condition this script would have written, and checks the provider type so an OIDC provider is not reused under `--provider-type aws`.
4. **The `get-iam-policy` read is kept out of the grep pipeline.** Piping it into `grep ... || true` would let a failed policy read produce empty output and pass as "no wildcard grants found".

Also added: narrow grants for identities other than this run's are surfaced (a re-run with a corrected role otherwise leaves the previous one impersonating), and a warning when the AWS role name is long enough that the session ARN risks exceeding GCP's 127-character `google.subject` limit.

## Upgrade path (breaking)

**Anyone who ran an earlier version of this script still has the pool-wide grant and remains exposed until they re-run it.** Re-running is not enough on its own: the script now detects wildcard pool grants on the service account - across *every* pool and *every* role, not just this run's - and **exits nonzero without printing the credential config** while any survive, either printing the `remove-iam-policy-binding` commands or deleting them under `--remove-legacy-pool-binding`. A pre-existing provider whose attribute condition is missing, different, or merely non-empty is refused rather than silently reused.

## The Terraform sibling is worse, and is now its own p0

#1544's body frames both defects as "the shell path lacks the guard its Terraform sibling enforces". That premise is **disproved** by this PR, and I have posted a correction on the issue so no later reader treats `iac/federation/gcp-target/terraform` as the safe reference. It is the worse of the two paths, and it is equally customer-facing (`iac/embed.go:9` embeds `federation`; `handler_federation.go:641-655` serves `federation/gcp-target` as the default bundle for `target=gcp`).

Filed as **#1667** (p0/critical): the Terraform module carries the same pool-wide grant at `main.tf:162`, *plus* a live bypass this script never had. It maps `attribute.aws_role = "assertion.arn"` raw and substring-tests it with `contains('assumed-role/<role>/')`, so an attacker with only `iam:CreateUser` in the trusted account creates an IAM **user** with path `/assumed-role/<role>/` (legal under AWS's `(/)|(/[!-~]+/)` path regex), and `GetCallerIdentity` returns an ARN containing the exact substring the condition tests for. IAM *role* paths do not work, because STS strips the path from `assumed-role` ARNs; it is specifically the user ARN, which retains its path, that defeats a substring test.

**This is the argument for the fix shape used here.** The script is immune because it normalises the assertion down to the role ARN and compares with `==`, which no user ARN can satisfy at any path. The Terraform module's inline comment claiming exact-match "cannot work" for AWS is what this PR disproves.

Divergence worth noting: `pool_wide_grants()` in this PR flags a **Terraform-created** grant as legacy and refuses to report success, so the two onboarding paths actively contradict each other until #1667 lands.

`Closes #1544` is nonetheless correct - that issue is file-scoped by both its title and its "two defects in one script" body, and both are fully fixed here.

## Verification

- `bash -n` - exit 0. `shellcheck` 0.11.0 - exit 0, no findings.
- All four CI runs green on the first commit (CI - Build & Test, pre-commit, AWS Sanity, Azure Sanity).
- 11 fail-closed argument paths exercised (both missing-pin flags, the removed `--subject-condition`, `*` in subject / role / pool-id, the `' || true || '` CEL break-out, a `${...}` placeholder, `http://` issuer, non-numeric account ID): **all exit 1**, and a stub `gcloud` that exits 99 on any invocation was never reached, confirming nothing is created before validation.
- 15 further scenarios for the second commit, each asserted against an expected exit code: legacy grant in a *different* pool; wildcard under `serviceAccountTokenCreator` with and without the flag; wildcards under both roles at once (both removed); existing provider with condition `true`, with `assertion.sub != ''`, and with the Terraform sibling's `contains()` form (all rejected); existing provider with the exact expected condition (still reused, no false mismatch); wrong provider type; stale narrow grant surfaced; `|` and `,` now accepted.
- Both `create-aws` / `create-oidc` / `add-iam-policy-binding` invocations captured against a stubbed `gcloud` and checked argument by argument.
- Third commit (8fde9daaf), three review follow-ups, each verified: a sibling grant to `CUDly-Execution-Admin` is now surfaced while pinning `CUDly-Execution` (`grep -vF` had suppressed it as a substring) and the run's own member is still correctly excluded; the `google.subject` budget lands exactly on the boundary after the 38 -> 39 correction (23-char role = 127 chars, no warning; 24-char = 128, warns); and the pool-scope notice now prints once on a freshly created pool, not only on reuse.
- **CodeRabbit has not reviewed this PR.** Both triggers returned "Review limit reached" under the Fair Usage policy with **zero** formal reviews; the green commit status and the empty unresolved-thread count are artefacts of the throttle (repo issue #1530), not a clean review. No further pings will be sent from here - the global trigger is held by #1641. The adversarial review summarised above is a substitute for, not a confirmation of, a CR pass.
- **Not verified:** no run against a real GCP project (no credentials in this environment). Every claim about *gcloud's own* behaviour rests on the invocation shape and Google's documentation, not a live API call. In particular the pre-existing `create-cred-config` problem in item 3 of #1661 is reported as unconfirmed for that reason.

## Reported, not changed here

Filed as **#1667** (p0): the Terraform bypass and pool-wide grant, above.

Filed as **#1661** (p1): the served onboarding template `internal/iacfiles/templates/gcp-wif-cli.sh.tmpl` swallowing provider-create failures with `|| echo "(provider may already exist)"`, its unvalidated `CUDLY_FEDERATED_SUBJECT` reaching a CEL literal, and `create-cred-config` being called with no credential source in this script's OIDC branch (pre-existing, unverified against a live gcloud).

Checked and clean or out of scope:

- The served template is **not** vulnerable to either #1544 defect - it always sets `--attribute-condition` and binds `principal://.../subject/...`, and its AWS-STS provider path was deliberately removed (asserted by `templates_test.go`'s `mustNot: "create-aws"`). This is the #1602-style "second reachable copy" check, and it came back clean.
- `internal/iacfiles/templates/gcp-wif.tfvars.tmpl` ships `aws_role_name` / `oidc_subject` commented out and labelled "Recommended" while the module's preconditions make them **required**. Fails closed (the apply errors), so this is a wording bug, not a hole.
- No `--allowed-audiences` is pinned; GCP's default allowed audience is the provider's own resource URL, already provider-scoped.
- Pool reuse is a real residual: GCP principal identifiers are pool-scoped, not provider-scoped, so another provider in a shared pool that mints the same attribute value satisfies the grant. The script now warns on reuse and recommends a dedicated pool. There is no provider-scoped principal form in GCP to fix this properly.
- No secrets are echoed; `create-cred-config` output contains none, as the script states.
- Left untouched per scope: `iac/federation/aws-target/**` (#1602) and the ARM template (#1545).
- **Behaviour change worth knowing:** `--project` is now format-checked as a GCP project **ID**, so a numeric project *number* is rejected where `gcloud projects describe` previously accepted it. Fails closed with a clear message; flagged rather than fixed because project IDs are what every other argument and the printed registration values assume.
- No docs reference the script's arguments (`docs/DEPLOYMENT.md` mentions the auth mode only; `frontend/src/index.html` names the script without flags), so the usage examples in the script header are the only documentation updated.

