### PR TITLE
chore(docker): adopt hadolint 2.15.1 and fix the four findings it reports

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -182,8 +182,11 @@ jobs:
             exit 1
           }
 
-      # Note: the local `hadolint` pre-commit hook (.pre-commit-config.yaml:81)
-      # runs ghcr.io/hadolint/hadolint pinned by digest to v2.14.0. We do NOT
+      # Note: the local `hadolint` hook in .pre-commit-config.yaml (search for
+      # `id: hadolint`; no line number, because this comment has already gone
+      # stale twice as that file shifted) runs ghcr.io/hadolint/hadolint pinned
+      # by digest. The version lives in that entry and is the single source of
+      # truth; do not restate it here, or this comment rots again. We do NOT
       # install a host binary here — it would be dead code (never invoked by
       # the hook) AND a supply-chain hole (latest tag, no checksum). Note:
       # an earlier version of this comment claimed the hook already pinned

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,21 +67,26 @@ repos:
   # The upstream hadolint-docker hook (hadolint/hadolint's own
   # .pre-commit-hooks.yaml) declares `entry: ghcr.io/hadolint/hadolint
   # hadolint` with no image tag, so Docker resolves it to `:latest` on every
-  # run -- independent of the `rev:` pin above, which only pins which
-  # commit of the *hook definition* is used, not the Docker image it runs.
-  # When upstream published hadolint 2.15.1 as `latest`, CI silently
-  # started linting with a newer ruleset (new DL3066/DL3025 findings on
-  # unchanged Dockerfiles) with no corresponding change in this repo.
+  # run -- independent of any `rev:` pin, which only pins which commit of the
+  # *hook definition* is used, not the Docker image it runs. When upstream
+  # published hadolint 2.15.1 as `latest`, CI silently started linting with a
+  # newer ruleset (new DL3066/DL3025 findings on unchanged Dockerfiles) with no
+  # corresponding change in this repo, and `main` went red (issue #1695).
   #
-  # Defined as a local hook instead, pinned to the immutable digest of the
-  # v2.14.0 image, so the linter version can only change via an explicit
-  # bump here.
+  # Defined as a local hook instead, pinned to an immutable digest, so the
+  # linter version can only change through an explicit edit to this line.
+  #
+  # Pinned to 2.15.1 -- the version that surfaced the findings -- rather than
+  # back to 2.14.0. Pinning to the older image would also have made CI green,
+  # but only by un-seeing findings that are real; the four it reported are
+  # fixed in the Dockerfiles rather than silenced. Bumping this digest is
+  # expected to require fixing whatever the new version finds.
   - repo: local
     hooks:
       - id: hadolint
         name: Lint Dockerfiles
         language: docker_image
-        entry: ghcr.io/hadolint/hadolint:v2.14.0@sha256:27086352fd5e1907ea2b934eb1023f217c5ae087992eb59fde121dce9c9ff21e hadolint
+        entry: ghcr.io/hadolint/hadolint:v2.15.1@sha256:32dac94127fd60b7b7e3fbfc65e1383b9b5e25c9bfd7b8536de7a539fe68a12d hadolint
         types: [dockerfile]
 
   # Markdown linting

--- a/Dockerfile
+++ b/Dockerfile
@@ -145,8 +145,11 @@ COPY --from=frontend-builder --chown=cudly:cudly /frontend/dist /app/static
 COPY --chown=cudly:cudly scripts/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
-# Switch to non-root user
-USER cudly
+# Switch to non-root user. Numeric form so the identity is resolvable without
+# the image's /etc/passwd: Kubernetes `runAsNonRoot` and similar admission
+# checks cannot verify a name-form USER and will refuse to start the pod.
+# 1000:1000 is exactly the uid:gid created above, so this is a rename only.
+USER 1000:1000
 
 # Environment defaults
 ENV DB_MIGRATIONS_PATH=/app/migrations \
@@ -162,8 +165,14 @@ ENV DB_MIGRATIONS_PATH=/app/migrations \
 EXPOSE 8080
 
 # Health check (works for HTTP mode, ignored in Lambda mode)
+#
+# JSON (exec) form, but invoking /bin/sh explicitly: the `||` is a shell
+# operator, so a bare exec-form list would hand `||` and `exit` to curl as
+# literal arguments and the healthcheck would never report unhealthy correctly.
+# This is the same process tree the shell form produced, written so the
+# dependency on a shell is declared rather than implied.
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
-    CMD curl -f http://localhost:8080/health || exit 1
+    CMD ["/bin/sh", "-c", "curl -f http://localhost:8080/health || exit 1"]
 
 # Unified entrypoint handles both Lambda and HTTP modes
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -55,11 +55,16 @@ RUN if [ ! -f .air.toml ]; then air init; fi
 
 EXPOSE 8080
 
-# Create non-root user for security; grant ownership of app dir and Go paths
-RUN addgroup -S devuser && adduser -S devuser -G devuser && \
+# Create non-root user for security; grant ownership of app dir and Go paths.
+# uid/gid are pinned explicitly rather than left to `adduser -S`, which picks
+# the first free system id and so varies with the base image's existing users.
+# A numeric USER below needs a value that is known here, not discovered later.
+RUN addgroup -g 1001 devuser && \
+    adduser -D -u 1001 -G devuser devuser && \
     chown -R devuser:devuser /app /root/go /root/.cache 2>/dev/null || true
 
-USER devuser
+# Numeric form so the identity is resolvable without the image's /etc/passwd.
+USER 1001:1001
 
 # Start with Air for hot reload
 CMD ["air", "-c", ".air.toml"]

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -18,7 +18,9 @@ WORKDIR /e2e
 
 COPY --chown=e2e:e2e tests/e2e/ ./
 
-USER e2e
+# Numeric form so the identity is resolvable without the image's /etc/passwd.
+# 10001 is exactly the uid created above, so this is a rename only.
+USER 10001
 
 # Pre-compile the test binary so `docker compose up` failures are runtime
 # failures, not compile errors discovered after the stack is already up.


### PR DESCRIPTION
Closes #1701

## What this is now

This PR was opened against #1695 before I discovered that #1697 had already landed the fix for it. **#1695 is closed and `main`'s `pre-commit` is green** as of `218f3858e` (12:53). The queue is unblocked, and nothing here is needed for that.

The branch has been rebased onto current `main`, and the duplicate pin commit dropped out automatically (`git rebase`: *"dropping 0010d704... -- patch contents already upstream"*). What remains is the half `main` does **not** have.

## What remains, and why it is worth landing

#1697 pinned the hadolint image to the **v2.14.0** digest. That correctly fixes the root cause (the upstream `hadolint-docker` hook declares `entry: ghcr.io/hadolint/hadolint hadolint` with no image tag, so `rev:` pinned the hook definition while Docker resolved `:latest` every run).

But it leaves the four findings **un-seen rather than fixed**. 2.14.0 reports nothing only because it predates the rules. This PR moves the pin to 2.15.1 and fixes them, with no `.hadolint.yaml` ignore entries and no inline `# hadolint ignore=` directives.

**DL3066, non-numeric user id** (`Dockerfile:149`, `Dockerfile.test:21`, `Dockerfile.dev:62`). A name-form `USER` cannot be verified by Kubernetes `runAsNonRoot` and similar admission checks, which see only the numeric id.

- `Dockerfile` and `Dockerfile.test` already pinned uids explicitly (1000, 10001), so those are substitutions with no behaviour change.
- `Dockerfile.dev` used `adduser -S`, which takes the first free system id and so varies with the base image; uid/gid are now pinned to 1001. Its uid value does change. Nothing outside `Dockerfile.dev` refers to `devuser`, so it is contained.

**DL3025, JSON notation** (`Dockerfile:165`). This is the one that could have broken the running image. The flagged line is the **HEALTHCHECK** CMD, not the container `ENTRYPOINT`/`CMD` (already exec form):

```dockerfile
CMD curl -f http://localhost:8080/health || exit 1
```

`||` is a shell operator. Converting to `["curl","-f","...","||","exit","1"]` would hand `||` and `exit` to curl as literal arguments and the healthcheck would stop reporting unhealthy correctly. Written instead as `["/bin/sh", "-c", "curl -f http://localhost:8080/health || exit 1"]` — JSON notation, same process tree, shell dependency declared rather than implied.

## Verification

Docker was available, so this is built and exercised rather than reasoned about:

- hadolint 2.15.1 against all three Dockerfiles: **exit 0**. `pre-commit run hadolint --all-files`: **exit 0**.
- All three images build: `Dockerfile`, `Dockerfile.dev`, `Dockerfile.test`, **exit 0** each.
- Runtime identity resolves as intended: `uid=1000(cudly)`, `uid=10001(e2e)`, `uid=1001(devuser)`. The numeric form still resolves to the named user.
- Healthcheck recorded as `["CMD","/bin/sh","-c","curl -f http://localhost:8080/health || exit 1"]` and exercised **both directions**: exit 1 with no server listening (proving `||` is shell-evaluated, not passed to curl) and exit 0 on the short-circuit path.

## For the record, on the root cause

My first hypothesis on #1695 — that a pinned tag had been rebuilt underneath us — was **wrong**. The image was never pinned at all. Registry confirms `v2.14.0` (`sha256:27086352…`) and `v2.15.1` (`sha256:32dac941…`, identical to `latest`) are different images, and reproducing both directions locally gives exit 0 and exit 1 respectively.

## One unrelated failure, reported not fixed

`pre-commit run --all-files` exits 1 locally on **Terraform validate**: `Failed to install provider ... Error while installing hashicorp/azurerm v4.74.0: mkdir ...: file exists`. That is a shared `~/.terraform.d/plugin-cache` race between concurrent worktrees, not a config error. This diff touches **zero** `.tf` files.

## If you would rather not take this

Closing is a reasonable call. `main` is green, and this is hygiene rather than a fix for anything currently broken. The argument for landing it is that staying on 2.14.0 means never picking up new hadolint rules, which is the slow version of the drift #1695 was about.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved container health-check command handling for more reliable status reporting.
  - Standardized container user and group IDs across runtime, development, and test environments.

- **Chores**
  - Updated the Hadolint pre-commit check to version 2.15.1 with an immutable image reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->