### PR TITLE
fix(iac/aws): unblock deploy on rds:DescribeDBInstances and close audited grant gaps

### DIFF
--- a/terraform/environments/aws/ci-cd-permissions/policy_compute.tf
+++ b/terraform/environments/aws/ci-cd-permissions/policy_compute.tf
@@ -152,6 +152,19 @@ resource "aws_iam_policy" "compute" {
         # Function mutations live in policy_compute_b.tf — the function
         # resource type does not support aws:ResourceTag per the AWS
         # Service Authorization Reference, so it needs ARN scoping.
+        #
+        # StringEqualsIgnoreCase for the same reason as KMSMutateTaggedOnly
+        # below (see PR #1496): the distribution's Project tag comes from
+        # local.common_tags (terraform/environments/aws/main.tf), which sets
+        # Project = var.project_name, and project_name is the lowercase
+        # "cudly". That resource-level tag overrides the provider's
+        # default_tags value of "CUDly" for this distribution, so a
+        # case-sensitive match against "CUDly" never matched and every action
+        # in this statement was silently denied. This is the same defect
+        # #1496 fixed on the KMS statements; it was left unfixed here because
+        # enable_cdn is false in every tfvars, so nothing exercised it. Note
+        # it would also have killed the destroy path: deleting a distribution
+        # requires UpdateDistribution to disable it first.
         Sid    = "CloudFrontMutateTaggedOnly"
         Effect = "Allow"
         Action = [
@@ -162,7 +175,7 @@ resource "aws_iam_policy" "compute" {
         ]
         Resource = "*"
         Condition = {
-          StringEquals = {
+          StringEqualsIgnoreCase = {
             "aws:ResourceTag/Project" = "CUDly"
           }
         }

--- a/terraform/environments/aws/ci-cd-permissions/policy_compute_b.tf
+++ b/terraform/environments/aws/ci-cd-permissions/policy_compute_b.tf
@@ -98,6 +98,38 @@ resource "aws_iam_policy" "compute_b" {
         }
       },
       {
+        # ecr:PutImageScanningConfiguration is the writer for
+        # aws_ecr_repository's image_scanning_configuration block. Its sibling
+        # ecr:PutImageTagMutability is granted in policy_compute.tf's
+        # ECRRepositoryScoped but this one was not, so any change to
+        # scan_on_push (or importing a repository whose setting differs from
+        # the config) fails the apply. Same repository ARN scope as the
+        # statement it belongs with; it lives here only because
+        # policy_compute.tf is at the 6144-char ceiling.
+        Sid      = "ECRImageScanningConfig"
+        Effect   = "Allow"
+        Action   = ["ecr:PutImageScanningConfiguration"]
+        Resource = "arn:aws:ecr:*:*:repository/cudly-*"
+      },
+      {
+        # The ELB update path that policy_compute.tf's ELBFargate misses.
+        # ELBFargate grants Create/Delete plus the Modify* family, but changing
+        # a load balancer's subnets or security groups (which is what bumping
+        # az_count does) goes through the Set* family instead, and
+        # ModifyListenerAttributes is the writer whose reader
+        # (DescribeListenerAttributes) is already granted. Resource = "*"
+        # matches ELBFargate, whose ARNs are not name-scopeable.
+        Sid    = "ELBFargateSetAttributes"
+        Effect = "Allow"
+        Action = [
+          "elasticloadbalancing:ModifyListenerAttributes",
+          "elasticloadbalancing:SetIpAddressType",
+          "elasticloadbalancing:SetSecurityGroups",
+          "elasticloadbalancing:SetSubnets",
+        ]
+        Resource = "*"
+      },
+      {
         Sid    = "KMSAliasMutate"
         Effect = "Allow"
         Action = [

--- a/terraform/environments/aws/ci-cd-permissions/policy_data.tf
+++ b/terraform/environments/aws/ci-cd-permissions/policy_data.tf
@@ -39,6 +39,17 @@ resource "aws_iam_policy" "data" {
           "iam:UntagInstanceProfile",
           "iam:UntagPolicy",
           "iam:UntagRole",
+          # iam:UpdateAssumeRolePolicy / UpdateRole / UpdateRoleDescription are
+          # what the provider calls when a role's assume_role_policy,
+          # max_session_duration or description drifts (resourceRoleUpdate in
+          # internal/service/iam/role.go). Without them any edit to a trust
+          # policy or role description in terraform/modules/** fails the apply
+          # rather than the plan, which is why this gap stayed invisible.
+          # IAMDenyModifyDeployRoleAndPolicies below stops these from being
+          # turned on the deploy role itself.
+          "iam:UpdateAssumeRolePolicy",
+          "iam:UpdateRole",
+          "iam:UpdateRoleDescription",
         ]
         Resource = [
           "arn:aws:iam::*:role/cudly-*",
@@ -65,6 +76,20 @@ resource "aws_iam_policy" "data" {
               "lambda.amazonaws.com",
               "ecs-tasks.amazonaws.com",
               "rds.amazonaws.com",
+              # ec2: the fck-nat instance profile referenced by the NAT launch
+              # template and Auto Scaling group
+              # (terraform/modules/networking/aws, enable_nat_gateway is
+              # hardcoded true in terraform/environments/aws/networking.tf, so
+              # this is on the deploy path in every environment).
+              "ec2.amazonaws.com",
+              # vpc-flow-logs: aws_flow_log passes its delivery role via
+              # DeliverLogsPermissionArn (enable_flow_logs is true for staging
+              # and prod).
+              "vpc-flow-logs.amazonaws.com",
+              # events: EventBridge targets that carry a role_arn, used by the
+              # scheduled ECS tasks on the Fargate deploy path
+              # (enable_scheduled_tasks is true in every tfvars).
+              "events.amazonaws.com",
             ]
           }
         }
@@ -84,6 +109,54 @@ resource "aws_iam_policy" "data" {
         Effect   = "Deny"
         Action   = ["iam:PassRole"]
         Resource = ["arn:aws:iam::*:role/cudly-terraform-deploy"]
+      },
+      {
+        # IAMDenyPassDeployRole above closes the pass-the-deploy-role door.
+        # This closes the other two doors into the same escalation, both of
+        # which IAMRolesAndPolicies leaves open because cudly-terraform-deploy
+        # is itself a cudly-* role and cudly-deploy-* are cudly-* policies:
+        #
+        #  1. Role side: iam:AttachRolePolicy / iam:PutRolePolicy let the
+        #     deploy role grant itself AdministratorAccess, and
+        #     iam:UpdateAssumeRolePolicy (added to IAMRolesAndPolicies above)
+        #     lets it rewrite its own trust policy so an arbitrary principal
+        #     can assume it.
+        #  2. Policy side: iam:CreatePolicyVersion on cudly-deploy-data (or
+        #     any sibling) rewrites the deploy role's own permissions in
+        #     place, reaching the same admin without ever touching the role.
+        #     Denying only the role side would look complete and would not be.
+        #
+        # Either turns a leaked GitHub Actions token into persistent
+        # account-wide admin. An explicit Deny always beats the Allow, so this
+        # closes both loops while leaving the workload roles and policies
+        # (cudly-<env>-<suffix>-*) fully manageable.
+        #
+        # This costs the deploy path nothing: cudly-terraform-deploy and the
+        # four cudly-deploy-* policies are all declared in this bootstrap
+        # root, which is applied manually by a privileged human and never by a
+        # deploy workflow. Action and Resource are matched as a cross product,
+        # so the combinations that do not apply (a role action against a
+        # policy ARN and vice versa) are simply inert.
+        Sid    = "IAMDenyModifyDeployRoleAndPolicies"
+        Effect = "Deny"
+        Action = [
+          "iam:AttachRolePolicy",
+          "iam:CreatePolicyVersion",
+          "iam:DeletePolicy",
+          "iam:DeletePolicyVersion",
+          "iam:DeleteRole",
+          "iam:DeleteRolePolicy",
+          "iam:DetachRolePolicy",
+          "iam:PutRolePolicy",
+          "iam:SetDefaultPolicyVersion",
+          "iam:UpdateAssumeRolePolicy",
+          "iam:UpdateRole",
+          "iam:UpdateRoleDescription",
+        ]
+        Resource = [
+          "arn:aws:iam::*:role/cudly-terraform-deploy",
+          "arn:aws:iam::*:policy/cudly-deploy-*",
+        ]
       },
       {
         Sid    = "IAMReadForPassRole"
@@ -112,11 +185,29 @@ resource "aws_iam_policy" "data" {
         }
       },
       {
-        # RDS actions that take a specific resource ARN are scoped to
-        # cudly-* DB instances, subnet groups, and proxies. This prevents
-        # the deploy SA from deleting or modifying unrelated RDS instances
-        # in the same account. DescribeDBEngineVersions does not accept a
-        # resource ARN (account-wide catalogue lookup) and is split below.
+        # RDS actions whose request carries a name we control are scoped to
+        # cudly-* DB instances, subnet groups and snapshots. This prevents the
+        # deploy SA from deleting or modifying unrelated RDS resources in the
+        # same account.
+        #
+        # rds:DescribeDBInstances deliberately does NOT live here; see
+        # RDSDescribeAccountWide below.
+        #
+        # KNOWN DEAD SCOPES: the proxy actions below (DeleteDBProxy,
+        # ModifyDBProxy, RegisterDBProxyTargets, DeregisterDBProxyTargets)
+        # can never be authorized, because their only resource types are
+        # `proxy` and `target-group`, whose real ARNs are
+        # arn:aws:rds:<r>:<a>:db-proxy:prx-<opaque> and
+        # arn:aws:rds:<r>:<a>:target-group:prx-tg-<opaque>: a different ARN
+        # segment (`db-proxy`, not `proxy`) and a server-assigned opaque id
+        # that never contains the resource name. `proxy:cudly-*` and
+        # `target-group:cudly-*` therefore match nothing. Nothing exercises
+        # this today (modules/database/aws is instantiated with
+        # enable_rds_proxy = false, terraform/environments/aws/database.tf),
+        # so it is left as-is rather than widened to db-proxy:* here; fixing
+        # it needs a scoping mechanism that actually constrains an opaque id
+        # (tag condition), tracked separately. Do NOT add new proxy actions
+        # to this statement; they would be dead on arrival.
         Sid    = "RDSResourceScoped"
         Effect = "Allow"
         Action = [
@@ -126,16 +217,13 @@ resource "aws_iam_policy" "data" {
           "rds:CreateDBSubnetGroup",
           "rds:DeleteDBInstance",
           "rds:DeleteDBSubnetGroup",
-          "rds:DescribeDBInstances",
           "rds:DescribeDBSubnetGroups",
           "rds:ListTagsForResource",
           "rds:DeleteDBProxy",
           "rds:DeregisterDBProxyTargets",
-          "rds:DescribeDBProxies",
-          "rds:DescribeDBProxyTargetGroups",
-          "rds:DescribeDBProxyTargets",
           "rds:ModifyDBInstance",
           "rds:ModifyDBProxy",
+          "rds:ModifyDBSubnetGroup",
           "rds:RegisterDBProxyTargets",
           "rds:RemoveTagsFromResource",
         ]
@@ -148,11 +236,43 @@ resource "aws_iam_policy" "data" {
         ]
       },
       {
-        # DescribeDBEngineVersions is a catalogue lookup that doesn't
-        # accept a resource ARN at the API level. Read-only, no state change.
-        Sid      = "RDSDescribeEngineVersions"
-        Effect   = "Allow"
-        Action   = ["rds:DescribeDBEngineVersions"]
+        # RDS reads that an ARN-scoped grant can never authorize.
+        #
+        # rds:DescribeDBEngineVersions is a catalogue lookup with no resource
+        # type at all, so it can only be granted on "*".
+        #
+        # rds:DescribeDBInstances is here because of the request shape the AWS
+        # provider uses, not because the action lacks a resource type. The
+        # Terraform id of aws_db_instance IS the DbiResourceId (`db-<opaque>`,
+        # set at internal/service/rds/instance.go in provider v5.100.0), and
+        # findDBInstanceByID branches on that: when the id looks like a
+        # DbiResourceId it sends DescribeDBInstances with
+        # Filters=[dbi-resource-id] and leaves DBInstanceIdentifier nil. RDS
+        # authorizes an identifier-less DescribeDBInstances against the
+        # wildcard ARN arn:aws:rds:<region>:<account>:db:*, which
+        # `db:cudly-*` cannot match, so every refresh of the instance 403'd:
+        #   AccessDenied: ... not authorized to perform: rds:DescribeDBInstances
+        #   on resource: arn:aws:rds:us-east-1:...:db:*
+        # This is unconditional on every read, not a not-found fallback: the
+        # provider's retry with the plain identifier only fires on NotFound,
+        # and AccessDenied is not NotFound, so the plan hard-fails.
+        #
+        # The DB proxy reads are here for a third reason: their resource ARNs
+        # use the `db-proxy:`/`target-group:` segments with server-assigned
+        # opaque ids (see the RDSResourceScoped note above), so no name-based
+        # ARN scope can ever match them.
+        #
+        # All five are read-only and expose only resource metadata; every
+        # mutating RDS action stays ARN-scoped above.
+        Sid    = "RDSDescribeAccountWide"
+        Effect = "Allow"
+        Action = [
+          "rds:DescribeDBEngineVersions",
+          "rds:DescribeDBInstances",
+          "rds:DescribeDBProxies",
+          "rds:DescribeDBProxyTargetGroups",
+          "rds:DescribeDBProxyTargets",
+        ]
         Resource = "*"
       },
       {
@@ -171,6 +291,20 @@ resource "aws_iam_policy" "data" {
         Resource = "*"
       },
       {
+        # secretsmanager:ListSecrets used to be in this list. It has no
+        # resource type per the AWS Service Authorization Reference, so
+        # inside an ARN-scoped statement it could never be satisfied: a
+        # silently dead grant. Nothing in the provider calls it (secret
+        # lookups go through DescribeSecret with an explicit id), so it is
+        # dropped rather than moved to a "*" statement.
+        #
+        # ListSecretVersionIds and UpdateSecretVersionStage are what
+        # aws_secretsmanager_secret_version calls when a version carries a
+        # stage other than a lone AWSCURRENT, and on the delete path when it
+        # has to move stages off the version before removing it
+        # (resourceSecretVersionDelete/Update in
+        # internal/service/secretsmanager/secret_version.go). Both take the
+        # secret ARN, so the cudly-* scope below applies.
         Sid    = "SecretsManager"
         Effect = "Allow"
         Action = [
@@ -179,13 +313,14 @@ resource "aws_iam_policy" "data" {
           "secretsmanager:DescribeSecret",
           "secretsmanager:GetResourcePolicy",
           "secretsmanager:GetSecretValue",
-          "secretsmanager:ListSecrets",
+          "secretsmanager:ListSecretVersionIds",
           "secretsmanager:PutSecretValue",
           "secretsmanager:RestoreSecret",
           "secretsmanager:RotateSecret",
           "secretsmanager:TagResource",
           "secretsmanager:UntagResource",
           "secretsmanager:UpdateSecret",
+          "secretsmanager:UpdateSecretVersionStage",
         ]
         Resource = "arn:aws:secretsmanager:*:*:secret:cudly-*"
       },

--- a/terraform/environments/aws/ci-cd-permissions/policy_data.tf
+++ b/terraform/environments/aws/ci-cd-permissions/policy_data.tf
@@ -168,18 +168,33 @@ resource "aws_iam_policy" "data" {
         Resource = "*"
       },
       {
+        # Service-linked roles are created lazily by AWS on the FIRST use of a
+        # service in an account/region, and the caller needs
+        # iam:CreateServiceLinkedRole for it. That makes these gaps invisible
+        # in an account that already has the role and a hard failure in a
+        # fresh region, which is exactly the kind of latent break this audit
+        # was meant to surface. autoscaling (fck-nat ASG, on every deploy
+        # path), elasticloadbalancing and ecs (Fargate ALB and cluster) were
+        # all missing; note that ecs.application-autoscaling is a different
+        # principal from plain ecs and does not cover it.
         Sid    = "IAMServiceLinkedRole"
         Effect = "Allow"
         Action = ["iam:CreateServiceLinkedRole"]
         Resource = [
           "arn:aws:iam::*:role/aws-service-role/rds.amazonaws.com/AWSServiceRoleForRDS",
           "arn:aws:iam::*:role/aws-service-role/ecs.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_ECSService",
+          "arn:aws:iam::*:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling",
+          "arn:aws:iam::*:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing",
+          "arn:aws:iam::*:role/aws-service-role/ecs.amazonaws.com/AWSServiceRoleForECS",
         ]
         Condition = {
           StringLike = {
             "iam:AWSServiceName" = [
               "rds.amazonaws.com",
               "ecs.application-autoscaling.amazonaws.com",
+              "autoscaling.amazonaws.com",
+              "elasticloadbalancing.amazonaws.com",
+              "ecs.amazonaws.com",
             ]
           }
         }

--- a/terraform/environments/aws/ci-cd-permissions/policy_data.tf
+++ b/terraform/environments/aws/ci-cd-permissions/policy_data.tf
@@ -205,8 +205,8 @@ resource "aws_iam_policy" "data" {
         # deploy SA from deleting or modifying unrelated RDS resources in the
         # same account.
         #
-        # rds:DescribeDBInstances deliberately does NOT live here; see
-        # RDSDescribeAccountWide below.
+        # NO rds:Describe* action lives here; they are all in
+        # RDSDescribeAccountWide below. See that statement for why.
         #
         # KNOWN DEAD SCOPES: the proxy actions below (DeleteDBProxy,
         # ModifyDBProxy, RegisterDBProxyTargets, DeregisterDBProxyTargets)
@@ -232,7 +232,6 @@ resource "aws_iam_policy" "data" {
           "rds:CreateDBSubnetGroup",
           "rds:DeleteDBInstance",
           "rds:DeleteDBSubnetGroup",
-          "rds:DescribeDBSubnetGroups",
           "rds:ListTagsForResource",
           "rds:DeleteDBProxy",
           "rds:DeregisterDBProxyTargets",
@@ -272,12 +271,34 @@ resource "aws_iam_policy" "data" {
         # provider's retry with the plain identifier only fires on NotFound,
         # and AccessDenied is not NotFound, so the plan hard-fails.
         #
+        # rds:DescribeDBSubnetGroups is here for the same reason as
+        # DescribeDBInstances, and it is worth being explicit about why,
+        # because the tempting simplification is wrong in both directions.
+        # Neither action lacks a resource type: per AWS's Service
+        # Authorization Reference both DO support one (`db` and `subgrp`
+        # respectively), and the real names DO match the patterns
+        # (cudly-<env>-<hex>-postgres against db:cudly-*,
+        # cudly-<env>-<hex>-db-subnet against subgrp:cudly-*). So this is not
+        # "ARN-scoped Describes are always dead" and it is not a name-prefix
+        # bug; the scoped grants were syntactically valid. What differs is the
+        # request shape: a resource-scoped grant authorizes only the form that
+        # targets one named resource, while the enumerate form (no identifier
+        # in the request) is authorized against the wildcard ARN. The
+        # production 403 on DescribeDBInstances is the empirical proof that
+        # the scoped form did not suffice, and DescribeDBSubnetGroups sits in
+        # exactly the same position: aws_db_subnet_group.main
+        # (terraform/modules/database/aws/main.tf) is created in every
+        # environment, so leaving it scoped just primes the next 403.
+        #
         # The DB proxy reads are here for a third reason: their resource ARNs
         # use the `db-proxy:`/`target-group:` segments with server-assigned
         # opaque ids (see the RDSResourceScoped note above), so no name-based
-        # ARN scope can ever match them.
+        # ARN scope can ever match them. Those are belt-and-braces rather than
+        # load-bearing: enable_rds_proxy is a literal `false` at
+        # terraform/environments/aws/database.tf:28, not a variable, so no
+        # tfvars can turn the proxy resources on.
         #
-        # All five are read-only and expose only resource metadata; every
+        # All six are read-only and expose only resource metadata; every
         # mutating RDS action stays ARN-scoped above.
         Sid    = "RDSDescribeAccountWide"
         Effect = "Allow"
@@ -287,6 +308,7 @@ resource "aws_iam_policy" "data" {
           "rds:DescribeDBProxies",
           "rds:DescribeDBProxyTargetGroups",
           "rds:DescribeDBProxyTargets",
+          "rds:DescribeDBSubnetGroups",
         ]
         Resource = "*"
       },

--- a/terraform/environments/aws/ci-cd-permissions/policy_networking.tf
+++ b/terraform/environments/aws/ci-cd-permissions/policy_networking.tf
@@ -22,6 +22,17 @@ resource "aws_iam_policy" "networking" {
           "ec2:CreateEgressOnlyInternetGateway",
           "ec2:CreateInternetGateway",
           "ec2:CreateLaunchTemplate",
+          # The fck-nat launch template sources its AMI from a
+          # most_recent = true data.aws_ami lookup, so every upstream AMI
+          # republish takes the launch template's UPDATE path rather than
+          # create: the provider calls CreateLaunchTemplateVersion for the new
+          # image_id and ModifyLaunchTemplate to move the default version
+          # (resourceLaunchTemplateUpdate). Only Create/DeleteLaunchTemplate
+          # were granted, so the first AMI rotation after the ASG exists would
+          # have failed the apply.
+          "ec2:CreateLaunchTemplateVersion",
+          "ec2:DeleteLaunchTemplateVersions",
+          "ec2:ModifyLaunchTemplate",
           "ec2:CreateRoute",
           "ec2:CreateRouteTable",
           "ec2:CreateSecurityGroup",
@@ -39,6 +50,12 @@ resource "aws_iam_policy" "networking" {
           "ec2:DeleteRouteTable",
           "ec2:DeleteSecurityGroup",
           "ec2:DeleteSubnet",
+          # ec2:DeleteTags is the other half of ec2:CreateTags: the provider's
+          # tag update path removes dropped keys with DeleteTags before adding
+          # new ones with CreateTags, so dropping any key from common_tags /
+          # default_tags on an existing VPC, subnet, route table, gateway,
+          # security group or launch template fails the apply without it.
+          "ec2:DeleteTags",
           "ec2:DeleteVpc",
           "ec2:DeleteVpcEndpoints",
           "ec2:DescribeAccountAttributes",
@@ -66,6 +83,11 @@ resource "aws_iam_policy" "networking" {
           "ec2:ModifyVpcAttribute",
           "ec2:ModifyVpcEndpoint",
           "ec2:ReplaceRoute",
+          # aws_route_table_association's update path calls
+          # ReplaceRouteTableAssociation rather than
+          # Disassociate + Associate, so moving a subnet between route tables
+          # needs it even though both halves of that pair are granted.
+          "ec2:ReplaceRouteTableAssociation",
           "ec2:RevokeSecurityGroupEgress",
           "ec2:RevokeSecurityGroupIngress",
         ]
@@ -73,16 +95,28 @@ resource "aws_iam_policy" "networking" {
       },
       {
         # ec2:RunInstances is needed for the fck-nat AutoScaling group
-        # (one t4g.nano per AZ). Scoping to the fck-nat launch template
-        # and restricting allowed instance types prevents the deploy SA
-        # from launching arbitrary large instances and attaching CUDly IAM
-        # roles to exfiltrate credentials or run compute at account cost.
+        # (one t4g.nano per AZ). Restricting allowed instance types prevents
+        # the deploy SA from launching arbitrary large instances and attaching
+        # CUDly IAM roles to exfiltrate credentials or run compute at account
+        # cost.
+        #
+        # The operator MUST be StringEqualsIfExists, not StringEquals. AWS
+        # authorizes a single RunInstances call against every resource type it
+        # touches (instance, volume, network-interface, security-group,
+        # subnet, image, key-pair, launch-template), and ec2:InstanceType is
+        # only in the request context for the INSTANCE leg. With a plain
+        # StringEquals the key is absent on every other leg, the condition
+        # evaluates false there, and the call is denied as a whole even though
+        # the instance type is correct. StringEqualsIfExists keeps the t4g.nano
+        # restriction exactly where the key exists and lets the supporting legs
+        # through, which is the pattern the IAM condition-operators reference
+        # documents for precisely this call.
         Sid      = "EC2RunInstancesFckNAT"
         Effect   = "Allow"
         Action   = ["ec2:RunInstances"]
         Resource = "*"
         Condition = {
-          StringEquals = {
+          StringEqualsIfExists = {
             "ec2:InstanceType" = ["t4g.nano"]
           }
         }


### PR DESCRIPTION
Closes #1698 · follow-ups tracked in #1703 and #1707

## The immediate failure

`Deploy to AWS Lambda` on `main` (run 30809235060) fails at **Terraform Plan**:

```
Error: reading RDS DB Instance (cudly-dev-426fc8af-postgres): operation error RDS: DescribeDBInstances,
StatusCode: 403, AccessDenied: ... is not authorized to perform: rds:DescribeDBInstances
on resource: arn:aws:rds:us-east-1:909626172446:db:*
```

`rds:DescribeDBInstances` was **already granted**, scoped to `arn:aws:rds:*:*:db:cudly-*`, and the instance name matches that prefix. The denial nevertheless names `db:*`.

**Root cause.** The Terraform id of `aws_db_instance` is the **DbiResourceId** (`db-<opaque>`), not the DB identifier. In terraform-provider-aws v5.100.0, `findDBInstanceByID` (`internal/service/rds/instance.go`) branches on the shape of the id and, for a DbiResourceId, sends `DescribeDBInstances` with `Filters=[dbi-resource-id]` and `DBInstanceIdentifier` nil. RDS authorizes an identifier-less `DescribeDBInstances` against the **wildcard** ARN `db:*`, which no name-scoped grant can match.

This is unconditional on every read, not a not-found fallback: the provider's retry with the plain identifier only fires on `NotFound`, and `AccessDenied` is not `NotFound`, so the plan hard-fails.

**On the deposed objects.** The repeated `# (left over from a partially-failed replacement of this instance)` lines in the plan output are deposed objects from earlier failed applies. They are a *consequence* of this, not the trigger, and are not chased here.

## Why this is not another one-action patch

This grant has been patched four times by adding whatever 403'd next (#1496, #1514, #1671). Each fix was correct and each left the next gap in place. So this PR enumerates every `resource`/`data` block under `terraform/environments/aws/` and its modules, lists the API calls provider v5.100.0 makes for read/create/update/delete, and diffs that against the union of the four policies. Deploy-path status was resolved against `github-{dev,staging,prod}.tfvars` and both deploy workflows.

The audit named a **third** failure mode the previous patches did not account for:

1. **Missing action** — absent from the policy. Discoverable by eye.
2. **Granted but unsatisfiable condition** — gated on a condition that cannot hold at call time (the #1671 `kms:TagResource` bug; the #1514 tag-case bug).
3. **Granted but unmatchable resource** — the ARN pattern can never match the request, either because the call carries no identifier, or because the real ARN uses a different segment or a server-assigned opaque id.

Classes 2 and 3 both look completely fine when you read the policy. **All three classes turned up again in this audit**, in code nobody had looked at.

## Fixed here

### Blocking the deploy path

| Gap | Class | Effect if unfixed |
|---|---|---|
| `rds:DescribeDBInstances` scoped to `db:cudly-*` | unmatchable resource | **plan fails today, all envs** |
| `ec2:CreateLaunchTemplateVersion`, `ec2:ModifyLaunchTemplate`, `ec2:DeleteLaunchTemplateVersions` | missing | fck-nat's AMI comes from a `most_recent = true` lookup, so every republish takes the launch template's **update** path. Only Create/Delete were granted, so the first AMI rotation after the ASG exists fails the apply. All envs. |
| `EC2RunInstancesFckNAT` used `StringEquals` on `ec2:InstanceType` | unsatisfiable condition | AWS authorizes one `RunInstances` against every resource type it touches, and `ec2:InstanceType` is only in context for the **instance** leg. On the volume / ENI / security-group / subnet / image / launch-template legs the key is absent, `StringEquals` evaluates false, and the whole call is denied. Now `StringEqualsIfExists`, which keeps the `t4g.nano` restriction exactly where the key exists. |
| `iam:PassRole` missing `ec2.amazonaws.com` | unsatisfiable condition | `CreateAutoScalingGroup` dry-run validates PassRole for the fck-nat instance profile (`enable_nat_gateway` hardcoded `true`, `networking.tf:16`, all envs) |
| `iam:PassRole` missing `vpc-flow-logs.amazonaws.com` | unsatisfiable condition | apply fails creating/replacing `aws_flow_log` (staging + prod) |
| `iam:PassRole` missing `events.amazonaws.com` | unsatisfiable condition | apply fails on `events:PutTargets` with `role_arn` (Fargate path, `enable_scheduled_tasks = true` in all three tfvars) |
| `iam:CreateServiceLinkedRole` missing `autoscaling`, `elasticloadbalancing`, `ecs` | missing | SLRs are created lazily on first use of a service in an account/region: invisible where the role exists, hard failure in a fresh region. Note `ecs.application-autoscaling` was granted and is a **different principal** that does not cover plain `ecs`. |
| `rds:DescribeDBSubnetGroups` scoped to `subgrp:cudly-*` | unmatchable resource | same call shape as the `DescribeDBInstances` read that is 403ing. `aws_db_subnet_group.main` (`terraform/modules/database/aws/main.tf:73`) is created in every environment, so leaving it scoped primes the next 403. |
| `rds:ModifyDBSubnetGroup` | missing | apply fails if `az_count` or the private subnet set changes |

### Latent, fixed while the files were open

| Gap | Class | Reachable when |
|---|---|---|
| `CloudFrontMutateTaggedOnly` gated on case-sensitive `StringEquals "CUDly"` | unsatisfiable condition | The distribution's `Project` tag resolves to lowercase `cudly` via `local.common_tags`, so **all four** of its actions were silently denied. **This is #1496's KMS bug, unfixed on the CloudFront statement** because `enable_cdn = false` meant nothing exercised it. It would also have killed the destroy path, since deleting a distribution requires `UpdateDistribution` to disable it first. |
| `ec2:DeleteTags` | missing | the other half of `ec2:CreateTags`; dropping any key from `common_tags`/`default_tags` on an existing EC2 resource |
| `ec2:ReplaceRouteTableAssociation` | missing | the association's update path calls it instead of Disassociate + Associate |
| `ecr:PutImageScanningConfiguration` | missing | any `scan_on_push` change; its sibling `PutImageTagMutability` was already granted |
| `elasticloadbalancing:SetSubnets`, `SetSecurityGroups`, `SetIpAddressType`, `ModifyListenerAttributes` | missing | changing an ALB's subnets or security groups (i.e. bumping `az_count`) goes through `Set*`, not `Modify*` |
| `iam:UpdateAssumeRolePolicy`, `iam:UpdateRole`, `iam:UpdateRoleDescription` | missing | any trust-policy / description drift on a `cudly-*` role |
| `secretsmanager:UpdateSecretVersionStage`, `ListSecretVersionIds` | missing | any secret version carrying a stage other than a lone `AWSCURRENT` |
| `secretsmanager:ListSecrets` inside an ARN-scoped statement | dead grant | no resource type, so unsatisfiable; dropped (nothing on the deploy path calls it) |

Every `Resource = "*"` now documents **which** of the three reasons applies (no resource type / identifier-less request / opaque id), so a reviewer can tell a justified wildcard from a lazy one.

### Security: `IAMDenyModifyDeployRoleAndPolicies`

`iam:UpdateAssumeRolePolicy` on `role/cudly-*` also matches `cudly-terraform-deploy` itself, so granting it would let the deploy role rewrite its own trust policy and make itself assumable by an arbitrary principal. The new `Deny` closes that, plus two **pre-existing** doors into the same escalation that the audit surfaced:

- `iam:AttachRolePolicy` / `iam:PutRolePolicy` against the deploy role (attach `AdministratorAccess` to self);
- `iam:CreatePolicyVersion` against `policy/cudly-deploy-*` (rewrite the deploy role's own permissions in place, without ever touching the role).

Denying only the role side would have looked complete without being complete. Verified no workload name can collide: all workload roles/policies derive from `stack_name = "cudly-<env>-<hex>"`, while the Deny targets `role/cudly-terraform-deploy` and `policy/cudly-deploy-*` exactly. It costs the deploy path nothing, since those resources are declared in this bootstrap root and applied only by a human.

## Deliberately NOT fixed here → #1703

Scaled to what unblocks deploys, rather than shipping widenings I could not verify:

- **RDS proxy ARN scopes are dead as written.** `proxy:cudly-*` is wrong on two counts (segment is `db-proxy:`, id is an opaque `prx-…`), and `target-group:cudly-*` on the opaque-id count. That makes four proxy actions unauthorizable and `rds:ModifyDBProxyTargetGroup` missing. Gated off by `enable_rds_proxy = false`, which is a **literal** at `terraform/environments/aws/database.tf:28` and not a variable, so no tfvars can override it and all three proxy resources are `count = 0` in every environment. The missing `rds:ModifyDBProxyTargetGroup` is therefore inert, and the three proxy Describes moved account-wide here are belt-and-braces rather than load-bearing. Not fixed because scoping an opaque id correctly needs a tag condition whose satisfiability must be **verified**, not assumed — which is exactly the mistake #1671 made. The dead scopes are marked in place with a `KNOWN DEAD SCOPES` comment and a "do not add new proxy actions here" warning.
- **CloudFront cannot be enabled**: `cloudfront:TagResource` is unsatisfiable at `CreateDistributionWithTags` (same shape as #1671), and `aws_cloudfront_origin_access_control` has no permissions at all.
- **`module "monitoring"` is not instantiated** and has no permissions. Several would be dead on arrival if added naively: SNS topic ARNs have no resource-type segment; CloudWatch dashboard ARNs have an empty region segment and a `/` separator; GuardDuty detector ids are opaque hex; the Security Hub hub ARN is literally `hub/default`; `logs:*QueryDefinition*`, `xray:GetSamplingRules` and `guardduty:CreateDetector`/`ListDetectors` have no resource type at all.
- **Wrong comment in the tree**: `terraform/modules/compute/aws/lambda/migration-alarm.tf:25-29` claims the bootstrap grants `logs:PutMetricFilter`. It does not.
- **`rds:DescribeDBSnapshots` is granted by no statement in any of the four policies.** `github-prod.tfvars:50` sets `database_skip_final_snapshot = false`, so a prod DB destroy takes a final snapshot and the provider waits on it. Destroy-path only, so it does not block this deploy. Filed as **#1707**; the scoping decision there (ARN-scoped vs account-wide) has to be made from the provider's actual request shape, not by analogy.
- Opt-in leftovers: `lambda:*FunctionConcurrency`, `acm:RemoveTagsFromCertificate`, `route53:CreateHostedZone`/`DeleteHostedZone`/`ChangeTagsForResource`, `logs:DeleteRetentionPolicy`, and `iam:PassRole` for `monitoring.rds.amazonaws.com` if RDS enhanced monitoring is ever enabled.

## Policy sizes (6144-char managed-policy limit)

Measured by rendering each `jsonencode` through Terraform, so these are the exact documents AWS sees:

| Policy | Before | After | Remaining |
|---|---|---|---|
| `cudly-deploy-compute` | 5923 | 5933 | 211 |
| `cudly-deploy-compute-b` | 905 | 1290 | 4854 |
| `cudly-deploy-data` | 3548 | 4588 | 1556 |
| `cudly-deploy-networking` | 2675 | 2831 | 3313 |

`policy_compute.tf` was already at 5923 of 6144, so the only thing added to it is the 10-character `StringEquals` → `StringEqualsIgnoreCase` operator change. The new ECR and ELB statements go in `policy_compute_b.tf`, which exists for exactly this reason. No split was needed.

## Verification

- `terraform fmt -check` clean, `terraform validate` **Success** on all four policies.
- Full `pre-commit` on the changed files: Terraform format / validate / **lint (tflint)** / Trivy config scanner / AWS secret scan all **Passed**. No `--no-verify`.
- CI green on the first commit (AWS Sanity, Azure Sanity, CI Build & Test, pre-commit all `success`).
- Every factual claim in the new comments checked against the tree: `enable_nat_gateway = true` (`networking.tf:16`), `enable_flow_logs` false/true/true across dev/staging/prod, `enable_scheduled_tasks = true` in all three tfvars, `aws_iam_instance_profile.fck_nat` referenced by the launch template, `aws_flow_log.iam_role_arn`, and the lowercase `project_name = "cudly"` that drives the CloudFront tag-case fix.
- `tfplan`, `.terraform/` and `backend.hcl` confirmed gitignored and absent from the diff.

**Not verified against live AWS**: no AWS mutation was attempted from here by design. The authoritative check is the bootstrap `terraform plan` below.

## ⚠️ Requires a manual bootstrap apply by a privileged human

`terraform/environments/aws/ci-cd-permissions/` is a **bootstrap-only** root: it defines the deploy role's own permissions and is applied manually, never by a deploy workflow. **Merging this does not unblock deploys on its own.** After merge, with privileged credentials:

```
cd terraform/environments/aws/ci-cd-permissions
terraform init -backend-config=backend.hcl
terraform plan -out=tfplan
terraform apply tfplan
```

Expect changes to all four `aws_iam_policy` resources (a new default policy version each). Then re-run `Deploy to AWS Lambda` on `main`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded deployment capabilities for EC2, VPC Flow Logs, EventBridge, Auto Scaling, load balancing, ECS, RDS, and secrets management.
  * Added support for managing launch template versions, route-table associations, EC2 tags, load balancer settings, and container image scanning.
  * Improved compatibility with varied project tag capitalization and supporting EC2 resource authorization.

* **Security**
  * Added safeguards preventing modification of deployment roles and policies.
  * Restricted EC2 instance launches to the approved instance type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->