### PR TITLE
fix(ci): pin hadolint image by digest to stop drift off the rev pin

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -182,13 +182,17 @@ jobs:
             exit 1
           }
 
-      # Note: the hadolint-docker pre-commit hook
-      # (.pre-commit-config.yaml:80) runs the official
-      # hadolint/hadolint:v2.14.0 Docker image. We do NOT install a host
-      # binary here — it would be dead code (never invoked by the hook)
-      # AND a supply-chain hole (latest tag, no checksum). If a future
-      # change switches the hook from hadolint-docker to plain hadolint,
-      # install a pinned + sha256-verified binary here.
+      # Note: the local `hadolint` pre-commit hook (.pre-commit-config.yaml:81)
+      # runs ghcr.io/hadolint/hadolint pinned by digest to v2.14.0. We do NOT
+      # install a host binary here — it would be dead code (never invoked by
+      # the hook) AND a supply-chain hole (latest tag, no checksum). Note:
+      # an earlier version of this comment claimed the hook already pinned
+      # the image to v2.14.0 via the hook repo's `rev:` -- it did not; that
+      # `rev:` only pins hadolint's *hook definition*, whose upstream entry
+      # (`ghcr.io/hadolint/hadolint hadolint`) has no image tag and floats to
+      # `:latest`. See the digest pin in .pre-commit-config.yaml for the fix.
+      # If a future change switches the hook to a host binary, install a
+      # pinned + sha256-verified binary here.
 
       - name: Install pre-commit
         run: pip install 'pre-commit==4.0.1'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,11 +63,26 @@ repos:
         name: Check for case conflicts
 
   # Dockerfile linting
-  - repo: https://github.com/hadolint/hadolint
-    rev: v2.14.0
+  #
+  # The upstream hadolint-docker hook (hadolint/hadolint's own
+  # .pre-commit-hooks.yaml) declares `entry: ghcr.io/hadolint/hadolint
+  # hadolint` with no image tag, so Docker resolves it to `:latest` on every
+  # run -- independent of the `rev:` pin above, which only pins which
+  # commit of the *hook definition* is used, not the Docker image it runs.
+  # When upstream published hadolint 2.15.1 as `latest`, CI silently
+  # started linting with a newer ruleset (new DL3066/DL3025 findings on
+  # unchanged Dockerfiles) with no corresponding change in this repo.
+  #
+  # Defined as a local hook instead, pinned to the immutable digest of the
+  # v2.14.0 image, so the linter version can only change via an explicit
+  # bump here.
+  - repo: local
     hooks:
-      - id: hadolint-docker
+      - id: hadolint
         name: Lint Dockerfiles
+        language: docker_image
+        entry: ghcr.io/hadolint/hadolint:v2.14.0@sha256:27086352fd5e1907ea2b934eb1023f217c5ae087992eb59fde121dce9c9ff21e hadolint
+        types: [dockerfile]
 
   # Markdown linting
   - repo: https://github.com/igorshubovych/markdownlint-cli


### PR DESCRIPTION
## Summary
- `pre-commit --all-files` (the CI "Run pre-commit hooks" job lints the whole merge ref) started failing the `hadolint-docker` hook on `main`, blocking every open PR including ones that touch zero Docker files (e.g. #1658)
- Root cause is **version drift, not new Dockerfile debt**: the upstream `hadolint-docker` hook entry (`ghcr.io/hadolint/hadolint hadolint`) has no image tag, so it floats to `:latest` independent of this repo's `rev: v2.14.0` pin, which only fixes the hook *definition* commit, not the Docker image. Upstream published hadolint 2.15.1 as `latest`, which applies DL3066 to any named `USER` directive and DL3025 to `HEALTHCHECK`'s `CMD` sub-clause -- neither of which existed in 2.14.0's ruleset. None of the three Dockerfiles changed.
- Replaces the external `hadolint-docker` hook with a local hook pinned to the immutable digest of the same `v2.14.0` image, so the linter version can only move via an explicit bump here
- Corrects a stale comment in `.github/workflows/pre-commit.yml` that had assumed the old hook was already image-pinned via the `rev:`
- No Dockerfile changes

## Verification
- `pre-commit run hadolint --all-files` -> exit 0 (previously exit 1 on `main`)
- `pre-commit run --all-files` -> only remaining failure is `terraform_validate`, and it's a local-machine artifact unrelated to this change (`mkdir ... file exists` race on the shared `~/.terraform.d/plugin-cache`, reproduced consistently on retry, not present in this diff)
- Confirmed via `docker run ... hadolint --version`: `v2.14.0` tag = 2.14.0, `latest` tag = 2.15.1
- Confirmed identical findings reproduce against `latest` and disappear against the pinned digest, on the unchanged Dockerfiles, with `.hadolint.yaml`'s ignore list applied (matching what pre-commit actually mounts)
- Built all three images locally to prove the config change doesn't affect the build: `Dockerfile`, `Dockerfile.dev`, `Dockerfile.test` all built successfully

Closes #1696
