### PR TITLE
fix(arm): validate attribute mapping on GCP WIF provider reuse

### DIFF
--- a/arm/CUDly-CrossSubscription/setup-gcp-wif.sh
+++ b/arm/CUDly-CrossSubscription/setup-gcp-wif.sh
@@ -126,7 +126,19 @@ if [[ "$PROVIDER_TYPE" == "aws" ]]; then
   # token exchange is refused rather than admitted on a partition mismatch.
   AWS_ROLE_ARN="arn:aws:sts::${AWS_ACCOUNT_ID}:assumed-role/${AWS_ROLE_NAME}"
   EXPECTED_CONDITION="attribute.aws_role == '${AWS_ROLE_ARN}'"
-  # google.subject is the full session ARN here and GCP caps it at 127 chars.
+  # attribute.aws_role normalises the session ARN
+  # (arn:aws:sts::<acct>:assumed-role/<role>/<session>) down to the role ARN,
+  # so both EXPECTED_CONDITION above and the IAM grant below can match it
+  # exactly instead of relying on a substring test. Kept in a variable (not
+  # inlined at the create-provider call below) so the reuse path can validate
+  # an existing provider against the exact same expression instead of a
+  # second hand-copied literal that could silently drift from this one.
+  EXPECTED_MAPPING="google.subject=assertion.arn,attribute.aws_role=assertion.arn.contains('assumed-role') ? assertion.arn.extract('{account_arn}assumed-role/') + 'assumed-role/' + assertion.arn.extract('assumed-role/{role_name}/') : assertion.arn"
+  # google.subject is the full session ARN here and GCP caps it at 127 bytes,
+  # not characters (127 chars is used below only because both charset
+  # regexes constraining this value -- --aws-role-name above and
+  # --oidc-subject below -- are ASCII-only, so chars == bytes; this budget
+  # would silently under/over-count if that charset were ever widened).
   # "arn:aws:sts::<12 digits>:assumed-role/" is 39 characters, and the session
   # name is preceded by a "/", so the role name leaves 127 - 39 - len(role) - 1
   # for a session name that AWS allows to reach 64.
@@ -151,6 +163,7 @@ else
   # rejected at token-exchange time, long after this script reported success.
   [[ ${#OIDC_SUBJECT} -le 127 ]] || die "--oidc-subject must be at most 127 characters (google.subject limit); got ${#OIDC_SUBJECT}"
   EXPECTED_CONDITION="google.subject == '${OIDC_SUBJECT}'"
+  EXPECTED_MAPPING="google.subject=assertion.sub"
 fi
 
 PROJECT_NUMBER=$(gcloud projects describe "$PROJECT" --format='value(projectNumber)')
@@ -192,21 +205,34 @@ echo "      provider in pool '${POOL_ID}' that maps the same attribute value wou
 echo "      also satisfy the grant below. Keep this pool dedicated to CUDly" >&2
 echo "      (--pool-id) unless you intend to share it." >&2
 
+# gcloud's `value(...)` printer renders a map field (attributeMapping) as its
+# entries sorted by key and delimiter-joined with ';' by CsvPrinter._AddRecord
+# (the same code path ValuePrinter inherits from), not the comma-joined
+# "key=value,key=value" form the --attribute-mapping flag takes as input.
+# Comparing the raw describe output against EXPECTED_MAPPING as strings would
+# therefore report every correctly-configured provider as mismatched. This
+# splits each side on its own pair separator, re-sorts, and compares parsed
+# key/value pairs so neither the input-vs-output shape difference nor a
+# hypothetical future change to gcloud's own key ordering can produce a false
+# positive; a mapping that actually differs still compares unequal.
+normalize_mapping() {
+  local mapping="$1" pair_sep="$2"
+  local -a pairs
+  IFS="$pair_sep" read -ra pairs <<<"$mapping"
+  printf '%s\n' "${pairs[@]}" | sort
+}
+
 # ── Idempotent provider creation ───────────────────────────────────────────────
 if ! gcloud iam workload-identity-pools providers describe "$PROVIDER_ID" \
      --project="$PROJECT" --location=global \
      --workload-identity-pool="$POOL_ID" &>/dev/null; then
   echo "Creating ${PROVIDER_TYPE} provider '${PROVIDER_ID}'..."
   if [[ "$PROVIDER_TYPE" == "aws" ]]; then
-    # attribute.aws_role normalises the session ARN
-    # (arn:aws:sts::<acct>:assumed-role/<role>/<session>) down to the role ARN,
-    # so both the condition below and the IAM grant can match it exactly instead
-    # of relying on a substring test.
     gcloud iam workload-identity-pools providers create-aws "$PROVIDER_ID" \
       --project="$PROJECT" --location=global \
       --workload-identity-pool="$POOL_ID" \
       --account-id="$AWS_ACCOUNT_ID" \
-      --attribute-mapping="google.subject=assertion.arn,attribute.aws_role=assertion.arn.contains('assumed-role') ? assertion.arn.extract('{account_arn}assumed-role/') + 'assumed-role/' + assertion.arn.extract('assumed-role/{role_name}/') : assertion.arn" \
+      --attribute-mapping="$EXPECTED_MAPPING" \
       --attribute-condition="$EXPECTED_CONDITION" \
       --quiet
   else
@@ -218,7 +244,7 @@ if ! gcloud iam workload-identity-pools providers describe "$PROVIDER_ID" \
       --project="$PROJECT" --location=global \
       --workload-identity-pool="$POOL_ID" \
       --issuer-uri="$ISSUER_URI" \
-      --attribute-mapping="google.subject=assertion.sub" \
+      --attribute-mapping="$EXPECTED_MAPPING" \
       --attribute-condition="$EXPECTED_CONDITION" \
       --quiet
   fi
@@ -256,7 +282,29 @@ A condition that is merely non-empty is not a restriction: 'true' and
 Delete the provider and re-run:
 ${DELETE_HINT}"
   fi
-  echo "Reusing existing provider '${PROVIDER_ID}' (attribute condition matches: ${EXISTING_CONDITION})"
+  # The condition alone does not decide who gets in: it is evaluated against
+  # whatever value the mapping produces, so a provider can carry the exact
+  # expected condition while a different mapping feeds it a normalised value
+  # derived from an identity this script never authorised (e.g. one where
+  # attribute.aws_role is built from a caller-controlled ARN path segment
+  # rather than the actual assumed-role name). Validating the condition
+  # without also validating the mapping only checks half of that property.
+  EXISTING_MAPPING=$(gcloud iam workload-identity-pools providers describe "$PROVIDER_ID" \
+    --project="$PROJECT" --location=global \
+    --workload-identity-pool="$POOL_ID" \
+    --format='value(attributeMapping)')
+  if [[ "$(normalize_mapping "$EXISTING_MAPPING" ';')" != "$(normalize_mapping "$EXPECTED_MAPPING" ',')" ]]; then
+    die "provider '${PROVIDER_ID}' already exists with a different attribute mapping, so this script cannot vouch for which identities enter pool '${POOL_ID}'.
+  found   : ${EXISTING_MAPPING:-(none)}
+  expected: ${EXPECTED_MAPPING}
+A matching attribute condition is not sufficient on its own: the mapping
+decides what value the condition is evaluated against, so a mismatched
+mapping can satisfy the condition while admitting an identity this script
+never authorised.
+Delete the provider and re-run:
+${DELETE_HINT}"
+  fi
+  echo "Reusing existing provider '${PROVIDER_ID}' (attribute condition and mapping match expected values)"
 fi
 
 # ── Grant service account impersonation to one principal ──────────────────────

--- a/arm/CUDly-CrossSubscription/setup-gcp-wif.sh
+++ b/arm/CUDly-CrossSubscription/setup-gcp-wif.sh
@@ -260,18 +260,32 @@ else
     --workload-identity-pool="$POOL_ID" \
     --format='value(attributeCondition)')
   # A provider of the other type would emit a credential config that does not
-  # match it and mint an attribute the grant below never names.
-  EXISTING_TYPE=$(gcloud iam workload-identity-pools providers describe "$PROVIDER_ID" \
-    --project="$PROJECT" --location=global \
-    --workload-identity-pool="$POOL_ID" \
-    --format='value(aws.accountId,oidc.issuerUri)')
-  if [[ "$PROVIDER_TYPE" == "aws" && "$EXISTING_TYPE" != "${AWS_ACCOUNT_ID}"* ]]; then
-    die "provider '${PROVIDER_ID}' already exists but is not an AWS provider for account ${AWS_ACCOUNT_ID} (describe reports: ${EXISTING_TYPE}). Delete it and re-run:
+  # match it and mint an attribute the grant below never names. Compared as an
+  # exact match on the single relevant field, not a prefix/suffix test against
+  # the account-id/issuer-uri pair gcloud tab-joins under `value(a,b)`: a
+  # suffix test here would accept any issuer URI merely ENDING in the expected
+  # one (e.g. an attacker-hosted https://evil.example.com/<expected-issuer>,
+  # whose /.well-known/openid-configuration GCP would then fetch from the
+  # attacker, who can mint a token with any subject), and a prefix test would
+  # accept any account ID merely STARTING with the expected one.
+  if [[ "$PROVIDER_TYPE" == "aws" ]]; then
+    EXISTING_ACCOUNT_ID=$(gcloud iam workload-identity-pools providers describe "$PROVIDER_ID" \
+      --project="$PROJECT" --location=global \
+      --workload-identity-pool="$POOL_ID" \
+      --format='value(aws.accountId)')
+    if [[ "$EXISTING_ACCOUNT_ID" != "$AWS_ACCOUNT_ID" ]]; then
+      die "provider '${PROVIDER_ID}' already exists but is not an AWS provider for account ${AWS_ACCOUNT_ID} (describe reports account: ${EXISTING_ACCOUNT_ID:-none}). Delete it and re-run:
 ${DELETE_HINT}"
-  fi
-  if [[ "$PROVIDER_TYPE" == "oidc" && "$EXISTING_TYPE" != *"${ISSUER_URI}" ]]; then
-    die "provider '${PROVIDER_ID}' already exists but is not an OIDC provider for issuer ${ISSUER_URI} (describe reports: ${EXISTING_TYPE}). Delete it and re-run:
+    fi
+  else
+    EXISTING_ISSUER=$(gcloud iam workload-identity-pools providers describe "$PROVIDER_ID" \
+      --project="$PROJECT" --location=global \
+      --workload-identity-pool="$POOL_ID" \
+      --format='value(oidc.issuerUri)')
+    if [[ "$EXISTING_ISSUER" != "$ISSUER_URI" ]]; then
+      die "provider '${PROVIDER_ID}' already exists but is not an OIDC provider for issuer ${ISSUER_URI} (describe reports issuer: ${EXISTING_ISSUER:-none}). Delete it and re-run:
 ${DELETE_HINT}"
+    fi
   fi
   if [[ "$EXISTING_CONDITION" != "$EXPECTED_CONDITION" ]]; then
     die "provider '${PROVIDER_ID}' already exists with a different attribute condition, so this script cannot vouch for which identities enter pool '${POOL_ID}'.


### PR DESCRIPTION
Closes #1672 (refs #1544)

PR #1651 (merged as `3fc9b5700`) hardened `arm/CUDly-CrossSubscription/setup-gcp-wif.sh`'s provider-reuse path to reject an existing provider whose `attributeCondition` doesn't match what this script would have written. A follow-up adversarial review found that check validates only half of the property it exists to enforce: the condition is only meaningful relative to the `attributeMapping` that produces the value it is evaluated against, and the mapping was never compared on reuse.

## The bypass this closes

A pre-existing provider whose condition is byte-identical to the one this script would write (so the existing check passes) but whose mapping is:

```
attribute.aws_role = 'arn:aws:sts::' + assertion.account + ':assumed-role/' + assertion.arn.extract('assumed-role/{role_name}/')
```

An attacker holding only `iam:CreateUser` in the trusted AWS account creates an IAM **user** with path `/assumed-role/CUDly-Execution/`. `extract('assumed-role/{role_name}/')` then yields `CUDly-Execution`, so `attribute.aws_role` becomes exactly the pinned role ARN, satisfying both the condition and the narrow `principalSet` grant this script installs. Full service-account impersonation, and the script reports "Reusing existing provider (attribute condition matches: ...)" as success.

This is the same substring-vs-normalisation bypass class as the Terraform sibling's bug (#1667), reachable here only through a hand-crafted mapping on a provider this script did not itself create (this script's own create path is immune, since it writes the mapping and condition together).

## The fix

`EXPECTED_MAPPING` is now built once per provider type (previously duplicated inline at both the `create-aws` and `create-oidc` call sites — a drift risk this change also removes) and compared against the existing provider's mapping on reuse, failing the same way the condition check does, naming what differed.

`gcloud`'s `value(...)` printer renders `attributeMapping` as **semicolon**-joined, key-**sorted** pairs (confirmed by reading `googlecloudsdk/core/resource/csv_printer.py`'s `CsvPrinter._AddRecord` / `ValuePrinter`), not the **comma**-joined form `--attribute-mapping` takes as input — a raw string comparison would report every correctly-configured provider as mismatched. `normalize_mapping()` splits each side on its own pair separator, re-sorts, and compares parsed key/value pairs, so neither that shape difference nor a hypothetical future change to gcloud's key ordering produces a false positive, while an actually-different mapping (including the bypass above) still compares unequal.

Also recorded in a comment: the AWS session-ARN 127-**byte** budget computed a few lines above is only correct because the role-name and OIDC-subject charsets are both ASCII-only (chars == bytes); it would silently mis-budget if that charset were ever widened.

## Verification

- `bash -n` — exit 0. `shellcheck` 0.11.0 — exit 0, no findings.
- Unit-tested `normalize_mapping()` in isolation: a matching AWS mapping (comma-joined input form vs. semicolon-joined, sorted describe-output form) compares equal; a matching single-pair OIDC mapping compares equal; the exact bypass mapping above compares **unequal** to expected; gcloud output with keys in the opposite order still compares equal (order independence).
- End-to-end against a stubbed `gcloud` exercising the real script: a provider with a matching condition and matching mapping reaches "Reusing existing provider (attribute condition and mapping match expected values)" and proceeds to grant impersonation. The same setup with the bypass mapping substituted exits 1 with `provider 'cudly-aws' already exists with a different attribute mapping...`, printing both the found and expected values.
- Diff reviewed against `origin/main` (cherry-picked cleanly onto current main; scope is exactly this file, this change).

## Note on branch history

This fix was originally developed against #1651 while that PR was still open (worktree `wt-1544`, branch `sec/1544-gcp-wif-attribute-condition`). By the time it was ready, #1651 had merged (squashed into `3fc9b5700`), so that branch's push had no PR to land on. This PR is the same commit cherry-picked onto current `main` via a fresh branch.

## Update: account/issuer reuse check was also a substring test

A second look at the same provider-reuse path (`65de3d24b`) found the check just above the ones this PR added — the one confirming an existing provider is actually the right *type* (AWS vs. OIDC) before the condition/mapping checks even run — had the identical bypass shape, and it is **pre-existing** (introduced by #1651, not by this PR).

It ran a single `describe --format='value(aws.accountId,oidc.issuerUri)'` and tab-joined the two columns, then tested the OIDC side with a suffix glob (`!= *"${ISSUER_URI}"`) and the AWS side with a prefix glob (`!= "${AWS_ACCOUNT_ID}"*`). Both are substring tests standing in for equality:

- An existing OIDC provider whose issuer merely **ends with** the expected one — e.g. `https://evil.example.com/https://token.actions.githubusercontent.com`, an ordinary HTTPS URL from which GCP fetches `/.well-known/openid-configuration` — passed the suffix test, letting the attacker mint tokens with any `sub`.
- An existing AWS provider whose account ID merely **starts with** the expected one (e.g. `123456789012999999` against expected `123456789012`) passed the prefix test.

Either way, the type check this PR's condition/mapping checks depend on was vacuous, so a provider under attacker control could pass everything downstream too. This is the **fifth** substring-standing-in-for-equality defect found in this codebase (after #1667's Terraform sibling, and others in the same review sweep).

Fixed by splitting into two separate `describe` calls — `value(aws.accountId)` and `value(oidc.issuerUri)` — each compared with exact `!=`, mirroring the pattern the condition/mapping checks already use.

Verified against three hostile OIDC issuer shapes (path-embedded, query-string, and concatenated-host, all ending in the legitimate issuer string) plus a digit-appended AWS account ID: all four are **accepted** by the pre-fix code and **rejected** post-fix, while a byte-identical legitimate provider is accepted both before and after in both the AWS and OIDC branches. `bash -n` and `shellcheck` 0.11.0 both exit 0 on the updated file.
