### PR TITLE
fix(iac/aws): extend OIDC trust allowlist to cover every job assuming cudly_deploy

### DIFF
--- a/terraform/environments/aws/ci-cd-permissions/README.md
+++ b/terraform/environments/aws/ci-cd-permissions/README.md
@@ -147,5 +147,33 @@ new workflow job that assumes this role and binds to a not-yet-listed `environme
 subject to `role.tf` and re-apply *before* that job runs, or `configure-aws-credentials` fails with
 `AssumeRoleWithWebIdentity`/`Not authorized`.
 
-Related: #1648 (this allowlist gap), #1660 (the environments themselves have no protection rules
-yet), #1674 (binds the destroy workflows' jobs to environments covered by this list).
+### This allowlist alone does not restrict deploys to `main`
+
+The owner constraint on this repo is: only `main` may deploy. `ref:refs/heads/main` in the list
+above enforces that for a job with no `environment:` binding. It does **not** enforce it for an
+environment-bound job, because the OIDC `sub` for those is `repo:<repo>:environment:<name>`, which
+is ref-agnostic: it says which environment the job bound to, nothing about which branch triggered
+the run. A `workflow_dispatch` fired from any branch against an environment-bound job presents the
+exact same subject a `main` run would, so this allowlist admits it.
+
+The only control that reattaches the branch requirement is a **deployment branch policy** on each
+environment (`custom_branch_policies` restricted to `main`), configured on the GitHub side. As of
+this writing, per #1660's own evidence, none of the environments below have any protection rules,
+and several do not exist yet. Every environment named in the allowlist above needs this, before this
+policy actually delivers "only main deploys" rather than "only these environments deploy, from any
+branch":
+
+`dev`, `staging`, `prod`, `aws-fargate-dev`, `aws-fargate-staging`, `aws-fargate-prod`, `aws-db-dev`,
+`aws-db-staging`, `aws-db-prod`, `aws-lambda-dev-rollback`, `aws-lambda-staging-rollback`,
+`aws-lambda-prod-rollback`, `aws-fargate-dev-rollback`, `aws-fargate-staging-rollback`,
+`aws-fargate-prod-rollback`.
+
+This module has no GitHub provider configured (no `provider "github"` or `github_repository_*`
+resource anywhere under `terraform/` or `iac/`), so none of the above can be created or configured
+declaratively today; it is a manual, per-environment step in **Settings -> Environments** on the
+repo, same as the required-reviewer rules in #1660. Adding a GitHub Terraform provider so this
+becomes code is #1660's scope, not this module's.
+
+Related: #1648 (this allowlist gap), #1660 (the environments themselves have no protection rules or
+deployment branch policy yet, and don't all exist), #1674 (binds the destroy workflows' jobs to
+environments covered by this list).

--- a/terraform/environments/aws/ci-cd-permissions/README.md
+++ b/terraform/environments/aws/ci-cd-permissions/README.md
@@ -149,31 +149,53 @@ subject to `role.tf` and re-apply *before* that job runs, or `configure-aws-cred
 
 ### This allowlist alone does not restrict deploys to `main`
 
-The owner constraint on this repo is: only `main` may deploy. `ref:refs/heads/main` in the list
-above enforces that for a job with no `environment:` binding. It does **not** enforce it for an
-environment-bound job, because the OIDC `sub` for those is `repo:<repo>:environment:<name>`, which
-is ref-agnostic: it says which environment the job bound to, nothing about which branch triggered
-the run. A `workflow_dispatch` fired from any branch against an environment-bound job presents the
-exact same subject a `main` run would, so this allowlist admits it.
+The owner constraint on this repo is: only `main` may deploy. Three **different** GitHub-side
+controls keep getting conflated across this repo's issues, and this module (and this allowlist)
+implements only the first of them:
 
-The only control that reattaches the branch requirement is a **deployment branch policy** on each
-environment (`custom_branch_policies` restricted to `main`), configured on the GitHub side. As of
-this writing, per #1660's own evidence, none of the environments below have any protection rules,
-and several do not exist yet. Every environment named in the allowlist above needs this, before this
-policy actually delivers "only main deploys" rather than "only these environments deploy, from any
-branch":
+1. **Allowlist membership** (`role.tf`'s `sub` list, this module): can the job authenticate to AWS
+   at all? Nothing below matters if this says no.
+2. **Deployment branch policy** (a GitHub environment setting, not configured by this module): which
+   *branch* may trigger a deploy to that environment. This is what "only `main` may deploy" actually
+   requires, and nothing in this module sets it.
+3. **Required reviewers / protection rules** (a GitHub environment setting, not configured by this
+   module): *who* must approve before a job bound to that environment proceeds. The subject of
+   #1591/#1674/#1660, not this module.
 
-`dev`, `staging`, `prod`, `aws-fargate-dev`, `aws-fargate-staging`, `aws-fargate-prod`, `aws-db-dev`,
-`aws-db-staging`, `aws-db-prod`, `aws-lambda-dev-rollback`, `aws-lambda-staging-rollback`,
-`aws-lambda-prod-rollback`, `aws-fargate-dev-rollback`, `aws-fargate-staging-rollback`,
-`aws-fargate-prod-rollback`.
+`ref:refs/heads/main` in the allowlist enforces (2) on its own for a job with no `environment:`
+binding: no environment, no policy needed, the ref check *is* the restriction. `environment:<name>`
+subjects enforce **neither (2) nor (3)** on their own, because the OIDC `sub` for those is
+`repo:<repo>:environment:<name>`, which is ref-agnostic: it says which environment the job bound to,
+nothing about which branch triggered the run. A `workflow_dispatch` fired from any branch against an
+environment-bound job presents the exact same subject a `main` run would, so this allowlist admits
+it. The only control that reattaches the branch requirement is a deployment branch policy
+(`custom_branch_policies` restricted to `main`) on that environment, configured on the GitHub side.
 
-This module has no GitHub provider configured (no `provider "github"` or `github_repository_*`
-resource anywhere under `terraform/` or `iac/`), so none of the above can be created or configured
-declaratively today; it is a manual, per-environment step in **Settings -> Environments** on the
-repo, same as the required-reviewer rules in #1660. Adding a GitHub Terraform provider so this
-becomes code is #1660's scope, not this module's.
+**Live state, checked against the GitHub API directly** (`gh api repos/LeanerCloud/CUDly/environments`),
+not assumed from an earlier issue's snapshot:
 
-Related: #1648 (this allowlist gap), #1660 (the environments themselves have no protection rules or
-deployment branch policy yet, and don't all exist), #1674 (binds the destroy workflows' jobs to
-environments covered by this list).
+| Environment | Exists today? | Protection rules | Deployment branch policy |
+| --- | --- | --- | --- |
+| `dev` | Yes | none | none |
+| `staging` | **No** | n/a | n/a |
+| `prod` | **No** | n/a | n/a |
+| `aws-fargate-dev` | Yes | none | none |
+| `aws-fargate-staging` | Yes | none | none |
+| `aws-fargate-prod` | **No** | n/a | n/a |
+| `aws-db-dev` / `aws-db-staging` / `aws-db-prod` | **No** (all three) | n/a | n/a |
+| `aws-lambda-{dev,staging,prod}-rollback` | **No** (all three) | n/a | n/a |
+| `aws-fargate-{dev,staging,prod}-rollback` | **No** (all three) | n/a | n/a |
+
+Only 3 of the 15 environments this allowlist names exist yet, and none of the 3, including `dev`
+which multiple deploy jobs already use in production, has a branch policy or protection rules of any
+kind. Every environment above needs (2) configured (and the 12 that don't exist yet also need to be
+created) before this allowlist actually delivers "only `main` deploys" rather than "only these
+environments deploy, from any branch". This module has no GitHub provider configured (no
+`provider "github"` or `github_repository_*` resource anywhere under `terraform/` or `iac/`), so
+none of this, creation, branch policy, or reviewers, can be done declaratively today; it is a
+manual, per-environment step in **Settings -> Environments** on the repo. Adding a GitHub Terraform
+provider so this becomes code is #1660's scope, not this module's.
+
+Related: #1648 (this allowlist gap, control 1), #1660 (controls 2 and 3: environments need creating,
+a branch policy, and protection rules), #1674 (binds the destroy workflows' jobs to environments
+covered by this list).

--- a/terraform/environments/aws/ci-cd-permissions/README.md
+++ b/terraform/environments/aws/ci-cd-permissions/README.md
@@ -126,5 +126,26 @@ for temporary AWS credentials via `sts:AssumeRoleWithWebIdentity`, and injects `
 
 ### Trust policy conditions
 
-The trust policy allows only workflows from `repo:LeanerCloud/CUDly:*`. If you fork CUDly or use a
-different repo, set `github_repo` in `terraform.tfvars` to the new `owner/repo` value and re-apply.
+The trust policy does **not** allow all workflows from the repo: `repo:LeanerCloud/CUDly:*` would
+let any branch, including an unprotected feature branch, mint valid deploy credentials. Instead the
+OIDC `sub` claim is checked against an explicit, enumerated allowlist (`role.tf`'s
+`token.actions.githubusercontent.com:sub` condition):
+
+- `repo:LeanerCloud/CUDly:ref:refs/heads/main`, for workflows dispatched on `main` with no
+  `environment:` binding.
+- `repo:LeanerCloud/CUDly:environment:<name>`, one entry per exact environment name a job that
+  assumes this role binds to. A job's `environment:` **replaces** the ref-based subject with an
+  environment-scoped one (never both), so every such value must be listed explicitly or that job
+  cannot authenticate. See the comment above the `sub` list in `role.tf` for the full derivation:
+  which workflow/job each entry covers, and what was deliberately left out and why (`pull_request`
+  jobs, and an unreachable `workflow_call` input path), kept in one place so it cannot drift out of
+  sync with the policy itself.
+
+If you fork CUDly or use a different repo, set `github_repo` in `terraform.tfvars` to the new
+`owner/repo` value and re-apply; the prefix changes, the enumerated suffixes do not. If you add a
+new workflow job that assumes this role and binds to a not-yet-listed `environment:`, add its exact
+subject to `role.tf` and re-apply *before* that job runs, or `configure-aws-credentials` fails with
+`AssumeRoleWithWebIdentity`/`Not authorized`.
+
+Related: #1648 (this allowlist gap), #1660 (the environments themselves have no protection rules
+yet), #1674 (binds the destroy workflows' jobs to environments covered by this list).

--- a/terraform/environments/aws/ci-cd-permissions/role.tf
+++ b/terraform/environments/aws/ci-cd-permissions/role.tf
@@ -25,11 +25,84 @@ resource "aws_iam_role" "cudly_deploy" {
             # Restrict to protected branches and named deployment environments.
             # Any-branch wildcard (repo:org/repo:*) would let a developer push to
             # an unprotected feature branch and mint valid deploy credentials.
+            #
+            # An OIDC `sub` is EITHER `...:ref:refs/heads/<branch>` OR
+            # `...:environment:<name>` -- never both -- so every job in every
+            # AWS-assuming workflow that binds to an `environment:` needs its
+            # exact subject listed here, or it cannot authenticate at all. This
+            # list is derived from grepping every `role-to-assume: ${{
+            # vars.AWS_ROLE_TO_ASSUME }}` step across .github/workflows/ and
+            # tracing each job's `environment:` value to its source (see #1648
+            # and the PR that added this comment for the full per-job table).
+            # `StringEquals` (exact match, not `StringLike`) on purpose: every
+            # value below is enumerable from a `type: choice` input, so a
+            # pattern would only widen what this policy admits, never narrow
+            # it usefully.
+            #
+            # Deliberately NOT listed, and why:
+            #   - `pull_request` subjects: no job that assumes THIS role
+            #     (cudly_deploy) runs on `pull_request`. `aws_sanity.yml` is the
+            #     only pull_request-triggered workflow that calls
+            #     configure-aws-credentials, and it assumes a separate,
+            #     already-read-only role via `secrets.AWS_CICD_READONLY_ROLE_ARN`,
+            #     not this one. Also note GitHub does not mint OIDC tokens for
+            #     `pull_request` runs from forked repos by default, independent
+            #     of this policy.
+            #   - `environment:aws-db-<anything>` from database-migration.yml's
+            #     `workflow_call` trigger: that trigger declares `environment`
+            #     as an unconstrained `type: string`, but nothing in this repo
+            #     currently calls this workflow via `workflow_call` (grepped
+            #     `.github/workflows/` for `uses:.*database-migration.yml`: no
+            #     hits). Only the `workflow_dispatch` path, constrained to
+            #     dev/staging/prod, is reachable today -- covered below. If a
+            #     caller is ever added, this must be revisited before that
+            #     caller can authenticate.
             "token.actions.githubusercontent.com:sub" = [
               "repo:${var.github_repo}:ref:refs/heads/main",
+
+              # Bare deployment environments. Bound directly by
+              # deploy-aws-lambda.yml's build-and-deploy / test-deployment jobs
+              # (environment: ${{ needs.prepare.outputs.environment }}, always
+              # dev/staging/prod per that job's own resolution logic), and --
+              # once #1674 merges -- by cleanup-staging.yml's two AWS destroy
+              # jobs (environment: staging) and destroy-fargate-dev.yml's
+              # destroy job (environment: dev).
               "repo:${var.github_repo}:environment:dev",
               "repo:${var.github_repo}:environment:staging",
               "repo:${var.github_repo}:environment:prod",
+
+              # deploy-aws-fargate.yml's `deploy` job binds to
+              # `aws-fargate-${{ needs.prepare.outputs.environment }}`, and that
+              # output is always dev/staging/prod (workflow_dispatch choice
+              # input, workflow_call from deploy-all.yml which is itself
+              # choice-constrained, or the untriggered-input "dev" fallback).
+              "repo:${var.github_repo}:environment:aws-fargate-dev",
+              "repo:${var.github_repo}:environment:aws-fargate-staging",
+              "repo:${var.github_repo}:environment:aws-fargate-prod",
+
+              # database-migration.yml's `migrate-aws` job binds to
+              # `aws-db-${{ inputs.environment }}` on its `workflow_dispatch`
+              # trigger, where `inputs.environment` is a choice input
+              # constrained to dev/staging/prod. See the workflow_call caveat
+              # above for what is deliberately excluded.
+              "repo:${var.github_repo}:environment:aws-db-dev",
+              "repo:${var.github_repo}:environment:aws-db-staging",
+              "repo:${var.github_repo}:environment:aws-db-prod",
+
+              # rollback.yml's rollback-aws-lambda / rollback-aws-fargate jobs
+              # bind to `aws-lambda-${{ inputs.environment }}-rollback` /
+              # `aws-fargate-${{ inputs.environment }}-rollback`; inputs.environment
+              # is a workflow_dispatch choice input constrained to
+              # dev/staging/prod. Listing the subject here only fixes
+              # authentication (this issue, #1648); it does not add a reviewer
+              # gate -- these environments are auto-created bare on first use
+              # with no protection rules until #1660's provisioning work lands.
+              "repo:${var.github_repo}:environment:aws-lambda-dev-rollback",
+              "repo:${var.github_repo}:environment:aws-lambda-staging-rollback",
+              "repo:${var.github_repo}:environment:aws-lambda-prod-rollback",
+              "repo:${var.github_repo}:environment:aws-fargate-dev-rollback",
+              "repo:${var.github_repo}:environment:aws-fargate-staging-rollback",
+              "repo:${var.github_repo}:environment:aws-fargate-prod-rollback",
             ]
           }
         }

--- a/terraform/environments/aws/ci-cd-permissions/role.tf
+++ b/terraform/environments/aws/ci-cd-permissions/role.tf
@@ -39,6 +39,22 @@ resource "aws_iam_role" "cudly_deploy" {
             # pattern would only widen what this policy admits, never narrow
             # it usefully.
             #
+            # THIS LIST DOES NOT BY ITSELF RESTRICT DEPLOYS TO `main`. Owner
+            # constraint is "only main may deploy". `ref:refs/heads/main`
+            # enforces that for an unbound job. `environment:<name>` does NOT:
+            # it is ref-agnostic (it encodes which environment the job bound
+            # to, not which branch triggered the run), so a `workflow_dispatch`
+            # from ANY branch against an environment-bound job presents the
+            # identical subject a `main` run would. The only thing that
+            # re-attaches the branch requirement is a deployment branch policy
+            # on the environment itself (GitHub-side, restricting it to
+            # `main`), and per #1648/#1660 none of the environments listed
+            # below have one today -- several do not exist at all yet. Until
+            # that manual step is done per environment, this allowlist
+            # delivers "only these environments deploy, from any branch", not
+            # "only main deploys". See the PR that added this comment for the
+            # full list of environments needing that policy.
+            #
             # Deliberately NOT listed, and why:
             #   - `pull_request` subjects: no job that assumes THIS role
             #     (cudly_deploy) runs on `pull_request`. `aws_sanity.yml` is the

--- a/terraform/environments/aws/ci-cd-permissions/role.tf
+++ b/terraform/environments/aws/ci-cd-permissions/role.tf
@@ -40,20 +40,35 @@ resource "aws_iam_role" "cudly_deploy" {
             # it usefully.
             #
             # THIS LIST DOES NOT BY ITSELF RESTRICT DEPLOYS TO `main`. Owner
-            # constraint is "only main may deploy". `ref:refs/heads/main`
-            # enforces that for an unbound job. `environment:<name>` does NOT:
-            # it is ref-agnostic (it encodes which environment the job bound
-            # to, not which branch triggered the run), so a `workflow_dispatch`
-            # from ANY branch against an environment-bound job presents the
-            # identical subject a `main` run would. The only thing that
-            # re-attaches the branch requirement is a deployment branch policy
-            # on the environment itself (GitHub-side, restricting it to
-            # `main`), and per #1648/#1660 none of the environments listed
-            # below have one today -- several do not exist at all yet. Until
-            # that manual step is done per environment, this allowlist
-            # delivers "only these environments deploy, from any branch", not
-            # "only main deploys". See the PR that added this comment for the
-            # full list of environments needing that policy.
+            # constraint is "only main may deploy". Three DIFFERENT controls
+            # keep getting conflated in this repo's issues; this list is only
+            # the first of them:
+            #   1. Allowlist membership (THIS list): can the job authenticate
+            #      to AWS at all? Nothing else below matters if this says no.
+            #   2. Deployment branch policy (GitHub environment setting,
+            #      manual, NOT configured by this module): which BRANCH may
+            #      trigger a deploy to that environment. This is what "only
+            #      main may deploy" actually requires, and nothing here sets
+            #      it.
+            #   3. Required reviewers / protection rules (GitHub environment
+            #      setting, manual, NOT configured by this module): WHO must
+            #      approve before a job bound to that environment proceeds.
+            #      The subject of #1591/#1674/#1660, not this file.
+            #
+            # `ref:refs/heads/main` enforces (2) on its own, for an unbound
+            # job: no environment, no policy needed, the ref check IS the
+            # restriction. `environment:<name>` subjects enforce NEITHER (2)
+            # nor (3) on their own: they are ref-agnostic (the subject encodes
+            # which environment the job bound to, not which branch triggered
+            # the run), so a `workflow_dispatch` from ANY branch against an
+            # environment-bound job presents the identical subject a `main`
+            # run would. Until a deployment branch policy exists on that
+            # environment, this allowlist delivers "only these environments
+            # deploy, from any branch", not "only main deploys" -- and per a
+            # live check against the GitHub API, none of the environments
+            # below have one, or any protection rules, today. See the PR that
+            # added this comment for the full list of environments needing
+            # that policy, and which of them exist yet at all.
             #
             # Deliberately NOT listed, and why:
             #   - `pull_request` subjects: no job that assumes THIS role
@@ -83,6 +98,9 @@ resource "aws_iam_role" "cudly_deploy" {
               # once #1674 merges -- by cleanup-staging.yml's two AWS destroy
               # jobs (environment: staging) and destroy-fargate-dev.yml's
               # destroy job (environment: dev).
+              # Live check (`gh api repos/.../environments`): `dev` exists,
+              # `staging`/`prod` do not. None has a deployment branch policy or
+              # protection rules -- see the top-of-list note.
               "repo:${var.github_repo}:environment:dev",
               "repo:${var.github_repo}:environment:staging",
               "repo:${var.github_repo}:environment:prod",
@@ -92,6 +110,9 @@ resource "aws_iam_role" "cudly_deploy" {
               # output is always dev/staging/prod (workflow_dispatch choice
               # input, workflow_call from deploy-all.yml which is itself
               # choice-constrained, or the untriggered-input "dev" fallback).
+              # Live check: `aws-fargate-dev` and `aws-fargate-staging` exist,
+              # `aws-fargate-prod` does not. Same "no branch policy, no
+              # protection rules" caveat as above applies to all three.
               "repo:${var.github_repo}:environment:aws-fargate-dev",
               "repo:${var.github_repo}:environment:aws-fargate-staging",
               "repo:${var.github_repo}:environment:aws-fargate-prod",
@@ -100,7 +121,8 @@ resource "aws_iam_role" "cudly_deploy" {
               # `aws-db-${{ inputs.environment }}` on its `workflow_dispatch`
               # trigger, where `inputs.environment` is a choice input
               # constrained to dev/staging/prod. See the workflow_call caveat
-              # above for what is deliberately excluded.
+              # above for what is deliberately excluded. Live check: none of
+              # the three exist yet.
               "repo:${var.github_repo}:environment:aws-db-dev",
               "repo:${var.github_repo}:environment:aws-db-staging",
               "repo:${var.github_repo}:environment:aws-db-prod",
@@ -109,10 +131,11 @@ resource "aws_iam_role" "cudly_deploy" {
               # bind to `aws-lambda-${{ inputs.environment }}-rollback` /
               # `aws-fargate-${{ inputs.environment }}-rollback`; inputs.environment
               # is a workflow_dispatch choice input constrained to
-              # dev/staging/prod. Listing the subject here only fixes
-              # authentication (this issue, #1648); it does not add a reviewer
-              # gate -- these environments are auto-created bare on first use
-              # with no protection rules until #1660's provisioning work lands.
+              # dev/staging/prod. Listing the subject here only fixes control
+              # (1) above (this issue, #1648); it does nothing for controls
+              # (2) or (3). Live check: none of these six exist yet -- first
+              # dispatch auto-creates them bare, with neither a branch policy
+              # nor reviewers, unless #1660's provisioning work lands first.
               "repo:${var.github_repo}:environment:aws-lambda-dev-rollback",
               "repo:${var.github_repo}:environment:aws-lambda-staging-rollback",
               "repo:${var.github_repo}:environment:aws-lambda-prod-rollback",


### PR DESCRIPTION
Refs #1648, #1674

## Not applied. Do not apply.

`terraform/environments/aws/ci-cd-permissions/` is bootstrap-only, applied manually by a privileged human, never by a deploy workflow. Live AWS currently trusts the pre-`b876d7fa0` wildcard `repo:LeanerCloud/CUDly:*`, not even the 4-entry allowlist already committed to `role.tf`, which is why that role has never been re-applied: doing so as currently written would immediately break every job whose OIDC subject isn't one of the 4 listed values. This PR extends the allowlist so that when it *is* applied, nothing breaks. The apply itself is a separate, manual step for whoever holds the credentials.

## Owner constraint: only `main` may deploy. This PR's code half does not fully deliver that yet.

**`pull_request` is not in this allowlist, and was never a candidate.** I checked whether any job assuming *this specific role* (`cudly_deploy`) runs on `pull_request`: none does (see the judgment-call section below for the evidence). Nothing to report, nothing to allowlist.

**Three separate GitHub-side controls keep getting conflated across this repo's issues. This PR implements only the first.**

1. **Allowlist membership** (`role.tf`'s `sub` list, this PR): can the job authenticate to AWS at all? Nothing below matters if this says no.
2. **Deployment branch policy** (a GitHub environment setting, not touched by this PR): which *branch* may trigger a deploy to that environment. This is what "only `main` may deploy" actually requires.
3. **Required reviewers / protection rules** (a GitHub environment setting, not touched by this PR): *who* must approve before a job bound to that environment proceeds. The subject of #1591/#1674/#1660, not this PR.

`ref:refs/heads/main` enforces (2) on its own for a job with no `environment:` binding: no environment, no policy needed, the ref check *is* the restriction. `environment:<name>` subjects enforce **neither (2) nor (3)** on their own, because that OIDC `sub` is ref-agnostic: it encodes which environment the job bound to, not which branch triggered the run. A `workflow_dispatch` fired from any branch against an environment-bound job presents the *identical* subject a `main` run would. So allowlisting `environment:staging` admits a `staging` deploy dispatched from an arbitrary branch, exactly what "only main deploys" is supposed to rule out. The only control that reattaches the branch requirement is a **deployment branch policy** (`custom_branch_policies`, restricted to `main`) configured per-environment on GitHub's side.

**Live state, checked directly against the GitHub API just now** (`gh api repos/LeanerCloud/CUDly/environments`), not assumed from an earlier issue's snapshot:

| Environment | Exists today? | Protection rules | Deployment branch policy |
|---|---|---|---|
| `dev` | Yes | none | none |
| `staging` | **No** | n/a | n/a |
| `prod` | **No** | n/a | n/a |
| `aws-fargate-dev` | Yes | none | none |
| `aws-fargate-staging` | Yes | none | none |
| `aws-fargate-prod` | **No** | n/a | n/a |
| `aws-db-{dev,staging,prod}` | **No**, all three | n/a | n/a |
| `aws-lambda-{dev,staging,prod}-rollback` | **No**, all three | n/a | n/a |
| `aws-fargate-{dev,staging,prod}-rollback` | **No**, all three | n/a | n/a |

Only **3 of the 15** environments this allowlist names exist yet (`dev`, `aws-fargate-dev`, `aws-fargate-staging`), and *none* of those 3, including `dev` which live deploy jobs already use today, has a branch policy or protection rules of any kind. **Until (2) is configured on every environment above, and the 12 that don't exist yet are created, this allowlist delivers "only these environments deploy, from any branch", not "only main deploys".** That is the honest characterization; I am not calling this "main-only" anywhere in this PR.

**Correction from the previous revision of this table:** an earlier pass here said "3 environments exist" without qualifying it against this allowlist's 15 names, which read as (and was pointed out to be) a different, broader claim than intended. The account has **5** environments in total; the table above covers the 3 that overlap with this allowlist. The other 2, `azure-` and `gcp-` (malformed, trailing-hyphen names), are unrelated to this PR: investigated and confirmed dead code (root-caused to a `push`-triggered job in `deploy-azure.yml`/`deploy-gcp.yml` at commit `cb386249e`, interpolating an empty `inputs.environment`; fixed by a later refactor, no deployment against either since 2026-03-25) and structurally unreachable by any job that assumes `cudly_deploy` (wrong cloud, wrong role, wrong action entirely). Filed as its own issue, #1684, cross-linked to #1660 rather than folded into this PR.

**No job that assumes `cudly_deploy` can bind to an empty-suffix environment, so applying this allowlist is safe on that axis.** Every compound name any AWS-role job currently produces carries a non-empty prefix segment or a suffix after the interpolation point (`aws-fargate-`, `aws-db-`, `aws-lambda-...-rollback`, `aws-fargate-...-rollback`), never a bare `aws-` or a name that could collapse to something outside the 16 entries above given the `type: choice` constraint on every reachable input. `rollback.yml`'s `gcp-*-rollback` (`google-github-actions/auth`) and `azure-*-rollback` (`azure/login`) jobs, and `database-migration.yml`'s `migrate-gcp`/`migrate-azure` jobs (same two actions), authenticate to their own clouds, not this role; only `rollback.yml`'s two `aws-*-rollback` jobs and `database-migration.yml`'s `migrate-aws` job use `vars.AWS_ROLE_TO_ASSUME`, confirmed by re-reading every credentialed step, not by pattern-matching names.

**Deliverable is therefore two halves:**

| Half | What | Who | Status |
|---|---|---|---|
| Code (control 1) | `role.tf`'s allowlist, exactly the subjects credentialed jobs present | this PR | done |
| Manual (controls 2 and 3) | Create the 12 missing environments; set a deployment branch policy limited to `main` on all 15; set required reviewers where warranted | privileged human, GitHub Settings -> Environments (no GitHub Terraform provider exists in this repo to do any of this declaratively, confirmed by grep: no `provider "github"` / `github_repository_*` resource anywhere under `terraform/` or `iac/`; adding one is #1660's scope) | **not done** |

I did not solve the manual half in code, and I did not omit any of these environment entries to force branch-scoping by omission, that would just reproduce #1648: break the destroy and rollback jobs' authentication entirely. Landing the allowlist and stating the residual gap, per-environment, is the honest version of this change.

## Method: evidence, not a list handed down

Grepped every workflow for `role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME }}` (the var that resolves to this role's ARN, confirmed via `outputs.tf`'s description) rather than trusting any prior characterization of which jobs need what. 9 job-steps across 7 files assume this specific role. For each, traced the job's `environment:` binding to its concrete value(s) by reading the job's own resolution logic (a `prepare` job's `if/elif` chain, or a `workflow_dispatch` input's `type: choice` `options:`), not by assuming the binding is a literal.

An OIDC `sub` is *either* `...:ref:refs/heads/<branch>` *or* `...:environment:<name>`, never both, so a job's `environment:` binding **replaces** its ref-based subject. Every environment-bound job's exact subject has to be in the allowlist or that job cannot authenticate at all, independent of whether the environment has any protection rules (#1660 is a separate concern from the allowlist gap this PR closes).

## The table

| Workflow / job | Trigger | `environment:` binding | Resolved subject(s) | In allowlist before this PR? |
|---|---|---|---|---|
| `deploy-aws-lambda.yml` `build-and-deploy`, `test-deployment` | push, workflow_dispatch, release, workflow_call | `${{ needs.prepare.outputs.environment }}` | `dev`, `staging`, `prod` (prepare job: `release`→`prod`, `workflow_dispatch`/`workflow_call`→`inputs.environment` choice, else→`dev`) | Yes |
| `deploy-aws-fargate.yml` `deploy` | workflow_dispatch, workflow_call | `aws-fargate-${{ needs.prepare.outputs.environment }}` | `aws-fargate-dev`, `aws-fargate-staging`, `aws-fargate-prod` | **No** |
| `database-migration.yml` `migrate-aws` | workflow_dispatch, workflow_call | `aws-db-${{ inputs.environment }}` | `aws-db-dev`, `aws-db-staging`, `aws-db-prod` (workflow_dispatch path only, see below) | **No** |
| `rollback.yml` `rollback-aws-lambda` | workflow_dispatch | `aws-lambda-${{ inputs.environment }}-rollback` | `aws-lambda-dev-rollback`, `aws-lambda-staging-rollback`, `aws-lambda-prod-rollback` | **No** |
| `rollback.yml` `rollback-aws-fargate` | workflow_dispatch | `aws-fargate-${{ inputs.environment }}-rollback` | `aws-fargate-dev-rollback`, `aws-fargate-staging-rollback`, `aws-fargate-prod-rollback` | **No** |
| `cleanup-staging.yml` `destroy-aws-lambda`, `destroy-aws-fargate` | workflow_dispatch | none on current `main`; `staging` once #1674 merges | `ref:refs/heads/main` today, `environment:staging` after #1674 | Yes (both forms) |
| `destroy-fargate-dev.yml` `destroy` | workflow_dispatch | none on current `main`; `dev` once #1674 merges | `ref:refs/heads/main` today, `environment:dev` after #1674 | Yes (both forms) |

12 new entries added: `aws-fargate-{dev,staging,prod}`, `aws-db-{dev,staging,prod}`, `aws-lambda-{dev,staging,prod}-rollback`, `aws-fargate-{dev,staging,prod}-rollback`. Existing 4 entries (`ref:refs/heads/main`, `environment:{dev,staging,prod}`) kept unchanged. Total 16.

`inputs.environment` on every `workflow_dispatch` above is a `type: choice` with `options: [dev, staging, prod]` (checked each one individually, not assumed uniform), so every compound value is exhaustively enumerable, no `StringLike` pattern needed or used. Confirmed the `deploy-all.yml` orchestrator, the only caller of `deploy-aws-fargate.yml`/`deploy-aws-lambda.yml` via `workflow_call`, is itself constrained the same way (its own `environment` input is `type: choice options: [dev, staging, prod]`, and its `release`-triggered path hardcodes `prod`), so the `workflow_call` trigger on those two files can't introduce a value outside the enumerated set either.

## Two judgment calls, made explicitly

**1. `pull_request` is excluded, not forgotten, and is now dropped as a matter of policy, not just because nothing needs it today.** Checked whether any job assuming *this* role (`cudly_deploy`) runs on `pull_request`: none does. `aws_sanity.yml` is the only `pull_request`-triggered workflow calling `configure-aws-credentials`, and it uses `role-to-assume: ${{ secrets.AWS_CICD_READONLY_ROLE_ARN }}`, a separate, already-scoped-down role, confirmed by grep (`role-to-assume` appears in `aws_sanity.yml` exactly once, with that secret, not `vars.AWS_ROLE_TO_ASSUME`). Given the owner's "only main may deploy" constraint, `pull_request` would be excluded regardless of what I'd found; the wildcard's over-permission of it today is exactly the hole this allowlist exists to close, not a capability to carry forward. For the record: GitHub does not issue OIDC tokens to `pull_request`-triggered runs from forked repositories by default, independent of this trust policy. I could not find the readonly role's own trust policy anywhere under `terraform/`, so I can't speak to its scoping; out of scope for this PR since it's a different role entirely.

**2. No `StringLike` patterns.** Every value in the table above is a `StringEquals` exact match, drawn from a finite, enumerated set. The temptation with 16 entries is to collapse `aws-fargate-*`-shaped names into a pattern; resisted it, because a `StringLike` in a trust policy is exactly the substring-standing-in-for-equality shape that produced four separate defects elsewhere in this codebase today (#1544/#1667's GCP WIF mapping/condition bypasses, the AWS user-path `contains()` bypass in #1667's Terraform sibling). A trust policy is the worst place to add a fifth. If a pattern is ever proposed here later, it should have to prove what it admits beyond the intended set, which none of the current 16 values need.

## Deliberately not covered, and why

`database-migration.yml`'s `workflow_call` trigger declares `environment` as an unconstrained `type: string` (not `choice`), unlike its `workflow_dispatch` path (`type: choice`, `options: [dev, staging, prod]`, cannot be empty). Grepped `.github/workflows/` for `uses:.*database-migration.yml`: zero hits. Nothing in this repo calls it via `workflow_call` today, so that path is unreachable and its arbitrary-string `environment` value was not enumerated (there's nothing to enumerate, and adding a wildcard to pre-cover a hypothetical future caller would be exactly the kind of unjustified widening this PR argues against elsewhere). If a caller is ever added, its `environment:` binding needs an explicit new entry here before it can authenticate.

This is not a hypothetical failure shape, it is the concrete one: a `workflow_call` caller passing `environment: ""` would produce `aws-db-` on `migrate-aws`, the job at `database-migration.yml:170/190` that *does* assume `cudly_deploy`. That is the exact same empty-interpolation defect class that produced the `azure-`/`gcp-` junk environments (#1684), just on a job that would authenticate to AWS instead of one that couldn't reach this role at all. `migrate-gcp` (`:246/264`, `google-github-actions/auth`) and `migrate-azure` (`:313/331`, `azure/login`) use their own clouds' credentials, not this role, same split confirmed for `rollback.yml`'s GCP/Azure jobs below. Flagged in both `role.tf`'s comment and the README so it doesn't silently rot into a "why doesn't this work" surprise later.

## Also fixed: stale README

`terraform/environments/aws/ci-cd-permissions/README.md`'s "Trust policy conditions" section said "The trust policy allows only workflows from `repo:LeanerCloud/CUDly:*`", describing the wildcard, not what `role.tf` has actually specified since `b876d7fa0` (predates this PR). Directly adjacent to what I'm changing and actively misleading about what the committed policy does, so corrected it to describe the enumerated allowlist, added the "does not restrict to `main` by itself" section with the same environment list as above, and cross-linked #1648/#1660/#1674 rather than duplicating their content.

## Verification

- `terraform fmt -check -diff` on `terraform/environments/aws/ci-cd-permissions/`: exit 0.
- `terraform init -backend=false && terraform validate`: exit 0, "Success! The configuration is valid."
- `pre-commit run` on both changed files (both commits): exit 0, all applicable hooks passed (Terraform format/validate/lint, Trivy config scanner, secret scanners, Markdown lint); no hook skipped via `--no-verify` or similar.
- Computed the resulting trust policy's compact JSON size with the full 16-entry list: 1234 characters, comfortably under AWS's 2048-character default limit for role trust policies (no quota increase needed).
- No GitHub provider / `github_repository_environment` resource found anywhere under `terraform/` or `iac/` (grep), confirming the manual-half table above is accurate: these environments and their branch policies cannot be created declaratively in this repo today.
- Three review passes on the diff across both commits; two corrections made: a comment conflated this issue (#1648) with #1660's separate "environments need protection rules" scope, corrected to cross-link the right issue for the right claim; and the ref-agnostic branch-scoping gap itself, added after the owner's follow-up constraint, not present in the first commit.

## What this does not do

Does not touch Azure or GCP trust policies (separate concerns, separate files). Does not provision the GitHub environments themselves, their protection rules, or their deployment branch policies (#1660, and the manual half above). Does not apply anything to live AWS (bootstrap-only, manual). Does not add a reviewer gate; adding an entry here only lets an already environment-bound job authenticate, it says nothing about whether that environment has required reviewers. Does not, on its own, deliver "only `main` deploys" for environment-bound jobs; see the constraint section above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded deployment authorization documentation with clearer guidance on trusted workflow environments, branch rules, forks, and new deployment jobs.
  * Added explanations of expected authorization behavior when new environments or workflows are not configured in advance.

* **Chores**
  * Updated deployment permissions to explicitly support approved development, staging, production, rollback, database, and container deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



