### PR TITLE
fix(iac/aws): grant kms:TagResource for KMS CreateKey tag-on-create

### DIFF
--- a/terraform/environments/aws/ci-cd-permissions/policy_compute_b.tf
+++ b/terraform/environments/aws/ci-cd-permissions/policy_compute_b.tf
@@ -28,6 +28,44 @@
 #    SA from enumerating key policies of unrelated workloads sharing the
 #    account (account-wide key-policy reconnaissance). Split from the main
 #    policy because the 6144-char limit was reached.
+#
+#  - KMSTagOnCreate: kms:TagResource against a key that does NOT exist
+#    yet (the CreateKey Tags parameter, per the AWS KMS API reference's
+#    "Required permissions" for CreateKey) can never satisfy
+#    aws:ResourceTag/Project: there is no resource, so no resource tag,
+#    at authorization time. KMSMutateTaggedOnly's tag-on-EXISTING-key
+#    grant (policy_compute.tf) therefore denies kms:TagResource during
+#    aws_kms_key creation with Terraform's `tags` argument, breaking
+#    every `terraform apply` that creates a new CMK (e.g. the OIDC
+#    signing key in modules/compute/aws/lambda/signing-key.tf). AWS
+#    authorizes tag-on-create via the aws:RequestTag/aws:TagKeys
+#    condition keys instead, which inspect the tags being attached in
+#    the request rather than tags already on the resource; see
+#    "Controlling access during AWS requests" in the IAM user guide.
+#    This MUST stay a separate statement: folding aws:RequestTag into
+#    KMSMutateTaggedOnly would AND it with that statement's
+#    aws:ResourceTag condition, which is exactly the unsatisfiable
+#    combination this statement exists to avoid. Kept resource-unscoped
+#    (Resource = "*") like KMSCreateAndRead/KMSReadTaggedOnly, since the
+#    key ARN isn't known until CreateKey returns; the condition is what
+#    limits it to CUDly-tagged create calls. StringEqualsIgnoreCase
+#    matches the case-insensitive convention documented on
+#    KMSMutateTaggedOnly (policy_compute.tf) for the same Project tag.
+#    Added here (rather than policy_compute.tf) because the main policy
+#    is within ~60 characters of the 6144-char limit; this statement
+#    would not reliably fit.
+#    aws:RequestTag alone would be an unintended privilege escalation:
+#    it says nothing about the resource's CURRENT tags, so without more
+#    it would let a leaked deploy token call kms:TagResource on ANY
+#    existing key in the account (not just ones it creates), self-attach
+#    Project=CUDly, and then use KMSMutateTaggedOnly to disable, delete,
+#    or rewrite the key policy of that now-mistagged key, i.e. hijack a
+#    key it never created. The added Null condition on
+#    aws:ResourceTag/Project restricts the statement to resources with
+#    NO Project tag yet (true for a brand-new key mid-CreateKey, false
+#    for anything already tagged, ours or not), so it can only ever
+#    perform the initial tag-on-create and can't be used to claim an
+#    existing key.
 
 resource "aws_iam_policy" "compute_b" {
   name        = "cudly-deploy-compute-b"
@@ -94,6 +132,27 @@ resource "aws_iam_policy" "compute_b" {
         Condition = {
           StringEqualsIgnoreCase = {
             "aws:ResourceTag/Project" = "CUDly"
+          }
+        }
+      },
+      {
+        # kms:TagResource for the CreateKey Tags parameter. See the
+        # KMSTagOnCreate note in the file header comment above for why
+        # this must be a separate, aws:RequestTag-gated statement rather
+        # than folded into KMSMutateTaggedOnly's aws:ResourceTag gate,
+        # and why the Null condition on aws:ResourceTag/Project is
+        # required to stop this from being usable to hijack an existing,
+        # unrelated key by self-tagging it.
+        Sid      = "KMSTagOnCreate"
+        Effect   = "Allow"
+        Action   = ["kms:TagResource"]
+        Resource = "*"
+        Condition = {
+          StringEqualsIgnoreCase = {
+            "aws:RequestTag/Project" = "CUDly"
+          }
+          Null = {
+            "aws:ResourceTag/Project" = "true"
           }
         }
       },


### PR DESCRIPTION
## Summary

Every AWS deploy that creates a new KMS CMK is currently failing:

```
Error: creating KMS Key: AccessDeniedException: User: arn:aws:sts::909626172446:assumed-role/cudly-terraform-deploy/GitHubActions
is not authorized to perform: kms:TagResource because no identity-based policy allows the kms:TagResource action
  with module.compute_lambda[0].aws_kms_key.signing,
  on ../../modules/compute/aws/lambda/signing-key.tf line 8
```

`CreateKey`'s `Tags` parameter requires `kms:TagResource` (AWS KMS API reference, "Required permissions"), but the only existing grant (`KMSMutateTaggedOnly` in `policy_compute.tf`) is gated on `aws:ResourceTag/Project`, a condition key evaluated against tags already on an *existing* resource. At `CreateKey` time the key doesn't exist yet, so this condition can never be satisfied and the call is denied.

Verified against current AWS docs:
- KMS `CreateKey` API reference: "Required permissions: kms:CreateKey ... To use the Tags parameter, kms:TagResource."
- IAM "Controlling access during AWS requests" guide: `aws:RequestTag` gates what tags can be passed *in a request* (the correct key for tag-on-create); `aws:ResourceTag` gates access based on tags *already on the resource*.

## Fix

Adds `KMSTagOnCreate` to `terraform/environments/aws/ci-cd-permissions/policy_compute_b.tf` (not `policy_compute.tf` — see "Why `policy_compute_b.tf`" below):

```hcl
{
  Sid      = "KMSTagOnCreate"
  Effect   = "Allow"
  Action   = ["kms:TagResource"]
  Resource = "*"
  Condition = {
    StringEqualsIgnoreCase = {
      "aws:RequestTag/Project" = "CUDly"
    }
    Null = {
      "aws:ResourceTag/Project" = "true"
    }
  }
},
```

The `Null` condition is a deliberate hardening beyond the minimal fix: `aws:RequestTag` alone says nothing about a resource's *current* tags, so without it a leaked deploy token could call `kms:TagResource` on any existing KMS key in the account (not just ones it creates), self-attach `Project=CUDly`, then use `KMSMutateTaggedOnly` to disable/delete/repolicy that now-mistagged key — i.e. hijack a key it never created. `Null: {"aws:ResourceTag/Project": "true"}` restricts the statement to resources that currently have **no** Project tag at all (true for a brand-new key mid-`CreateKey`, false for anything already tagged, ours or not), so it can only ever perform the initial tag-on-create.

### Why `policy_compute_b.tf`

`policy_compute.tf`'s compiled JSON is ~5923 of the AWS 6144-char managed-policy limit (per its own header comment, it's already the reason `policy_compute_b.tf` exists). Adding the new statement there would land at ~6083 chars — technically under the limit but with only ~60 chars of margin, which is too fragile. `policy_compute_b.tf` already houses the other KMS statements that were split out of the main policy for size reasons (`KMSAliasMutate`, `KMSReadTaggedOnly`), so it's the natural, low-risk home for this one too.

## Completeness checks

1. **Every `aws_kms_key` the deploy role creates carries a Project tag**: the only KMS key actually created by this deploy role's live apply graph is `aws_kms_key.signing` (`modules/compute/aws/lambda/signing-key.tf`), tagged via `local.common_tags.Project = var.project_name` (same lowercase-`cudly` path documented on `KMSMutateTaggedOnly`, matched case-insensitively). `modules/monitoring/aws` also defines an `aws_kms_key.sns`, but that module isn't wired into any `terraform/environments/aws` root today, so it isn't exercised by this deploy role.
2. **`kms:TagResource` is the only missing permission on this path**: walked the AWS provider's create/read calls for `aws_kms_key`/`aws_kms_alias` (CreateKey, TagResource, DescribeKey, ListResourceTags, GetKeyPolicy, GetKeyRotationStatus, CreateAlias) against the granted statements. Tag-gated reads (`GetKeyPolicy`, the key-side of alias creation) are safe because `CreateKey`'s `Tags` parameter tags the key atomically during creation, so the tag is already present by the time any subsequent read happens.
3. **Sibling clouds**: GCP's `ci-cd-permissions` uses the broad predefined `roles/cloudkms.admin` (no ABAC tag-condition, so this bug shape can't occur); Azure's `ci-cd-permissions/role.tf` has zero tag/condition constructs. No equivalent gap found in either; no follow-up filed.
4. **`test-iam-role.sh`**: this is a full live-AWS destroy+apply integration script (not run in CI), with a generic `AccessDenied` grep that already surfaces any missing action generically. No existing precedent in the script adds bespoke per-permission checks, so none was added here to avoid forcing a fit that doesn't match its structure.

## Manual apply required

**This fix does not take effect until a privileged human re-applies `terraform/environments/aws/ci-cd-permissions/`.** The CI deploy role (`cudly-terraform-deploy`) cannot grant itself new IAM permissions — that would be self-privilege-escalation, and this bootstrap root is intentionally out of the CI deploy role's own write scope.

```bash
cd terraform/environments/aws/ci-cd-permissions
terraform init -reconfigure   # if backend.hcl differs from your last run
terraform plan
terraform apply
```

Run this with your own (human, non-CI) AWS credentials that have permission to modify the `cudly-deploy-compute-b` managed policy.

Closes #1670
