### PR TITLE
sec(ci): bind destroy jobs to an environment and narrow id-token on destroy workflows

### DIFF
--- a/.github/workflows/cleanup-staging.yml
+++ b/.github/workflows/cleanup-staging.yml
@@ -30,14 +30,22 @@ on:
 # What each cloud does with that subject differs; see the per-job comments.
 #
 # It is NOT a reviewer gate. GitHub only blocks a job once required-reviewer
-# protection rules are configured on the environment in repo settings, and as of
-# this change NO environment in this repo has any. `staging` does not exist at
-# all yet, so the first dispatch will AUTO-CREATE it bare — no reviewers, no
-# branch policy. Until that is configured out-of-band these destroy jobs still
-# run unapproved. See #1660.
+# protection rules are configured on the environment, and at the time of writing
+# no environment in this repo has any. Note GitHub AUTO-CREATES a referenced
+# environment bare on first use — no reviewers, no branch policy — so a binding
+# to an environment nobody has configured runs straight through. Until that is
+# configured out-of-band these destroy jobs still run unapproved. See #1660 for
+# the live state; deliberately not restated here so this comment cannot rot into
+# false reassurance.
 #
-# Because the environment subject is ref-agnostic, the `guard` job below
-# separately enforces that this workflow may only be dispatched from `main`.
+# The environment subject is ref-agnostic, so the binding does not by itself keep
+# this workflow on `main`. The `guard` job below checks the ref, but that check is
+# defense-in-depth against ACCIDENTS ONLY and is NOT a security boundary:
+# `workflow_dispatch` runs the workflow file as it exists on the dispatched ref, so
+# anyone able to push a branch can delete the check and still present the
+# `environment:staging` subject. The only control that survives that is a
+# deployment branch policy, which GitHub evaluates before the job starts and
+# before the token is minted. See #1660.
 permissions:
   contents: read
 
@@ -52,17 +60,21 @@ jobs:
     permissions: {}
     steps:
       # An OIDC `sub` is EITHER `…:ref:refs/heads/<branch>` OR
-      # `…:environment:<name>` -- never both. So binding the destroy jobs to an
+      # `…:environment:<name>` -- never both (absent a custom sub-claim
+      # template, and this repo sets none). So binding the destroy jobs to an
       # environment (below) REPLACES the ref-scoped subject with a ref-agnostic
       # one, and neither `dev` nor `staging` carries a deployment_branch_policy.
-      # Without this check that would trade a main-only restriction for
-      # any-branch access -- a widening, on the workflow this change exists to
-      # narrow.
+      # Without a ref check that trades a main-only restriction for any-branch
+      # access -- a widening, on the workflow this change exists to narrow.
       #
-      # Enforced here rather than via the environment's branch policy because
-      # `main` is not a protected branch, so a protected-branches policy would
-      # match nothing and block every deploy. Keep this check until `main` is
-      # protected AND the environments carry an explicit branch policy (#1660).
+      # This step catches the accidental case only. It is NOT a security
+      # boundary: `workflow_dispatch` runs the workflow file as it exists on the
+      # dispatched ref, so anyone who can push a branch can delete this step and
+      # still present the `environment:staging` subject. The control that
+      # survives that is a deployment branch policy on the environment
+      # (custom_branch_policies + a `main` pattern), which GitHub evaluates
+      # before the job starts and before the token is minted, and which does NOT
+      # require `main` to be a protected branch. Tracked in #1660.
       - name: Restrict to main
         env:
           REF: ${{ github.ref }}
@@ -359,8 +371,11 @@ jobs:
           # Routed via env: rather than interpolated into this script's source,
           # per the zero-expression-interpolation-in-run-blocks rule from #1641.
           PROJECT="$GCP_PROJECT_ID"
-          if [ -z "$PROJECT" ]; then
-            echo "::error::vars.GCP_PROJECT_ID is unset; refusing to run Cloud SQL cleanup against an empty project"
+          # Validate the shape, not merely non-emptiness: a whitespace-only or
+          # malformed value would otherwise reach `gcloud --project=`, match no
+          # instance, and silently skip the deletion this step exists to perform.
+          if ! printf '%s' "$PROJECT" | grep -Eq '^[a-z][a-z0-9-]{5,29}$'; then
+            echo "::error::vars.GCP_PROJECT_ID is unset or malformed ('$PROJECT'); refusing to run Cloud SQL cleanup"
             exit 1
           fi
           # Find and delete the staging Cloud SQL instance to avoid PostgreSQL dependency errors

--- a/.github/workflows/cleanup-staging.yml
+++ b/.github/workflows/cleanup-staging.yml
@@ -354,8 +354,15 @@ jobs:
       - name: Delete Cloud SQL instance directly (avoids user/DB ordering deadlock)
         env:
           TF_VAR_project_id: ${{ vars.GCP_PROJECT_ID }}
+          GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
         run: |
-          PROJECT="${{ vars.GCP_PROJECT_ID }}"
+          # Routed via env: rather than interpolated into this script's source,
+          # per the zero-expression-interpolation-in-run-blocks rule from #1641.
+          PROJECT="$GCP_PROJECT_ID"
+          if [ -z "$PROJECT" ]; then
+            echo "::error::vars.GCP_PROJECT_ID is unset; refusing to run Cloud SQL cleanup against an empty project"
+            exit 1
+          fi
           # Find and delete the staging Cloud SQL instance to avoid PostgreSQL dependency errors
           INSTANCE=$(gcloud sql instances list --project="$PROJECT" \
             --filter="name:cudly-staging" --format="value(name)" 2>/dev/null | head -1)

--- a/.github/workflows/cleanup-staging.yml
+++ b/.github/workflows/cleanup-staging.yml
@@ -21,8 +21,24 @@ on:
         description: 'Type "destroy" to confirm destruction of ALL staging resources'
         required: true
 
+# Least privilege: `id-token: write` is granted per job, only to the four jobs
+# that assume a cloud deploy role, and each of those is bound to the `staging`
+# deployment environment. `guard` authenticates to nothing and must not hold it.
+#
+# IMPORTANT — what the `environment:` binding does and does not buy. It scopes
+# secrets/vars and sets the OIDC subject to `repo:<org/repo>:environment:staging`.
+# What each cloud does with that subject differs; see the per-job comments.
+#
+# It is NOT a reviewer gate. GitHub only blocks a job once required-reviewer
+# protection rules are configured on the environment in repo settings, and as of
+# this change NO environment in this repo has any. `staging` does not exist at
+# all yet, so the first dispatch will AUTO-CREATE it bare — no reviewers, no
+# branch policy. Until that is configured out-of-band these destroy jobs still
+# run unapproved. See #1660.
+#
+# Because the environment subject is ref-agnostic, the `guard` job below
+# separately enforces that this workflow may only be dispatched from `main`.
 permissions:
-  id-token: write
   contents: read
 
 env:
@@ -33,7 +49,29 @@ jobs:
   guard:
     name: Confirm Destruction
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
+      # An OIDC `sub` is EITHER `…:ref:refs/heads/<branch>` OR
+      # `…:environment:<name>` -- never both. So binding the destroy jobs to an
+      # environment (below) REPLACES the ref-scoped subject with a ref-agnostic
+      # one, and neither `dev` nor `staging` carries a deployment_branch_policy.
+      # Without this check that would trade a main-only restriction for
+      # any-branch access -- a widening, on the workflow this change exists to
+      # narrow.
+      #
+      # Enforced here rather than via the environment's branch policy because
+      # `main` is not a protected branch, so a protected-branches policy would
+      # match nothing and block every deploy. Keep this check until `main` is
+      # protected AND the environments carry an explicit branch policy (#1660).
+      - name: Restrict to main
+        env:
+          REF: ${{ github.ref }}
+        run: |
+          if [ "$REF" != "refs/heads/main" ]; then
+            echo "::error::Refusing to destroy from '$REF'; this workflow may only be dispatched from refs/heads/main"
+            exit 1
+          fi
+
       - name: Check confirmation
         env:
           CONFIRM: ${{ inputs.confirm }}
@@ -48,6 +86,13 @@ jobs:
     name: Destroy AWS Lambda (staging)
     runs-on: ubuntu-24.04-arm
     needs: guard
+    permissions:
+      id-token: write
+      contents: read
+    # AWS: role.tf's sub allowlist includes `environment:staging`, so this is
+    # the subject the trust policy matches. Not a reviewer gate until
+    # protection rules exist -- see the note at the top of this file.
+    environment: staging
     env:
       AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
 
@@ -118,6 +163,13 @@ jobs:
     name: Destroy AWS Fargate (staging)
     runs-on: ubuntu-24.04-arm
     needs: guard
+    permissions:
+      id-token: write
+      contents: read
+    # AWS: role.tf's sub allowlist includes `environment:staging`, so this is
+    # the subject the trust policy matches. Not a reviewer gate until
+    # protection rules exist -- see the note at the top of this file.
+    environment: staging
     env:
       AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
 
@@ -188,6 +240,16 @@ jobs:
     name: Destroy Azure (staging)
     runs-on: ubuntu-latest
     needs: guard
+    permissions:
+      id-token: write
+      contents: read
+    # Azure: REQUIRES the bootstrap module
+    # terraform/environments/azure/ci-cd-permissions to have been re-applied
+    # with `github_environments` including "staging". Until that manual apply
+    # happens this job fails with AADSTS70021, because the only federated
+    # credentials that exist are ref:refs/heads/main and pull_request (#1648).
+    # Not a reviewer gate either -- see the note at the top of this file.
+    environment: staging
     env:
       ARM_USE_OIDC: "true"
       ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
@@ -253,6 +315,16 @@ jobs:
     name: Destroy GCP (staging)
     runs-on: ubuntu-latest
     needs: guard
+    permissions:
+      id-token: write
+      contents: read
+    # GCP: the WIF provider keys on assertion.repository and assertion.ref
+    # only (gcp/ci-cd-permissions/github_oidc.tf:37), and the impersonation
+    # binding is on attribute.repository -- nothing reads the subject. So this
+    # binding does NOT affect whether the token mints; it is here for parity
+    # and so protection rules can apply once they exist. GCP therefore stays
+    # main-only via assertion.ref regardless.
+    environment: staging
     env:
       GCP_REGION: ${{ vars.GCP_REGION || 'us-central1' }}
 

--- a/.github/workflows/destroy-fargate-dev.yml
+++ b/.github/workflows/destroy-fargate-dev.yml
@@ -21,18 +21,23 @@ on:
 # which the AWS trust policy's sub allowlist accepts (role.tf:30).
 #
 # It is NOT a reviewer gate. GitHub only blocks a job once required-reviewer
-# protection rules are configured on the environment in repo settings, and as of
-# this change NO environment in this repo has any — `dev` exists but carries
-# `protection_rules: []` and no branch policy. Until that is configured
-# out-of-band this destroy job still runs unapproved. See #1660.
+# protection rules are configured on the environment, and at the time of writing
+# no environment in this repo has any. Until that is configured out-of-band this
+# destroy job still runs unapproved. See #1660 for the live state — deliberately
+# not restated here, so this comment cannot rot into false reassurance.
 #
-# Because the environment subject is ref-agnostic, the `guard` job below
-# separately enforces that this workflow may only be dispatched from `main`.
+# The environment subject is ref-agnostic, so the binding does not by itself keep
+# this workflow on `main`. The `guard` job below checks the ref, but that check is
+# defense-in-depth against ACCIDENTS ONLY and is NOT a security boundary:
+# `workflow_dispatch` runs the workflow file as it exists on the dispatched ref, so
+# anyone able to push a branch can delete the check and still present the
+# `environment:dev` subject. The only control that survives that is a deployment
+# branch policy, which GitHub evaluates before the job starts and before the token
+# is minted. See #1660.
 permissions:
   contents: read
 
 env:
-  AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
   TF_VERSION: '1.10.0'
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
@@ -42,13 +47,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     steps:
-      # See the note in cleanup-staging.yml: an environment binding replaces the
-      # ref-scoped OIDC subject with a ref-agnostic one, and `dev` carries no
-      # deployment_branch_policy, so without this check the binding would widen
-      # the destroy path from main-only to any-branch. Enforced in code because
-      # `main` is unprotected, so a protected-branches policy would match
-      # nothing. Keep until `main` is protected and `dev` has a branch policy
-      # (#1660).
+      # Catches the accidental "dispatched from the wrong branch" case. It does
+      # NOT stop a deliberate one: this file is attacker-controlled on the ref
+      # being dispatched, so the step can simply be deleted on that branch. The
+      # server-side equivalent is a deployment branch policy on `dev`
+      # (custom_branch_policies + a `main` pattern) — which does NOT require
+      # `main` to be a protected branch — tracked in #1660.
       - name: Restrict to main
         env:
           REF: ${{ github.ref }}
@@ -78,6 +82,11 @@ jobs:
     # trust policy matches on. Not a reviewer gate until protection rules exist
     # on this environment -- see the note at the top of this file.
     environment: dev
+    # Set at job level, not workflow level: workflow-level `env:` is resolved
+    # before this job's `dev` environment is in scope, so an environment-scoped
+    # AWS_REGION variable would be invisible there. Matches cleanup-staging.yml.
+    env:
+      AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/destroy-fargate-dev.yml
+++ b/.github/workflows/destroy-fargate-dev.yml
@@ -12,8 +12,23 @@ on:
         description: 'Type "destroy" to confirm'
         required: true
 
+# Least privilege: `id-token: write` is granted per job, only to the job that
+# assumes the AWS deploy role, and that job is bound to the `dev` deployment
+# environment. `guard` authenticates to nothing and must not hold it.
+#
+# IMPORTANT — what the `environment:` binding does and does not buy. It scopes
+# secrets/vars and sets the OIDC subject to `repo:<org/repo>:environment:dev`,
+# which the AWS trust policy's sub allowlist accepts (role.tf:30).
+#
+# It is NOT a reviewer gate. GitHub only blocks a job once required-reviewer
+# protection rules are configured on the environment in repo settings, and as of
+# this change NO environment in this repo has any — `dev` exists but carries
+# `protection_rules: []` and no branch policy. Until that is configured
+# out-of-band this destroy job still runs unapproved. See #1660.
+#
+# Because the environment subject is ref-agnostic, the `guard` job below
+# separately enforces that this workflow may only be dispatched from `main`.
 permissions:
-  id-token: write
   contents: read
 
 env:
@@ -25,7 +40,24 @@ jobs:
   guard:
     name: Confirm Destruction
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
+      # See the note in cleanup-staging.yml: an environment binding replaces the
+      # ref-scoped OIDC subject with a ref-agnostic one, and `dev` carries no
+      # deployment_branch_policy, so without this check the binding would widen
+      # the destroy path from main-only to any-branch. Enforced in code because
+      # `main` is unprotected, so a protected-branches policy would match
+      # nothing. Keep until `main` is protected and `dev` has a branch policy
+      # (#1660).
+      - name: Restrict to main
+        env:
+          REF: ${{ github.ref }}
+        run: |
+          if [ "$REF" != "refs/heads/main" ]; then
+            echo "::error::Refusing to destroy from '$REF'; this workflow may only be dispatched from refs/heads/main"
+            exit 1
+          fi
+
       - name: Check confirmation
         env:
           CONFIRM: ${{ inputs.confirm }}
@@ -39,6 +71,13 @@ jobs:
     name: Terraform Destroy (Fargate dev)
     runs-on: ubuntu-24.04-arm
     needs: guard
+    permissions:
+      id-token: write
+      contents: read
+    # Binds the OIDC subject to repo:<org/repo>:environment:dev, which the AWS
+    # trust policy matches on. Not a reviewer gate until protection rules exist
+    # on this environment -- see the note at the top of this file.
+    environment: dev
 
     steps:
       - name: Checkout code

--- a/terraform/environments/azure/ci-cd-permissions/README.md
+++ b/terraform/environments/azure/ci-cd-permissions/README.md
@@ -13,6 +13,7 @@ secrets ever need to be stored.
 | `azuread_service_principal.cudly_deploy` | Service principal (identity) |
 | `azuread_application_federated_identity_credential.github_main` | Federated credential for main-branch deployments |
 | `azuread_application_federated_identity_credential.github_pr` | Federated credential for pull-request plan checks |
+| `azuread_application_federated_identity_credential.github_environment` | Federated credential per deployment environment (`var.github_environments`) |
 | `azurerm_role_definition.cudly_deploy` | Custom role with minimum required permissions |
 | `azurerm_role_assignment.cudly_deploy` | Assigns the custom role to the SP at subscription scope |
 | `module.cudly_reservation_role` (`azurerm_role_definition`) | Host-side custom "CUDly Reservation Purchaser" role definition consumed by the runtime container-apps deploy |
@@ -159,12 +160,24 @@ the `az` CLI context for all subsequent steps.
 
 ### Federated credential subjects
 
-Two subjects are registered:
+Azure federated credentials allow no wildcards, so one resource is required per subject:
 
 | Credential | Subject | Use case |
 | --- | --- | --- |
 | `github-actions-main` | `repo:LeanerCloud/CUDly:ref:refs/heads/main` | Deployments from main |
 | `github-actions-pr` | `repo:LeanerCloud/CUDly:pull_request` | Plan runs on PRs |
+| `github-actions-env-<name>` | `repo:LeanerCloud/CUDly:environment:<name>` | Jobs bound to a deployment environment (one per `var.github_environments`) |
 
-If you need to deploy from a different branch or repo, add additional
-`azuread_application_federated_identity_credential` resources to `sp.tf`.
+A job declaring `environment: <name>` presents the **environment** subject, not the
+main-branch one, so it cannot authenticate unless `<name>` is in
+`var.github_environments`. Omitting this is what makes `azure/login` fail with
+`AADSTS70021` on an otherwise-correct workflow (see issue #1648).
+
+Note the environment subject is **ref-agnostic** — it does not encode the branch. Adding
+a name here therefore lets any branch that can reach a job bound to that environment
+obtain the deploy service principal. Restrict the branch in the workflow itself, or via
+the environment's `deployment_branch_policy`.
+
+To allow a new deployment environment, add its name to `var.github_environments`. To
+deploy from a different branch or repo, add a further
+`azuread_application_federated_identity_credential` resource to `sp.tf`.

--- a/terraform/environments/azure/ci-cd-permissions/README.md
+++ b/terraform/environments/azure/ci-cd-permissions/README.md
@@ -175,8 +175,10 @@ main-branch one, so it cannot authenticate unless `<name>` is in
 
 Note the environment subject is **ref-agnostic** — it does not encode the branch. Adding
 a name here therefore lets any branch that can reach a job bound to that environment
-obtain the deploy service principal. Restrict the branch in the workflow itself, or via
-the environment's `deployment_branch_policy`.
+obtain the deploy service principal. Restrict the branch via the environment's
+`deployment_branch_policy`; a ref check inside the workflow does **not** bind, because
+`workflow_dispatch` runs the workflow file as it exists on the dispatched ref, so the
+check can be removed on that branch.
 
 To allow a new deployment environment, add its name to `var.github_environments`. To
 deploy from a different branch or repo, add a further

--- a/terraform/environments/azure/ci-cd-permissions/sp.tf
+++ b/terraform/environments/azure/ci-cd-permissions/sp.tf
@@ -23,8 +23,18 @@ resource "azuread_service_principal" "cudly_deploy" {
 # GitHub Actions Federated Identity Credentials
 # =============================================================================
 # Azure federated credentials require one entry per allowed subject (no
-# wildcards). We create two: one for main-branch deployments and one for
-# pull-request plan checks.
+# wildcards), so each named deployment environment needs its own resource.
+#
+# The `github_environment` entries below are what let an environment-bound job
+# authenticate at all. A job carrying `environment: staging` presents the
+# subject `repo:<org/repo>:environment:staging`, NOT the main-branch subject,
+# so without a matching credential `azure/login` fails with AADSTS70021 even
+# though the workflow is running on main. Adding an `environment:` binding to
+# an Azure job and forgetting this is the exact breakage recorded in #1648.
+#
+# NOTE: this module is bootstrap-only (see CLAUDE.md) — it is applied manually
+# by a privileged human, not by the deploy workflow. The Azure destroy job in
+# cleanup-staging.yml cannot authenticate until that re-apply happens.
 
 resource "azuread_application_federated_identity_credential" "github_main" {
   count = var.github_repo != "" ? 1 : 0
@@ -46,4 +56,19 @@ resource "azuread_application_federated_identity_credential" "github_pr" {
   audiences      = ["api://AzureADTokenExchange"]
   issuer         = "https://token.actions.githubusercontent.com"
   subject        = "repo:${var.github_repo}:pull_request"
+}
+
+# One credential per named deployment environment, so environment-bound jobs
+# can authenticate. Mirrors the `environment:{dev,staging,prod}` subjects the
+# AWS role's trust policy already allows
+# (terraform/environments/aws/ci-cd-permissions/role.tf).
+resource "azuread_application_federated_identity_credential" "github_environment" {
+  for_each = var.github_repo != "" ? toset(var.github_environments) : toset([])
+
+  application_id = azuread_application.cudly_deploy.id
+  display_name   = "github-actions-env-${each.value}"
+  description    = "GitHub Actions OIDC — ${var.github_repo} ${each.value} environment"
+  audiences      = ["api://AzureADTokenExchange"]
+  issuer         = "https://token.actions.githubusercontent.com"
+  subject        = "repo:${var.github_repo}:environment:${each.value}"
 }

--- a/terraform/environments/azure/ci-cd-permissions/variables.tf
+++ b/terraform/environments/azure/ci-cd-permissions/variables.tf
@@ -19,11 +19,23 @@ variable "github_environments" {
     NOTE the subject is ref-agnostic: it does not encode the branch, so a
     credential here lets ANY branch that can reach a job bound to that environment
     obtain the deploy service principal. Add a name only once a workflow actually
-    presents it, and prefer restricting the branch in the workflow or via the
-    environment's deployment_branch_policy.
+    presents it, and restrict the branch via the environment's
+    deployment_branch_policy — an in-workflow ref check does not bind, because
+    workflow_dispatch runs the file as it exists on the dispatched ref.
 
-    `prod` is deliberately absent: no Azure job binds to it today, and adding it
-    would mint a credential for a path with no consumer.
+    This list is NOT a complete enumeration of the environment subjects this repo
+    presents to Azure. It covers exactly the two destroy jobs bound by
+    cleanup-staging.yml (`staging`) and destroy-fargate-dev.yml (`dev`).
+
+    Knowingly NOT covered, tracked in #1648 — these Azure jobs bind to compound
+    environment names and therefore still fail with AADSTS70021:
+      - rollback.yml           -> azure-{dev,staging,prod}-rollback
+      - database-migration.yml -> azure-db-{dev,staging,prod}
+
+    They are excluded here rather than fixed because each needs its environment
+    created and gated first; minting a credential for an ungated environment that
+    does not yet exist would widen access without adding a control. Do not read
+    the absence of a name as "no job uses it".
   EOT
   type        = list(string)
   default     = ["dev", "staging"]

--- a/terraform/environments/azure/ci-cd-permissions/variables.tf
+++ b/terraform/environments/azure/ci-cd-permissions/variables.tf
@@ -8,3 +8,33 @@ variable "github_repo" {
   type        = string
   default     = "LeanerCloud/CUDly"
 }
+
+variable "github_environments" {
+  description = <<-EOT
+    GitHub deployment environment names whose jobs may authenticate via federated
+    identity credentials. A job carrying `environment: <name>` presents the OIDC
+    subject repo:<github_repo>:environment:<name>, so a name absent from this list
+    cannot authenticate (AADSTS70021).
+
+    NOTE the subject is ref-agnostic: it does not encode the branch, so a
+    credential here lets ANY branch that can reach a job bound to that environment
+    obtain the deploy service principal. Add a name only once a workflow actually
+    presents it, and prefer restricting the branch in the workflow or via the
+    environment's deployment_branch_policy.
+
+    `prod` is deliberately absent: no Azure job binds to it today, and adding it
+    would mint a credential for a path with no consumer.
+  EOT
+  type        = list(string)
+  default     = ["dev", "staging"]
+
+  validation {
+    condition     = length(var.github_environments) == length(distinct(var.github_environments))
+    error_message = "github_environments must not contain duplicates; toset() would silently collapse them, so a duplicate indicates a typo."
+  }
+
+  validation {
+    condition     = alltrue([for e in var.github_environments : trimspace(e) != ""])
+    error_message = "github_environments entries must be non-empty; an empty name yields the unmatchable subject repo:<repo>:environment:."
+  }
+}


### PR DESCRIPTION
Closes #1591

## Read this first: this PR does not add a reviewer gate

The issue title says these workflows have "no environment binding, so no reviewer gate". This PR **adds the binding**. It does **not** add the reviewer gate, and closing #1591 should not be read as "destroy is now gated".

`environment:` buys exactly two things: it scopes secrets/vars, and it sets the OIDC subject to `repo:<org/repo>:environment:<name>`. GitHub only *blocks* a job once **protection rules are configured on the environment**, and re-confirmed against the live API on this branch:

```
$ gh api repos/LeanerCloud/CUDly/environments
total_count: 5
aws-fargate-dev:     protection_rules=[]  can_admins_bypass=true
aws-fargate-staging: protection_rules=[]  can_admins_bypass=true
azure-:              protection_rules=[]  can_admins_bypass=true
dev:                 protection_rules=[]  can_admins_bypass=true
gcp-:                protection_rules=[]  can_admins_bypass=true
```

**No environment in this repo has any protection rules, and `staging` does not exist at all.** GitHub auto-creates a referenced environment *bare* on first use, so the first `cleanup-staging` dispatch will mint `staging` with no reviewers and run straight through. Until someone configures rules out-of-band, these destroy jobs still run unapproved.

### The code / manual split, explicitly

| Half | Who does it | Status |
|---|---|---|
| Bind destroy jobs to an environment; narrow `id-token: write`; per-env Azure federated credentials | this PR | done |
| Create `staging`; set **required reviewers** on `dev` and `staging`; set a **deployment branch policy**; consider `can_admins_bypass=false` | **privileged human, repo settings or API** | **not done** |
| Re-apply the Azure `ci-cd-permissions` bootstrap module | **privileged human** (bootstrap-only per CLAUDE.md) | **not done — Azure destroy fails until then** |

**Exact manual steps**, on environments `dev` and `staging`:

1. Create `staging` (`dev` already exists). Neither can be created declaratively today: there is no `github_repository_environment` resource anywhere under `terraform/` or `iac/`, and no GitHub Terraform provider is configured in this repo. Adding that provider is #1660's scope, not this PR's.
2. **Required reviewers** — the actual gate. Without this, nothing in this PR stops anything.
3. **Deployment branch policy** — `custom_branch_policies` with pattern `main`. See below for why this one is load-bearing.
4. Re-apply `terraform/environments/azure/ci-cd-permissions` so the new per-environment federated credentials exist. Until this runs, the Azure destroy job fails with `AADSTS70021` — it is knowingly merged broken, matching the pre-existing state recorded in #1648.

Cross-referenced, not duplicated: **#1660** owns environments-have-no-protection-rules and `main`-is-unprotected. **#1648** owns the trust-policy `sub` allowlist gaps. **#1659** owns the sibling deploy workflows. Nothing new filed; this family already has enough overlapping issues.

## The binding is a widening unless the branch is pinned

An OIDC `sub` is **either** `…:ref:refs/heads/<branch>` **or** `…:environment:<name>` — never both (absent a custom sub-claim template; this repo sets none). So adding `environment:` **replaces** the ref-scoped subject with a ref-agnostic one. Since neither `dev` nor `staging` carries a deployment branch policy, the binding on its own trades a main-only restriction for any-branch access — a widening, on the workflows this change exists to narrow.

There is a `Restrict to main` step in each `guard` job for this. **It is defense-in-depth against accidents and is not a security boundary**, and the comments say so in those words. `workflow_dispatch` runs the workflow file *as it exists on the dispatched ref*, so anyone who can push a branch can delete the step and still present the `environment:<name>` subject. The control that survives that is the deployment branch policy in step 3 above, which GitHub evaluates before the job starts and before the token is minted — and which does **not** require `main` to be protected.

An earlier revision of this branch got that reason wrong, claiming a branch policy was unavailable because `main` is unprotected. It was corrected in c39adc3; `custom_branch_policies` takes an explicit pattern and works on an unprotected branch.

## Also in scope, since I was in these files

**`permissions:`** — both workflows declared `permissions: id-token: write` at *workflow* level, handing an OIDC-mintable token to every job including the confirmation guard. Now `contents: read` at workflow level, `id-token: write` granted per job only to the five jobs that assume a cloud role, and `permissions: {}` on both `guard` jobs (neither checks out code). Same split #1657 applied to `deploy-aws-lambda.yml`. This is the destroy-workflow analogue of #1665.

**Residual `${{ }}` in `run:` blocks** — #1641's rule is zero. `destroy-fargate-dev.yml` was already clean. `cleanup-staging.yml` had one, `vars.GCP_PROJECT_ID` interpolated into the Cloud SQL cleanup step; routed through `env:` and referenced as a quoted shell variable. Admin-settable, so hardening rather than a live injection. Both files are now at zero, as is `rollback.yml`.

**`workflow_dispatch` input validation** — the only input on either workflow is `confirm`, already compared against the literal `destroy` via `env:`. No input reaches anything credentialed. Note the guard is in a *preceding job in the same run*, typed by the same person who dispatched — it is a typo-catcher, not an authorization control, which is the substance of #1591.

**`rollback.yml` is untouched, deliberately.** #1591 names it, but PR #1641 already fixed it: workflow level is `contents: read`, `id-token: write` sits only on the four environment-bound `rollback-*` jobs, and `validate`/`summary` are `contents: read`. Verified on current `main`, not assumed. Its remaining gap is the missing protection rules — #1660 — not a missing binding.

## Verification

**I did not dispatch a real destroy, so no end-to-end verification is claimed.** Neither workflow can be exercised without deleting a live estate. What was actually run, on `c39adc3`:

| check | result |
|---|---|
| `actionlint` — `cleanup-staging.yml` | **exit 0** |
| `actionlint` — `destroy-fargate-dev.yml` | **exit 0** |
| `actionlint` — `rollback.yml` (untouched, regression check) | **exit 0** |
| YAML parses (`yaml.safe_load`) | pass, both files |
| `${{ }}` inside any `run:` block | **0**, both files |
| jobs with `id-token: write` and no `environment:` | **0**, both files |
| every destroy job transitively `needs: guard` | confirmed, all 5 |
| `pre-commit` (incl. terraform fmt/validate/tflint, trivy) | passed |

Structural checks were done by parsing the YAML rather than grepping, so a job that inherits `id-token` cannot hide from them.

Independent adversarial review of the branch confirmed the OIDC subject claim, confirmed the `needs:` graph has no bypass, confirmed `permissions: {}` does not break either guard (neither checks out code), and confirmed `role.tf:30-31` allowlists `environment:dev` and `environment:staging`. Its two high findings were both about my own comments overstating the ref check; both are fixed in c39adc3.

## Known-broken on merge

The Azure destroy job in `cleanup-staging.yml` cannot authenticate until the bootstrap re-apply in manual step 4. This is pre-existing (#1648) and is flagged in the workflow itself, but it is a checklist item, not just a comment: **do not treat Azure staging cleanup as working until that apply has run.**
