### PR TITLE
fix(ci): npm audit advisories and scanner decoupling in Security Scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,6 +299,12 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Run govulncheck CVE scanner (all modules)
+        # always(): each scanner step below is independent evidence for the
+        # Security tab. Without this, one scanner failing (e.g. a live npm
+        # advisory) skips every scanner after it in the same job, silently
+        # disabling Go SAST and Terraform IaC coverage repo-wide. The job
+        # still fails overall if any scanner step here fails.
+        if: always()
         run: |
           # Pinned (not @latest): a govulncheck release with new
           # detection logic could silently change the gate's verdict
@@ -315,12 +321,19 @@ jobs:
           done
 
       - name: Run npm audit (frontend)
+        # always(): must not skip the scanners below it just because
+        # govulncheck failed, and its own failure must not skip gosec/Trivy.
+        if: always()
         run: |
           if [ -f frontend/package.json ]; then
             cd frontend && npm audit --audit-level=high
           fi
 
       - name: Run gosec Security Scanner
+        id: gosec
+        # always(): don't let an earlier scanner's failure (e.g. npm audit)
+        # skip Go SAST coverage. The job still fails if gosec itself fails.
+        if: always()
         run: |
           # Install pinned gosec using the job's existing setup-go.
           # The securego/gosec Docker action bundles its own Go toolchain which
@@ -348,12 +361,21 @@ jobs:
           echo "Merged $(jq '.runs | length' gosec-results.sarif) SARIF runs"
 
       - name: Upload gosec results to GitHub Security
-        if: always()
+        # Tolerate a missing SARIF only when the gosec step itself never ran
+        # (e.g. an earlier infra step like checkout/setup-go failed). If
+        # gosec ran and the file is still missing, fail loud instead of
+        # masking it as a skip.
+        if: always() && steps.gosec.outcome != 'skipped'
         uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           sarif_file: gosec-results.sarif
 
       - name: Run Trivy vulnerability scanner (filesystem)
+        id: trivy_fs
+        # always(): don't let an earlier scanner's failure skip Trivy fs
+        # coverage. This scan uses the default exit-code 0 (see the IaC
+        # scan comment below), so it does not gate the job on its own.
+        if: always()
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: 'fs'
@@ -370,6 +392,8 @@ jobs:
           version: 'v0.72.0'
 
       - name: Upload Trivy results to GitHub Security
+        # Tolerate a missing SARIF only when the Trivy fs step never ran.
+        if: always() && steps.trivy_fs.outcome != 'skipped'
         uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           sarif_file: 'trivy-results.sarif'
@@ -384,6 +408,10 @@ jobs:
       # to the Security tab without gating the job -- matching tfsec's prior
       # soft_fail: true behaviour while preserving Terraform IaC coverage.
       - name: Run Trivy IaC misconfiguration scanner (Terraform)
+        id: trivy_iac
+        # always(): don't let an earlier scanner's failure skip Terraform
+        # IaC coverage.
+        if: always()
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: 'config'
@@ -396,7 +424,8 @@ jobs:
           version: 'v0.72.0'
 
       - name: Upload Trivy IaC results to GitHub Security
-        if: always()
+        # Tolerate a missing SARIF only when the Trivy IaC step never ran.
+        if: always() && steps.trivy_iac.outcome != 'skipped'
         uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           sarif_file: 'trivy-config-results.sarif'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,9 +388,13 @@ jobs:
             exit 1
           fi
           # jq is preinstalled on the GitHub Ubuntu runner image (no new deps).
+          # Written to $RUNNER_TEMP, not the checkout root: never save working
+          # files in the repository root (repo coding guideline), and this
+          # file is purely a hand-off to the upload step below.
+          merged="$RUNNER_TEMP/gosec-results.sarif"
           jq -s '{version: "2.1.0", "$schema": "https://json.schemastore.org/sarif-2.1.0.json", runs: [.[].runs[]]}' \
-            "${sarif_files[@]}" > gosec-results.sarif
-          echo "Merged $(jq '.runs | length' gosec-results.sarif) SARIF runs"
+            "${sarif_files[@]}" > "$merged"
+          echo "Merged $(jq '.runs | length' "$merged") SARIF runs"
           exit "$status"
 
       - name: Upload gosec results to GitHub Security
@@ -401,7 +405,7 @@ jobs:
         if: always() && steps.checkout.outcome == 'success' && steps.setup_go.outcome == 'success' && steps.gosec.outcome != 'skipped'
         uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
-          sarif_file: gosec-results.sarif
+          sarif_file: ${{ runner.temp }}/gosec-results.sarif
 
       - name: Run Trivy vulnerability scanner (filesystem)
         id: trivy_fs
@@ -415,7 +419,9 @@ jobs:
           scan-type: 'fs'
           scan-ref: '.'
           format: 'sarif'
-          output: 'trivy-results.sarif'
+          # $RUNNER_TEMP, not the checkout root (repo coding guideline: never
+          # save working files in the repository root).
+          output: '${{ runner.temp }}/trivy-results.sarif'
           severity: 'CRITICAL,HIGH'
           # Pin the Trivy binary independently of the action SHA. v0.36.0 is
           # the latest trivy-action release but bundles Trivy v0.70.0, which
@@ -430,7 +436,7 @@ jobs:
         if: always() && steps.checkout.outcome == 'success' && steps.setup_go.outcome == 'success' && steps.trivy_fs.outcome != 'skipped'
         uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
-          sarif_file: 'trivy-results.sarif'
+          sarif_file: '${{ runner.temp }}/trivy-results.sarif'
 
       # Terraform IaC misconfiguration scanning. Replaces the deprecated
       # aquasecurity/tfsec-action, whose bundled HCL parser rejects Terraform
@@ -452,7 +458,9 @@ jobs:
           scan-type: 'config'
           scan-ref: 'terraform/'
           format: 'sarif'
-          output: 'trivy-config-results.sarif'
+          # $RUNNER_TEMP, not the checkout root (repo coding guideline: never
+          # save working files in the repository root).
+          output: '${{ runner.temp }}/trivy-config-results.sarif'
           severity: 'CRITICAL,HIGH'
           # Same pinned Trivy binary as the filesystem scan above (>= v0.72.0
           # avoids the adaptDefaultTags panic on null default_tags vars).
@@ -463,7 +471,7 @@ jobs:
         if: always() && steps.checkout.outcome == 'success' && steps.setup_go.outcome == 'success' && steps.trivy_iac.outcome != 'skipped'
         uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
-          sarif_file: 'trivy-config-results.sarif'
+          sarif_file: '${{ runner.temp }}/trivy-config-results.sarif'
           # Distinct category so this IaC analysis does not overwrite the
           # filesystem Trivy analysis uploaded above (both report as "Trivy").
           category: 'trivy-iac'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,11 +289,13 @@ jobs:
 
     steps:
       - name: Checkout code
+        id: checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           persist-credentials: false
 
       - name: Set up Go
+        id: setup_go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ env.GO_VERSION }}
@@ -303,8 +305,10 @@ jobs:
         # Security tab. Without this, one scanner failing (e.g. a live npm
         # advisory) skips every scanner after it in the same job, silently
         # disabling Go SAST and Terraform IaC coverage repo-wide. The job
-        # still fails overall if any scanner step here fails.
-        if: always()
+        # still fails overall if any scanner step here fails. Still requires
+        # checkout and Go setup to have actually succeeded -- an infra
+        # failure there must not be papered over as "scanner found nothing".
+        if: always() && steps.checkout.outcome == 'success' && steps.setup_go.outcome == 'success'
         run: |
           # Pinned (not @latest): a govulncheck release with new
           # detection logic could silently change the gate's verdict
@@ -323,7 +327,8 @@ jobs:
       - name: Run npm audit (frontend)
         # always(): must not skip the scanners below it just because
         # govulncheck failed, and its own failure must not skip gosec/Trivy.
-        if: always()
+        # Still requires checkout to have succeeded (see govulncheck above).
+        if: always() && steps.checkout.outcome == 'success' && steps.setup_go.outcome == 'success'
         run: |
           if [ -f frontend/package.json ]; then
             cd frontend && npm audit --audit-level=high
@@ -333,7 +338,8 @@ jobs:
         id: gosec
         # always(): don't let an earlier scanner's failure (e.g. npm audit)
         # skip Go SAST coverage. The job still fails if gosec itself fails.
-        if: always()
+        # Still requires checkout and Go setup to have succeeded.
+        if: always() && steps.checkout.outcome == 'success' && steps.setup_go.outcome == 'success'
         run: |
           # Install pinned gosec using the job's existing setup-go.
           # The securego/gosec Docker action bundles its own Go toolchain which
@@ -342,12 +348,29 @@ jobs:
           # Multi-module repo: each ./... only walks the current module so scanning root
           # alone silently misses pkg/ and providers/*. Mirror the govulncheck per-module
           # loop, collect per-module SARIF, then merge for the upload step.
+          #
+          # gosec exits non-zero both for real findings and for a processing
+          # error. A bare `set -e` loop aborts at the first non-zero module,
+          # skipping the merge below entirely -- the upload step then fails
+          # on a missing file instead of surfacing the actual finding
+          # (issue #1717). Guarding the gosec call in `if ! ( ... )` exempts
+          # it from errexit so every module still gets scanned and merged;
+          # `status` records whether the job should still fail at the end.
           set -e
+          status=0
           for mod in . pkg providers/aws providers/azure providers/gcp tests/e2e; do
             tag=$(echo "$mod" | tr './' '--' | sed 's/^-/root/')
             out="$RUNNER_TEMP/gosec-${tag}.sarif"
             echo "==> gosec in $mod"
-            (cd "$mod" && gosec -fmt sarif -out "$out" ./...)
+            if ! (cd "$mod" && gosec -fmt sarif -out "$out" ./...); then
+              echo "::warning::gosec exited non-zero in $mod (findings or a scan error)"
+              status=1
+            fi
+            if [ ! -f "$out" ]; then
+              echo "::error::gosec produced no SARIF output for $mod"
+              status=1
+              continue
+            fi
             # Code scanning rejects a SARIF file whose runs share a category
             # (github.blog changelog 2025-07-21), so give each module's run a
             # unique automationDetails.id before merging.
@@ -355,17 +378,27 @@ jobs:
               "$out" > "$out.tmp" && mv "$out.tmp" "$out"
           done
           # Merge per-module SARIF runs into one file for the upload step.
+          # Only modules that actually produced a file are included; if
+          # gosec crashed before writing any of them, fail loud here rather
+          # than uploading an empty result silently.
+          shopt -s nullglob
+          sarif_files=("$RUNNER_TEMP"/gosec-*.sarif)
+          if [ "${#sarif_files[@]}" -eq 0 ]; then
+            echo "::error::no gosec SARIF output was produced by any module" >&2
+            exit 1
+          fi
           # jq is preinstalled on the GitHub Ubuntu runner image (no new deps).
           jq -s '{version: "2.1.0", "$schema": "https://json.schemastore.org/sarif-2.1.0.json", runs: [.[].runs[]]}' \
-            "$RUNNER_TEMP"/gosec-*.sarif > gosec-results.sarif
+            "${sarif_files[@]}" > gosec-results.sarif
           echo "Merged $(jq '.runs | length' gosec-results.sarif) SARIF runs"
+          exit "$status"
 
       - name: Upload gosec results to GitHub Security
         # Tolerate a missing SARIF only when the gosec step itself never ran
-        # (e.g. an earlier infra step like checkout/setup-go failed). If
-        # gosec ran and the file is still missing, fail loud instead of
-        # masking it as a skip.
-        if: always() && steps.gosec.outcome != 'skipped'
+        # (e.g. checkout/setup-go failed, so gosec's own `if:` above skipped
+        # it). If gosec ran and the file is still missing, fail loud instead
+        # of masking it as a skip.
+        if: always() && steps.checkout.outcome == 'success' && steps.setup_go.outcome == 'success' && steps.gosec.outcome != 'skipped'
         uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           sarif_file: gosec-results.sarif
@@ -375,7 +408,8 @@ jobs:
         # always(): don't let an earlier scanner's failure skip Trivy fs
         # coverage. This scan uses the default exit-code 0 (see the IaC
         # scan comment below), so it does not gate the job on its own.
-        if: always()
+        # Still requires checkout and Go setup to have succeeded.
+        if: always() && steps.checkout.outcome == 'success' && steps.setup_go.outcome == 'success'
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: 'fs'
@@ -393,7 +427,7 @@ jobs:
 
       - name: Upload Trivy results to GitHub Security
         # Tolerate a missing SARIF only when the Trivy fs step never ran.
-        if: always() && steps.trivy_fs.outcome != 'skipped'
+        if: always() && steps.checkout.outcome == 'success' && steps.setup_go.outcome == 'success' && steps.trivy_fs.outcome != 'skipped'
         uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           sarif_file: 'trivy-results.sarif'
@@ -410,8 +444,9 @@ jobs:
       - name: Run Trivy IaC misconfiguration scanner (Terraform)
         id: trivy_iac
         # always(): don't let an earlier scanner's failure skip Terraform
-        # IaC coverage.
-        if: always()
+        # IaC coverage. Still requires checkout and Go setup to have
+        # succeeded.
+        if: always() && steps.checkout.outcome == 'success' && steps.setup_go.outcome == 'success'
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: 'config'
@@ -425,7 +460,7 @@ jobs:
 
       - name: Upload Trivy IaC results to GitHub Security
         # Tolerate a missing SARIF only when the Trivy IaC step never ran.
-        if: always() && steps.trivy_iac.outcome != 'skipped'
+        if: always() && steps.checkout.outcome == 'success' && steps.setup_go.outcome == 'success' && steps.trivy_iac.outcome != 'skipped'
         uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           sarif_file: 'trivy-config-results.sarif'

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -127,14 +127,14 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/go/bin
-          key: go-tools-${{ runner.os }}-gosec-v2.22.4-gocyclo-v0.6.0
+          key: go-tools-${{ runner.os }}-gosec-v2.28.0-gocyclo-v0.6.0
 
       - name: Install gosec
         if: steps.cache-go-tools.outputs.cache-hit != 'true'
         # Pinned to the same version ci.yml's `securego/gosec` Action uses,
         # so an upstream gosec release with rule changes can't silently
         # downgrade the gate between the two workflows.
-        run: go install github.com/securego/gosec/v2/cmd/gosec@v2.22.4
+        run: go install github.com/securego/gosec/v2/cmd/gosec@v2.28.0
 
       - name: Install gocyclo
         if: steps.cache-go-tools.outputs.cache-hit != 'true'

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ GIT_SHA?=$(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
 # Dev tool versions - keep in sync with the CI pins in
 # .github/workflows/ci.yml, pre-commit.yml and database-migration.yml
 GOLANGCI_LINT_VERSION?=v2.10.1
-GOSEC_VERSION?=v2.22.4
+GOSEC_VERSION?=v2.28.0
 GOCYCLO_VERSION?=v0.6.0
 MIGRATE_VERSION?=v4.19.1
 # staticcheck has no CI pin; it is used by scripts/security-scan.sh

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4006,9 +4006,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5752,9 +5752,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Closes #1712
Closes #1717

## What

Four fixes, landed as four commits:

1. **Patch the npm audit advisories** (`frontend/package-lock.json` only). `brace-expansion` and `fast-uri` are transitive dependencies; `npm audit fix` bumps only their lockfile entries. `package.json`'s direct dependency ranges are unchanged.
2. **Decouple the Security Scanning job's scanners** (`.github/workflows/ci.yml`). Give `govulncheck`, `npm audit`, `gosec`, and both Trivy scans `if: always()` so a failing scanner no longer skips the ones after it in the same job. The job still fails overall if any scanner fails (`always()` does not suppress a step's own failure). The gosec/Trivy SARIF upload steps now also check `steps.<scanner>.outcome != 'skipped'`, so a genuinely unrun scanner is tolerated without the confusing "Path does not exist" failure, while a scanner that ran and left no file still fails loud.
3. **Fix the gosec `set -e` SARIF-loss bug (#1717, found while building #2 and confirmed live by CodeRabbit).** The gosec per-module loop ran under `set -e`; gosec itself exits non-zero on a real finding, which aborted the loop before later modules were scanned and before the SARIF merge ran -- so a real finding surfaced as a missing-file upload failure instead of a reported finding. Guard the gosec call in `if ! ( ... )` so a non-zero exit is recorded instead of aborting the script; every module still gets scanned and merged, and the job still fails if anything was found. Also add `id: checkout` / `id: setup_go` and require both to have succeeded before any scanner (and its upload) runs, so a checkout/setup-go failure can no longer look like "scanner ran, found nothing".
4. **Align `pre-commit.yml`'s cached gosec pin with the CI gate.** `pre-commit.yml`'s tool-cache priming step was still pinned to gosec v2.22.4 while `ci.yml` and the local pre-commit hook (`scripts/gosec-hook.sh`) both already run v2.28.0. Bumped upward to v2.28.0 (cache key + install), matching `GO_VERSION` 1.26.5's toolchain support for that gosec release in both workflows.

## Before / after: npm audit

Before (reproduced against `origin/main` at `02702a108`, matching the issue):

```
# npm audit report

brace-expansion  4.0.0 - 5.0.8
Severity: high
brace-expansion: DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation - https://github.com/advisories/GHSA-rgw5-rvv9-x895
fix available via `npm audit fix`
node_modules/brace-expansion

fast-uri  3.0.0 - 3.1.4
Severity: high
fast-uri vulnerable to host confusion via backslash authority introducer - https://github.com/advisories/GHSA-7p8r-x3mc-p8w7
fix available via `npm audit fix`
node_modules/fast-uri

2 high severity vulnerabilities

To address all issues, run:
  npm audit fix
EXIT=1
```

After:

```
found 0 vulnerabilities
EXIT=0
```

Lockfile diff is exactly the two transitive bumps, no direct dependency ranges touched:

```
-      "version": "5.0.8",   +      "version": "5.0.9",    (brace-expansion)
-      "version": "3.1.4",   +      "version": "3.1.5",    (fast-uri)
```

`npm run build` (webpack production) still succeeds. `npm test` still passes at the same baseline: 2773 passing, 8 pre-existing failures in `src/__tests__/{approval-details,utils,riexchange}.test.ts` caused by this sandbox's non-`en-US` ICU locale rendering `$1,200` as `$1.200`. Confirmed these 8 failures are identical (same tests, same count) on unmodified `main` before the lockfile change, so they are pre-existing and environment-caused, not introduced by this PR.

## Decoupling evidence

I don't have permission to trigger a real GitHub Actions run from here, so I built and executed a local `act` (v0.2.89, via Docker) simulation that reproduces the exact `if:` expressions used in `ci.yml`, to get real executed evidence instead of just reasoning about the YAML.

**Scenario A** - mirrors the actual bug: an `npm-audit-sim` step that deliberately fails, with `gosec-sim`, `trivy-fs-sim`, and `trivy-iac-sim` steps (each `id: <name>`, `if: always()`) and matching `upload-*-sim` steps (`if: always() && steps.<name>.outcome != 'skipped'`) after it, matching the shape of the real job:

```
⭐ Run Main npm-audit-sim (deliberately fails, mirrors a live advisory)
❌  Failure - Main npm-audit-sim (deliberately fails, mirrors a live advisory)

⭐ Run Main gosec-sim
| gosec ran despite npm-audit-sim failure
✅  Success - Main gosec-sim
⭐ Run Main upload-gosec-sim
| upload-gosec-sim ran, outcome=success, file exists=yes
✅  Success - Main upload-gosec-sim

⭐ Run Main trivy-fs-sim
| trivy fs ran despite npm-audit-sim failure
✅  Success - Main trivy-fs-sim
⭐ Run Main upload-trivy-fs-sim
| upload-trivy-fs-sim ran, outcome=success, file exists=yes
✅  Success - Main upload-trivy-fs-sim

⭐ Run Main trivy-iac-sim
| trivy iac ran despite npm-audit-sim failure
✅  Success - Main trivy-iac-sim
⭐ Run Main upload-trivy-iac-sim
| upload-trivy-iac-sim ran, outcome=success, file exists=yes
✅  Success - Main upload-trivy-iac-sim

🏁  Job failed
```

Every scanner after the failing one still ran and its upload found the file. The job still reports failed overall, because `always()` only unblocks *later* steps, it does not suppress the failing step's own outcome.

**Scenario B** - a scanner step that is genuinely never run (`if: false`, standing in for something like a checkout/setup-go failure upstream of the scanner steps themselves):

```
[only "Set up job" and "Complete job" ran; the gosec-sim step and its
upload-gosec-sim step were both skipped by act's own if: evaluation]
🏁  Job succeeded
```

No "Path does not exist" failure: `steps.gosec.outcome != 'skipped'` correctly evaluates false when the scanner step itself never ran, so the upload step is skipped too instead of erroring on a missing file.

## #1717 fix: evidence

CodeRabbit flagged this on the lines this PR itself edits, and it's the same coupling defect one level in (a real finding surfacing as a missing-SARIF error), so it's fixed here rather than deferred, per @cristim.

I extracted the exact `run:` script from the gosec step (with the module list swapped for a local two-module fixture: `modA` clean, `modB` with a deliberate `crypto/md5` weak-hash finding) and ran it with a locally installed `gosec@v2.28.0` (the pinned version), once against the OLD script and once against the NEW one.

**OLD script** (as it existed on `main` before this PR):

```
==> gosec in modA
==> gosec in modB
OLD_EXIT_STATUS=1
---
gosec-results-OLD.sarif does NOT exist
```

The script aborted right after modB's finding. No merge ever ran, no SARIF file was ever produced -- exactly the "Path does not exist" failure mode #1717 describes, reproduced on a real gosec finding rather than reasoned about.

**NEW script** (this PR):

```
==> gosec in modA
==> gosec in modB
::warning::gosec exited non-zero in modB (findings or a scan error)
Merged 2 SARIF runs
EXIT_STATUS=1
```

Both modules scanned, both SARIF runs merged (`gosec-results.sarif` has 2 runs, one per module, each independently uploadable), and the script still exits 1 -- the finding still fails the job, but it is now actually reported instead of eaten by the missing-file error.

## Checkout/setup-go gating evidence

Added `id: checkout` / `id: setup_go` and gated every scanner + upload step on both. Verified with a third `act` simulation: a `checkout-sim-fails` step (`id: checkout`, deliberately `exit 1`) followed by a `setup-go-sim` step and a `gosec-sim` step gated the same way as the real job.

```
⭐ Run Main checkout-sim-fails
❌  Failure - Main checkout-sim-fails
⭐ Run Main setup-go-sim
✅  Success - Main setup-go-sim
✅  Success - Complete job
🏁  Job failed
```

`gosec-sim` and `upload-gosec-sim` never appear in the log at all -- `if: always() && steps.checkout.outcome == 'success' && ...` correctly skipped both, with no "Path does not exist" noise, while the job still failed overall because checkout itself failed.

## Verification checklist

- [x] `npm audit --audit-level=high` exits 0 in `frontend/` after the lockfile bump
- [x] `frontend/package.json` unchanged (lockfile-only fix)
- [x] `npm run build` succeeds
- [x] `npm test` passes at baseline (2773/2782, 8 pre-existing locale failures confirmed present on unmodified `main` too)
- [x] `.github/workflows/ci.yml` and `.github/workflows/pre-commit.yml` are valid YAML (`yaml.safe_load`)
- [x] Cross-scanner decoupling executed and observed via local `act` simulation
- [x] gosec `set -e` SARIF-loss fix executed against a real gosec finding, old-vs-new, via a local fixture (not just reasoned about)
- [x] checkout/setup-go gating executed and observed via local `act` simulation
- [x] Confirmed `.pre-commit-config.yaml` / `scripts/gosec-hook.sh` already pin v2.28.0; only `pre-commit.yml`'s cache-priming step was stale at v2.22.4
- [x] npm finding and gosec findings still fail the job; only the coupling between scanners (and the SARIF-loss-on-failure bug) is removed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the reliability and consistency of automated security checks.
  * Security scans now run independently so available results can still be collected when another check encounters issues.
  * Enhanced validation and reporting for security scan results, including clearer handling of missing or incomplete reports.
  * Updated security scanning tools to improve vulnerability coverage and reporting quality.
  * Improved feedback when security checks are skipped, fail, or produce no results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
